### PR TITLE
chore: normalize konnect api responses

### DIFF
--- a/packages/insomnia/src/konnect/__tests__/api.test.ts
+++ b/packages/insomnia/src/konnect/__tests__/api.test.ts
@@ -116,9 +116,9 @@ describe('validatePat', () => {
 
 describe('fetchAllControlPlanes', () => {
   it('yields a single page when total <= PAGE_SIZE', async () => {
-    const cps = [{ id: 'cp-1', name: 'CP 1', description: '', config: { cluster_type: 'HYBRID', control_plane_endpoint: '' } }];
+    const page1Data = [{ id: 'cp-1', name: 'CP 1', description: '', config: { cluster_type: 'HYBRID', control_plane_endpoint: '' } }];
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
-      jsonResponse({ data: cps, meta: { page: { total: 1, size: 100, number: 1 } } }),
+      jsonResponse({ data: page1Data, meta: { page: { total: 1, size: 100, number: 1 } } }),
     ));
 
     const pages: any[][] = [];
@@ -127,7 +127,7 @@ describe('fetchAllControlPlanes', () => {
     }
 
     expect(pages).toHaveLength(1);
-    expect(pages[0]).toEqual(cps);
+    expect(pages[0]).toEqual(page1Data.map(cp => ({ ...cp, proxy_urls: null })));
   });
 
   it('yields multiple pages when total > PAGE_SIZE', async () => {
@@ -148,7 +148,7 @@ describe('fetchAllControlPlanes', () => {
 
     expect(pages).toHaveLength(2);
     expect(pages[0]).toHaveLength(100);
-    expect(pages[1]).toEqual(page2Data);
+    expect(pages[1]).toEqual(page2Data.map(cp => ({ ...cp, proxy_urls: null })));
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock.mock.calls[0][0]).toContain('page[number]=1');
     expect(fetchMock.mock.calls[1][0]).toContain('page[number]=2');
@@ -401,7 +401,7 @@ describe('retry on 429', () => {
     await iterPromise;
 
     expect(pages).toHaveLength(1);
-    expect(pages[0]).toEqual(page1Data);
+    expect(pages[0]).toEqual(page1Data.map(cp => ({ ...cp, proxy_urls: null })));
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/insomnia/src/konnect/__tests__/api.test.ts
+++ b/packages/insomnia/src/konnect/__tests__/api.test.ts
@@ -161,6 +161,24 @@ describe('fetchAllControlPlanes', () => {
     await expect(gen.next()).rejects.toThrow('Konnect API error 500 fetching control planes');
   });
 
+  it('normalizes omitted proxy_urls to null', async () => {
+    // The fetch boundary owns the `T | null` type contract: every nullable
+    // field must be defined, even when the upstream payload omits it. Without
+    // this, downstream code reading `controlPlane.proxy_urls` would see
+    // `undefined` despite the type saying otherwise.
+    const rawCp = { id: 'cp-1', name: 'CP 1', description: '', config: { cluster_type: 'HYBRID', control_plane_endpoint: '' } };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      jsonResponse({ data: [rawCp], meta: { page: { total: 1, size: 100, number: 1 } } }),
+    ));
+
+    const pages: any[][] = [];
+    for await (const page of fetchAllControlPlanes('faketoken')) {
+      pages.push(page);
+    }
+
+    expect(pages[0][0]).toEqual({ ...rawCp, proxy_urls: null });
+  });
+
   it('yields empty data when total is 0', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
       jsonResponse({ data: [], meta: { page: { total: 0, size: 100, number: 1 } } }),
@@ -218,6 +236,19 @@ describe('fetchAllServices', () => {
     expect(fetchMock.mock.calls[0][0]).toMatch(/^https:\/\/eu\.api\.konghq\.com/);
   });
 
+  it('normalizes omitted nullable fields (name, path, tags) to null', async () => {
+    // The fetch boundary owns the `T | null` type contract: every nullable
+    // field must be defined, even when the upstream payload omits it. If a
+    // future change drops this normalization, downstream consumers reading
+    // `service.name` would see `undefined` despite the type saying otherwise.
+    const rawSvc = { id: 'svc-1', protocol: 'http', host: 'h', port: 80, enabled: true };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ data: [rawSvc], offset: null })));
+
+    const result = await fetchAllServices('faketoken', 'cp-1', 'us');
+
+    expect(result[0]).toEqual({ ...rawSvc, name: null, path: null, tags: null });
+  });
+
   it('throws on non-ok response', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('', { status: 502 })));
 
@@ -251,6 +282,30 @@ describe('fetchRoutesForService', () => {
     await fetchRoutesForService('faketoken', 'cp-1', 'svc-42', 'us');
 
     expect(fetchMock.mock.calls[0][0]).toContain('/services/svc-42/routes');
+  });
+
+  it('normalizes omitted nullable fields to null so sanitizeRoute can rely on them', async () => {
+    // The fetch boundary owns the `T | null` type contract: every nullable
+    // field must be defined, even when the upstream payload omits it.
+    // sanitizeRoute uses strict `!== null` checks on name/expression, so if
+    // this normalization regresses we'd hit `stripTemplateSyntax(undefined)`
+    // at runtime — caught here instead of in production.
+    const rawRoute = { id: 'r-1', protocols: ['http'] };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ data: [rawRoute], offset: null })));
+
+    const result = await fetchRoutesForService('faketoken', 'cp-1', 'svc-1', 'us');
+
+    expect(result[0]).toEqual({
+      ...rawRoute,
+      name: null,
+      methods: null,
+      paths: null,
+      hosts: null,
+      headers: null,
+      snis: null,
+      expression: null,
+      service: null,
+    });
   });
 });
 

