### PR TITLE
refactor: import to main

### DIFF
--- a/packages/insomnia/config/renderer-node-import-baseline.json
+++ b/packages/insomnia/config/renderer-node-import-baseline.json
@@ -33,10 +33,6 @@
       "builtin": "path"
     },
     {
-      "importer": "src/network/url-matches-cert-host.ts",
-      "builtin": "url"
-    },
-    {
       "importer": "src/plugins/context/response.ts",
       "builtin": "fs"
     },

--- a/packages/insomnia/config/renderer-node-import-baseline.json
+++ b/packages/insomnia/config/renderer-node-import-baseline.json
@@ -33,6 +33,10 @@
       "builtin": "path"
     },
     {
+      "importer": "src/network/url-matches-cert-host.ts",
+      "builtin": "url"
+    },
+    {
       "importer": "src/plugins/context/response.ts",
       "builtin": "fs"
     },

--- a/packages/insomnia/config/renderer-node-import-baseline.json
+++ b/packages/insomnia/config/renderer-node-import-baseline.json
@@ -17,50 +17,6 @@
       "builtin": "path"
     },
     {
-      "importer": "src/main/importers/importers/openapi-3.ts",
-      "builtin": "crypto"
-    },
-    {
-      "importer": "src/main/importers/importers/openapi-3.ts",
-      "builtin": "url"
-    },
-    {
-      "importer": "src/main/network/libcurl-promise.ts",
-      "builtin": "fs"
-    },
-    {
-      "importer": "src/main/network/libcurl-promise.ts",
-      "builtin": "path"
-    },
-    {
-      "importer": "src/main/network/libcurl-promise.ts",
-      "builtin": "url"
-    },
-    {
-      "importer": "src/main/network/multipart.ts",
-      "builtin": "fs"
-    },
-    {
-      "importer": "src/main/network/multipart.ts",
-      "builtin": "os"
-    },
-    {
-      "importer": "src/main/network/multipart.ts",
-      "builtin": "path"
-    },
-    {
-      "importer": "src/main/secure-read-file.ts",
-      "builtin": "fs"
-    },
-    {
-      "importer": "src/main/secure-read-file.ts",
-      "builtin": "os"
-    },
-    {
-      "importer": "src/main/secure-read-file.ts",
-      "builtin": "path"
-    },
-    {
       "importer": "src/models/helpers/response-operations.ts",
       "builtin": "fs"
     },
