### PR TITLE
feat: import deep-link login experience [INS-2416]

### DIFF
--- a/packages/insomnia/src/entry.main.ts
+++ b/packages/insomnia/src/entry.main.ts
@@ -8,7 +8,6 @@ import contextMenu from 'electron-context-menu';
 import installExtension, { REACT_DEVELOPER_TOOLS } from 'electron-devtools-installer';
 import { configureFetch } from 'insomnia-api';
 
-import { getCurrentSessionId } from '~/account/session';
 import { insomniaFetch } from '~/common/insomnia-fetch';
 import type { Project, RemoteProject, Stats } from '~/insomnia-data';
 import { database, initDatabase, initServices, services } from '~/insomnia-data';
@@ -43,6 +42,7 @@ import { checkIfRestartNeeded } from './main/squirrel-startup';
 import * as updates from './main/updates';
 import * as windowUtils from './main/window-utils';
 import * as models from './models/index';
+
 // Override the Electron userData path
 // This makes Chromium use this folder for eg localStorage
 // ensure userData dir change is made before configure sentry SDK (https://docs.sentry.io/platforms/javascript/guides/electron/#app-userdata-directory)
@@ -256,15 +256,6 @@ const _launchApp = async () => {
           window.focus();
         } else {
           window = windowUtils.createWindowsAndReturnMain();
-        }
-        // Block imports when not logged in
-        const isImportDeeplink = url.includes('://app/import');
-        const isLoggedIn = (await getCurrentSessionId()) ? true : false;
-        const shouldShowLoginPrompt = isImportDeeplink && !isLoggedIn;
-        if (shouldShowLoginPrompt) {
-          const title = encodeURIComponent('You must be logged in to open this link');
-          const message = encodeURIComponent('Please log in and try again.');
-          return window.webContents.send('shell:open', `insomnia://app/alert?title=${title}&message=${message}`);
         }
         return window.webContents.send('shell:open', url);
       };

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -24,6 +24,7 @@ import { useLatest } from 'react-use';
 import { EXTERNAL_VAULT_PLUGIN_NAME, isDevelopment } from '~/common/constants';
 import type { Settings, UserSession } from '~/insomnia-data';
 import { services } from '~/insomnia-data';
+import { SCRATCHPAD_ORGANIZATION_ID } from '~/models/organization';
 import { executePluginMainAction, reloadPlugins } from '~/plugins';
 import { createPlugin } from '~/plugins/create';
 import { setTheme } from '~/plugins/misc';
