### PR TITLE
fix: ensure plugin directory exists before showing it

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/app.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/app.test.ts
@@ -5,8 +5,9 @@ import { test } from '../../playwright/test';
 test('can send requests', async ({ page, insomnia }) => {
   test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
 
-  const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
+  const statusTag = page.getByTestId('response-pane').getByTestId('response-status-tag');
   const responseBody = page.getByTestId('response-pane');
+  const responsePreviewBody = page.locator('[data-testid="response-pane"] >> [data-testid="CodeEditor"]:visible');
 
   await insomnia.projectPage.importFixture('smoke-test-collection.yaml');
 
@@ -33,10 +34,10 @@ test('can send requests', async ({ page, insomnia }) => {
     .toBeVisible();
   await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
   await expect.soft(statusTag).toContainText('200 OK');
-  await expect.soft(responseBody).toContainText('"id": "1"');
+  await expect.soft(responsePreviewBody).toContainText('"id": "1"');
   await page.getByRole('button', { name: 'Preview' }).click();
   await page.getByRole('menuitem', { name: 'Raw Data' }).click();
-  await expect.soft(responseBody).toContainText('{"id":"1"}');
+  await expect.soft(responsePreviewBody).toContainText('{"id":"1"}');
 
   await page
     .getByLabel('Request Collection')
@@ -47,7 +48,7 @@ test('can send requests', async ({ page, insomnia }) => {
     .toBeVisible();
   await page.getByTestId('request-pane').getByRole('button', { name: 'Connect' }).click();
   await expect.soft(statusTag).toContainText('200 OK');
-  await page.getByRole('tab', { name: 'Console' }).click();
+  await page.getByTestId('response-pane').getByRole('tab', { name: 'Console' }).click();
   await expect.soft(responseBody).toContainText('Connected to 127.0.0.1');
   await page.getByTestId('request-pane').getByRole('button', { name: 'Disconnect' }).click();
 
@@ -64,7 +65,7 @@ test('can send requests', async ({ page, insomnia }) => {
   await expect.soft(statusTag).toContainText('200 OK');
   await page.getByRole('button', { name: 'Preview' }).click();
   await page.getByRole('menuitem', { name: 'Raw Data' }).click();
-  await expect.soft(responseBody).toContainText('a,b,c');
+  await expect.soft(responsePreviewBody).toContainText('a,b,c');
 
   await page
     .getByLabel('Request Collection')
@@ -77,8 +78,8 @@ test('can send requests', async ({ page, insomnia }) => {
     .toBeVisible();
   await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
   await expect.soft(statusTag).toContainText('200 OK');
-  await expect.soft(responseBody).toContainText('xml version="1.0"');
-  await expect.soft(responseBody).toContainText('<LoginResult>');
+  await expect.soft(responsePreviewBody).toContainText('xml version="1.0"');
+  await expect.soft(responsePreviewBody).toContainText('<LoginResult>');
 
   await page
     .getByLabel('Request Collection')
@@ -110,13 +111,18 @@ test('can send requests', async ({ page, insomnia }) => {
     timeout: 5000,
   });
 
-  await page.getByRole('tab', { name: 'Console' }).click();
+  await page.getByTestId('response-pane').getByRole('tab', { name: 'Console' }).click();
   await page.locator('pre').filter({ hasText: '< Content-Type: application/pdf' }).click();
+  await page.getByTestId('response-pane').getByRole('tab', { name: 'Preview' }).click();
 
   await page.getByLabel('Request Collection').getByTestId('sends request with basic authentication').press('Enter');
+  await expect
+    .soft(page.getByTestId('request-pane').getByTestId('OneLineEditor').getByText('http://127.0.0.1:4010/auth/basic'))
+    .toBeVisible();
   await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
   await expect.soft(statusTag).toContainText('200 OK');
-  await expect.soft(responseBody).toContainText('basic auth received');
+  await page.getByTestId('response-pane').getByRole('tab', { name: 'Preview' }).click();
+  await expect.soft(responsePreviewBody).toContainText('basic auth received');
 
   await page
     .getByLabel('Request Collection')
@@ -127,7 +133,7 @@ test('can send requests', async ({ page, insomnia }) => {
     .toBeVisible();
   await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
   await expect.soft(statusTag).toContainText('200 OK');
-  await page.getByRole('tab', { name: 'Console' }).click();
+  await page.getByTestId('response-pane').getByRole('tab', { name: 'Console' }).click();
   await expect.soft(responseBody).toContainText('Set-Cookie: insomnia-test-cookie=value123');
 
   await page.getByLabel('Request Collection').getByTestId('delayed request').press('Enter');

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -399,8 +399,7 @@ export function registerMainHandlers() {
   ipcMainHandle('readDir', readDir);
 
   ipcMainHandle('readOrCreateDataDir', async (_, options: { folder: string }) => {
-    const dataPath = app.getPath('userData');
-    const folderPath = path.join(dataPath, options.folder);
+    const folderPath = path.join(app.getPath('userData'), options.folder);
     mkdirSync(folderPath, { recursive: true });
     return readDir(_, { path: folderPath });
   });

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -401,7 +401,11 @@ export function registerMainHandlers() {
   ipcMainHandle('readOrCreateDataDir', async (_, options: { folder: string }) => {
     const folderPath = path.join(app.getPath('userData'), options.folder);
     mkdirSync(folderPath, { recursive: true });
-    return readDir(_, { path: folderPath });
+    try {
+      return await readDir(_, { path: folderPath });
+    } catch {
+      return [];
+    }
   });
 
   ipcMainHandle('curlRequest', (_, options: Parameters<typeof curlRequest>[0]) => {

--- a/packages/insomnia/src/ui/components/settings/plugins.tsx
+++ b/packages/insomnia/src/ui/components/settings/plugins.tsx
@@ -394,9 +394,7 @@ export const Plugins: FC = () => {
                     patchSettings({ npmRegistryUrl: trimmedRegistryUrl });
                   }}
                 />
-                <FieldError className="text-xs text-(--color-danger)">
-                  {npmRegistryUrlError}
-                </FieldError>
+                <FieldError className="text-xs text-(--color-danger)">{npmRegistryUrlError}</FieldError>
               </TextField>
               {npmRegistryUrl && (
                 <Button
@@ -586,11 +584,10 @@ export const Plugins: FC = () => {
             or{' '}
             <Button
               className="text-(--color-surprise) underline"
-              onPress={() =>
-                window.shell.showItemInFolder(
-                  window.path.resolve(process.env['INSOMNIA_DATA_PATH'] || window.app.getPath('userData'), 'plugins'),
-                )
-              }
+              onPress={async () => {
+                await window.main.readOrCreateDataDir({ folder: 'plugins' });
+                window.shell.showItemInFolder(window.path.resolve(window.app.getPath('userData'), 'plugins'));
+              }}
             >
               Reveal Plugins Folder
             </Button>{' '}


### PR DESCRIPTION
Basic fix to ensure the link to reveal the plugins folder always works