@@ -75,18 +31,6 @@
     {
       "importer": "src/network/network.ts",
       "builtin": "path"
-    },
-    {
-      "importer": "src/network/o-auth-2/get-token.ts",
-      "builtin": "crypto"
-    },
-    {
-      "importer": "src/network/o-auth-2/get-token.ts",
-      "builtin": "querystring"
-    },
-    {
-      "importer": "src/network/o-auth-2/utils.ts",
-      "builtin": "crypto"
     },
     {
       "importer": "src/network/url-matches-cert-host.ts",

--- a/packages/insomnia/config/renderer-node-import-baseline.json
+++ b/packages/insomnia/config/renderer-node-import-baseline.json
@@ -25,6 +25,30 @@
       "builtin": "url"
     },
     {
+      "importer": "src/main/network/libcurl-promise.ts",
+      "builtin": "fs"
+    },
+    {
+      "importer": "src/main/network/libcurl-promise.ts",
+      "builtin": "path"
+    },
+    {
+      "importer": "src/main/network/libcurl-promise.ts",
+      "builtin": "url"
+    },
+    {
+      "importer": "src/main/network/multipart.ts",
+      "builtin": "fs"
+    },
+    {
+      "importer": "src/main/network/multipart.ts",
+      "builtin": "os"
+    },
+    {
+      "importer": "src/main/network/multipart.ts",
+      "builtin": "path"
+    },
+    {
       "importer": "src/main/secure-read-file.ts",
       "builtin": "fs"
     },

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -78,20 +78,6 @@ const isSubEnvironmentResource = (environment: Environment) => {
 
 export const isInsomniaV4Import = ({ id }: Pick<InsomniaImporter, 'id'>) => id === 'insomnia-4';
 
-// These helpers load main-process modules lazily via a runtime string so that Vite
-// does not statically analyse or bundle them into the renderer. The path string is
-// kept out of the import() call itself to prevent bundler rewriting; the
-// /* @vite-ignore */ comment suppresses the remaining Vite warning.
-const importMainConvertModule = async () => {
-  const modulePath = '../main/importers/convert';
-  return import(/* @vite-ignore */ modulePath);
-};
-
-const importSecureReadFileModule = async () => {
-  const modulePath = '../main/secure-read-file';
-  return import(/* @vite-ignore */ modulePath);
-};
-
 export async function fetchImportContentFromURI({ uri }: { uri: string }) {
   const url = new URL(uri);
 
@@ -106,12 +92,12 @@ export async function fetchImportContentFromURI({ uri }: { uri: string }) {
     return content;
   } else if (uri.match(/^(file):\/\//)) {
     const path = uri.replace(/^(file):\/\//, '');
-    if (process.type === 'renderer') {
-      return window.main.insecureReadFile({ path });
-    }
+    const readFileProcessFork = async (path: string) =>
+      process.type === 'renderer'
+        ? window.main.insecureReadFile({ path })
+        : (await import('../main/secure-read-file')).insecureReadFile(path);
 
-    const { insecureReadFile } = await importSecureReadFileModule();
-    return insecureReadFile(path);
+    return readFileProcessFork(path);
   }
   // Treat everything else as raw text
   const content = decodeURIComponent(uri);
@@ -221,9 +207,9 @@ export async function scanResources(importEntries: ImportEntry[]): Promise<ScanR
             },
           };
         } else {
-          const processFork =
-            process.type === 'renderer' ? window.main.parseImport : (await importMainConvertModule()).convert;
-          result = (await processFork(importEntry)) as unknown as ConvertResult;
+          const convertProcessFork =
+            process.type === 'renderer' ? window.main.parseImport : (await import('../main/importers/convert')).convert;
+          result = (await convertProcessFork(importEntry)) as unknown as ConvertResult;
         }
       } catch (err: unknown) {
         if (v5Error) {

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -17,11 +17,9 @@ import type {
   Workspace,
 } from '~/insomnia-data';
 import { services } from '~/insomnia-data';
-import { insecureReadFile } from '~/main/secure-read-file';
 
 import type { InsomniaImporter } from '../main/importers/convert';
 import type { ImportEntry } from '../main/importers/entities';
-import { pathWithParamsAsPathParameters } from '../main/importers/importers/openapi-3';
 import { id as postmanEnvImporterId } from '../main/importers/importers/postman-env';
 import * as models from '../models/index';
 import { type AllTypes, type BaseModel, getModel } from '../models/index';
@@ -31,6 +29,7 @@ import { JSON_ORDER_PREFIX, JSON_ORDER_SEPARATOR } from './constants';
 import { database as db } from './database';
 import { tryImportV5Data } from './insomnia-v5';
 import { generateId } from './misc';
+import { pathWithParamsAsPathParameters } from './path-with-params';
 
 const { isRequest } = models.request;
 const { isApiSpec } = models.apiSpec;
@@ -79,6 +78,20 @@ const isSubEnvironmentResource = (environment: Environment) => {
 
 export const isInsomniaV4Import = ({ id }: Pick<InsomniaImporter, 'id'>) => id === 'insomnia-4';
 
+// These helpers load main-process modules lazily via a runtime string so that Vite
+// does not statically analyse or bundle them into the renderer. The path string is
+// kept out of the import() call itself to prevent bundler rewriting; the
+// /* @vite-ignore */ comment suppresses the remaining Vite warning.
+const importMainConvertModule = async () => {
+  const modulePath = '../main/importers/convert';
+  return import(/* @vite-ignore */ modulePath);
+};
+
+const importSecureReadFileModule = async () => {
+  const modulePath = '../main/secure-read-file';
+  return import(/* @vite-ignore */ modulePath);
+};
+
 export async function fetchImportContentFromURI({ uri }: { uri: string }) {
   const url = new URL(uri);
 
@@ -93,7 +106,11 @@ export async function fetchImportContentFromURI({ uri }: { uri: string }) {
     return content;
   } else if (uri.match(/^(file):\/\//)) {
     const path = uri.replace(/^(file):\/\//, '');
-    // allow reading the file as it is chosen by user
+    if (process.type === 'renderer') {
+      return window.main.insecureReadFile({ path });
+    }
+
+    const { insecureReadFile } = await importSecureReadFileModule();
     return insecureReadFile(path);
   }
   // Treat everything else as raw text
@@ -205,7 +222,7 @@ export async function scanResources(importEntries: ImportEntry[]): Promise<ScanR
           };
         } else {
           const processFork =
-            process.type === 'renderer' ? window.main.parseImport : (await import('../main/importers/convert')).convert;
+            process.type === 'renderer' ? window.main.parseImport : (await importMainConvertModule()).convert;
           result = (await processFork(importEntry)) as unknown as ConvertResult;
         }
       } catch (err: unknown) {

--- a/packages/insomnia/src/common/path-with-params.ts
+++ b/packages/insomnia/src/common/path-with-params.ts
@@ -1,0 +1,3 @@
+const VARIABLE_SEARCH_VALUE = /{([^}]+)}/g;
+
+export const pathWithParamsAsPathParameters = (path?: string) => path?.replace(VARIABLE_SEARCH_VALUE, ':$1') ?? '';

--- a/packages/insomnia/src/main/cloud-sync/ipc.ts
+++ b/packages/insomnia/src/main/cloud-sync/ipc.ts
@@ -62,14 +62,14 @@ export interface SyncBridgeAPI extends SyncBridgeMethods {
     projectId: string;
     workspaceId: string;
   }>;
-  resolveConflict: (options: { requestId: string; conflicts: MergeConflict[] }) => void;
-  cancelConflict: (options: { requestId: string }) => void;
+  resolveConflict: (options: { handlerId: string; conflicts: MergeConflict[] }) => void;
+  cancelConflict: (options: { handlerId: string }) => void;
   on: (
     channel: 'sync.merge-conflicts',
     listener: (
       event: IpcRendererEvent,
       options: {
-        requestId: string;
+        handlerId: string;
         conflicts: MergeConflict[];
         labels: { ours: string; theirs: string };
       },
@@ -86,17 +86,17 @@ export const registerSyncHandlers = () => {
     return pullRemoteBackendProjectWithSingleton(event.sender, options);
   });
 
-  ipcMainOn('sync.resolveConflict', (event, options: { requestId: string; conflicts: MergeConflict[] }) => {
+  ipcMainOn('sync.resolveConflict', (event, options: { handlerId: string; conflicts: MergeConflict[] }) => {
     resolvePendingSyncConflict({
-      requestId: options.requestId,
+      handlerId: options.handlerId,
       sender: event.sender,
       conflicts: options.conflicts,
     });
   });
 
-  ipcMainOn('sync.cancelConflict', (event, options: { requestId: string }) => {
+  ipcMainOn('sync.cancelConflict', (event, options: { handlerId: string }) => {
     cancelPendingSyncConflict({
-      requestId: options.requestId,
+      handlerId: options.handlerId,
       sender: event.sender,
     });
   });

--- a/packages/insomnia/src/main/cloud-sync/vcs.ts
+++ b/packages/insomnia/src/main/cloud-sync/vcs.ts
@@ -37,15 +37,15 @@ const requestConflictResolution = (conflicts: MergeConflict[], labels: { ours: s
   const context = syncInvocationContext.getStore();
   invariant(context, 'Sync conflict resolution requires a renderer context');
 
-  const requestId = randomUUID();
+  const handlerId = randomUUID();
   context.sender.send('sync.merge-conflicts', {
-    requestId,
+    handlerId,
     conflicts,
     labels,
   });
 
   return new Promise<MergeConflict[]>((resolve, reject) => {
-    pendingConflictResolutions.set(requestId, {
+    pendingConflictResolutions.set(handlerId, {
       senderId: context.sender.id,
       resolve,
       reject,
@@ -82,34 +82,34 @@ export const invokeMainVCS = async (sender: WebContents, methodName: string, ...
 };
 
 export const resolvePendingSyncConflict = ({
-  requestId,
+  handlerId,
   sender,
   conflicts,
 }: {
-  requestId: string;
+  handlerId: string;
   sender: WebContents;
   conflicts: MergeConflict[];
 }) => {
-  const pendingConflictResolution = pendingConflictResolutions.get(requestId);
-  invariant(pendingConflictResolution, `Unknown sync conflict request: ${requestId}`);
+  const pendingConflictResolution = pendingConflictResolutions.get(handlerId);
+  invariant(pendingConflictResolution, `Unknown sync conflict request: ${handlerId}`);
   invariant(
     pendingConflictResolution.senderId === sender.id,
-    `Sync conflict request ${requestId} was resolved by an unexpected renderer`,
+    `Sync conflict request ${handlerId} was resolved by an unexpected renderer`,
   );
 
-  pendingConflictResolutions.delete(requestId);
+  pendingConflictResolutions.delete(handlerId);
   pendingConflictResolution.resolve(conflicts);
 };
 
-export const cancelPendingSyncConflict = ({ requestId, sender }: { requestId: string; sender: WebContents }) => {
-  const pendingConflictResolution = pendingConflictResolutions.get(requestId);
-  invariant(pendingConflictResolution, `Unknown sync conflict request: ${requestId}`);
+export const cancelPendingSyncConflict = ({ handlerId, sender }: { handlerId: string; sender: WebContents }) => {
+  const pendingConflictResolution = pendingConflictResolutions.get(handlerId);
+  invariant(pendingConflictResolution, `Unknown sync conflict request: ${handlerId}`);
   invariant(
     pendingConflictResolution.senderId === sender.id,
-    `Sync conflict request ${requestId} was cancelled by an unexpected renderer`,
+    `Sync conflict request ${handlerId} was cancelled by an unexpected renderer`,
   );
 
-  pendingConflictResolutions.delete(requestId);
+  pendingConflictResolutions.delete(handlerId);
   pendingConflictResolution.reject(new UserAbortResolveMergeConflictError());
 };
 

--- a/packages/insomnia/src/main/importers/importers/openapi-3.ts
+++ b/packages/insomnia/src/main/importers/importers/openapi-3.ts
@@ -5,6 +5,7 @@ import SwaggerParser from '@apidevtools/swagger-parser';
 import type { OpenAPIV2, OpenAPIV3 } from 'openapi-types';
 import YAML from 'yaml';
 
+import { pathWithParamsAsPathParameters } from '../../../common/path-with-params';
 import type { Converter, ImportRequest } from '../entities';
 import { unthrowableParseJson } from '../utils';
 
@@ -253,7 +254,7 @@ const importFolderItem =
  *
  * I.e. "/foo/{bar}" => "/foo/:bar"
  */
-export const pathWithParamsAsPathParameters = (path?: string) => path?.replace(VARIABLE_SEARCH_VALUE, ':$1') ?? '';
+export { pathWithParamsAsPathParameters };
 
 /**
  * Return Insomnia request

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -100,6 +100,17 @@ const writeResponseBodyToFile = async (
   _: unknown,
   options: { sourcePath: string; destinationPath: string; bodyCompression?: 'zip' | null },
 ) => {
+  // Validate sourcePath is within the expected responses directory to prevent a
+  // compromised renderer from using this handler to read arbitrary files on disk.
+  const userdataDirectory = process.env.INSOMNIA_DATA_PATH || app.getPath('userData');
+  const allowedResponsesDir = path.join(userdataDirectory, 'responses');
+  const resolvedSource = path.resolve(options.sourcePath);
+  if (!resolvedSource.startsWith(allowedResponsesDir + path.sep) || !resolvedSource.endsWith('.response')) {
+    throw new Error(
+      'writeResponseBodyToFile: sourcePath is outside the allowed responses directory or does not end in .response',
+    );
+  }
+
   try {
     const dir = path.dirname(options.destinationPath);
     await fs.promises.mkdir(dir, { recursive: true });

--- a/packages/insomnia/src/main/network/curl.ts
+++ b/packages/insomnia/src/main/network/curl.ts
@@ -14,11 +14,11 @@ import { readCurlResponse } from '~/models/helpers/response-operations';
 
 import { describeByteSize, generateId, getSetCookieHeaders } from '../../common/misc';
 import { filterClientCertificates } from '../../network/certificate';
+import { parseHeaderStrings } from '../../network/parse-header-strings';
 import { addSetCookiesToToughCookieJar } from '../../network/set-cookie-util';
 import { invariant } from '../../utils/invariant';
 import { ipcMainHandle, ipcMainOn } from '../ipc/electron';
 import { createConfiguredCurlInstance } from './libcurl-promise';
-import { parseHeaderStrings } from './parse-header-strings';
 
 export interface CurlConnection extends Curl {
   _id: string;

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -26,9 +26,9 @@ import type { ClientCertificate, RequestHeader, ResponseHeader } from '~/insomni
 import { version } from '../../../package.json';
 import { type AuthTypes, CONTENT_TYPE_FORM_DATA, CONTENT_TYPE_FORM_URLENCODED } from '../../common/constants';
 import { cannotAccessPathError, describeByteSize, hasAuthHeader } from '../../common/misc';
+import { parseHeaderStrings } from '../../network/parse-header-strings';
 import { insecureReadFile, isPathAllowed } from '../secure-read-file';
 import { buildMultipart } from './multipart';
-import { parseHeaderStrings } from './parse-header-strings';
 export interface CurlRequestOptions {
   requestId: string; // for cancellation
   req: RequestUsedHere;

--- a/packages/insomnia/src/main/network/multipart.ts
+++ b/packages/insomnia/src/main/network/multipart.ts
@@ -10,7 +10,7 @@ import { lookup } from 'mime-types';
 
 import type { RequestBodyParameter } from '~/insomnia-data';
 
-export const DEFAULT_BOUNDARY = 'X-INSOMNIA-BOUNDARY';
+import { DEFAULT_BOUNDARY } from '../../network/multipart-constants';
 
 interface Multipart {
   boundary: typeof DEFAULT_BOUNDARY;

--- a/packages/insomnia/src/network/__tests__/multipart.test.ts
+++ b/packages/insomnia/src/network/__tests__/multipart.test.ts
@@ -3,7 +3,8 @@ import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { buildMultipart, DEFAULT_BOUNDARY } from '../../main/network/multipart';
+import { buildMultipart } from '../../main/network/multipart';
+import { DEFAULT_BOUNDARY } from '../multipart-constants';
 
 describe('buildMultipart()', () => {
   it('builds a simple request', async () => {

--- a/packages/insomnia/src/network/__tests__/network.test.ts
+++ b/packages/insomnia/src/network/__tests__/network.test.ts
@@ -11,10 +11,10 @@ import { filterHeaders } from '../../common/misc';
 import { getRenderedRequestAndContext } from '../../common/render';
 import { HttpVersions } from '../../common/settings';
 import { _parseHeaders, getHttpVersion } from '../../main/network/libcurl-promise';
-import { DEFAULT_BOUNDARY } from '../../main/network/multipart';
-import { _getAwsAuthHeaders } from '../../main/network/parse-header-strings';
 import * as models from '../../models';
 import { getBodyBuffer } from '../../models/helpers/response-operations';
+import { _getAwsAuthHeaders } from '../../network/parse-header-strings';
+import { DEFAULT_BOUNDARY } from '../multipart-constants';
 import * as networkUtils from '../network';
 import { getAuthQueryParams, getSetCookiesFromResponseHeaders } from '../network';
 

--- a/packages/insomnia/src/network/__tests__/parse-header-strings.test.ts
+++ b/packages/insomnia/src/network/__tests__/parse-header-strings.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { CONTENT_TYPE_FORM_DATA } from '../../common/constants';
-import { parseHeaderStrings } from '../../main/network/parse-header-strings';
+import { parseHeaderStrings } from '../parse-header-strings';
 
 describe('parseHeaderStrings', () => {
   it('should default with empty inputs', () => {

--- a/packages/insomnia/src/network/__tests__/url-matches-cert-host.test.ts
+++ b/packages/insomnia/src/network/__tests__/url-matches-cert-host.test.ts
@@ -28,6 +28,12 @@ describe('urlMatchesCertHost', () => {
       expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(true);
     });
 
+    it('should return true if the request URL uses an IPv4 host with an explicit port', () => {
+      const requestUrl = 'http://127.0.0.1:4010';
+      const certificateHost = 'http://127.0.0.1:4010';
+      expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(true);
+    });
+
     it('should return false if the request URL and certificate host have different ports', () => {
       const requestUrl = 'https://www.example.org:1234/some/resources?query=1';
       const certificateHost = 'https://www.example.org:123';
@@ -62,6 +68,12 @@ describe('urlMatchesCertHost', () => {
       const requestUrl = 'https://www.example.org/some/resources?query=1';
       const certificateHost = 'https://www.example.org';
       expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(true);
+    });
+
+    it('should return false if an IPv4 request URL and certificate host use different ports', () => {
+      const requestUrl = 'http://127.0.0.1:4010';
+      const certificateHost = 'http://127.0.0.1:4011';
+      expect(urlMatchesCertHost(certificateHost, requestUrl)).toBe(false);
     });
   });
 

--- a/packages/insomnia/src/network/multipart-constants.ts
+++ b/packages/insomnia/src/network/multipart-constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_BOUNDARY = 'X-INSOMNIA-BOUNDARY';

--- a/packages/insomnia/src/network/parse-header-strings.ts
+++ b/packages/insomnia/src/network/parse-header-strings.ts
@@ -1,11 +1,9 @@
-import { parse as urlParse } from 'node:url';
-
 import aws4 from 'aws4';
 import clone from 'clone';
 
 import type { RequestAuthentication } from '~/insomnia-data';
 
-import { CONTENT_TYPE_FORM_DATA } from '../../common/constants';
+import { CONTENT_TYPE_FORM_DATA } from '../common/constants';
 import {
   getContentTypeHeader,
   getHostHeader,
@@ -13,46 +11,50 @@ import {
   hasAcceptHeader,
   hasAuthHeader,
   hasContentTypeHeader,
-} from '../../common/misc';
-import { DEFAULT_BOUNDARY } from './multipart';
+} from '../common/misc';
+import { DEFAULT_BOUNDARY } from './multipart-constants';
 
-// Special header value that will prevent the header being sent
 const DISABLE_HEADER_VALUE = '__Di$aB13d__';
+
 interface Input {
   req: Req;
-  finalUrl: string;
+  finalUrl?: string;
   requestBody?: string;
   requestBodyPath?: string;
   authHeader?: { name: string; value: string };
 }
+
 interface Req {
   headers: any;
-  method: string;
+  method?: string;
   body: { mimeType?: string | null };
   authentication: {} | RequestAuthentication;
 }
+
 export const parseHeaderStrings = ({ req, finalUrl, requestBody, requestBodyPath, authHeader }: Input) => {
   const headers = clone(req.headers);
 
-  // Disable Expect and Transfer-Encoding headers when we have POST body/file
-  const hasRequestBodyOrFilePath = requestBody !== undefined || requestBodyPath;
-  if (hasRequestBodyOrFilePath) {
+  if (requestBody !== undefined || requestBodyPath) {
     headers.push(
       { name: 'Expect', value: DISABLE_HEADER_VALUE },
       { name: 'Transfer-Encoding', value: DISABLE_HEADER_VALUE },
     );
   }
-  const { authentication, method } = req;
+
+  const { authentication, method = 'GET' } = req;
   if (authentication && 'type' in authentication) {
     const isDigest = authentication.type === 'digest';
     const isNTLM = authentication.type === 'ntlm';
     const isAWSIAM = authentication.type === 'iam';
     const hasNoAuthorisationAndNotDisabledAWSBasicOrDigest =
       !hasAuthHeader(headers) && !authentication.disabled && !isAWSIAM && !isDigest && !isNTLM;
+
     if (hasNoAuthorisationAndNotDisabledAWSBasicOrDigest && authHeader) {
       headers.push(authHeader);
     }
-    if (isAWSIAM) {
+
+    // Guard on finalUrl: new URL() would throw on undefined, and AWS signing is meaningless without a target URL.
+    if (isAWSIAM && finalUrl) {
       const hostHeader = getHostHeader(headers)?.value;
       const contentTypeHeader = getContentTypeHeader(headers)?.value;
       _getAwsAuthHeaders({
@@ -65,8 +67,8 @@ export const parseHeaderStrings = ({ req, finalUrl, requestBody, requestBodyPath
       }).forEach(header => headers.push(header));
     }
   }
-  const isMultipartForm = req.body.mimeType === CONTENT_TYPE_FORM_DATA;
-  if (isMultipartForm && requestBodyPath) {
+
+  if (req.body.mimeType === CONTENT_TYPE_FORM_DATA && requestBodyPath) {
     const contentTypeHeader = getContentTypeHeader(headers);
     if (contentTypeHeader) {
       contentTypeHeader.value = `multipart/form-data; boundary=${DEFAULT_BOUNDARY}`;
@@ -74,29 +76,23 @@ export const parseHeaderStrings = ({ req, finalUrl, requestBody, requestBodyPath
       headers.push({ name: 'Content-Type', value: `multipart/form-data; boundary=${DEFAULT_BOUNDARY}` });
     }
   }
-  // Send a default Accept headers of anything
+
   if (!hasAcceptHeader(headers)) {
-    headers.push({ name: 'Accept', value: '*/*' }); // Default to anything
+    headers.push({ name: 'Accept', value: '*/*' });
   }
 
-  // Don't auto-send Accept-Encoding header
   if (!hasAcceptEncodingHeader(headers)) {
     headers.push({ name: 'Accept-Encoding', value: DISABLE_HEADER_VALUE });
   }
 
-  // Prevent curl from adding default content-type header
   if (!hasContentTypeHeader(headers)) {
     headers.push({ name: 'content-type', value: DISABLE_HEADER_VALUE });
   }
 
   return headers
-    .filter((h: any) => h.name)
+    .filter((header: any) => header.name)
     .map(({ name, value }: any) =>
-      value === ''
-        ? `${name};` // Curl needs a semicolon suffix to send empty header values
-        : value === DISABLE_HEADER_VALUE
-          ? `${name}:` // Tell Curl NOT to send the header if value is null
-          : `${name}: ${value}`,
+      value === '' ? `${name};` : value === DISABLE_HEADER_VALUE ? `${name}:` : `${name}: ${value}`,
     );
 };
 
@@ -114,6 +110,7 @@ interface AWSOptions {
   contentTypeHeader?: string;
   body?: string;
 }
+
 export function _getAwsAuthHeaders({
   authentication,
   url,
@@ -122,7 +119,7 @@ export function _getAwsAuthHeaders({
   contentTypeHeader,
   body,
 }: AWSOptions): { name: string; value: any }[] {
-  const { path, host } = urlParse(url);
+  const parsedUrl = new URL(url);
   const onlyContentTypeHeader = contentTypeHeader ? { 'content-type': contentTypeHeader } : {};
   const { service, region, accessKeyId, secretAccessKey, sessionToken } = authentication;
   const signature = aws4.sign(
@@ -132,16 +129,17 @@ export function _getAwsAuthHeaders({
       body,
       method,
       headers: onlyContentTypeHeader,
-      path: path || undefined,
-      // AWS uses host header for signing so prioritize that if the user set it manually
-      host: hostHeader || host || undefined,
+      path: `${parsedUrl.pathname}${parsedUrl.search}` || undefined,
+      host: hostHeader || parsedUrl.host || undefined,
     },
     { accessKeyId, secretAccessKey, sessionToken },
   );
+
   if (!signature.headers) {
     return [];
   }
+
   return Object.entries(signature.headers)
-    .filter(([name]) => name !== 'content-type') // Don't add this because we already have it
+    .filter(([name]) => name !== 'content-type')
     .map(([name, value]) => ({ name, value }));
 }

--- a/packages/insomnia/src/network/parse-header-strings.ts
+++ b/packages/insomnia/src/network/parse-header-strings.ts
@@ -1,9 +1,7 @@
 import aws4 from 'aws4';
 import clone from 'clone';
 
-import type { RequestAuthentication } from '~/insomnia-data';
-
-import { CONTENT_TYPE_FORM_DATA } from '../common/constants';
+import { CONTENT_TYPE_FORM_DATA } from '~/common/constants';
 import {
   getContentTypeHeader,
   getHostHeader,
@@ -11,14 +9,16 @@ import {
   hasAcceptHeader,
   hasAuthHeader,
   hasContentTypeHeader,
-} from '../common/misc';
+} from '~/common/misc';
+import type { RequestAuthentication } from '~/insomnia-data';
+
 import { DEFAULT_BOUNDARY } from './multipart-constants';
 
+// Special header value that will prevent the header being sent
 const DISABLE_HEADER_VALUE = '__Di$aB13d__';
-
 interface Input {
   req: Req;
-  finalUrl?: string;
+  finalUrl: string;
   requestBody?: string;
   requestBodyPath?: string;
   authHeader?: { name: string; value: string };
@@ -26,35 +26,33 @@ interface Input {
 
 interface Req {
   headers: any;
-  method?: string;
+  method: string;
   body: { mimeType?: string | null };
   authentication: {} | RequestAuthentication;
 }
-
 export const parseHeaderStrings = ({ req, finalUrl, requestBody, requestBodyPath, authHeader }: Input) => {
   const headers = clone(req.headers);
 
-  if (requestBody !== undefined || requestBodyPath) {
+  // Disable Expect and Transfer-Encoding headers when we have POST body/file
+  const hasRequestBodyOrFilePath = requestBody !== undefined || requestBodyPath;
+  if (hasRequestBodyOrFilePath) {
     headers.push(
       { name: 'Expect', value: DISABLE_HEADER_VALUE },
       { name: 'Transfer-Encoding', value: DISABLE_HEADER_VALUE },
     );
   }
 
-  const { authentication, method = 'GET' } = req;
+  const { authentication, method } = req;
   if (authentication && 'type' in authentication) {
     const isDigest = authentication.type === 'digest';
     const isNTLM = authentication.type === 'ntlm';
     const isAWSIAM = authentication.type === 'iam';
     const hasNoAuthorisationAndNotDisabledAWSBasicOrDigest =
       !hasAuthHeader(headers) && !authentication.disabled && !isAWSIAM && !isDigest && !isNTLM;
-
     if (hasNoAuthorisationAndNotDisabledAWSBasicOrDigest && authHeader) {
       headers.push(authHeader);
     }
-
-    // Guard on finalUrl: new URL() would throw on undefined, and AWS signing is meaningless without a target URL.
-    if (isAWSIAM && finalUrl) {
+    if (isAWSIAM) {
       const hostHeader = getHostHeader(headers)?.value;
       const contentTypeHeader = getContentTypeHeader(headers)?.value;
       _getAwsAuthHeaders({
@@ -67,8 +65,8 @@ export const parseHeaderStrings = ({ req, finalUrl, requestBody, requestBodyPath
       }).forEach(header => headers.push(header));
     }
   }
-
-  if (req.body.mimeType === CONTENT_TYPE_FORM_DATA && requestBodyPath) {
+  const isMultipartForm = req.body.mimeType === CONTENT_TYPE_FORM_DATA;
+  if (isMultipartForm && requestBodyPath) {
     const contentTypeHeader = getContentTypeHeader(headers);
     if (contentTypeHeader) {
       contentTypeHeader.value = `multipart/form-data; boundary=${DEFAULT_BOUNDARY}`;
@@ -76,23 +74,29 @@ export const parseHeaderStrings = ({ req, finalUrl, requestBody, requestBodyPath
       headers.push({ name: 'Content-Type', value: `multipart/form-data; boundary=${DEFAULT_BOUNDARY}` });
     }
   }
-
+  // Send a default Accept headers of anything
   if (!hasAcceptHeader(headers)) {
-    headers.push({ name: 'Accept', value: '*/*' });
+    headers.push({ name: 'Accept', value: '*/*' }); // Default to anything
   }
 
+  // Don't auto-send Accept-Encoding header
   if (!hasAcceptEncodingHeader(headers)) {
     headers.push({ name: 'Accept-Encoding', value: DISABLE_HEADER_VALUE });
   }
 
+  // Prevent curl from adding default content-type header
   if (!hasContentTypeHeader(headers)) {
     headers.push({ name: 'content-type', value: DISABLE_HEADER_VALUE });
   }
 
   return headers
-    .filter((header: any) => header.name)
+    .filter((h: any) => h.name)
     .map(({ name, value }: any) =>
-      value === '' ? `${name};` : value === DISABLE_HEADER_VALUE ? `${name}:` : `${name}: ${value}`,
+      value === ''
+        ? `${name};` // Curl needs a semicolon suffix to send empty header values
+        : value === DISABLE_HEADER_VALUE
+          ? `${name}:` // Tell Curl NOT to send the header if value is null
+          : `${name}: ${value}`,
     );
 };
 
@@ -130,6 +134,7 @@ export function _getAwsAuthHeaders({
       method,
       headers: onlyContentTypeHeader,
       path: `${parsedUrl.pathname}${parsedUrl.search}` || undefined,
+      // AWS uses host header for signing so prioritize that if the user set it manually
       host: hostHeader || parsedUrl.host || undefined,
     },
     { accessKeyId, secretAccessKey, sessionToken },
@@ -140,6 +145,6 @@ export function _getAwsAuthHeaders({
   }
 
   return Object.entries(signature.headers)
-    .filter(([name]) => name !== 'content-type')
+    .filter(([name]) => name !== 'content-type') // Don't add this because we already have it
     .map(([name, value]) => ({ name, value }));
 }

--- a/packages/insomnia/src/network/url-matches-cert-host.ts
+++ b/packages/insomnia/src/network/url-matches-cert-host.ts
@@ -1,5 +1,3 @@
-import { parse as urlParse, URL } from 'node:url';
-
 import { escapeRegex } from '../common/misc';
 import { setDefaultProtocol } from '../utils/url/protocol';
 
@@ -7,7 +5,17 @@ const DEFAULT_PORT = 443;
 
 export function urlMatchesCertHost(certificateHost: string, requestUrl: string, needCheckPort = true) {
   const cHostWithProtocol = setDefaultProtocol(certificateHost, 'https:');
-  const { hostname, port } = urlParse(requestUrl);
+
+  let hostname = '';
+  let port = '';
+  try {
+    const parsedUrl = new URL(requestUrl);
+    hostname = parsedUrl.hostname;
+    port = parsedUrl.port;
+  } catch {
+    // If URL parsing fails, return false
+    return false;
+  }
   let certificateHostWithProtocol = new URL('https://example.com');
   try {
     certificateHostWithProtocol = new URL(cHostWithProtocol);
@@ -15,8 +23,13 @@ export function urlMatchesCertHost(certificateHost: string, requestUrl: string, 
     // return false early if the certificate host is invalid
     return false;
   }
-  const { hostname: cHostname, port: cPort } = certificateHostWithProtocol;
-  // @ts-expect-error -- TSCONVERSION `parseInt(null)` returns `NaN`
+  let { hostname: cHostname, port: cPort } = certificateHostWithProtocol;
+  // This function is used in both main and renderer processes. In the renderer process,
+  // URL API encodes * in the hostname and port (e.g. *.example.com becomes %2A.example.com).
+  // Here we decode them back to * to make it consistent.
+  cHostname = decodeURIComponent(cHostname);
+  cPort = decodeURIComponent(cPort);
+
   const assumedPort = Number.parseInt(port) || DEFAULT_PORT;
   const assumedCPort = Number.parseInt(cPort) || DEFAULT_PORT;
   const cHostnameRegex = escapeRegex(cHostname || '').replace(/\\\*/g, '.*');

--- a/packages/insomnia/src/network/url-matches-cert-host.ts
+++ b/packages/insomnia/src/network/url-matches-cert-host.ts
@@ -1,5 +1,3 @@
-import { parse as urlParse, URL } from 'node:url';
-
 import { escapeRegex } from '../common/misc';
 import { setDefaultProtocol } from '../utils/url/protocol';
 
@@ -7,16 +5,17 @@ const DEFAULT_PORT = 443;
 
 export function urlMatchesCertHost(certificateHost: string, requestUrl: string, needCheckPort = true) {
   const cHostWithProtocol = setDefaultProtocol(certificateHost, 'https:');
-  const { hostname, port } = urlParse(requestUrl);
-  let certificateHostWithProtocol = new URL('https://example.com');
+  let requestUrlWithProtocol: URL;
+  let certificateHostWithProtocol: URL;
   try {
+    requestUrlWithProtocol = new URL(requestUrl);
     certificateHostWithProtocol = new URL(cHostWithProtocol);
   } catch {
-    // return false early if the certificate host is invalid
+    // Return false early if either URL is invalid.
     return false;
   }
+  const { hostname, port } = requestUrlWithProtocol;
   const { hostname: cHostname, port: cPort } = certificateHostWithProtocol;
-  // @ts-expect-error -- TSCONVERSION `parseInt(null)` returns `NaN`
   const assumedPort = Number.parseInt(port) || DEFAULT_PORT;
   const assumedCPort = Number.parseInt(cPort) || DEFAULT_PORT;
   const cHostnameRegex = escapeRegex(cHostname || '').replace(/\\\*/g, '.*');

--- a/packages/insomnia/src/network/url-matches-cert-host.ts
+++ b/packages/insomnia/src/network/url-matches-cert-host.ts
@@ -1,3 +1,5 @@
+import { parse as urlParse, URL } from 'node:url';
+
 import { escapeRegex } from '../common/misc';
 import { setDefaultProtocol } from '../utils/url/protocol';
 
@@ -5,17 +7,7 @@ const DEFAULT_PORT = 443;
 
 export function urlMatchesCertHost(certificateHost: string, requestUrl: string, needCheckPort = true) {
   const cHostWithProtocol = setDefaultProtocol(certificateHost, 'https:');
-
-  let hostname = '';
-  let port = '';
-  try {
-    const parsedUrl = new URL(requestUrl);
-    hostname = parsedUrl.hostname;
-    port = parsedUrl.port;
-  } catch {
-    // If URL parsing fails, return false
-    return false;
-  }
+  const { hostname, port } = urlParse(requestUrl);
   let certificateHostWithProtocol = new URL('https://example.com');
   try {
     certificateHostWithProtocol = new URL(cHostWithProtocol);
@@ -23,13 +15,8 @@ export function urlMatchesCertHost(certificateHost: string, requestUrl: string, 
     // return false early if the certificate host is invalid
     return false;
   }
-  let { hostname: cHostname, port: cPort } = certificateHostWithProtocol;
-  // This function is used in both main and renderer processes. In the renderer process,
-  // URL API encodes * in the hostname and port (e.g. *.example.com becomes %2A.example.com).
-  // Here we decode them back to * to make it consistent.
-  cHostname = decodeURIComponent(cHostname);
-  cPort = decodeURIComponent(cPort);
-
+  const { hostname: cHostname, port: cPort } = certificateHostWithProtocol;
+  // @ts-expect-error -- TSCONVERSION `parseInt(null)` returns `NaN`
   const assumedPort = Number.parseInt(port) || DEFAULT_PORT;
   const assumedCPort = Number.parseInt(cPort) || DEFAULT_PORT;
   const cHostnameRegex = escapeRegex(cHostname || '').replace(/\\\*/g, '.*');

--- a/packages/insomnia/src/network/url-matches-cert-host.ts
+++ b/packages/insomnia/src/network/url-matches-cert-host.ts
@@ -1,3 +1,5 @@
+import { parse as urlParse, URL } from 'node:url';
+
 import { escapeRegex } from '../common/misc';
 import { setDefaultProtocol } from '../utils/url/protocol';
 
@@ -5,17 +7,16 @@ const DEFAULT_PORT = 443;
 
 export function urlMatchesCertHost(certificateHost: string, requestUrl: string, needCheckPort = true) {
   const cHostWithProtocol = setDefaultProtocol(certificateHost, 'https:');
-  let requestUrlWithProtocol: URL;
-  let certificateHostWithProtocol: URL;
+  const { hostname, port } = urlParse(requestUrl);
+  let certificateHostWithProtocol = new URL('https://example.com');
   try {
-    requestUrlWithProtocol = new URL(requestUrl);
     certificateHostWithProtocol = new URL(cHostWithProtocol);
   } catch {
-    // Return false early if either URL is invalid.
+    // return false early if the certificate host is invalid
     return false;
   }
-  const { hostname, port } = requestUrlWithProtocol;
   const { hostname: cHostname, port: cPort } = certificateHostWithProtocol;
+  // @ts-expect-error -- TSCONVERSION `parseInt(null)` returns `NaN`
   const assumedPort = Number.parseInt(port) || DEFAULT_PORT;
   const assumedCPort = Number.parseInt(cPort) || DEFAULT_PORT;
   const cHostnameRegex = escapeRegex(cHostname || '').replace(/\\\*/g, '.*');

--- a/packages/insomnia/src/sync/vcs/__tests__/insomnia-sync.test.ts
+++ b/packages/insomnia/src/sync/vcs/__tests__/insomnia-sync.test.ts
@@ -41,7 +41,7 @@ describe('insomnia-sync', () => {
     const cancelConflict = vi.fn();
     const on = vi.fn((_channel, listener) => {
       listener(undefined, {
-        requestId: 'req_123',
+        handlerId: 'req_123',
         conflicts: [{ key: 'doc_1' }],
         labels: { ours: 'ours', theirs: 'theirs' },
       });
@@ -75,8 +75,8 @@ describe('insomnia-sync', () => {
     modalOptions.onResolveAll([{ key: 'doc_2' }]);
     modalOptions.onCancelUnresolved();
 
-    expect(resolveConflict).toHaveBeenCalledWith({ requestId: 'req_123', conflicts: [{ key: 'doc_2' }] });
-    expect(cancelConflict).toHaveBeenCalledWith({ requestId: 'req_123' });
+    expect(resolveConflict).toHaveBeenCalledWith({ handlerId: 'req_123', conflicts: [{ key: 'doc_2' }] });
+    expect(cancelConflict).toHaveBeenCalledWith({ handlerId: 'req_123' });
   });
 
   it('exports the renderer abort error class', async () => {

--- a/packages/insomnia/src/sync/vcs/insomnia-sync.ts
+++ b/packages/insomnia/src/sync/vcs/insomnia-sync.ts
@@ -12,15 +12,15 @@ export const registerSyncMergeConflictListener = () => {
   }
 
   hasRegisteredConflictListener = true;
-  window.main.sync.on('sync.merge-conflicts', (_event, { requestId, conflicts, labels }) => {
+  window.main.sync.on('sync.merge-conflicts', (_event, { handlerId, conflicts, labels }) => {
     showModal(SyncMergeModal, {
       conflicts,
       labels,
       onResolveAll: (resolvedConflicts: MergeConflict[]) => {
-        window.main.sync.resolveConflict({ requestId, conflicts: resolvedConflicts });
+        window.main.sync.resolveConflict({ handlerId, conflicts: resolvedConflicts });
       },
       onCancelUnresolved: () => {
-        window.main.sync.cancelConflict({ requestId });
+        window.main.sync.cancelConflict({ handlerId });
       },
     });
   });


### PR DESCRIPTION
Plan: https://github.com/Kong/insomnia/pull/9803
blocked by: #9827 
Removes 9 renderer node imports

## Purpose
- Stop renderer-reachable code from importing `src/main` implementations when only pure helpers, constants, or types are needed.
- Extract shared logic out of main-only modules while leaving privileged behavior in the main process.

## Files in scope
- `packages/insomnia/src/main/importers/importers/openapi-3.ts`
- `packages/insomnia/src/main/network/parse-header-strings.ts`
- `packages/insomnia/src/main/network/multipart.ts`
- `packages/insomnia/src/network/parse-header-strings.ts`
- `packages/insomnia/src/network/multipart-constants.ts`
- `packages/insomnia/src/common/import.ts`
- `packages/insomnia/src/common/path-with-params.ts`
- `packages/insomnia/src/common/misc.ts`
- `packages/insomnia/src/common/significant-diff-detection.ts`
- `packages/insomnia/src/utils/url/querystring.ts`
- `packages/insomnia/src/ui/components/modals/proto-files-modal.tsx`
- `packages/insomnia/config/renderer-node-import-baseline.json`

## Baseline entries expected to be removed
- `src/main/importers/importers/curl.ts -> url`
- `src/main/importers/importers/openapi-3.ts -> crypto`
- `src/main/importers/importers/openapi-3.ts -> url`
- `src/main/importers/importers/swagger-2.ts -> crypto`
- `src/main/network/parse-header-strings.ts -> url`
- Additional nearby baseline reductions landed where the extracted shared helpers removed renderer-reachable main imports.

## Any new preload or IPC surface added
- None. This PR is focused on module boundaries and shared helper extraction rather than new bridge surface.

## Any deliberate deferrals to later PRs
- The broader network and gRPC privileged boundary pass remains in PR 5.
- Sync and storage boundary work remains in PR 6.
- Plugin and templating boundary work remains in PR 7.

## Future Optimization Candidate:

- For large Postman workspace imports (zip files with hundreds of entries), consider profiling the `scanResources()` parsing performance in the main process. If bulk imports cause noticeable UI freeze, an Electron utility process dedicated to import parsing could isolate heavy workloads from the main thread. This would require IPC serialization cost analysis, but the overhead would likely be justified if parsing takes >1–2 seconds on large files. Defer investigation until user feedback indicates performance issues with large imports.
