### PR TITLE
fix: user can not resolve conflict in app

### DIFF
--- a/packages/insomnia/src/entry.preload.ts
+++ b/packages/insomnia/src/entry.preload.ts
@@ -196,7 +196,7 @@ const git: GitServiceAPI = {
   pullFromGitRemote: options => invokeWithNormalizedError('git.pullFromGitRemote', options),
   continueMerge: options => invokeWithNormalizedError('git.continueMerge', options),
   discardChanges: options => invokeWithNormalizedError('git.discardChanges', options),
-  abortMerge: () => invokeWithNormalizedError('git.abortMerge'),
+  abortMerge: options => invokeWithNormalizedError('git.abortMerge', options),
   gitStatus: options => invokeWithNormalizedError('git.gitStatus', options),
   diff: () => invokeWithNormalizedError('git.diff'),
   multipleCommitToGitRepo: options => invokeWithNormalizedError('git.multipleCommitToGitRepo', options),
@@ -265,7 +265,8 @@ const main: Window['main'] = {
     requestId: string,
     authentication: AuthTypeOAuth2,
     forceRefresh?: boolean,
-  ): Promise<OAuth2Token | undefined> => invokeWithNormalizedError('getOAuth2Token', requestId, authentication, forceRefresh),
+  ): Promise<OAuth2Token | undefined> =>
+    invokeWithNormalizedError('getOAuth2Token', requestId, authentication, forceRefresh),
   insecureReadFile: options => invokeWithNormalizedError('insecureReadFile', options),
   insecureReadFileWithEncoding: options => invokeWithNormalizedError('insecureReadFileWithEncoding', options),
   secureReadFile: options => invokeWithNormalizedError('secureReadFile', options),

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -61,7 +61,7 @@ import GitVCS, {
 import { MemClient } from '../sync/git/mem-client';
 import { NeDBClient } from '../sync/git/ne-db-client';
 import { projectRoutableFSClient } from '../sync/git/project-routable-fs-client';
-import { repoFileWatcherRegistry } from '../sync/git/repo-file-watcher';
+import { createElectronNotifier, RepoFileWatcherRegistry, type WatcherNotifier } from '../sync/git/repo-file-watcher';
 import { routableFSClient } from '../sync/git/routable-fs-client';
 import { shallowClone } from '../sync/git/shallow-clone';
 import type { AutoResolvedConflict, MergeConflict } from '../sync/types';
@@ -71,6 +71,35 @@ import { ipcMainHandle } from './ipc/electron';
 
 // Initialize Git Remote Providers on module load
 initializeGitRemoteProviders();
+
+/**
+ * Set of repo IDs for which conflict problems should be suppressed in the
+ * file-problems-changed IPC broadcast.  Active while the user is resolving
+ * conflicts via SyncMergeModal so the generic "CLI conflict" blocking modal
+ * does not appear on top of the interactive resolver.
+ */
+const suppressedConflictRepos = new Set<string>();
+
+const _electronNotifier = createElectronNotifier();
+const conflictFilteringNotifier: WatcherNotifier = {
+  onDbSynced: () => _electronNotifier.onDbSynced(),
+  onProblemsChanged: payload => {
+    _electronNotifier.onProblemsChanged({
+      ...payload,
+      conflictsSuppressed: suppressedConflictRepos.has(payload.repoId),
+    });
+  },
+};
+
+const repoFileWatcherRegistry = new RepoFileWatcherRegistry(conflictFilteringNotifier);
+
+function suppressConflictProblems(repoId: string): void {
+  suppressedConflictRepos.add(repoId);
+}
+
+function clearConflictSuppression(repoId: string): void {
+  suppressedConflictRepos.delete(repoId);
+}
 
 type PushPull = 'push' | 'pull';
 type VCSAction =
@@ -1982,6 +2011,7 @@ export const mergeGitBranch = async ({
   const bufferId = await database.bufferChanges();
 
   try {
+    suppressConflictProblems(gitRepository._id);
     await GitVCS.merge({
       theirsBranch,
       allowUncommittedChangesBeforeMerge,
@@ -1993,6 +2023,7 @@ export const mergeGitBranch = async ({
     // Import all YAML files from disk into the DB after merge + checkout
     const gitRepoId = gitRepository._id;
     await repoFileWatcherRegistry.importAllFiles(gitRepoId);
+    clearConflictSuppression(gitRepository._id);
 
     trackSegmentEvent(SegmentEvent.vcsAction, {
       ...vcsSegmentEventProperties('git', 'merge_branch'),
@@ -2013,8 +2044,10 @@ export const mergeGitBranch = async ({
     return {};
   } catch (err) {
     if (err instanceof MergeConflictError) {
+      // Keep suppression active — user will resolve via SyncMergeModal.
       return err.data;
     }
+    clearConflictSuppression(gitRepository._id);
     let errorMessage = getErrorMessage(err);
 
     if (err instanceof Errors.HttpError) {
@@ -2231,9 +2264,12 @@ export async function fetchGitRemoteBranches({
 }
 
 export async function pullFromGitRemote({ projectId, workspaceId }: { projectId: string; workspaceId?: string }) {
+  let repoId: string | null = null;
   try {
     await assertBranchOnOrigin('pull');
     const gitRepository = await getGitRepository({ projectId, workspaceId });
+    repoId = gitRepository._id;
+    suppressConflictProblems(repoId);
     invariant(gitRepository.credentialsId, 'Git Credentials ID is required');
     const credentials = await services.gitCredentials.getById(gitRepository.credentialsId);
     invariant(credentials, 'Git Credentials not found');
@@ -2243,6 +2279,7 @@ export async function pullFromGitRemote({ projectId, workspaceId }: { projectId:
 
     // Import all YAML files from disk into the DB after pull
     await repoFileWatcherRegistry.importAllFiles(gitRepository._id);
+    clearConflictSuppression(repoId);
 
     trackSegmentEvent(SegmentEvent.vcsAction, {
       ...vcsSegmentEventProperties('git', 'pull'),
@@ -2266,8 +2303,12 @@ export async function pullFromGitRemote({ projectId, workspaceId }: { projectId:
     };
   } catch (err: unknown) {
     if (err instanceof MergeConflictError) {
+      // Keep suppression active — user will resolve via SyncMergeModal.
+      // clearConflictSuppression is called by continueMerge or abortMergeAction.
       return err.data;
     }
+
+    if (repoId) clearConflictSuppression(repoId);
 
     if (
       err instanceof Errors.UserCanceledError ||
@@ -2334,6 +2375,9 @@ export const continueMerge = async ({
 
     // Import all YAML files from disk into the DB after merge resolution
     await repoFileWatcherRegistry.importAllFiles(gitRepository._id);
+    // Files are clean now — lift the conflict suppression so any remaining
+    // issues (parse errors etc.) are reported normally.
+    clearConflictSuppression(gitRepository._id);
 
     const log = (await GitVCS.log({ depth: 1 })) || [];
 
@@ -2414,7 +2458,9 @@ export const discardChangesAction = async ({
   }
 };
 
-export const abortMergeAction = async () => {
+export const abortMergeAction = async ({ projectId, workspaceId }: { projectId: string; workspaceId?: string }) => {
+  const gitRepository = await getGitRepository({ projectId, workspaceId });
+  clearConflictSuppression(gitRepository._id);
   return GitVCS.abortMerge();
 };
 
@@ -2869,7 +2915,9 @@ export async function runAllGitRepoMigrations(): Promise<MigrationSummary> {
 
   const ts = () => new Date().toISOString();
   const projectList = gitProjects.map(p => `"${p.name}"`).join(', ');
-  logs.push(`${ts()} [INFO] Starting migration v${CURRENT_MIGRATION_VERSION} for ${gitProjects.length} repo(s): ${projectList}`);
+  logs.push(
+    `${ts()} [INFO] Starting migration v${CURRENT_MIGRATION_VERSION} for ${gitProjects.length} repo(s): ${projectList}`,
+  );
 
   await Promise.all(
     gitProjects.map(async project => {
@@ -3036,7 +3084,7 @@ export const registerGitServiceAPI = () => {
   ipcMainHandle('git.discardChanges', (_, options: Parameters<typeof discardChangesAction>[0]) =>
     discardChangesAction(options),
   );
-  ipcMainHandle('git.abortMerge', _ => abortMergeAction());
+  ipcMainHandle('git.abortMerge', (_, options: Parameters<typeof abortMergeAction>[0]) => abortMergeAction(options));
   ipcMainHandle('git.gitStatus', (_, options: Parameters<typeof gitStatusAction>[0]) => gitStatusAction(options));
   ipcMainHandle('git.diff', () => diff());
   ipcMainHandle('git.stageChanges', (_, options: Parameters<typeof stageChangesAction>[0]) =>

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -1572,6 +1572,7 @@ export const resetGitRepoAction = async ({ projectId, workspaceId }: { projectId
   await services.gitRepository.remove(repo);
   // Stop the file watcher for this repository (project-scoped flow only).
   repoFileWatcherRegistry.stopWatcher(repo._id);
+  clearConflictSuppression(repo._id);
 
   await database.flushChanges(flushId);
 

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.tsx
@@ -401,7 +401,7 @@ const Component = () => {
     projectId: string;
     workspaceId: string;
   };
-  const { issuesByWorkspaceId } = useGitFileIssues();
+  const { issuesByWorkspaceId, conflictsSuppressed } = useGitFileIssues();
   const currentIssue = issuesByWorkspaceId[workspaceId];
 
   const handleBackToList = () => {
@@ -414,7 +414,9 @@ const Component = () => {
   };
 
   const modalText = currentIssue ? workspaceFileIssueModalText[currentIssue.kind] : null;
-  const isIssueModalOpen = Boolean(currentIssue && modalText);
+  const isIssueModalOpen = Boolean(
+    currentIssue && modalText && !(currentIssue.kind === 'conflict' && conflictsSuppressed),
+  );
 
   return (
     <div className="h-full w-full overflow-hidden" data-testid="workspace-page">

--- a/packages/insomnia/src/sync/git/repo-file-watcher.ts
+++ b/packages/insomnia/src/sync/git/repo-file-watcher.ts
@@ -73,6 +73,8 @@ export interface FileProblemsChangedPayload {
   repoId: string;
   problems: FileIssue[];
   workspaceIssues: WorkspaceFileIssue[];
+  /** True when the main process is suppressing conflict display (e.g. SyncMergeModal is open). */
+  conflictsSuppressed: boolean;
 }
 
 /** Compute a SHA-256 hex digest of a string. */
@@ -792,6 +794,7 @@ class RepoFileWatcher {
       repoId: this.repoId,
       problems: this.getProblems(),
       workspaceIssues: this.getWorkspaceIssues(),
+      conflictsSuppressed: false,
     });
   }
 }
@@ -900,7 +903,7 @@ export class RepoFileWatcherRegistry {
 }
 
 /** Default notifier that broadcasts to all Electron BrowserWindows. */
-function createElectronNotifier(): WatcherNotifier {
+export function createElectronNotifier(): WatcherNotifier {
   return {
     onDbSynced: () => {
       for (const w of BrowserWindow.getAllWindows()) {
@@ -914,5 +917,3 @@ function createElectronNotifier(): WatcherNotifier {
     },
   };
 }
-
-export const repoFileWatcherRegistry = new RepoFileWatcherRegistry(createElectronNotifier());

--- a/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
@@ -459,6 +459,7 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository, activeProject
               });
           },
           onCancelUnresolved: () => {
+            window.main.git.abortMerge({ projectId });
             closeGitProjectStagingModalRef.current?.();
             setIsPulling(false);
             showToast({

--- a/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
@@ -458,8 +458,8 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository, activeProject
                 revalidate();
               });
           },
-          onCancelUnresolved: async () => {
-            await window.main.git.abortMerge({ projectId });
+          onCancelUnresolved: () => {
+            window.main.git.abortMerge({ projectId });
             closeGitProjectStagingModalRef.current?.();
             setIsPulling(false);
             showToast({

--- a/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
@@ -458,8 +458,8 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository, activeProject
                 revalidate();
               });
           },
-          onCancelUnresolved: () => {
-            window.main.git.abortMerge({ projectId });
+          onCancelUnresolved: async () => {
+            await window.main.git.abortMerge({ projectId });
             closeGitProjectStagingModalRef.current?.();
             setIsPulling(false);
             showToast({

--- a/packages/insomnia/src/ui/components/dropdowns/workspace-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-sync-dropdown.tsx
@@ -22,20 +22,24 @@ export const WorkspaceSyncDropdown: FC = () => {
   }
 
   const isLocalProject =
-    !models.project.isRemoteProject(activeProject) && !activeWorkspaceMeta?.gitRepositoryId && !models.project.isGitProject(activeProject);
+    !models.project.isRemoteProject(activeProject) &&
+    !activeWorkspaceMeta?.gitRepositoryId &&
+    !models.project.isGitProject(activeProject);
 
   if (isLocalProject) {
     return <LocalProjectBar />;
   }
 
-  const shouldShowCloudSyncDropdown = models.project.isRemoteProject(activeProject) && !activeWorkspaceMeta?.gitRepositoryId;
+  const shouldShowCloudSyncDropdown =
+    models.project.isRemoteProject(activeProject) && !activeWorkspaceMeta?.gitRepositoryId;
 
   if (shouldShowCloudSyncDropdown) {
     return <SyncDropdown key={activeWorkspace?._id} workspace={activeWorkspace} project={activeProject} />;
   }
 
   const shouldShowGitSyncDropdown =
-    features.gitSync.enabled && (activeWorkspaceMeta?.gitRepositoryId || !models.project.isRemoteProject(activeProject));
+    features.gitSync.enabled &&
+    (activeWorkspaceMeta?.gitRepositoryId || !models.project.isRemoteProject(activeProject));
   if (shouldShowGitSyncDropdown) {
     if (models.project.isGitProject(activeProject)) {
       return (

--- a/packages/insomnia/src/ui/components/modals/git-project-branches-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-project-branches-modal.tsx
@@ -166,7 +166,7 @@ const LocalBranchItem = ({
                       },
                       onCancelUnresolved: () => {
                         // user aborted merge
-                        window.main.git.abortMerge();
+                        window.main.git.abortMerge({ projectId });
                         // TODO: the abortMerge method provided by isomorphic-git is unreliable
                         // clean up any partial merges here
                         reject(

--- a/packages/insomnia/src/ui/components/modals/git-project-branches-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-project-branches-modal.tsx
@@ -164,9 +164,9 @@ const LocalBranchItem = ({
                             revalidate();
                           });
                       },
-                      onCancelUnresolved: async () => {
+                      onCancelUnresolved: () => {
                         // user aborted merge
-                        await window.main.git.abortMerge({ projectId });
+                        window.main.git.abortMerge({ projectId });
                         // TODO: the abortMerge method provided by isomorphic-git is unreliable
                         // clean up any partial merges here
                         reject(

--- a/packages/insomnia/src/ui/components/modals/git-project-branches-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-project-branches-modal.tsx
@@ -164,9 +164,9 @@ const LocalBranchItem = ({
                             revalidate();
                           });
                       },
-                      onCancelUnresolved: () => {
+                      onCancelUnresolved: async () => {
                         // user aborted merge
-                        window.main.git.abortMerge({ projectId });
+                        await window.main.git.abortMerge({ projectId });
                         // TODO: the abortMerge method provided by isomorphic-git is unreliable
                         // clean up any partial merges here
                         reject(

--- a/packages/insomnia/src/ui/hooks/use-git-file-issues.ts
+++ b/packages/insomnia/src/ui/hooks/use-git-file-issues.ts
@@ -19,6 +19,7 @@ const mapIssuesByWorkspaceId = (issues: WorkspaceFileIssue[]) => {
 
 export interface GitFileIssuesValue {
   issuesByWorkspaceId: Record<string, WorkspaceFileIssue>;
+  conflictsSuppressed: boolean;
 }
 
 const GitFileIssuesContext = createContext<GitFileIssuesValue | undefined>(undefined);
@@ -43,6 +44,7 @@ export const useProjectGitFileIssues = ({
   gitRepositoryId?: string | null;
 }): GitFileIssuesValue => {
   const [issuesByWorkspaceId, setIssuesByWorkspaceId] = useState<Record<string, WorkspaceFileIssue>>({});
+  const [conflictsSuppressed, setConflictsSuppressed] = useState(false);
 
   const loadIssues = useCallback(async () => {
     if (!projectId || !gitRepositoryId) {
@@ -76,6 +78,7 @@ export const useProjectGitFileIssues = ({
         return;
       }
 
+      setConflictsSuppressed(payload.conflictsSuppressed);
       setIssuesByWorkspaceId(mapIssuesByWorkspaceId(payload.workspaceIssues));
     });
   }, [gitRepositoryId]);
@@ -83,7 +86,8 @@ export const useProjectGitFileIssues = ({
   return useMemo<GitFileIssuesValue>(
     () => ({
       issuesByWorkspaceId,
+      conflictsSuppressed,
     }),
-    [issuesByWorkspaceId],
+    [issuesByWorkspaceId, conflictsSuppressed],
   );
 };


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
INS-2436
When merging branches within the App, if a conflict occurs, the Resolve Conflict Modal opens automatically but displays a "cannot read file" error. This prevents users from resolving conflicts through the modal.
We should only show the resolve conflict modal in this case.
<img width="1920" height="1196" alt="image" src="https://github.com/user-attachments/assets/4362a882-e9da-4700-a8c8-39c8a5f8c5aa" />
