### PR TITLE
fix: socket.io server sent disconnect state

### DIFF
--- a/packages/insomnia/src/main/network/socket-io.ts
+++ b/packages/insomnia/src/main/network/socket-io.ts
@@ -300,6 +300,7 @@ const openSocketIOConnection = async (
       query: options.query,
       ca: caCertificate,
       passphrase,
+      reconnection: false,
       // @ts-expect-error: Type mismatch for agent field
       agent: settings.proxyEnabled ? getProxyAgent(url, settings.httpProxy, settings.httpsProxy) : false,
     };


### PR DESCRIPTION
The fix was pretty simple; the socket.io client defaults to reconnect, which breaks the Insomnia-managed connectivity state