### PR TITLE
fix: encoded value be decoded issue

### DIFF
--- a/packages/insomnia/src/utils/url/querystring.test.ts
+++ b/packages/insomnia/src/utils/url/querystring.test.ts
@@ -69,7 +69,7 @@ describe('querystring', () => {
     });
   });
 
-  describe('build()', () => {
+  describe('buildQueryParameter()', () => {
     it('builds simple param', () => {
       const str = buildQueryParameter({ name: 'foo', value: 'bar??' });
       expect(str).toBe('foo=bar%3F%3F');
@@ -85,6 +85,21 @@ describe('querystring', () => {
       expect(str).toBe('foo');
     });
 
+    it('builds param with encoded value and name', () => {
+      const str = buildQueryParameter({ name: 'foo%11%09%2A%9D%0F', value: 'bar%11%09%2A%9D%0F' });
+      expect(str).toBe('foo%11%09%2A%9D%0F=bar%11%09%2A%9D%0F');
+    });
+
+    it('builds param with null value and disable strict', () => {
+      const str = buildQueryParameter({ name: 'foo', value: null }, false);
+      expect(str).toBe('foo=');
+    });
+
+    it('builds param with spaces', () => {
+      const str = buildQueryParameter({ name: 'foo bar', value: 'baz qux' });
+      expect(str).toBe('foo%20bar=baz%20qux');
+    });
+
     it('builds param with null value and enable strictNullHandling', () => {
       const str = buildQueryParameter({ name: 'foo', value: null }, true, { strictNullHandling: true });
       expect(str).toBe('foo');
@@ -93,6 +108,11 @@ describe('querystring', () => {
     it('builds param with empty string value', () => {
       const str = buildQueryParameter({ name: 'foo', value: '' });
       expect(str).toBe('foo');
+    });
+
+    it('builds param with empty string value and disable strict', () => {
+      const str = buildQueryParameter({ name: 'foo', value: '' }, false);
+      expect(str).toBe('foo=');
     });
 
     it('builds param with empty string value and enable strictNullHandling', () => {
@@ -112,9 +132,34 @@ describe('querystring', () => {
       expect(str).toBe('number=10');
       expect(str2).toBe('number=0');
     });
+
+    it('builds param ignore commas in the value', () => {
+      const str = buildQueryParameter({ name: 'foo,', value: '1,2,3' });
+      expect(str).toBe('foo%2C=1,2,3');
+    });
+
+    it('builds param without decode the commas back', () => {
+      const str = buildQueryParameter({ name: 'foo', value: '1%2C' });
+      expect(str).toBe('foo=1%2C');
+    });
+
+    it.fails('build query param with __ENC__ returns incorrect result', () => {
+      const str = buildQueryParameter({ name: 'foo', value: '__ENC__11' });
+      expect(str).toBe('foo=__ENC__11');
+    });
+
+    it.fails('build query param with __RAW__ returns incorrect result', () => {
+      const str = buildQueryParameter({ name: 'foo', value: '__RAW__22' });
+      expect(str).toBe('foo=__RAW__22');
+    });
+
+    it.fails('build query param with __RAW__AA throws error', () => {
+      const str = buildQueryParameter({ name: 'foo', value: '__RAW__AA' });
+      expect(str).toBe(expect.anything());
+    });
   });
 
-  describe('buildFromParams()', () => {
+  describe('buildQueryStringFromParams()', () => {
     it('builds from params', () => {
       const str = buildQueryStringFromParams([
         { name: 'foo', value: 'bar??' },
@@ -128,6 +173,7 @@ describe('querystring', () => {
 
       expect(str).toBe('foo=bar%3F%3F&foo1&foo2&hello&hi%20there=bar%3F%3F');
     });
+
     it('builds from params', () => {
       const str = buildQueryStringFromParams(
         [
@@ -142,6 +188,7 @@ describe('querystring', () => {
 
       expect(str).toBe('foo=bar%3F%3F&hello=&hi%20there=bar%3F%3F&=bar%3F%3F&=');
     });
+
     it('builds from params with strict mode and strictNullHandling', () => {
       const str = buildQueryStringFromParams(
         [
@@ -161,7 +208,7 @@ describe('querystring', () => {
     });
   });
 
-  describe('deconstructToParams()', () => {
+  describe('deconstructQueryStringToParams()', () => {
     it('builds from params', () => {
       const str = deconstructQueryStringToParams('foo=bar%3F%3F&hello&hi%20there=bar%3F%3F&=&=val');
 
@@ -171,6 +218,7 @@ describe('querystring', () => {
         { name: 'hi there', value: 'bar??' },
       ]);
     });
+
     it('builds from params with =', () => {
       const str = deconstructQueryStringToParams('foo=bar&1=2=3=4&hi');
 
@@ -200,6 +248,18 @@ describe('querystring', () => {
         { name: 'foo', value: 'bar' },
         { name: 'foo1', value: null },
         { name: 'foo2', value: '' },
+      ]);
+    });
+
+    it('builds from params with skipDecode', () => {
+      const str = deconstructQueryStringToParams('foo=bar%3F%3F&hello&hi%20there=bar%3F%3F&=&=val', true, {
+        skipDecode: true,
+      });
+
+      expect(str).toEqual([
+        { name: 'foo', value: 'bar%3F%3F' },
+        { name: 'hello', value: '' },
+        { name: 'hi%20there', value: 'bar%3F%3F' },
       ]);
     });
   });
@@ -289,6 +349,16 @@ describe('querystring', () => {
         strictNullHandling: true,
       });
       expect(urlNoEqualSign2).toBe('https://google.com/terminologies?foo=bar&foo1');
+    });
+
+    it('should not decode value back', () => {
+      expect(
+        smartEncodeUrl(
+          'https://google.com/?text=%4E%C3%A4%72%20%6D%61%6E%20%74%65%73%74%61%72%20%74%65%73%74%61%72%20%6D%61%6E',
+        ),
+      ).toBe(
+        'https://google.com/?text=%4E%C3%A4%72%20%6D%61%6E%20%74%65%73%74%61%72%20%74%65%73%74%61%72%20%6D%61%6E',
+      );
     });
   });
 });

--- a/packages/insomnia/src/utils/url/querystring.ts
+++ b/packages/insomnia/src/utils/url/querystring.ts
@@ -14,7 +14,7 @@ const RFC_3986_SUB_DELIMITERS = '$+,;='; // (unintentionally?) missing: !&'()*
 const URL_PATH_CHARACTER_WHITELIST = `${RFC_3986_GENERAL_DELIMITERS}${RFC_3986_SUB_DELIMITERS}`;
 
 interface IQueryStringOptions {
-  // Option to distingush between parameters with(&foo=) and without(&foo) equal signs. Both are converted to empty string by default.
+  // Option to distinguish between parameters with(&foo=) and without(&foo) equal signs. Both are converted to empty string by default.
   strictNullHandling?: boolean;
   // Option to encode parameters, default to true, necessary to disable for request.settingEncodeUrl = false
   encodeParams?: boolean;
@@ -80,7 +80,7 @@ export const buildQueryParameter = (
 
   /** allow empty names and values */
   strict?: boolean,
-  /** extra options like strict hanlde null value */
+  /** extra options like strict handle null value */
   options?: IQueryStringOptions,
 ) => {
   strict = strict === undefined ? true : strict;
@@ -101,8 +101,8 @@ export const buildQueryParameter = (
     if (!encodeParams) {
       return `${param.name}=${param.value}`;
     }
-    // Don't encode ',' in values
-    const value = flexibleEncodeComponent(param.value || '').replace(/%2C/gi, ',');
+    // Don't encode ',' in values, the original proposal was to keep values like 'foo,bar' intact
+    const value = flexibleEncodeComponent(param.value || '', ',');
     const name = flexibleEncodeComponent(param.name || '');
 
     return `${name}=${value}`;
@@ -117,7 +117,7 @@ export const buildQueryStringFromParams = (
   parameters: { name: string; value?: StrictNullSearchParamsValueType }[],
   /** allow empty names and values */
   strict?: boolean,
-  /** extra options like strict hanlde null value */
+  /** extra options like strict handle null value */
   options?: IQueryStringOptions,
 ) => {
   strict = strict === undefined ? true : strict;
@@ -142,14 +142,16 @@ export const buildQueryStringFromParams = (
  */
 export const deconstructQueryStringToParams = <T extends IQueryStringOptions>(
   qs?: string,
-
   /** allow empty names and values */
   strict?: boolean,
-  /** extra deconstruct options like strict hanlde null value */
-  options?: T,
+  /** extra deconstruct options like strict handle null value */
+  options?: T & {
+    /** skip decode the querystring */
+    skipDecode?: boolean;
+  },
 ): ProcessDeconstructFuncReturnType<T> => {
   strict = strict === undefined ? true : strict;
-  const { strictNullHandling = false } = options || {};
+  const { strictNullHandling = false, skipDecode = false } = options || {};
   const pairs: ProcessDeconstructFuncReturnType<T> = [];
   type ValueType = (typeof pairs)[number]['value'];
 
@@ -167,7 +169,7 @@ export const deconstructQueryStringToParams = <T extends IQueryStringOptions>(
 
     let name = '';
     try {
-      name = decodeURIComponent(encodedName || '');
+      name = skipDecode ? encodedName : decodeURIComponent(encodedName || '');
     } catch (error) {
       // Just leave it
       name = encodedName;
@@ -175,7 +177,12 @@ export const deconstructQueryStringToParams = <T extends IQueryStringOptions>(
 
     let value: ValueType = '';
     try {
-      value = strictNullHandling && encodedValue === null ? null : decodeURIComponent(encodedValue || '');
+      value =
+        strictNullHandling && encodedValue === null
+          ? null
+          : skipDecode
+            ? encodedValue
+            : decodeURIComponent(encodedValue || '');
     } catch (error) {
       // Just leave it
       value = encodedValue;
@@ -200,7 +207,7 @@ export const deconstructQueryStringToParams = <T extends IQueryStringOptions>(
 export const smartEncodeUrl = (url: string, encode?: boolean, options?: IQueryStringOptions) => {
   // Default autoEncode = true if not passed
   encode = encode === undefined ? true : encode;
-  // Default do not strcit handle null value
+  // Default do not strict handle null value
   const { strictNullHandling = false } = options || {};
   const urlWithProto = setDefaultProtocol(url);
 
@@ -224,16 +231,11 @@ export const smartEncodeUrl = (url: string, encode?: boolean, options?: IQuerySt
   // ~~~~~~~~~~~~~~ //
 
   if (parsedUrl.query) {
-    const qsParams = deconstructQueryStringToParams(parsedUrl.query, true, { strictNullHandling });
-    const encodedQsParams = [];
-    for (const { name, value } of qsParams) {
-      encodedQsParams.push({
-        name: flexibleEncodeComponent(name),
-        value: strictNullHandling && value === null ? null : flexibleEncodeComponent(value as string),
-      });
-    }
+    // Skip decode if already encoded, to avoid some decoded characters cannot be encoded again.
+    // E.g. %4E -> N, encodeURIComponent(decodeURIComponent('%4E')) is N which is not expected.
+    const qsParams = deconstructQueryStringToParams(parsedUrl.query, true, { strictNullHandling, skipDecode: true });
 
-    parsedUrl.query = buildQueryStringFromParams(encodedQsParams, true, { strictNullHandling });
+    parsedUrl.query = buildQueryStringFromParams(qsParams, true, { strictNullHandling });
     parsedUrl.search = `?${parsedUrl.query}`;
   }
 
@@ -245,10 +247,7 @@ export const smartEncodeUrl = (url: string, encode?: boolean, options?: IQuerySt
  * @param str string to encode
  * @param ignore characters to ignore
  */
-export const flexibleEncodeComponent = (str = '', ignore = '') => {
-  // Sometimes spaces screw things up because of url.parse
-  str = str.replace(/%20/g, ' ');
-
+const flexibleEncodeComponent = (str = '', ignore = '') => {
   // Handle all already-encoded characters so we don't touch them
   str = str.replace(/%([0-9a-fA-F]{2})/g, '__ENC__$1');
 


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

## Background

When users pass percent-encoded strings in the query parameters, the encoded characters will be decoded. E.g. %4E.

## Root Cause

1. `smartEncodeUrl` calls `deconstructQueryStringToParams` before `buildQueryStringFromParams`, `deconstructQueryStringToParams` always decodes the params, the original proposal I guess is to keep all the strings to be only encoded once. Although `encodeURIComponent` and `decodeURIComponent` are often thought of as complementary, **they are not exact opposites**. This is because `decodeURIComponent` will decode all percent-encoded sequences, whereas [`encodeURIComponent` only encodes necessary characters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#description).
2. When there is a `,` in the string, it'll be decoded to `%2C`, which seems it cause issues before, so `%2C` will always be replaced with `,`. But if there is `%2C` in the original input, we should consider it as `%2C` instead of `,`.

## Changes
1. Add `skipDecode` to `deconstructQueryStringToParams`
2. Use `ignore` param instead of replace all `%2C` to `,`
3. Remove unused whitespace replacement
4. Fix some typos

Closes #975 
