### PR TITLE
Feat: add custom npm registry mirror setting for plugin installation [INS-1269]

### DIFF
--- a/packages/insomnia/src/common/settings.ts
+++ b/packages/insomnia/src/common/settings.ts
@@ -163,4 +163,6 @@ export interface Settings {
   saveVaultKeyToOSSecretManager: boolean;
   vaultSecretCacheDuration: number;
   dataFolders: string[];
+  /** Custom npm registry URL for plugin installation (e.g., corporate mirror). Empty string uses the default https://registry.npmjs.org/. */
+  npmRegistryUrl: string;
 }

--- a/packages/insomnia/src/insomnia-data/src/models/settings.ts
+++ b/packages/insomnia/src/insomnia-data/src/models/settings.ts
@@ -76,5 +76,6 @@ export function init(): BaseSettings {
     // The duration in mins for which the external vault secret is cached
     vaultSecretCacheDuration: 30,
     dataFolders: [],
+    npmRegistryUrl: '',
   };
 }

--- a/packages/insomnia/src/main/install-plugin.ts
+++ b/packages/insomnia/src/main/install-plugin.ts
@@ -15,12 +15,14 @@ import { validatePluginName } from '../utils/plugin';
 // Promisified version of execFile to use async/await
 export const execFilePromise = promisify(execFile);
 
-// Allowed tarball hostnames for security
+// Default allowed tarball hostnames for security
 // This is a security measure to prevent downloading from untrusted sources
 // and to ensure that the tarball is from a known source.
 // The list can be expanded as needed, but should be kept minimal for security.
 // Currently, only npmjs.org and GitHub Packages are allowed.
