### PR TITLE
feat: implement hotkey conflict detection and display warnings by toast notification on startup

### DIFF
--- a/packages/insomnia/src/common/hotkeys.ts
+++ b/packages/insomnia/src/common/hotkeys.ts
@@ -23,7 +23,6 @@ export const keyboardShortcutDescriptions: Record<KeyboardShortcut, string> = {
   request_toggleHistory: 'Show Request History',
   request_focusUrl: 'Focus URL',
   request_showGenerateCodeEditor: 'Generate Code',
-  sidebar_focusFilter: 'Filter Sidebar',
   sidebar_toggle: 'Toggle Sidebar',
   response_focus: 'Focus Response',
   showCookiesEditor: 'Edit Cookies',
@@ -113,10 +112,6 @@ const defaultRegistry: HotKeyRegistry = {
   request_showGenerateCodeEditor: {
     macKeys: [{ shift: true, meta: true, keyCode: keyboardKeys.g.keyCode }],
     winLinuxKeys: [{ ctrl: true, shift: true, keyCode: keyboardKeys.g.keyCode }],
-  },
-  sidebar_focusFilter: {
-    macKeys: [{ shift: true, meta: true, keyCode: keyboardKeys.f.keyCode }],
-    winLinuxKeys: [{ ctrl: true, shift: true, keyCode: keyboardKeys.f.keyCode }],
   },
   sidebar_toggle: {
     macKeys: [{ meta: true, keyCode: keyboardKeys.backslash.keyCode }],

--- a/packages/insomnia/src/common/hotkeys.ts
+++ b/packages/insomnia/src/common/hotkeys.ts
@@ -193,6 +193,21 @@ export function newDefaultRegistry(): HotKeyRegistry {
 }
 
 /**
+ * Serialize a key combination into a comparable string key.
+ */
+function serializeKeyCombination(keyComb: KeyCombination): string {
+  const modifiers = [
+    keyComb.ctrl ? 'ctrl' : '',
+    keyComb.alt ? 'alt' : '',
+    keyComb.shift ? 'shift' : '',
+    keyComb.meta ? 'meta' : '',
+  ]
+    .filter(Boolean)
+    .join('+');
+  return `${modifiers}+${keyComb.keyCode}`;
+}
+
+/**
  * Get the key combinations based on the current platform.
  */
 export function getPlatformKeyCombinations(bindings: PlatformKeyCombinations): KeyCombination[] {
@@ -206,14 +221,8 @@ export function getPlatformKeyCombinations(bindings: PlatformKeyCombinations): K
 /**
  * Determine whether two key combinations are the same by comparing each of their keys.
  */
-export function areSameKeyCombinations(keyComb1: KeyCombination, keyComb2: KeyCombination) {
-  return (
-    keyComb1.keyCode === keyComb2.keyCode &&
-    Boolean(keyComb1.alt) === Boolean(keyComb2.alt) &&
-    Boolean(keyComb1.shift) === Boolean(keyComb2.shift) &&
-    Boolean(keyComb1.ctrl) === Boolean(keyComb2.ctrl) &&
-    Boolean(keyComb1.meta) === Boolean(keyComb2.meta)
-  );
+export function areSameKeyCombinations(keyComb1: KeyCombination, keyComb2: KeyCombination): boolean {
+  return serializeKeyCombination(keyComb1) === serializeKeyCombination(keyComb2);
 }
 
 /**
@@ -230,6 +239,58 @@ export function getChar(keyCode: number) {
   }
 
   return char || 'unknown';
+}
+export interface HotKeyConflict {
+  keyCombinationDisplay: string;
+  shortcuts: { id: KeyboardShortcut; description: string }[];
+}
+
+/**
+ * Flatten all platform-specific key combinations in the registry into a single list.
+ */
+function flattenPlatformKeyCombinations(
+  registry: Partial<HotKeyRegistry>,
+): { id: KeyboardShortcut; keyComb: KeyCombination }[] {
+  const result: { id: KeyboardShortcut; keyComb: KeyCombination }[] = [];
+  for (const [shortcutId, platformCombinations] of Object.entries(registry)) {
+    for (const keyComb of getPlatformKeyCombinations(platformCombinations)) {
+      result.push({ id: shortcutId as KeyboardShortcut, keyComb });
+    }
+  }
+  return result;
+}
+
+/**
+ * Detect conflicting hotkey bindings in the registry.
+ * A conflict is when 2+ shortcuts share the same key combination on the current platform.
+ * This typically happens when a user customized a shortcut in an older version,
+ * and a newer version assigns that same key combination as the default for a new shortcut.
+ */
+export function detectHotKeyConflicts(registry: HotKeyRegistry): HotKeyConflict[] {
+  const keyCombMap = new Map<string, { id: KeyboardShortcut; keyComb: KeyCombination }[]>();
+
+  for (const { id, keyComb } of flattenPlatformKeyCombinations(registry)) {
+    const serialized = serializeKeyCombination(keyComb);
+    if (!keyCombMap.has(serialized)) {
+      keyCombMap.set(serialized, []);
+    }
+    keyCombMap.get(serialized)!.push({ id, keyComb });
+  }
+
+  const conflicts: HotKeyConflict[] = [];
+  keyCombMap.forEach(entries => {
+    if (entries.length > 1) {
+      conflicts.push({
+        keyCombinationDisplay: constructKeyCombinationDisplay(entries[0].keyComb, true),
+        shortcuts: entries.map(e => ({
+          id: e.id,
+          description: keyboardShortcutDescriptions[e.id],
+        })),
+      });
+    }
+  });
+
+  return conflicts;
 }
 
 function joinHotKeys(mustUsePlus: boolean, keys: string[]) {

--- a/packages/insomnia/src/common/settings.ts
+++ b/packages/insomnia/src/common/settings.ts
@@ -44,7 +44,6 @@ export type KeyboardShortcut =
   | 'request_toggleHistory'
   | 'request_focusUrl'
   | 'request_showGenerateCodeEditor'
-  | 'sidebar_focusFilter'
   | 'sidebar_toggle'
   | 'response_focus'
   | 'showCookiesEditor'

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -1,5 +1,6 @@
 import { config } from '@fortawesome/fontawesome-svg-core';
 import type { IpcRendererEvent } from 'electron';
+import { once } from 'es-toolkit/function';
 import type { FC } from 'react';
 import { useEffect, useState } from 'react';
 import { Button } from 'react-aria-components';
@@ -19,6 +20,8 @@ import {
 } from 'react-router';
 
 import { EXTERNAL_VAULT_PLUGIN_NAME, isDevelopment } from '~/common/constants';
+import { detectHotKeyConflicts } from '~/common/hotkeys';
+import type { HotKeyRegistry } from '~/common/settings';
 import * as models from '~/models';
 import type { Settings } from '~/models/settings';
 import type { UserSession } from '~/models/user-session';
@@ -41,7 +44,7 @@ import { AlertModal } from '~/ui/components/modals/alert-modal';
 import { AskModal } from '~/ui/components/modals/ask-modal';
 import { ImportModal } from '~/ui/components/modals/import-modal/import-modal';
 import { SettingsModal } from '~/ui/components/modals/settings-modal';
-import { Toaster } from '~/ui/components/toast-notification';
+import { showToast, Toaster } from '~/ui/components/toast-notification';
 import { AppHooks } from '~/ui/containers/app-hooks';
 import cssHref from '~/ui/css/styles.css?url';
 import Modals from '~/ui/modals';
@@ -303,6 +306,25 @@ export const HydrateFallback = () => {
     </div>
   );
 };
+
+// Only detect hotkey conflicts once per app launch, since the detection can be expensive and hotkey registry is unlikely to change frequently during a session. If we want to detect more frequently in the future, we can consider adding a manual "Detect Conflicts" button in the Keyboard Shortcuts settings page that calls the detectHotKeyConflicts function directly.
+const detectHotKeyConflictsOnce = once((hotKeyRegistry: HotKeyRegistry) => {
+  const conflicts = detectHotKeyConflicts(hotKeyRegistry);
+  if (conflicts.length > 0) {
+    const details = conflicts
+      .map(c => `[${c.keyCombinationDisplay}]: ${c.shortcuts.map(s => s.description).join(', ')}`)
+      .join('\n');
+    showToast(
+      {
+        title: 'Keyboard shortcut conflicts detected',
+        description: `${conflicts.length} shortcut conflict(s) found. Please check Preferences > Keyboard to resolve them.\n${details}`,
+        status: 'warning',
+      },
+      // Give users enough time to read through the conflicts and take action, since this toast contains important information about how to resolve the conflicts
+      { timeout: 10_000 },
+    );
+  }
+});
 
 const Root = () => {
   const { organizationId, projectId } = useParams() as {
@@ -573,6 +595,12 @@ const Root = () => {
     navigate,
     redirectToDefaultBrowserSubmit,
   ]);
+
+  const rootData = useRootLoaderData();
+  useEffect(() => {
+    if (!rootData?.settings?.hotKeyRegistry) return;
+    detectHotKeyConflictsOnce(rootData.settings.hotKeyRegistry);
+  }, [rootData?.settings?.hotKeyRegistry]);
 
   return (
     <>

--- a/packages/insomnia/src/ui/components/toast-notification.tsx
+++ b/packages/insomnia/src/ui/components/toast-notification.tsx
@@ -114,7 +114,7 @@ export const Toaster = () => (
                 {toast.content.time && <span className="text-xs text-(--hl)">{toast.content.time}</span>}
               </Text>
               {toast.content.description && (
-                <Text slot="description" className="max-w-md text-xs">
+                <Text slot="description" className="max-w-md text-xs whitespace-pre-line">
                   {toast.content.description}
                 </Text>
               )}


### PR DESCRIPTION
## Background

[INS-2184](https://konghq.atlassian.net/browse/INS-2184)

- When users customize the shortcut in an old version, and that shortcut is used as the default value of a new shortcut, it causes a conflict.
- The sidebar_focusFilter is not used anywhere

## Changes

- Detect hotkey conflict on app startup
- Remove sidebar_focusFilter
- Supports in the toast line breaks via `\n`

## UI

<img width="533" height="188" alt="image" src="https://github.com/user-attachments/assets/3be999aa-7a7d-4782-96c3-ee1faaed21a6" />


[INS-2184]: https://konghq.atlassian.net/browse/INS-2184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