@@ -368,6 +369,9 @@ const Root = () => {
       }
       // Supports params: uri, curl, origin
       if (urlWithoutParams === 'insomnia://app/import') {
+        // Clean up the flag set during deep-link replay so it never leaks
+        // into later modal evaluations within the same session.
+        window.sessionStorage.removeItem('suppressWelcomeModals');
         const userSession = await services.userSession.getOrCreate();
         if (!userSession.id) {
           window.sessionStorage.setItem('pendingDeepLinkAfterAuthorize', url);
@@ -622,7 +626,7 @@ const Root = () => {
   // default in the import dialog is the correct behaviour.
   useEffect(() => {
     const pendingDeepLink = window.sessionStorage.getItem('pendingDeepLinkAfterAuthorize');
-    if (pendingDeepLink && organizationId && organizationId !== 'org_scratchpad') {
+    if (pendingDeepLink && organizationId && organizationId !== SCRATCHPAD_ORGANIZATION_ID) {
       window.sessionStorage.removeItem('pendingDeepLinkAfterAuthorize');
       window.sessionStorage.setItem('suppressWelcomeModals', 'true');
       window.main.openDeepLink(pendingDeepLink);

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -368,6 +368,12 @@ const Root = () => {
       }
       // Supports params: uri, curl, origin
       if (urlWithoutParams === 'insomnia://app/import') {
+        const userSession = await services.userSession.getOrCreate();
+        if (!userSession.id) {
+          window.sessionStorage.setItem('pendingDeepLinkAfterAuthorize', url);
+          window.localStorage.setItem('logoutMessage', 'Please log in to import this resource.');
+          return navigate(href('/auth/login'));
+        }
         window.main.trackSegmentEvent({
           event: SegmentEvent.importStarted,
           properties: {
@@ -608,6 +614,20 @@ const Root = () => {
     projectId,
     redirectToDefaultBrowserSubmit,
   ]);
+
+  // Replay a deep link that was queued before login (e.g. insomnia://app/import
+  // clicked while signed out).  We wait for organizationId so that the full
+  // redirect chain (org → project) has settled and the import modal can read
+  // route params.  For users with no projects yet the "-- New Project --"
+  // default in the import dialog is the correct behaviour.
+  useEffect(() => {
+    const pendingDeepLink = window.sessionStorage.getItem('pendingDeepLinkAfterAuthorize');
+    if (pendingDeepLink && organizationId && organizationId !== 'org_scratchpad') {
+      window.sessionStorage.removeItem('pendingDeepLinkAfterAuthorize');
+      window.sessionStorage.setItem('suppressWelcomeModals', 'true');
+      window.main.openDeepLink(pendingDeepLink);
+    }
+  }, [organizationId]);
 
   return (
     <>

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -36,7 +36,7 @@ import {
   GIT_PROVIDER_COMPLETE_SIGN_IN_FETCHER_KEY,
   useGitProviderCompleteSignInFetcher,
 } from '~/routes/git-credentials.complete-sign-in';
-import { SegmentEvent } from '~/ui/analytics';
+import { PENDING_IMPORT_ATTRIBUTION_KEY, SegmentEvent, trackImportEvent } from '~/ui/analytics';
 import { getLoginUrl } from '~/ui/auth-session-provider.client';
 import { CopyButton } from '~/ui/components/base/copy-button';
 import { Link } from '~/ui/components/base/link';
@@ -372,18 +372,25 @@ const Root = () => {
         // Clean up the flag set during deep-link replay so it never leaks
         // into later modal evaluations within the same session.
         window.sessionStorage.removeItem('suppressWelcomeModals');
+
+        const importSource = params.source?.trim() || undefined;
+        const importSourceUrl = params.sourceUrl?.trim() || undefined;
+        const hasAttribution = !!(importSource || importSourceUrl);
+        if (hasAttribution) {
+          window.sessionStorage.setItem(
+            PENDING_IMPORT_ATTRIBUTION_KEY,
+            JSON.stringify({ importSource, importSourceUrl }),
+          );
+        }
+
         const userSession = await services.userSession.getOrCreate();
         if (!userSession.id) {
           window.sessionStorage.setItem('pendingDeepLinkAfterAuthorize', url);
           window.localStorage.setItem('logoutMessage', 'Please log in to import this resource.');
+          trackImportEvent(SegmentEvent.importLoginRequired);
           return navigate(href('/auth/login'));
         }
-        window.main.trackSegmentEvent({
-          event: SegmentEvent.importStarted,
-          properties: {
-            source: 'import-url',
-          },
-        });
+        trackImportEvent(SegmentEvent.importStarted, { source: 'import-url' });
 
         if (params.uri) {
           return setImportObject({
@@ -629,6 +636,7 @@ const Root = () => {
     if (pendingDeepLink && organizationId && organizationId !== SCRATCHPAD_ORGANIZATION_ID) {
       window.sessionStorage.removeItem('pendingDeepLinkAfterAuthorize');
       window.sessionStorage.setItem('suppressWelcomeModals', 'true');
+      trackImportEvent(SegmentEvent.importResumedAfterLogin);
       window.main.openDeepLink(pendingDeepLink);
     }
   }, [organizationId]);

--- a/packages/insomnia/src/routes/import.scan.tsx
+++ b/packages/insomnia/src/routes/import.scan.tsx
@@ -9,7 +9,7 @@ import {
   scanResources,
 } from '~/common/import';
 import type { ImportEntry } from '~/main/importers/entities';
-import { SegmentEvent } from '~/ui/analytics';
+import { SegmentEvent, trackImportEvent } from '~/ui/analytics';
 import { invariant } from '~/utils/invariant';
 import { createFetcherSubmitHook } from '~/utils/router';
 
@@ -27,12 +27,7 @@ export const scanImportResources = async (data: {
   invariant(typeof source === 'string', 'Source is required.');
   invariant(IMPORT_SOURCE_TYPES.includes(source), 'Unsupported import type');
 
-  window.main.trackSegmentEvent({
-    event: SegmentEvent.importScanned,
-    properties: {
-      source,
-    },
-  });
+  trackImportEvent(SegmentEvent.importScanned, { source });
 
   const contentList: ImportEntry[] = [];
 

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx
@@ -26,7 +26,7 @@ import {
   tryToInterpolateRequest,
   tryToTransformRequestWithPlugins,
 } from '~/network/network';
-import { SegmentEvent } from '~/ui/analytics';
+import { type ImportAttribution, importAttributionKey, SegmentEvent } from '~/ui/analytics';
 import { parseGraphQLReqeustBody } from '~/utils/graph-ql';
 import { invariant } from '~/utils/invariant';
 import { createFetcherSubmitHook } from '~/utils/router';
@@ -368,6 +368,23 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
               count_tests: response.requestTestResults?.length || 0,
             },
           });
+
+          const attributionStorageKey = importAttributionKey(requestId);
+          const jsonImportAttribution = window.localStorage.getItem(attributionStorageKey);
+          if (jsonImportAttribution) {
+            try {
+              const importAttribution = JSON.parse(jsonImportAttribution) as ImportAttribution;
+              window.main.trackSegmentEvent({
+                event: SegmentEvent.importedRequestFirstSend,
+                properties: {
+                  ...importAttribution,
+                  protocol: activeRequest.type,
+                },
+              });
+            } finally {
+              window.localStorage.removeItem(attributionStorageKey);
+            }
+          }
         }
       }
     }

--- a/packages/insomnia/src/ui/analytics.ts
+++ b/packages/insomnia/src/ui/analytics.ts
@@ -8,6 +8,9 @@ export enum SegmentEvent {
   importStarted = 'Import Started',
   importScanned = 'Import Scanned',
   importCompleted = 'Import Completed',
+  importLoginRequired = 'Import Login Required',
+  importResumedAfterLogin = 'Import Resumed After Login',
+  importedRequestFirstSend = 'Imported Request First Send',
   documentCreate = 'Document Created',
   mockCreateModalOpened = 'Mock Server Create Modal Opened',
   mockCreate = 'Mock Created',
@@ -160,4 +163,29 @@ export function trackOnceDaily(event: SegmentEvent, properties?: Record<string, 
   }
   window.main.trackSegmentEvent({ event, properties });
   markTrackedToday(event);
+}
+
+export interface ImportAttribution {
+  importSource?: string;
+  importSourceUrl?: string;
+}
+
+export const PENDING_IMPORT_ATTRIBUTION_KEY = 'pendingImportAttribution';
+
+export const importAttributionKey = (requestId: string): string => `importAttribution:request:${requestId}`;
+
+export function readPendingImportAttribution(): ImportAttribution {
+  try {
+    const raw = window.sessionStorage.getItem(PENDING_IMPORT_ATTRIBUTION_KEY);
+    return raw ? (JSON.parse(raw) as ImportAttribution) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function trackImportEvent(event: SegmentEvent, properties: Record<string, unknown> = {}): void {
+  window.main.trackSegmentEvent({
+    event,
+    properties: { ...readPendingImportAttribution(), ...properties },
+  });
 }

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -21,7 +21,13 @@ import {
   type ScanResult,
 } from '../../../../common/import';
 import { invariant } from '../../../../utils/invariant';
-import { SegmentEvent } from '../../../analytics';
+import {
+  importAttributionKey,
+  PENDING_IMPORT_ATTRIBUTION_KEY,
+  readPendingImportAttribution,
+  SegmentEvent,
+  trackImportEvent,
+} from '../../../analytics';
 import { Modal, type ModalHandle, type ModalProps } from '../../base/modal';
 import { ModalHeader } from '../../base/modal-header';
 import { HelpTooltip } from '../../help-tooltip';
@@ -269,16 +275,18 @@ export const ImportModal: FC<ImportModalProps> = ({
   // Track the import completion event, redirect to the new workspace and close the modal
   useEffect(() => {
     if (importFetcher?.data?.done === true && scanResourcesFetcherData?.length) {
-      window.main.trackSegmentEvent({
-        event: SegmentEvent.importCompleted,
-        properties: {
-          workspaces: scanResourcesFetcherData.map(scanResult => scanResult.workspaces?.length || 0),
-          requests: scanResourcesFetcherData.map(scanResult => scanResult.requests?.length || 0),
-        },
+      trackImportEvent(SegmentEvent.importCompleted, {
+        workspaces: scanResourcesFetcherData.map(scanResult => scanResult.workspaces?.length || 0),
+        requests: scanResourcesFetcherData.map(scanResult => scanResult.requests?.length || 0),
       });
       const workspace = importFetcher?.data?.singleImportedWorkspace;
       const request = importFetcher?.data?.singleImportedRequest;
       const targetProjectId = importFetcher?.data?.singleImportedProjectId || createdProjectId || defaultProjectId;
+      const attribution = readPendingImportAttribution();
+      if ((attribution.importSource || attribution.importSourceUrl) && request) {
+        window.localStorage.setItem(importAttributionKey(request._id), JSON.stringify(attribution));
+      }
+      window.sessionStorage.removeItem(PENDING_IMPORT_ATTRIBUTION_KEY);
       if (workspace && request) {
         navigate(
           `/organization/${organizationId}/project/${targetProjectId}/workspace/${workspace._id}/debug/request/${request._id}`,
@@ -397,10 +405,7 @@ export const ImportModal: FC<ImportModalProps> = ({
                 .filter(({ errors }) => errors.length === 0)
                 .forEach(scanResult => {
                   const type = scanResult.type?.id ?? 'unknown';
-                  window.main.trackSegmentEvent({
-                    event: SegmentEvent.dataImport,
-                    properties: { 'data-import-type': type },
-                  });
+                  trackImportEvent(SegmentEvent.dataImport, { 'data-import-type': type });
                 });
             }}
           />

--- a/packages/insomnia/src/ui/components/modals/upgrade-plan-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/upgrade-plan-modal.tsx
@@ -63,6 +63,17 @@ export const UpgradePlanModal = () => {
 
   useEffect(() => {
     if (checkerData?.isEligible) {
+      // Don't show when a deep-link import is about to open (e.g. user just
+      // logged in to handle an insomnia://app/import link).
+      // Check both keys to cover the full timing window: pendingDeepLinkAfterAuthorize
+      // is present before the org loader drains it, suppressWelcomeModals is set after.
+      if (
+        window.sessionStorage.getItem('pendingDeepLinkAfterAuthorize') ||
+        window.sessionStorage.getItem('suppressWelcomeModals')
+      ) {
+        window.sessionStorage.removeItem('suppressWelcomeModals');
+        return;
+      }
       setOpen(true);
     }
   }, [checkerData?.isEligible]);

--- a/packages/insomnia/src/ui/components/modals/upgrade-plan-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/upgrade-plan-modal.tsx
@@ -66,7 +66,8 @@ export const UpgradePlanModal = () => {
       // Don't show when a deep-link import is about to open (e.g. user just
       // logged in to handle an insomnia://app/import link).
       // Check both keys to cover the full timing window: pendingDeepLinkAfterAuthorize
-      // is present before the org loader drains it, suppressWelcomeModals is set after.
+      // is present before the replay effect in root.tsx removes it,
+      // suppressWelcomeModals is set by that same effect just before replay.
       if (
         window.sessionStorage.getItem('pendingDeepLinkAfterAuthorize') ||
         window.sessionStorage.getItem('suppressWelcomeModals')


### PR DESCRIPTION
This change introduces a smoother experience for the deep-link import experience when the user is not logged in. Stores the deep-link in session storage to open again post-login, and suppresses welcome dialogs for those cases

Also include the analytics events