### PR TITLE
Fix: Simplify the nunjuck rendering cache mechanism

### DIFF
--- a/packages/insomnia/src/templating/types.ts
+++ b/packages/insomnia/src/templating/types.ts
@@ -63,7 +63,7 @@ export interface RenderContextAndKeys {
   }[];
 }
 
-export type HandleRender = <T>(whatever: T, contextCacheKey?: string | null) => Promise<T>;
+export type HandleRender = <T>(whatever: T) => Promise<T>;
 
 export interface BaseRenderContextOptions {
   environment?: string | Environment;

--- a/packages/insomnia/src/ui/components/.client/codemirror/extensions/nunjucks-tags.ts
+++ b/packages/insomnia/src/ui/components/.client/codemirror/extensions/nunjucks-tags.ts
@@ -56,10 +56,8 @@ async function _highlightNunjucksTags(
   showVariableSourceAndValue: boolean,
   editorId: string,
 ) {
-  const renderCacheKey = Math.random() + '';
-
-  const renderString = (text: any) => render(text, renderCacheKey);
-  const renderContextWithCacheKey = () => renderContext(renderCacheKey);
+  const renderString = (text: any) => render(text);
+  const renderContextWithCacheKey = () => renderContext();
 
   const activeMarks: CodeMirror.TextMarker[] = [];
   const doc: CodeMirror.Doc = this.getDoc();

--- a/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
@@ -66,7 +66,7 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
     const codeMirror = useRef<CodeMirror.EditorFromTextArea | null>(null);
     const { settings } = useRootLoaderData()!;
     const { isOwner, isEnterprisePlan } = usePlanData();
-    const { handleRender, handleGetRenderContext } = useNunjucks();
+    const { handleRender, handleGetRenderContext } = useNunjucks({ enableCache: true });
 
     const getKeyMap = useCallback(() => {
       if (!readOnly && settings.enableKeyMapForInlineTextEditors && settings.editorKeyMap) {

--- a/packages/insomnia/src/ui/context/nunjucks/use-nunjucks.ts
+++ b/packages/insomnia/src/ui/context/nunjucks/use-nunjucks.ts
@@ -1,26 +1,34 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { getRenderContext, getRenderContextAncestors, render } from '~/common/render';
+import { environment } from '~/models';
 import { useWorkspaceLoaderData } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
 import { useRequestLoaderData } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId';
 import { useRequestGroupLoaderData } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.$requestGroupId';
 import { NUNJUCKS_TEMPLATE_GLOBAL_PROPERTY_NAME } from '~/templating';
-import type { HandleRender, RenderContextOptions } from '~/templating/types';
+import type { BaseRenderContext, HandleRender, RenderContextOptions } from '~/templating/types';
 import { getKeys } from '~/templating/utils';
 
-let getRenderContextPromiseCache: any = {};
-
-export interface UseNunjucksOptions {
-  renderContext: Pick<Partial<RenderContextOptions>, 'purpose' | 'extraInfo'>;
+interface CacheOptions {
+  //If true, will cache the render context
+  enableCache?: boolean;
 }
-export const initializeNunjucksRenderPromiseCache = () => {
-  getRenderContextPromiseCache = {};
-};
-
-initializeNunjucksRenderPromiseCache();
+export type UseNunjucksOptions = {
+  renderContext?: Pick<Partial<RenderContextOptions>, 'purpose' | 'extraInfo'>;
+} & CacheOptions;
 
 /**
- * Access to functions useful for Nunjucks rendering
+ *
+ * Customized hook simplifies template rendering in React components by:
+ * - Retrieving render context based on current request/folder/workspace
+ * - Providing optional caching to optimize performance and avoid race conditions
+ * - Clear cache automatically when any of the environments change
+ *
+ * @param options - Configuration options for rendering and caching
+ * @param options.renderContext.purpose - Purpose of the render operation (e.g., 'send', 'preview')
+ * @param options.renderContext.extraInfo - Additional information to include in render context
+ * @param options.enableCache - Whether to cache the render context. Mainly used for editors with many nunjucks to render
+ *
  */
 export const useNunjucks = (options?: UseNunjucksOptions) => {
   // for all types of requests
@@ -28,61 +36,84 @@ export const useNunjucks = (options?: UseNunjucksOptions) => {
   // for request group (folder)
   const { activeRequestGroup } = useRequestGroupLoaderData() || {};
   const workspaceData = useWorkspaceLoaderData();
+  const { enableCache = false } = options || {};
+  const renderContextPromiseCache = useRef<Promise<BaseRenderContext>>();
 
   const fetchRenderContext = useCallback(async () => {
     const ancestors = await getRenderContextAncestors(
       requestData?.activeRequest || activeRequestGroup || workspaceData?.activeWorkspace,
     );
+    const baseEnvironment = workspaceData?.baseEnvironment;
+    const activeGlobalEnvironment = workspaceData?.activeGlobalEnvironment;
+    const isActiveGlobalBaseEnvironment = activeGlobalEnvironment?._id.startsWith('wrk_');
+
     return getRenderContext({
       request: requestData?.activeRequest || undefined,
-      environment: workspaceData?.activeEnvironment._id,
+      environment: workspaceData?.activeEnvironment,
+      baseEnvironment,
+      ...(activeGlobalEnvironment && {
+        rootGlobalEnvironment: isActiveGlobalBaseEnvironment
+          ? activeGlobalEnvironment
+          : (await environment.getById(activeGlobalEnvironment.parentId))!,
+        subGlobalEnvironment: isActiveGlobalBaseEnvironment ? undefined : activeGlobalEnvironment,
+      }),
       ancestors,
       ...options?.renderContext,
     });
   }, [
     requestData?.activeRequest,
-    workspaceData?.activeWorkspace,
-    workspaceData?.activeEnvironment._id,
-    options?.renderContext,
     activeRequestGroup,
+    workspaceData?.activeWorkspace,
+    workspaceData?.baseEnvironment,
+    workspaceData?.activeGlobalEnvironment,
+    workspaceData?.activeEnvironment,
+    options?.renderContext,
   ]);
 
-  const handleGetRenderContext = useCallback(
-    async (contextCacheKey?: string) => {
-      const context =
-        contextCacheKey && getRenderContextPromiseCache[contextCacheKey]
-          ? await getRenderContextPromiseCache[contextCacheKey]
-          : await fetchRenderContext();
-      const keys = getKeys(context, NUNJUCKS_TEMPLATE_GLOBAL_PROPERTY_NAME);
-      return { context, keys };
-    },
-    [fetchRenderContext],
-  );
+  const handleGetRenderContext = useCallback(async () => {
+    const context =
+      enableCache && renderContextPromiseCache.current
+        ? await renderContextPromiseCache.current
+        : await fetchRenderContext();
+    const keys = getKeys(context, NUNJUCKS_TEMPLATE_GLOBAL_PROPERTY_NAME);
+    return { context, keys };
+  }, [enableCache, fetchRenderContext]);
   /**
    * Heavily optimized render function
    *
    * @param text - template to render
-   * @param contextCacheKey - if rendering multiple times in parallel, set this
    * @returns {Promise}
    * @private
    */
   const handleRender: HandleRender = useCallback(
-    async <T>(obj: T, contextCacheKey: string | null = null) => {
-      if (!contextCacheKey || !getRenderContextPromiseCache[contextCacheKey]) {
-        // NOTE: We're caching promises here to avoid race conditions
-        // @ts-expect-error -- TSCONVERSION contextCacheKey being null used as object index
-        getRenderContextPromiseCache[contextCacheKey] = fetchRenderContext();
+    async <T>(obj: T) => {
+      let getOrCreateRenderContext: ReturnType<typeof fetchRenderContext>;
+      // Implement cache invalidation strategy for performance optimization:
+      // 1. Cache the render context to avoid expensive re-computation for multiple nunjucks
+      // 2. This pattern is mainly used for editors that render many nunjucks simultaneously
+      //    (For example: code-editor, one-line-editor)
+      // 3. With this approach, all templates rendered during the cache window share the same
+      //    context promise, avoiding redundant context creation and race conditions
+      if (enableCache) {
+        if (!renderContextPromiseCache.current) {
+          renderContextPromiseCache.current = fetchRenderContext();
+        }
+        getOrCreateRenderContext = renderContextPromiseCache.current;
+      } else {
+        getOrCreateRenderContext = fetchRenderContext();
       }
-
-      // Set timeout to delete the key eventually
-      // @ts-expect-error -- TSCONVERSION contextCacheKey being null used as object index
-      setTimeout(() => delete getRenderContextPromiseCache[contextCacheKey], 5000);
-      // @ts-expect-error -- TSCONVERSION contextCacheKey being null used as object index
-      const context = await getRenderContextPromiseCache[contextCacheKey];
+      const context = await getOrCreateRenderContext;
       return render(obj, context);
     },
-    [fetchRenderContext],
+    [enableCache, fetchRenderContext],
   );
+
+  useEffect(() => {
+    // Clean up the cache when fetchRenderContext changes
+    // fetchRenderContext will change when any of the environment changes
+    // This includes collection environment, global environment and folder environment
+    renderContextPromiseCache.current = undefined;
+  }, [enableCache, fetchRenderContext]);
 
   return {
     handleRender,


### PR DESCRIPTION
## Background
Current `use-nunjucks` hook which manages the Nunjuck rendering cache has the following issue:
- Components are required to generate and provide their own unique IDs to store cache entries.
- When new tags are created in the editor, the hook will create duplicate cache records instead of one.
- Caches are cleared via setTimeout with a hard-coded interval.

## Changes:
- Components only need to pass the `enableCache` option to the hook in order to enable caching
- Replace the global cache variable with a useRef-based cache, ensuring cache state is properly scoped to the hook instance and avoiding unique IDs.
- Clear the render cache automatically whenever any environment (folder, collection, or global level) changes, preventing stale caches.
- Add more meaningful inline comments to clarify the cache mechanism

Close [INS-1248](https://konghq.atlassian.net/browse/INS-1248)

[INS-1248]: https://konghq.atlassian.net/browse/INS-1248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