### PR TITLE
fix: propagate `organizationId` when opening the search dialog

### DIFF
--- a/packages/insomnia/src/ui/components/command-palette.tsx
+++ b/packages/insomnia/src/ui/components/command-palette.tsx
@@ -300,7 +300,7 @@ export const CommandPalette = () => {
         setIsOpen(isOpen);
         if (isOpen) {
           const searchParams = new URLSearchParams();
-
+          searchParams.set('organizationId', organizationId);
           searchParams.set('workspaceId', workspaceId);
           searchParams.set('projectId', projectId);
 


### PR DESCRIPTION
Closes #7199
