### PR TITLE
fix: bump node-libcurl and add ipv6 tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "packages/insomnia-scripting-environment"
       ],
       "dependencies": {
-        "@getinsomnia/node-libcurl": "3.2.1",
+        "@getinsomnia/node-libcurl": "3.2.2",
         "ajv": "^8.17.1"
       },
       "devDependencies": {
@@ -3534,9 +3534,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@getinsomnia/node-libcurl": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-3.2.1.tgz",
-      "integrity": "sha512-QaB81JOAvAxkGUNeXIBrERuUhONf+d46f7ZTyPg6ayc3q48NyAhQUznNcbajynbCJjXRsJBqb0qAY8pK2ShNGQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@getinsomnia/node-libcurl/-/node-libcurl-3.2.2.tgz",
+      "integrity": "sha512-O4FTODtfwvLpnk+pyPHCIINCmu8Io+UaDDmcY2bU73VumAu6p/p/egQ6ndUOOId6OQ7V2jyAppZFgNb+fev/Uw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -29169,7 +29169,7 @@
         "@fortawesome/free-regular-svg-icons": "^6.7.2",
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^3.0.2",
-        "@getinsomnia/node-libcurl": "3.2.1",
+        "@getinsomnia/node-libcurl": "3.2.2",
         "@getinsomnia/srp-js": "1.0.0-alpha.1",
         "@grpc/grpc-js": "^1.13.3",
         "@grpc/proto-loader": "^0.7.13",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     }
   },
   "dependencies": {
-    "@getinsomnia/node-libcurl": "3.2.1",
+    "@getinsomnia/node-libcurl": "3.2.2",
     "ajv": "^8.17.1"
   }
 }

--- a/packages/insomnia-smoke-test/fixtures/ipv6-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/ipv6-collection.yaml
@@ -1,0 +1,65 @@
+type: collection.insomnia.rest/5.0
+schema_version: "5.1"
+name: IPV6 Smoke tests
+meta:
+  id: wrk_92410798721649cc8cd6f7c312a8764d
+  created: 1736279960080
+  modified: 1736279960080
+collection:
+  - url: http://[::1]:4010/pets/1
+    name: send JSON request
+    meta:
+      id: req_22084aca139d42c6878afdc1a99db23b
+      created: 1636141014552
+      modified: 1636707449231
+      isPrivate: false
+    method: GET
+    headers:
+      - name: test
+        value: test
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+  - url: http://[::1]:4010/file/dummy.csv
+    name: sends dummy.csv request and shows rich response
+    meta:
+      id: req_ed583d913fec40c8b29f51b87b1843ef
+      created: 1636141038448
+      modified: 1636141047337
+      isPrivate: false
+    method: GET
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+cookieJar:
+  name: Default Jar
+  meta:
+    id: jar_0a46909e87a24a05961f3b7c6b591d23
+    created: 1636140994434
+    modified: 1637279629638
+  cookies:
+    - key: foo
+      value: bar
+      domain: domain.com
+      path: /
+      creation: 2021-11-18T23:53:05.310Z
+      id: "429589439757017"
+environments:
+  name: Base Environment
+  meta:
+    id: env_6fda0ba942704e71a81a02e2bf5fe5ff
+    created: 1636140994432
+    modified: 1636140994432
+    isPrivate: false
+  data:
+    customValue: fromEnvManager

--- a/packages/insomnia-smoke-test/server/index.ts
+++ b/packages/insomnia-smoke-test/server/index.ts
@@ -153,8 +153,10 @@ app.get('/v1/oauth/azure/config', (_req, res) => {
 });
 
 startWebSocketServer(
-  app.listen(port, () => {
+  app.listen(port, '::', () => {
     console.log(`Listening at http://localhost:${port}`);
+    console.log(`Listening at http://127.0.0.1:${port}`);
+    console.log(`Listening at http://[::1]:${port}`);
     console.log(`Listening at ws://localhost:${port}`);
   }),
 );
@@ -169,8 +171,10 @@ startWebSocketServer(
       rejectUnauthorized: false,
     },
     app,
-  ).listen(httpsPort, () => {
+  ).listen(httpsPort, '::', () => {
     console.log(`Listening at https://localhost:${httpsPort}`);
+    console.log(`Listening at https://127.0.0.1:${httpsPort}`);
+    console.log(`Listening at https://[::1]:${httpsPort}`);
     console.log(`Listening at wss://localhost:${httpsPort}`);
   }),
 );

--- a/packages/insomnia-smoke-test/tests/smoke/ipv6.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/ipv6.test.ts
@@ -1,0 +1,40 @@
+import { expect } from '@playwright/test';
+
+import { test } from '../../playwright/test';
+
+test('can send ipv6 requests', async ({ page, insomnia }) => {
+  test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
+
+  const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
+  const responseBody = page.getByTestId('response-pane');
+
+  await insomnia.projectPage.importFixture('ipv6-collection.yaml');
+
+  await page.getByLabel('Request Collection')
+    .getByTestId('send JSON request').press('Enter');
+  await expect.soft(page.getByTestId('request-pane')
+    .getByTestId('OneLineEditor')
+    .getByText('http://[::1]:4010/pets/1')
+  ).toBeVisible();
+
+  await page.getByTestId('request-pane')
+    .getByRole('button', { name: 'Send' }).click();
+  await expect.soft(statusTag).toContainText('200 OK');
+  await expect.soft(responseBody).toContainText('"id": "1"');
+
+  await page
+    .getByLabel('Request Collection')
+    .getByTestId('sends dummy.csv request and shows rich response')
+    .press('Enter');
+  await expect.soft(page.getByTestId('request-pane')
+    .getByTestId('OneLineEditor')
+    .getByText('http://[::1]:4010/file/dummy.csv')
+  ).toBeVisible();
+
+  await page.getByTestId('request-pane')
+    .getByRole('button', { name: 'Send' }).click();
+  await expect.soft(statusTag).toContainText('200 OK');
+  await page.getByRole('button', { name: 'Preview' }).click();
+  await page.getByRole('menuitem', { name: 'Raw Data' }).click();
+  await expect.soft(responseBody).toContainText('a,b,c');
+});

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -53,7 +53,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.7.2",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^3.0.2",
-    "@getinsomnia/node-libcurl": "3.2.1",
+    "@getinsomnia/node-libcurl": "3.2.2",
     "@getinsomnia/srp-js": "1.0.0-alpha.1",
     "@grpc/grpc-js": "^1.13.3",
     "@grpc/proto-loader": "^0.7.13",


### PR DESCRIPTION
Bumps `node-libcurl` which now includes explicit `ipv6` support
Adjust the test server to listen on both stacks via `::`
Added the first couple of smoke tests from `app.test.ts` to `ipv6.test.ts` with the IPv6 loopback address