### PR TITLE
feat: include app version in window title [INS-2465]

### DIFF
--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -188,7 +188,7 @@ export function createWindow(): ElectronBrowserWindow {
     backgroundColor: '#2C2C2C',
     fullscreen: fullscreen,
     fullscreenable: true,
-    title: getProductName(),
+    title: `${getProductName()} ${getAppVersion()}`,
     width: width || DEFAULT_WIDTH,
     height: height || DEFAULT_HEIGHT,
     minHeight: MINIMUM_HEIGHT,


### PR DESCRIPTION
Having the app version in the title would save quite a bit of back and forth when customers send us screenshots or even during internal conversations. This PR adds the app version, leading to the window title looking as follows:

<img width="596" height="163" alt="image" src="https://github.com/user-attachments/assets/4bb9a429-9d47-466c-874a-b4a868c684fd" />


Changes were tested by running the app locally. Automated tests were not added for this change because the likelihood of failure seems close enough to zero: The `getAppVersion` method is already used within `window-utils` and the method implementation is just reading a string field from package.json.