### PR TITLE
chore: comment out smctl credentials save in workflow

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -141,7 +141,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          smctl credentials save ${SM_API_KEY} ${SM_CLIENT_CERT_PASSWORD}
+          # smctl credentials save ${SM_API_KEY} ${SM_CLIENT_CERT_PASSWORD}
           NODE_OPTIONS='--max_old_space_size=6144' npm run package:windows:unpacked -w insomnia
         env:
           SM_HOST: ${{ vars.DIGICERT_SM_HOST }}


### PR DESCRIPTION
Saving smctl credentials seems not to be necessary according [this test](https://github.com/Kong/insomnia/actions/runs/25425929814?pr=9897).
The command is no longer executed while keeping it in place for future reference.