### PR TITLE
feat: Enhance response viewer behavior when receives large response content

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.tsx
@@ -171,7 +171,7 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
     // read the body if its smaller than the limit add it to the activeResponse
     const length = Math.max(activeResponse.bytesContent, activeResponse.bytesRead);
     const isOversizedResponse = length > LARGE_RESPONSE_MB * 1024 * 1024;
-    // Oversized repsonses are handled in the response-viewer.tsx for now
+    // Oversized responses are handled in the response-viewer.tsx for now
     if (!isOversizedResponse) {
       const buffer = await services.helpers.getResponseBodyBuffer(activeResponse);
       activeResponse.bodyBuffer = typeof buffer === 'string' ? undefined : buffer;

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.tsx
@@ -20,6 +20,7 @@ import type {
 import { models, services } from 'insomnia-data';
 import { href, Outlet, redirect, useRouteLoaderData } from 'react-router';
 
+import { LARGE_RESPONSE_MB } from '~/common/constants';
 import { database } from '~/common/database';
 import { showResourceNotFoundToast } from '~/ui/components/toast-notification';
 
@@ -169,7 +170,7 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (activeResponse && 'bodyPath' in activeResponse) {
     // read the body if its smaller than the limit add it to the activeResponse
     const length = Math.max(activeResponse.bytesContent, activeResponse.bytesRead);
-    const isOversizedResponse = length > 5 * 1024 * 1024; // 5MB
+    const isOversizedResponse = length > LARGE_RESPONSE_MB * 1024 * 1024;
     // Oversized repsonses are handled in the response-viewer.tsx for now
     if (!isOversizedResponse) {
       const buffer = await services.helpers.getResponseBodyBuffer(activeResponse);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.tsx
@@ -174,7 +174,7 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
     // read the body if its smaller than the limit add it to the activeResponse
     const length = Math.max(activeResponse.bytesContent, activeResponse.bytesRead);
     const isOversizedResponse = length > LARGE_RESPONSE_MB * 1024 * 1024;
-    // Oversized repsonses are handled in the response-viewer.tsx for now
+    // Oversized responses are handled in the response-viewer.tsx for now
     if (!isOversizedResponse) {
       const buffer = await getBodyBuffer(activeResponse);
       activeResponse.bodyBuffer = typeof buffer === 'string' ? Buffer.from(buffer) : buffer;

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.tsx
@@ -1,5 +1,6 @@
 import { href, Outlet, redirect, useRouteLoaderData } from 'react-router';
 
+import { LARGE_RESPONSE_MB } from '~/common/constants';
 import { database } from '~/common/database';
 import type {
   GrpcRequest,
@@ -172,7 +173,7 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (activeResponse && 'bodyPath' in activeResponse) {
     // read the body if its smaller than the limit add it to the activeResponse
     const length = Math.max(activeResponse.bytesContent, activeResponse.bytesRead);
-    const isOversizedResponse = length > 5 * 1024 * 1024; // 5MB
+    const isOversizedResponse = length > LARGE_RESPONSE_MB * 1024 * 1024;
     // Oversized repsonses are handled in the response-viewer.tsx for now
     if (!isOversizedResponse) {
       const buffer = await getBodyBuffer(activeResponse);

--- a/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
@@ -93,6 +93,7 @@ function setEditorValueWithTruncation(
   // split the original text by line with different line breaks across Different OS
   const lines = fullText.split(/\r\n?|\n/);
   const longLinesMap: Record<number, string> = {};
+  const markerMap = new Map<number, CodeMirror.TextMarker>();
   for (let i = 0; i < lines.length; i++) {
     if (lines[i].length > threshold) {
       // save the original long line in a map for later restoration
@@ -112,6 +113,8 @@ function setEditorValueWithTruncation(
     el.title = 'Expanding long values can affect performance';
     el.setAttribute('aria-label', 'Show full value');
     el.onclick = () => {
+      // clear the marker and restore the original long line when the widget is clicked
+      markerMap.get(lineNum)?.clear();
       editor.replaceRange(
         originalText,
         { line: lineNum, ch: 0 },
@@ -128,10 +131,11 @@ function setEditorValueWithTruncation(
     Object.keys(longLinesMap).forEach(lineStr => {
       const lineNum = Number.parseInt(lineStr, 10);
       const originalText = longLinesMap[lineNum];
-      editor.setBookmark(
+      const editorMarker = editor.setBookmark(
         { line: lineNum, ch: LONG_LINE_VISIBLE_CHARS },
         { widget: makeToggleWidget(lineNum, originalText), insertLeft: true },
       );
+      markerMap.set(lineNum, editorMarker);
     });
   });
 }

--- a/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
@@ -106,9 +106,7 @@ function setEditorValueWithTruncation(
     const el = document.createElement('span');
     el.className = 'line-collapse-widget';
     el.style.cssText =
-      'display:inline-block;padding:0 6px;margin:0 2px;background:var(--hl-md);color:var(--color-font);' +
-      'border-radius:3px;font-size:0.85em;cursor:pointer;vertical-align:baseline;';
-
+      'display:inline-block; padding:0 6px ;margin:0 2px; background:var(--hl-md); color:var(--color-font); border-radius:3px; font-size:0.85em; cursor:pointer; vertical-align:baseline;';
     el.textContent = '\u2026 Show full value \u2026';
     el.title = 'Expanding long values can affect performance';
     el.setAttribute('aria-label', 'Show full value');

--- a/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
@@ -125,10 +125,12 @@ function setEditorValueWithTruncation(
     return el;
   };
 
-  // Perform the editor update in a single operation to minimize reflows y
+  // Perform the editor update in a single operation to minimize reflows
   editor.operation(() => {
-    editor.setValue(lines.join('\n'));
-    Object.keys(longLinesMap).forEach(lineStr => {
+    const longLineMapKeys = Object.keys(longLinesMap);
+    const hasLongLines = longLineMapKeys.length > 0;
+    editor.setValue(hasLongLines ? lines.join('\n') : fullText);
+    longLineMapKeys.forEach(lineStr => {
       const lineNum = Number.parseInt(lineStr, 10);
       const originalText = longLinesMap[lineNum];
       const editorMarker = editor.setBookmark(
@@ -784,7 +786,7 @@ export const CodeEditor = memo(
           indexFromPos: (pos?: CodeMirror.Position) => (pos ? codeMirror.current?.indexFromPos(pos) || 0 : 0),
           getDoc: () => codeMirror.current?.getDoc(),
         }),
-        [],
+        [shouldTruncateLongLines],
       );
 
       useEffect(() => {

--- a/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
@@ -140,8 +140,6 @@ function setEditorValueWithTruncation(
   });
 }
 
-// Global object used for storing and persisting editor scroll, lint and folding margin states
-const editorStates: Record<string, EditorState> = {};
 export interface CodeEditorProps {
   autoPrettify?: boolean;
   className?: string;

--- a/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
@@ -45,6 +45,8 @@ import { getCachedEditorState, setCachedEditorState } from './editor-state-cache
 import { normalizeIrregularWhitespace } from './normalize-irregular-whitespace';
 const TAB_SIZE = 4;
 const MAX_SIZE_FOR_LINTING = 1_000_000; // Around 1MB
+const LONG_LINE_THRESHOLD = 10_000; // Collapse lines longer than 10,000 characters
+const LONG_LINE_VISIBLE_CHARS = 25; // Show first/last 25 chars if meets LONG_LINE_THRESHOLD
 
 export const shouldIndentWithTabs = ({ mode, indentWithTabs }: { mode?: string; indentWithTabs?: boolean }) => {
   // YAML is not valid when indented with Tabs
@@ -74,6 +76,60 @@ const widget = (cm: CodeMirror.EditorFromTextArea | null, from: CodeMirror.Posit
     return '\u2194';
   }
 };
+
+function setEditorValueWithTruncation(
+  editor: CodeMirror.EditorFromTextArea | null,
+  fullText: string,
+  threshold = LONG_LINE_THRESHOLD,
+) {
+  if (!editor) {
+    return;
+  }
+  // split the origin text by line with different line breaks across Different OS
+  const lines = fullText.split(/\r\n?|\n/);
+  const longLinesMap: Record<number, string> = {};
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].length > threshold) {
+      // save the original long line in a map for later restoration
+      longLinesMap[i] = lines[i];
+      // truncate the line, preserving both the start and end
+      lines[i] = lines[i].slice(0, LONG_LINE_VISIBLE_CHARS) + lines[i].slice(-LONG_LINE_VISIBLE_CHARS);
+    }
+  }
+  editor.setValue(lines.join('\n'));
+
+  const makeToggleWidget = (lineNum: number, originalText: string): HTMLSpanElement => {
+    const el = document.createElement('span');
+    el.className = 'line-collapse-widget';
+    el.style.cssText =
+      'display:inline-block;padding:0 6px;margin:0 2px;background:var(--hl-md);color:var(--color-font);' +
+      'border-radius:3px;font-size:0.85em;cursor:pointer;vertical-align:baseline;';
+
+    el.textContent = '\u2026 Show full value \u2026';
+    el.title = 'Expanding long values can affect performance';
+    el.onclick = () => {
+      editor.replaceRange(
+        originalText,
+        { line: lineNum, ch: 0 },
+        { line: lineNum, ch: editor.getLine(lineNum).length },
+      );
+    };
+
+    return el;
+  };
+
+  Object.keys(longLinesMap).forEach(lineStr => {
+    const lineNum = Number.parseInt(lineStr, 10);
+    const originalText = longLinesMap[lineNum];
+    editor.setBookmark(
+      { line: lineNum, ch: LONG_LINE_VISIBLE_CHARS },
+      { widget: makeToggleWidget(lineNum, originalText), insertLeft: true },
+    );
+  });
+}
+
+// Global object used for storing and persisting editor scroll, lint and folding margin states
+const editorStates: Record<string, EditorState> = {};
 export interface CodeEditorProps {
   autoPrettify?: boolean;
   className?: string;
@@ -107,6 +163,7 @@ export interface CodeEditorProps {
   pinToBottom?: boolean;
   placeholder?: string;
   readOnly?: boolean;
+  truncateLongLines?: boolean;
   style?: object;
   // NOTE: for caching scroll and marks
   historyKey?: string;
@@ -184,6 +241,7 @@ export const CodeEditor = memo(
         pinToBottom,
         placeholder,
         readOnly,
+        truncateLongLines,
         style,
         historyKey,
         updateFilter,
@@ -221,6 +279,7 @@ export const CodeEditor = memo(
       );
       const { handleRender, handleGetRenderContext } = useNunjucks();
       const isNunjucksEnabled = enableNunjucks && handleRender;
+      const shouldTruncateLongLines = !!readOnly && !!truncateLongLines;
 
       const maybePrettifyAndSetValue = useCallback(
         (code?: string, forcePrettify?: boolean, filter?: string) => {
@@ -290,9 +349,11 @@ export const CodeEditor = memo(
           if (currentCode === code) {
             return;
           }
-          codeMirror.current?.setValue(code || '');
+          shouldTruncateLongLines
+            ? setEditorValueWithTruncation(codeMirror.current, code)
+            : codeMirror.current?.setValue(code || '');
         },
-        [autoPrettify, mode, indentChars, updateFilter],
+        [autoPrettify, shouldTruncateLongLines, updateFilter, indentChars, mode],
       );
 
       useDocBodyKeyboardShortcuts({
@@ -376,6 +437,7 @@ export const CodeEditor = memo(
           styleActiveLine: !noStyleActiveLine,
           indentWithTabs,
           showCursorWhenSelecting: false,
+          maxHighlightLength: 1000,
           cursorScrollMargin: 12,
           // Only set keyMap if we're not read-only. This is so things like ctrl-a work on read-only mode.
           keyMap: !readOnly && settings.editorKeyMap ? settings.editorKeyMap : 'default',
@@ -681,7 +743,10 @@ export const CodeEditor = memo(
       useImperativeHandle(
         ref,
         () => ({
-          setValue: value => codeMirror.current?.setValue(value),
+          setValue: value =>
+            shouldTruncateLongLines
+              ? setEditorValueWithTruncation(codeMirror.current, value)
+              : codeMirror.current?.setValue(value || ''),
           getValue: () => codeMirror.current?.getValue() || '',
           selectAll: () =>
             codeMirror.current?.setSelection({ line: 0, ch: 0 }, { line: codeMirror.current.lineCount(), ch: 0 }),

--- a/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
@@ -85,7 +85,12 @@ function setEditorValueWithTruncation(
   if (!editor) {
     return;
   }
-  // split the origin text by line with different line breaks across Different OS
+  if (fullText.length <= threshold) {
+    // If the full text length is under the threshold, set it directly without processing
+    editor.setValue(fullText);
+    return;
+  }
+  // split the original text by line with different line breaks across Different OS
   const lines = fullText.split(/\r\n?|\n/);
   const longLinesMap: Record<number, string> = {};
   for (let i = 0; i < lines.length; i++) {
@@ -107,6 +112,7 @@ function setEditorValueWithTruncation(
 
     el.textContent = '\u2026 Show full value \u2026';
     el.title = 'Expanding long values can affect performance';
+    el.setAttribute('aria-label', 'Show full value');
     el.onclick = () => {
       editor.replaceRange(
         originalText,
@@ -437,7 +443,6 @@ export const CodeEditor = memo(
           styleActiveLine: !noStyleActiveLine,
           indentWithTabs,
           showCursorWhenSelecting: false,
-          maxHighlightLength: 1000,
           cursorScrollMargin: 12,
           // Only set keyMap if we're not read-only. This is so things like ctrl-a work on read-only mode.
           keyMap: !readOnly && settings.editorKeyMap ? settings.editorKeyMap : 'default',

--- a/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
@@ -46,7 +46,7 @@ import { normalizeIrregularWhitespace } from './normalize-irregular-whitespace';
 const TAB_SIZE = 4;
 const MAX_SIZE_FOR_LINTING = 1_000_000; // Around 1MB
 const LONG_LINE_THRESHOLD = 10_000; // Collapse lines longer than 10,000 characters
-const LONG_LINE_VISIBLE_CHARS = 25; // Show first/last 25 chars if meets LONG_LINE_THRESHOLD
+const LONG_LINE_VISIBLE_CHARS = 20; // Show first/last 20 chars if meets LONG_LINE_THRESHOLD
 
 export const shouldIndentWithTabs = ({ mode, indentWithTabs }: { mode?: string; indentWithTabs?: boolean }) => {
   // YAML is not valid when indented with Tabs

--- a/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
@@ -101,8 +101,6 @@ function setEditorValueWithTruncation(
       lines[i] = lines[i].slice(0, LONG_LINE_VISIBLE_CHARS) + lines[i].slice(-LONG_LINE_VISIBLE_CHARS);
     }
   }
-  editor.setValue(lines.join('\n'));
-
   const makeToggleWidget = (lineNum: number, originalText: string): HTMLSpanElement => {
     const el = document.createElement('span');
     el.className = 'line-collapse-widget';
@@ -124,13 +122,17 @@ function setEditorValueWithTruncation(
     return el;
   };
 
-  Object.keys(longLinesMap).forEach(lineStr => {
-    const lineNum = Number.parseInt(lineStr, 10);
-    const originalText = longLinesMap[lineNum];
-    editor.setBookmark(
-      { line: lineNum, ch: LONG_LINE_VISIBLE_CHARS },
-      { widget: makeToggleWidget(lineNum, originalText), insertLeft: true },
-    );
+  // Perform the editor update in a single operation to minimize reflows y
+  editor.operation(() => {
+    editor.setValue(lines.join('\n'));
+    Object.keys(longLinesMap).forEach(lineStr => {
+      const lineNum = Number.parseInt(lineStr, 10);
+      const originalText = longLinesMap[lineNum];
+      editor.setBookmark(
+        { line: lineNum, ch: LONG_LINE_VISIBLE_CHARS },
+        { widget: makeToggleWidget(lineNum, originalText), insertLeft: true },
+      );
+    });
   });
 }
 

--- a/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
@@ -100,6 +100,7 @@ function setEditorValueWithTruncation(
   // split the original text by line with different line breaks across Different OS
   const lines = fullText.split(/\r\n?|\n/);
   const longLinesMap: Record<number, string> = {};
+  const markerMap = new Map<number, CodeMirror.TextMarker>();
   for (let i = 0; i < lines.length; i++) {
     if (lines[i].length > threshold) {
       // save the original long line in a map for later restoration
@@ -119,6 +120,8 @@ function setEditorValueWithTruncation(
     el.title = 'Expanding long values can affect performance';
     el.setAttribute('aria-label', 'Show full value');
     el.onclick = () => {
+      // clear the marker and restore the original long line when the widget is clicked
+      markerMap.get(lineNum)?.clear();
       editor.replaceRange(
         originalText,
         { line: lineNum, ch: 0 },
@@ -135,10 +138,11 @@ function setEditorValueWithTruncation(
     Object.keys(longLinesMap).forEach(lineStr => {
       const lineNum = Number.parseInt(lineStr, 10);
       const originalText = longLinesMap[lineNum];
-      editor.setBookmark(
+      const editorMarker = editor.setBookmark(
         { line: lineNum, ch: LONG_LINE_VISIBLE_CHARS },
         { widget: makeToggleWidget(lineNum, originalText), insertLeft: true },
       );
+      markerMap.set(lineNum, editorMarker);
     });
   });
 }

--- a/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
@@ -132,10 +132,12 @@ function setEditorValueWithTruncation(
     return el;
   };
 
-  // Perform the editor update in a single operation to minimize reflows y
+  // Perform the editor update in a single operation to minimize reflows
   editor.operation(() => {
-    editor.setValue(lines.join('\n'));
-    Object.keys(longLinesMap).forEach(lineStr => {
+    const longLineMapKeys = Object.keys(longLinesMap);
+    const hasLongLines = longLineMapKeys.length > 0;
+    editor.setValue(hasLongLines ? lines.join('\n') : fullText);
+    longLineMapKeys.forEach(lineStr => {
       const lineNum = Number.parseInt(lineStr, 10);
       const originalText = longLinesMap[lineNum];
       const editorMarker = editor.setBookmark(
@@ -781,7 +783,7 @@ export const CodeEditor = memo(
           indexFromPos: (pos?: CodeMirror.Position) => (pos ? codeMirror.current?.indexFromPos(pos) || 0 : 0),
           getDoc: () => codeMirror.current?.getDoc(),
         }),
-        [],
+        [shouldTruncateLongLines],
       );
 
       useEffect(() => {

--- a/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
@@ -44,6 +44,8 @@ import { queryXPath } from '~/utils/xpath/query';
 import { normalizeIrregularWhitespace } from './normalize-irregular-whitespace';
 const TAB_SIZE = 4;
 const MAX_SIZE_FOR_LINTING = 1_000_000; // Around 1MB
+const LONG_LINE_THRESHOLD = 10_000; // Collapse lines longer than 10,000 characters
+const LONG_LINE_VISIBLE_CHARS = 25; // Show first/last 25 chars if meets LONG_LINE_THRESHOLD
 
 interface EditorState {
   scroll: CodeMirror.ScrollInfo;
@@ -81,6 +83,58 @@ const widget = (cm: CodeMirror.EditorFromTextArea | null, from: CodeMirror.Posit
     return '\u2194';
   }
 };
+
+function setEditorValueWithTruncation(
+  editor: CodeMirror.EditorFromTextArea | null,
+  fullText: string,
+  threshold = LONG_LINE_THRESHOLD,
+) {
+  if (!editor) {
+    return;
+  }
+  // split the origin text by line with different line breaks across Different OS
+  const lines = fullText.split(/\r\n?|\n/);
+  const longLinesMap: Record<number, string> = {};
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].length > threshold) {
+      // save the original long line in a map for later restoration
+      longLinesMap[i] = lines[i];
+      // truncate the line, preserving both the start and end
+      lines[i] = lines[i].slice(0, LONG_LINE_VISIBLE_CHARS) + lines[i].slice(-LONG_LINE_VISIBLE_CHARS);
+    }
+  }
+  editor.setValue(lines.join('\n'));
+
+  const makeToggleWidget = (lineNum: number, originalText: string): HTMLSpanElement => {
+    const el = document.createElement('span');
+    el.className = 'line-collapse-widget';
+    el.style.cssText =
+      'display:inline-block;padding:0 6px;margin:0 2px;background:var(--hl-md);color:var(--color-font);' +
+      'border-radius:3px;font-size:0.85em;cursor:pointer;vertical-align:baseline;';
+
+    el.textContent = '\u2026 Show full value \u2026';
+    el.title = 'Expanding long values can affect performance';
+    el.onclick = () => {
+      editor.replaceRange(
+        originalText,
+        { line: lineNum, ch: 0 },
+        { line: lineNum, ch: editor.getLine(lineNum).length },
+      );
+    };
+
+    return el;
+  };
+
+  Object.keys(longLinesMap).forEach(lineStr => {
+    const lineNum = Number.parseInt(lineStr, 10);
+    const originalText = longLinesMap[lineNum];
+    editor.setBookmark(
+      { line: lineNum, ch: LONG_LINE_VISIBLE_CHARS },
+      { widget: makeToggleWidget(lineNum, originalText), insertLeft: true },
+    );
+  });
+}
+
 // Global object used for storing and persisting editor scroll, lint and folding margin states
 const editorStates: Record<string, EditorState> = {};
 export interface CodeEditorProps {
@@ -116,6 +170,7 @@ export interface CodeEditorProps {
   pinToBottom?: boolean;
   placeholder?: string;
   readOnly?: boolean;
+  truncateLongLines?: boolean;
   style?: object;
   // NOTE: for caching scroll and marks
   uniquenessKey?: string;
@@ -193,6 +248,7 @@ export const CodeEditor = memo(
         pinToBottom,
         placeholder,
         readOnly,
+        truncateLongLines,
         style,
         uniquenessKey,
         updateFilter,
@@ -229,6 +285,7 @@ export const CodeEditor = memo(
       );
       const { handleRender, handleGetRenderContext } = useNunjucks();
       const isNunjucksEnabled = enableNunjucks && handleRender;
+      const shouldTruncateLongLines = !!readOnly && !!truncateLongLines;
 
       const maybePrettifyAndSetValue = useCallback(
         (code?: string, forcePrettify?: boolean, filter?: string) => {
@@ -296,9 +353,11 @@ export const CodeEditor = memo(
           if (currentCode === code) {
             return;
           }
-          codeMirror.current?.setValue(code || '');
+          shouldTruncateLongLines
+            ? setEditorValueWithTruncation(codeMirror.current, code)
+            : codeMirror.current?.setValue(code || '');
         },
-        [autoPrettify, mode, indentChars, updateFilter],
+        [autoPrettify, shouldTruncateLongLines, updateFilter, indentChars, mode],
       );
 
       useDocBodyKeyboardShortcuts({
@@ -382,6 +441,7 @@ export const CodeEditor = memo(
           styleActiveLine: !noStyleActiveLine,
           indentWithTabs,
           showCursorWhenSelecting: false,
+          maxHighlightLength: 1000,
           cursorScrollMargin: 12,
           // Only set keyMap if we're not read-only. This is so things like ctrl-a work on read-only mode.
           keyMap: !readOnly && settings.editorKeyMap ? settings.editorKeyMap : 'default',
@@ -680,7 +740,10 @@ export const CodeEditor = memo(
       useImperativeHandle(
         ref,
         () => ({
-          setValue: value => codeMirror.current?.setValue(value),
+          setValue: value =>
+            shouldTruncateLongLines
+              ? setEditorValueWithTruncation(codeMirror.current, value)
+              : codeMirror.current?.setValue(value || ''),
           getValue: () => codeMirror.current?.getValue() || '',
           selectAll: () =>
             codeMirror.current?.setSelection({ line: 0, ch: 0 }, { line: codeMirror.current.lineCount(), ch: 0 }),

--- a/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
@@ -108,8 +108,6 @@ function setEditorValueWithTruncation(
       lines[i] = lines[i].slice(0, LONG_LINE_VISIBLE_CHARS) + lines[i].slice(-LONG_LINE_VISIBLE_CHARS);
     }
   }
-  editor.setValue(lines.join('\n'));
-
   const makeToggleWidget = (lineNum: number, originalText: string): HTMLSpanElement => {
     const el = document.createElement('span');
     el.className = 'line-collapse-widget';
@@ -131,13 +129,17 @@ function setEditorValueWithTruncation(
     return el;
   };
 
-  Object.keys(longLinesMap).forEach(lineStr => {
-    const lineNum = Number.parseInt(lineStr, 10);
-    const originalText = longLinesMap[lineNum];
-    editor.setBookmark(
-      { line: lineNum, ch: LONG_LINE_VISIBLE_CHARS },
-      { widget: makeToggleWidget(lineNum, originalText), insertLeft: true },
-    );
+  // Perform the editor update in a single operation to minimize reflows y
+  editor.operation(() => {
+    editor.setValue(lines.join('\n'));
+    Object.keys(longLinesMap).forEach(lineStr => {
+      const lineNum = Number.parseInt(lineStr, 10);
+      const originalText = longLinesMap[lineNum];
+      editor.setBookmark(
+        { line: lineNum, ch: LONG_LINE_VISIBLE_CHARS },
+        { widget: makeToggleWidget(lineNum, originalText), insertLeft: true },
+      );
+    });
   });
 }
 

--- a/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
@@ -92,7 +92,12 @@ function setEditorValueWithTruncation(
   if (!editor) {
     return;
   }
-  // split the origin text by line with different line breaks across Different OS
+  if (fullText.length <= threshold) {
+    // If the full text length is under the threshold, set it directly without processing
+    editor.setValue(fullText);
+    return;
+  }
+  // split the original text by line with different line breaks across Different OS
   const lines = fullText.split(/\r\n?|\n/);
   const longLinesMap: Record<number, string> = {};
   for (let i = 0; i < lines.length; i++) {
@@ -114,6 +119,7 @@ function setEditorValueWithTruncation(
 
     el.textContent = '\u2026 Show full value \u2026';
     el.title = 'Expanding long values can affect performance';
+    el.setAttribute('aria-label', 'Show full value');
     el.onclick = () => {
       editor.replaceRange(
         originalText,
@@ -441,7 +447,6 @@ export const CodeEditor = memo(
           styleActiveLine: !noStyleActiveLine,
           indentWithTabs,
           showCursorWhenSelecting: false,
-          maxHighlightLength: 1000,
           cursorScrollMargin: 12,
           // Only set keyMap if we're not read-only. This is so things like ctrl-a work on read-only mode.
           keyMap: !readOnly && settings.editorKeyMap ? settings.editorKeyMap : 'default',

--- a/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
@@ -45,7 +45,7 @@ import { normalizeIrregularWhitespace } from './normalize-irregular-whitespace';
 const TAB_SIZE = 4;
 const MAX_SIZE_FOR_LINTING = 1_000_000; // Around 1MB
 const LONG_LINE_THRESHOLD = 10_000; // Collapse lines longer than 10,000 characters
-const LONG_LINE_VISIBLE_CHARS = 25; // Show first/last 25 chars if meets LONG_LINE_THRESHOLD
+const LONG_LINE_VISIBLE_CHARS = 20; // Show first/last 20 chars if meets LONG_LINE_THRESHOLD
 
 interface EditorState {
   scroll: CodeMirror.ScrollInfo;

--- a/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
@@ -113,9 +113,7 @@ function setEditorValueWithTruncation(
     const el = document.createElement('span');
     el.className = 'line-collapse-widget';
     el.style.cssText =
-      'display:inline-block;padding:0 6px;margin:0 2px;background:var(--hl-md);color:var(--color-font);' +
-      'border-radius:3px;font-size:0.85em;cursor:pointer;vertical-align:baseline;';
-
+      'display:inline-block; padding:0 6px ;margin:0 2px; background:var(--hl-md); color:var(--color-font); border-radius:3px; font-size:0.85em; cursor:pointer; vertical-align:baseline;';
     el.textContent = '\u2026 Show full value \u2026';
     el.title = 'Expanding long values can affect performance';
     el.setAttribute('aria-label', 'Show full value');

--- a/packages/insomnia/src/ui/components/mcp/event-view.tsx
+++ b/packages/insomnia/src/ui/components/mcp/event-view.tsx
@@ -221,6 +221,7 @@ export const MessageEventView = ({ event }: Props) => {
             updateFilter={handleSetFilter}
             filterHistory={filterHistory}
             readOnly
+            truncateLongLines
             autoPrettify
           />
         </div>

--- a/packages/insomnia/src/ui/components/mcp/event-view.tsx
+++ b/packages/insomnia/src/ui/components/mcp/event-view.tsx
@@ -222,6 +222,7 @@ export const MessageEventView = ({ event }: Props) => {
             updateFilter={handleSetFilter}
             filterHistory={filterHistory}
             readOnly
+            truncateLongLines
             autoPrettify
           />
         </div>

--- a/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
@@ -261,6 +261,7 @@ export const ResponseViewer = ({
         placeholder="..."
         readOnly
         historyKey={responseId}
+        truncateLongLines
         updateFilter={filter => {
           updateFilter?.(filter);
 
@@ -388,6 +389,7 @@ export const ResponseViewer = ({
       placeholder="..."
       readOnly
       historyKey={responseId}
+      truncateLongLines
       updateFilter={filter => {
         updateFilter?.(filter);
 

--- a/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
@@ -243,6 +243,7 @@ export const ResponseViewer = ({
         }
         placeholder="..."
         readOnly
+        truncateLongLines
         uniquenessKey={responseId}
         updateFilter={filter => {
           updateFilter?.(filter);
@@ -370,6 +371,7 @@ export const ResponseViewer = ({
       }
       placeholder="..."
       readOnly
+      truncateLongLines
       uniquenessKey={responseId}
       updateFilter={filter => {
         updateFilter?.(filter);


### PR DESCRIPTION
# Background:
When viewing a large API response (eg: MCP app resources contains the entire DOM tree), the response editor would hang or become unresponsive on load due to CodeMirror performance issue.

# Changes:
- Collapse lines whose length exceeds the limit
- Insert a CM bookmark allow user to expand the line to view the entire content
<img width="1268" height="784" alt="truncate-large-response" src="https://github.com/user-attachments/assets/194038ba-8527-48f7-a6a2-b2c201e17c5d" />


[INS-2250](https://konghq.atlassian.net/browse/INS-2250)

[INS-2250]: https://konghq.atlassian.net/browse/INS-2250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