### PR TITLE
feat: enrich Request Executed analytics event with script, param, and certificate properties

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx
@@ -6,12 +6,14 @@ import { v4 as uuidv4 } from 'uuid';
 import { getContentDispositionHeader } from '~/common/misc';
 import type {
   Environment,
+  Request,
+  RequestGroup,
   RequestMeta,
   ResponseInfo,
   RunnerResultPerRequestPerIteration,
   UserUploadEnvironment,
 } from '~/insomnia-data';
-import { models, services } from '~/insomnia-data';
+import { database as db, models, services } from '~/insomnia-data';
 import type { ResponsePatch } from '~/main/network/libcurl-promise';
 import type { TimingStep } from '~/main/network/request-timing';
 import {
@@ -334,7 +336,7 @@ export const sendActionImplementation = async (options: {
 };
 
 export async function clientAction({ request, params }: Route.ClientActionArgs) {
-  const { requestId } = params;
+  const { requestId, workspaceId } = params;
   const { shouldPromptForPathAfterResponse, ignoreUndefinedEnvVariable } = (await request.json()) as SendActionParams;
 
   try {
@@ -353,6 +355,20 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
         const activeRequest = await services.request.getById(requestId);
 
         if (activeRequest) {
+          const [requestAndAncestors, clientCertificates] = await Promise.all([
+            db.withAncestors<Request | RequestGroup>(
+              activeRequest as Request,
+              [models.request.type, models.requestGroup.type],
+            ),
+            services.clientCertificate.findByParentId(workspaceId),
+          ]);
+          const docsWithScripts = requestAndAncestors.filter(
+            (doc): doc is Request | RequestGroup =>
+              models.request.isRequest(doc) || models.requestGroup.isRequestGroup(doc),
+          );
+          const allPreScripts = docsWithScripts.map(doc => doc.preRequestScript).filter((s): s is string => !!s);
+          const allPostScripts = docsWithScripts.map(doc => doc.afterResponseScript).filter((s): s is string => !!s);
+
           window.main.trackSegmentEvent({
             event: SegmentEvent.requestExecuted,
             properties: {
@@ -365,10 +381,14 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
               count_headers: response.headers.length,
               count_cookies: response.headers.find(h => h.name === 'set-cookie')?.value.split(',').length || 0,
               count_tests: response.requestTestResults?.length || 0,
-              has_prescript: !!activeRequest.preRequestScript,
-              has_postscript: !!activeRequest.afterResponseScript,
-              count_prescript_lines: activeRequest.preRequestScript ? activeRequest.preRequestScript.split('\n').length : 0,
-              count_postscript_lines: activeRequest.afterResponseScript ? activeRequest.afterResponseScript.split('\n').length : 0,
+              has_prescript: allPreScripts.length > 0,
+              has_postscript: allPostScripts.length > 0,
+              count_prescript_lines: allPreScripts.reduce((sum, s) => sum + s.split('\n').length, 0),
+              count_postscript_lines: allPostScripts.reduce((sum, s) => sum + s.split('\n').length, 0),
+              count_query_parameters: activeRequest.parameters?.length ?? 0,
+              count_path_parameters: activeRequest.pathParameters?.length ?? 0,
+              has_docs: !!activeRequest.description,
+              count_certificates: clientCertificates.length,
             },
           });
 

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx
@@ -365,6 +365,10 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
               count_headers: response.headers.length,
               count_cookies: response.headers.find(h => h.name === 'set-cookie')?.value.split(',').length || 0,
               count_tests: response.requestTestResults?.length || 0,
+              has_prescript: !!activeRequest.preRequestScript,
+              has_postscript: !!activeRequest.afterResponseScript,
+              count_prescript_lines: activeRequest.preRequestScript ? activeRequest.preRequestScript.split('\n').length : 0,
+              count_postscript_lines: activeRequest.afterResponseScript ? activeRequest.afterResponseScript.split('\n').length : 0,
             },
           });
 


### PR DESCRIPTION
- [x] Adds has_prescript, has_postscript, count_prescript_lines, count_postscript_lines to the Request Executed Segment event, script values are aggregated across the request and all ancestor folders, matching the source of truth used during execution (tryToExecutePreRequestScript / tryToExecuteAfterResponseScript)
- [x] Adds count_query_parameters, count_path_parameters, has_docs, count_certificates to bring Request Executed to full parity with Request Created