-const allowedTarballHostnames = ['registry.npmjs.org', 'npm.pkg.github.com'];
+const defaultAllowedTarballHostnames = ['registry.npmjs.org', 'npm.pkg.github.com'];
+
+const DEFAULT_NPM_REGISTRY = 'https://registry.npmjs.org/';
 
 interface InsomniaPlugin {
   // Insomnia attribute from package.json
@@ -102,6 +104,7 @@ export default async function installPlugin(pluginName: string, allowScopedPacka
     try {
       // After fetching info, check the info.dist.tarball. This prevents downloading from weird hosts.
       const tarballUrl = new URL(info.dist.tarball);
+      const allowedTarballHostnames = await getAllowedTarballHostnames();
       if (!allowedTarballHostnames.includes(tarballUrl.hostname)) {
         throw new Error(`Tarball must come from an allowed host. Got: ${tarballUrl.hostname}`);
       }
@@ -211,7 +214,8 @@ export async function getPluginInfo(lookupName: string, allowScopedPackageNames 
 
   console.log('[plugins] Fetching module info from npm');
 
-  const stdout = await runYarnCommand(['info', lookupName, '--json', '--registry', 'https://registry.npmjs.org/']);
+  const registryUrl = await getRegistryUrl();
+  const stdout = await runYarnCommand(['info', lookupName, '--json', '--registry', registryUrl]);
 
   let yarnOutput;
   try {
@@ -262,6 +266,7 @@ export async function installPluginToTmpDir(lookupName: string, allowScopedPacka
 
     console.log(`[plugins] Installing plugin into temp dir: ${tmpDir}`);
 
+    const registryUrl = await getRegistryUrl();
     await runYarnCommand(
       [
         'add',
@@ -275,7 +280,7 @@ export async function installPluginToTmpDir(lookupName: string, allowScopedPacka
         '--no-progress',
         '--ignore-workspace-root-check',
         '--registry',
-        'https://registry.npmjs.org/',
+        registryUrl,
       ],
       tmpDir,
     );
@@ -463,6 +468,49 @@ export function buildProxyEnv(settings: any): Record<string, string> {
   }
 
   return proxyEnv;
+}
+
+/**
+ * Returns the npm registry URL from settings, falling back to the default.
+ */
+export async function getRegistryUrl(): Promise<string> {
+  const settings = await services.settings.get();
+  const customRegistry = safeTrim(settings.npmRegistryUrl);
+  if (customRegistry) {
+    // Validate it's a proper URL
+    try {
+      const parsed = new URL(customRegistry);
+      if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+        console.warn(`[plugins] npmRegistryUrl must be http/https, got "${parsed.protocol}", using default`);
+        return DEFAULT_NPM_REGISTRY;
+      }
+    } catch {
+      console.warn(`[plugins] Invalid npmRegistryUrl "${customRegistry}", using default`);
+      return DEFAULT_NPM_REGISTRY;
+    }
+    // Ensure trailing slash for consistency
+    return customRegistry.endsWith('/') ? customRegistry : customRegistry + '/';
+  }
+  return DEFAULT_NPM_REGISTRY;
+}
+
+/**
+ * Returns the list of allowed tarball hostnames, including the custom registry hostname if configured.
+ */
+export async function getAllowedTarballHostnames(): Promise<string[]> {
+  const settings = await services.settings.get();
+  const customRegistry = safeTrim(settings.npmRegistryUrl);
+  if (customRegistry) {
+    try {
+      const registryHostname = new URL(customRegistry).hostname;
+      if (!defaultAllowedTarballHostnames.includes(registryHostname)) {
+        return [...defaultAllowedTarballHostnames, registryHostname];
+      }
+    } catch {
+      // Invalid URL, just use defaults
+    }
+  }
+  return defaultAllowedTarballHostnames;
 }
 
 /**

--- a/packages/insomnia/src/ui/components/settings/plugins.tsx
+++ b/packages/insomnia/src/ui/components/settings/plugins.tsx
@@ -2,6 +2,7 @@ import React, { type FC, useEffect, useState } from 'react';
 import {
   Button,
   Checkbox,
+  FieldError,
   FileTrigger,
   GridList,
   GridListItem,
@@ -27,6 +28,24 @@ import { Icon } from '../icon';
 import { Tooltip } from '../tooltip';
 import { CreatePluginModal } from './create-plugin-modal';
 
+const getNpmRegistryUrlValidationError = (url: string): string | null => {
+  if (!url) {
+    return null;
+  }
+
+  try {
+    const parsedUrl = new URL(url);
+
+    if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+      return 'Enter a valid HTTP or HTTPS URL.';
+    }
+
+    return null;
+  } catch {
+    return 'Enter a valid HTTP or HTTPS URL.';
+  }
+};
+
 interface State {
   plugins: Plugin[];
   npmPluginValue: string;
@@ -35,6 +54,8 @@ interface State {
   isInstallingFromNpm: boolean;
   isRefreshingPlugins: boolean;
   pluginNodeExtraCerts: string;
+  npmRegistryUrl: string;
+  npmRegistryUrlError: string | null;
 }
 
 export const Plugins: FC = () => {
@@ -50,6 +71,8 @@ export const Plugins: FC = () => {
       isRefreshingPlugins,
       npmPluginValue,
       pluginNodeExtraCerts,
+      npmRegistryUrl,
+      npmRegistryUrlError,
     },
     setState,
   ] = useState<State>({
@@ -60,6 +83,8 @@ export const Plugins: FC = () => {
     isInstallingFromNpm: false,
     isRefreshingPlugins: false,
     pluginNodeExtraCerts: settings.pluginNodeExtraCerts,
+    npmRegistryUrl: settings.npmRegistryUrl,
+    npmRegistryUrlError: null,
   });
 
   // If all plugins are enabled, we show the checked state
@@ -71,6 +96,10 @@ export const Plugins: FC = () => {
   useEffect(() => {
     setState(state => ({ ...state, pluginNodeExtraCerts: settings.pluginNodeExtraCerts }));
   }, [settings.pluginNodeExtraCerts]);
+
+  useEffect(() => {
+    setState(state => ({ ...state, npmRegistryUrl: settings.npmRegistryUrl, npmRegistryUrlError: null }));
+  }, [settings.npmRegistryUrl]);
 
   useEffect(() => {
     handleReloadPlugins();
@@ -313,6 +342,78 @@ export const Plugins: FC = () => {
               </div>
             </div>
           )}
+        </div>
+        <div className="flex w-full flex-col">
+          <div className="flex flex-col">
+            <div className="flex items-center gap-2">
+              <Label className="text-lg font-bold" slot="label">
+                npm Registry
+              </Label>
+
+              <Tooltip
+                className="cursor-pointer pt-2"
+                message="Set a custom npm registry URL (mirror) for plugin installation. Useful in corporate environments where direct npm access is restricted."
+              >
+                <i className="fa fa-info-circle" />
+              </Tooltip>
+            </div>
+            <Label className="p-0 text-sm font-semibold" slot="description">
+              <span className="text-(--hl)">Custom npm registry URL for plugin installation</span>
+            </Label>
+          </div>
+          <div className="mt-2 flex flex-col gap-2">
+            <div className="flex w-full gap-2">
+              <TextField
+                aria-label="npm Registry URL"
+                className="group relative flex max-w-full shrink-0 grow flex-col gap-2 overflow-hidden"
+                isInvalid={!!npmRegistryUrlError}
+                value={npmRegistryUrl}
+                onChange={value => {
+                  setState(state => ({ ...state, npmRegistryUrl: value, npmRegistryUrlError: null }));
+                }}
+              >
+                <Input
+                  placeholder="https://registry.npmjs.org/"
+                  className={({ isInvalid }) =>
+                    `flex h-(--line-height-xs) w-full items-center rounded-md border border-solid bg-(--hl-xxs) p-(--padding-sm) text-(--color-font) focus:border-(--hl-lg) focus:bg-transparent ${isInvalid ? 'border-(--color-danger)' : 'border-(--hl-md)'}`
+                  }
+                  onBlur={() => {
+                    const trimmedRegistryUrl = npmRegistryUrl.trim();
+                    const validationError = getNpmRegistryUrlValidationError(trimmedRegistryUrl);
+
+                    if (validationError) {
+                      setState(state => ({ ...state, npmRegistryUrlError: validationError }));
+                      return;
+                    }
+
+                    setState(state => ({
+                      ...state,
+                      npmRegistryUrl: trimmedRegistryUrl,
+                      npmRegistryUrlError: null,
+                    }));
+                    patchSettings({ npmRegistryUrl: trimmedRegistryUrl });
+                  }}
+                />
+                <FieldError className="text-xs text-(--color-danger)">
+                  {npmRegistryUrlError}
+                </FieldError>
+              </TextField>
+              {npmRegistryUrl && (
+                <Button
+                  className="flex h-(--line-height-xs) items-center justify-center rounded-md border border-solid border-(--hl-lg) px-(--padding-md) text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
+                  onPress={() => {
+                    setState(state => ({ ...state, npmRegistryUrl: '', npmRegistryUrlError: null }));
+                    patchSettings({ npmRegistryUrl: '' });
+                  }}
+                >
+                  Clear
+                </Button>
+              )}
+            </div>
+            <Label slot="description" className="p-0 text-sm text-(--hl)">
+              Leave empty to use the default npm registry (https://registry.npmjs.org/)
+            </Label>
+          </div>
         </div>
         <Separator className="my-4" />
         <div className="flex w-full flex-col">


### PR DESCRIPTION
## feat: Add configurable npm registry mirror for plugin installation in corporate environments

### Summary
Adds a configurable npm registry URL setting in **Preferences > Plugins** to enable Insomnia plugin installation in corporate environments where direct access to \`registry.npmjs.org\` is blocked.

### Problem
Many enterprise environments block direct access to the public npm registry, requiring all npm traffic to route through internal mirrors (e.g., Artifactory, Nexus, Verdaccio). Previously, Insomnia hardcoded \`https://registry.npmjs.org/\` for plugin metadata fetching and installation, making it impossible to install plugins in these environments.

### Solution
- Added \`npmRegistryUrl\` setting to store a custom npm registry URL
- Modified \`install-plugin.ts\` to use the custom registry for both \`yarn info\` and \`yarn add\` commands
- Automatically adds the custom registry's hostname to the allowed tarball hosts list for security validation
- Falls back to the default npm registry when the setting is empty or invalid

### Files Changed
| File | Change |
|------|--------|
| \`packages/insomnia/src/common/settings.ts\` | Added \`npmRegistryUrl: string\` to Settings interface |
| \`packages/insomnia/src/insomnia-data/src/models/settings.ts\` | Added default empty value for \`npmRegistryUrl\` |
| \`packages/insomnia/src/main/install-plugin.ts\` | Core logic: dynamic registry URL, hostname allowlisting, helper functions |
| \`packages/insomnia/src/ui/components/settings/plugins.tsx\` | UI: Registry URL input field with tooltip and auto-save on blur |

### UI Changes
- New **"npm Registry"** section in **Preferences > Plugins**
- Text input with placeholder \`https://registry.npmjs.org/\`
- Help tooltip explaining the feature
- Auto-saves on blur (trimmed value)

### How It Works
1. User enters their corporate npm mirror URL (e.g., \`https://artifactory.example.com/api/npm/npm-remote/\`)
2. The registry is used for:
   - \`yarn info <plugin> --registry <url>\` — fetching plugin metadata
   - \`yarn add <plugin> --registry <url>\` — installing the plugin
3. The registry's hostname is automatically added to the allowed tarball hostnames for security validation
4. Works alongside existing **Proxy** and **Certificate** settings for complete corporate environment support

### Documentation Notes (for Kong docs team)

#### Setting the npm Mirror via the UI

1. Open **Preferences** (Cmd/Ctrl + ,)
2. Go to the **Plugins** tab
3. Under **npm Registry**, enter your corporate mirror URL (e.g., \`https://artifactory.example.com/api/npm/npm-remote/\`)
4. The setting is saved on blur. Leave empty to use the default (\`https://registry.npmjs.org/\`)

#### How It Works (user-facing)

- The custom registry URL is used for both fetching plugin metadata (\`yarn info\`) and installing plugins (\`yarn add\`).
- The hostname of the custom registry is automatically added to the allowed tarball hosts, so tarballs served by your mirror will pass validation.
- If the custom URL is invalid, Insomnia falls back to the default npm registry.
- This setting works alongside existing **Proxy** and **Certificate** settings (HTTP/HTTPS proxy, \`NODE_EXTRA_CA_CERTS\`) which may also be needed in corporate environments.

#### Typical Corporate Setup

For a corporate environment behind a firewall, you may need to configure all of the following in **Preferences > Plugins**:

| Setting | Example | Purpose |
|---------|---------|---------|
| npm Registry | \`https://artifactory.corp.com/api/npm/npm-remote/\` | Route npm traffic through your mirror |
| Certification | Upload your corporate CA bundle (\`.pem\`, \`.crt\`) | Trust your corporate TLS-intercepting proxy |

And in **Preferences > Proxy**:

| Setting | Example | Purpose |
|---------|---------|---------|
| HTTP Proxy | \`http://proxy.corp.com:8080\` | Route HTTP traffic through corporate proxy |
| HTTPS Proxy | \`http://proxy.corp.com:8080\` | Route HTTPS traffic through corporate proxy |

### Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code comments added for complex logic
- [x] Changes generate no new warnings