### PR TITLE
Remove renderer dependency from script execution

### DIFF
--- a/packages/insomnia/src/network/cancellation.ts
+++ b/packages/insomnia/src/network/cancellation.ts
@@ -1,3 +1,5 @@
+import { appendFile } from 'node:fs/promises';
+
 import type { RequestContext } from '../../../insomnia-scripting-environment/src/objects';
 import type { CurlRequestOptions } from '../main/network/libcurl-promise';
 import { runScript as nodejsRunScript } from '../script-executor';
@@ -49,7 +51,9 @@ export const cancellableRunScript = async (options: { script: string; context: R
   try {
     const result = await cancellablePromise({
       signal: controller.signal,
-      fn: process.type === 'renderer' ? window.main.hiddenBrowserWindow.runScript(options) : nodejsRunScript(options),
+      fn: process.type === 'renderer'
+        ? window.main.hiddenBrowserWindow.runScript(options)
+        : nodejsRunScript({ ...options, appendTimelineEntry: ({ timelinePath, data }) => appendFile(timelinePath, data) }),
     });
 
     return result;

--- a/packages/insomnia/src/network/concurrency.ts
+++ b/packages/insomnia/src/network/concurrency.ts
@@ -1,3 +1,5 @@
+import { appendFile } from 'node:fs/promises';
+
 import type { queueAsPromised } from 'fastq';
 import * as fastq from 'fastq';
 
@@ -11,6 +13,7 @@ import type {
 } from '~/insomnia-data';
 
 import type { RequestContext, RequestTestResult } from '../../../insomnia-scripting-environment/src/objects';
+import { runScript } from '../script-executor';
 import { cancellableExecution } from './cancellation';
 
 export interface ExecuteScriptContext {
@@ -59,10 +62,17 @@ async function asyncWorker(arg: Task): Promise<any> {
   const timeoutPromise = new Promise<{ error: string }>(resolve =>
     setTimeout(resolve, timeoutValue, { error: `Executing script timeout: ${timeoutValue}` }),
   );
-  const executionPromise = Promise.race([
-    window.main.hiddenBrowserWindow.runScript({ script: arg.script, context: arg.context }),
-    timeoutPromise,
-  ]);
+
+  const scriptPromise =
+    process.type === 'renderer'
+      ? window.main.hiddenBrowserWindow.runScript({ script: arg.script, context: arg.context })
+      : runScript({
+          script: arg.script,
+          context: arg.context,
+          appendTimelineEntry: ({ timelinePath, data }) => appendFile(timelinePath, data),
+        });
+
+  const executionPromise = Promise.race([scriptPromise, timeoutPromise]);
   const result = await cancellableExecution({ id: arg.context.request._id, fn: executionPromise });
   return result;
 }

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -639,6 +639,8 @@ const tryToExecuteScript = async (context: RequestAndContextAndOptionalResponse)
 
     if (runtime) {
       await runtime.appendTimeline(timelinePath, output.logs);
+    } else if (process.type !== 'renderer' && output?.logs?.length) {
+      await fs.promises.appendFile(timelinePath, output.logs.join('\n'));
     }
 
     if (output?.transientVariables !== undefined) {

--- a/packages/insomnia/src/script-executor.ts
+++ b/packages/insomnia/src/script-executor.ts
@@ -1,5 +1,3 @@
-import { appendFile } from 'node:fs/promises';
-
 import * as _ from 'es-toolkit/compat';
 
 import { initInsomniaObject, InsomniaObject } from '../../insomnia-scripting-environment/src/objects';
@@ -17,9 +15,11 @@ import { invariant } from './utils/invariant';
 export const runScript = async ({
   script,
   context,
+  appendTimelineEntry,
 }: {
   script: string;
   context: RequestContext;
+  appendTimelineEntry: (opts: { timelinePath: string; data: string }) => Promise<void>;
 }): Promise<RequestContext> => {
   // console.log(script);
   const scriptConsole = getNewConsole();
@@ -67,7 +67,7 @@ export const runScript = async ({
   const updatedCertificates = mergeClientCertificates(context.clientCertificates, mutatedContextObject.request);
   const updatedCookieJar = mergeCookieJar(context.cookieJar, mutatedContextObject.cookieJar);
 
-  await appendFile(context.timelinePath, scriptConsole.dumpLogs());
+  await appendTimelineEntry({ timelinePath: context.timelinePath, data: scriptConsole.dumpLogs() });
 
   // console.log('mutatedInsomniaObject', mutatedContextObject);
   // console.log('context', context);


### PR DESCRIPTION
## Summary
- inject timeline appends into `runScript()` so the Node/main-process runner no longer depends on renderer APIs
- branch script execution in the concurrency and cancellation paths so main process uses direct Node execution while renderer keeps the hidden window path
- use `fs.promises.appendFile` for main-process timeline writes where script execution logs are persisted

## Why
This removes the remaining renderer-only dependency from the Node.js script execution path, which unblocks main-process and inso script execution without `window.main`.

## Validation
- `npm test -w packages/insomnia -- src/network/__tests__/network.test.ts`
- `npm run type-check -w packages/insomnia` *(blocked by existing worktree/setup issue resolving `@react-router/fs-routes`, unrelated to this branch)*