### PR TITLE
fix: delete file in watcher

### DIFF
--- a/packages/insomnia/src/sync/git/repo-file-watcher.ts
+++ b/packages/insomnia/src/sync/git/repo-file-watcher.ts
@@ -371,6 +371,16 @@ class RepoFileWatcher {
    */
   private async flushProjectWorkspacesToDisk(): Promise<void> {
     const entries = await this.getWorkspacesWithMeta();
+    const currentWorkspaceIds = new Set(entries.map(({ workspace }) => workspace._id));
+
+    // find deleted workspace and remove their files from disk
+    for (const [workspaceId, absPath] of Array.from(this.lastKnownGitFilePath.entries())) {
+      if (currentWorkspaceIds.has(workspaceId)) {
+        continue;
+      }
+
+      await this.removeWorkspaceFileFromDisk(workspaceId, absPath);
+    }
 
     for (const { workspace, meta } of entries) {
       if (this.stopped) {
@@ -407,16 +417,7 @@ class RepoFileWatcher {
 
         // New file written successfully — now safe to remove the old one
         if (isRename) {
-          try {
-            await fs.promises.unlink(previousAbsPath);
-            console.log('[repo-file-watcher] Removed old file after rename:', previousAbsPath, '→', absPath);
-          } catch {
-            // Old file may already be gone — that's fine
-          }
-          // Clean up tracking for the old path so the watcher doesn't
-          // try to re-import a file that no longer exists
-          this.lastSyncMtime.delete(previousAbsPath);
-          this.lastWrittenHash.delete(previousAbsPath);
+          await this.removeWorkspaceFileFromDisk(workspace._id, previousAbsPath);
         }
 
         // Record hash + mtime so the FS→DB side skips this echo
@@ -701,6 +702,26 @@ class RepoFileWatcher {
     this.lastSyncMtime.delete(normalised);
     this.lastWrittenHash.delete(normalised);
     this.clearProblem(normalised);
+  }
+
+  private cleanupRemovedWorkspaceFileTracking(workspaceId: string, normalisedPath: string): void {
+    if (this.lastKnownGitFilePath.get(workspaceId) === normalisedPath) {
+      this.lastKnownGitFilePath.delete(workspaceId);
+    }
+    this.lastSyncMtime.delete(normalisedPath);
+    this.lastWrittenHash.delete(normalisedPath);
+    this.clearProblem(normalisedPath);
+  }
+
+  private async removeWorkspaceFileFromDisk(workspaceId: string, normalisedPath: string): Promise<void> {
+    try {
+      await fs.promises.unlink(normalisedPath);
+      console.log('[repo-file-watcher] Removed workspace file from disk:', workspaceId, normalisedPath);
+    } catch {
+      // Old file may already be gone — that's fine.
+    }
+
+    this.cleanupRemovedWorkspaceFileTracking(workspaceId, normalisedPath);
   }
 
   /** Convert an absolute path to a posix-style path relative to the repo root. */

--- a/packages/insomnia/src/sync/git/repo-file-watcher.ts
+++ b/packages/insomnia/src/sync/git/repo-file-watcher.ts
@@ -373,7 +373,7 @@ class RepoFileWatcher {
     const entries = await this.getWorkspacesWithMeta();
     const currentWorkspaceIds = new Set(entries.map(({ workspace }) => workspace._id));
 
-    // find deleted workspace and remove their files from disk
+    // Find deleted workspaces and remove their files from disk.
     for (const [workspaceId, absPath] of Array.from(this.lastKnownGitFilePath.entries())) {
       if (currentWorkspaceIds.has(workspaceId)) {
         continue;

--- a/packages/insomnia/src/sync/git/repo-file-watcher.ts
+++ b/packages/insomnia/src/sync/git/repo-file-watcher.ts
@@ -717,11 +717,22 @@ class RepoFileWatcher {
     try {
       await fs.promises.unlink(normalisedPath);
       console.log('[repo-file-watcher] Removed workspace file from disk:', workspaceId, normalisedPath);
-    } catch {
-      // Old file may already be gone — that's fine.
-    }
+      this.cleanupRemovedWorkspaceFileTracking(workspaceId, normalisedPath);
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      if (err.code === 'ENOENT') {
+        // Old file may already be gone — that's fine.
+        this.cleanupRemovedWorkspaceFileTracking(workspaceId, normalisedPath);
+        return;
+      }
 
-    this.cleanupRemovedWorkspaceFileTracking(workspaceId, normalisedPath);
+      console.warn(
+        '[repo-file-watcher] Failed to remove workspace file from disk:',
+        workspaceId,
+        normalisedPath,
+        err,
+      );
+    }
   }
 
   /** Convert an absolute path to a posix-style path relative to the repo root. */


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
This pull request enhances the workspace file cleanup logic in the `RepoFileWatcher` class to ensure that files associated with deleted workspaces are properly removed from disk and their tracking data is cleaned up. The main improvements are in file deletion and tracking, particularly when workspaces are deleted or renamed.

**Workspace file cleanup improvements:**

* Added logic in `flushProjectWorkspacesToDisk` to detect deleted workspaces and remove their files from disk using a new helper method.
* Refactored file removal during workspace renames to use the new `removeWorkspaceFileFromDisk` method, ensuring consistent cleanup.

**Tracking data management:**

* Introduced `cleanupRemovedWorkspaceFileTracking` to centralize removal of tracking data for deleted files.
* Added `removeWorkspaceFileFromDisk`, which handles both file deletion and associated tracking cleanup, and is tolerant of missing files.