--- a/packages/insomnia/src/konnect/__tests__/sync.test.ts
+++ b/packages/insomnia/src/konnect/__tests__/sync.test.ts
@@ -28,6 +28,7 @@ function makeCp(overrides: Partial<KonnectControlPlane> = {}): KonnectControlPla
       cluster_type: 'CLUSTER_TYPE_HYBRID',
       control_plane_endpoint: 'https://abc123.us.cp0.konghq.com',
     },
+    proxy_urls: null,
     ...overrides,
   };
 }

--- a/packages/insomnia/src/konnect/api.ts
+++ b/packages/insomnia/src/konnect/api.ts
@@ -51,10 +51,11 @@ export interface KonnectRoute {
   service: { id: string } | null;
 }
 
-// The Konnect API sometimes omits nullable fields rather than returning `null`.
-// These normalizers run on every entity as it comes off the wire, so the rest
-// of the codebase can rely on the declared `T | null` shape without defensive
-// `?? null` / `arr == null` checks.
+// Boundary normalizers — coerce any missing nullable field to `null` so the
+// declared `T | null` types are honest. Defending against `undefined` once
+// here lets every downstream consumer use strict `=== null` checks and skip
+// the `?? null` / `arr == null` defensive plumbing that otherwise leaks
+// through sanitizeRoute, sync.ts, expression-parser, etc.
 function normalizeControlPlane(cp: KonnectControlPlane): KonnectControlPlane {
   return { ...cp, proxy_urls: cp.proxy_urls ?? null };
 }

--- a/packages/insomnia/src/konnect/api.ts
+++ b/packages/insomnia/src/konnect/api.ts
@@ -24,7 +24,7 @@ export interface KonnectControlPlane {
     cluster_type: string;
     control_plane_endpoint: string;
   };
-  proxy_urls?: KonnectProxyUrl[] | null;
+  proxy_urls: KonnectProxyUrl[] | null;
 }
 
 export interface KonnectService {
@@ -49,6 +49,32 @@ export interface KonnectRoute {
   snis: string[] | null;
   expression: string | null;
   service: { id: string } | null;
+}
+
+// The Konnect API sometimes omits nullable fields rather than returning `null`.
+// These normalizers run on every entity as it comes off the wire, so the rest
+// of the codebase can rely on the declared `T | null` shape without defensive
+// `?? null` / `arr == null` checks.
+function normalizeControlPlane(cp: KonnectControlPlane): KonnectControlPlane {
+  return { ...cp, proxy_urls: cp.proxy_urls ?? null };
+}
+
+function normalizeService(s: KonnectService): KonnectService {
+  return { ...s, name: s.name ?? null, path: s.path ?? null, tags: s.tags ?? null };
+}
+
+function normalizeRoute(r: KonnectRoute): KonnectRoute {
+  return {
+    ...r,
+    name: r.name ?? null,
+    methods: r.methods ?? null,
+    paths: r.paths ?? null,
+    hosts: r.hosts ?? null,
+    headers: r.headers ?? null,
+    snis: r.snis ?? null,
+    expression: r.expression ?? null,
+    service: r.service ?? null,
+  };
 }
 
 async function fetchWithRetry(url: string, pat: string, signal?: AbortSignal): Promise<Response> {
@@ -121,7 +147,7 @@ export async function* fetchAllControlPlanes(
     const total: number = body?.meta?.page?.total ?? 0;
     totalPages = Math.ceil(total / PAGE_SIZE) || 1;
 
-    yield body.data as KonnectControlPlane[];
+    yield (body.data as KonnectControlPlane[]).map(normalizeControlPlane);
     page++;
   } while (page <= totalPages);
 }
@@ -157,12 +183,13 @@ export async function fetchAllServices(
   region: string,
   signal?: AbortSignal,
 ): Promise<KonnectService[]> {
-  return fetchAllOffsetPaginated<KonnectService>(
+  const services = await fetchAllOffsetPaginated<KonnectService>(
     `${regionalApiBase(region)}/v2/control-planes/${cpId}/core-entities/services`,
     pat,
     `fetching services for CP ${cpId}`,
     signal,
   );
+  return services.map(normalizeService);
 }
 
 export async function fetchRoutesForService(
@@ -172,12 +199,13 @@ export async function fetchRoutesForService(
   region: string,
   signal?: AbortSignal,
 ): Promise<KonnectRoute[]> {
-  return fetchAllOffsetPaginated<KonnectRoute>(
+  const routes = await fetchAllOffsetPaginated<KonnectRoute>(
     `${regionalApiBase(region)}/v2/control-planes/${cpId}/core-entities/services/${serviceId}/routes`,
     pat,
     `fetching routes for service ${serviceId}`,
     signal,
   );
+  return routes.map(normalizeRoute);
 }
 
 function regionalApiBase(region: string): string {


### PR DESCRIPTION
The Konnect API started omitting a nullable field, breaking sync. This PR introduces more stringent API response normalization to explicitly handle these cases.