### PR TITLE
Fix: Document design page do not show collection list

### DIFF
--- a/packages/insomnia/src/basic-components/modal.tsx
+++ b/packages/insomnia/src/basic-components/modal.tsx
@@ -1,6 +1,6 @@
 import classnames from 'classnames';
 import type React from 'react';
-import { useRef } from 'react';
+import { useLayoutEffect, useRef } from 'react';
 import { Overlay, useOverlay } from 'react-aria';
 import { Button, Dialog, Heading, Modal as RAModal, ModalOverlay } from 'react-aria-components';
 
@@ -13,7 +13,6 @@ interface Props {
   closable?: boolean;
   isDismissable?: boolean;
   className?: string;
-  // Custom parents must already establish a positioning context.
   parent?: HTMLElement | null;
   centered?: boolean;
 }
@@ -50,6 +49,34 @@ export const Modal: React.FC<React.PropsWithChildren<Props>> = ({
     },
     dialogRef,
   );
+
+  useLayoutEffect(() => {
+    if (!isOpen || !hasCustomParent || !parent || window.getComputedStyle(parent).position !== 'static') {
+      return;
+    }
+
+    // Multiple scoped modals can share a parent, so only restore its original
+    // positioning after the last modal using this fallback has closed.
+    const currentCount = Number(parent.dataset.insomniaModalParentCount || '0');
+    if (currentCount === 0) {
+      parent.dataset.insomniaModalParentOriginalPosition = parent.style.position;
+    }
+
+    parent.dataset.insomniaModalParentCount = String(currentCount + 1);
+    parent.style.position = 'relative';
+
+    return () => {
+      const nextCount = Math.max(0, Number(parent.dataset.insomniaModalParentCount || '1') - 1);
+      if (nextCount === 0) {
+        parent.style.position = parent.dataset.insomniaModalParentOriginalPosition || '';
+        delete parent.dataset.insomniaModalParentCount;
+        delete parent.dataset.insomniaModalParentOriginalPosition;
+        return;
+      }
+
+      parent.dataset.insomniaModalParentCount = String(nextCount);
+    };
+  }, [hasCustomParent, isOpen, parent]);
 
   const dialogContent = (
     <>

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
@@ -784,7 +784,7 @@ const Debug = () => {
         ref={sidebarPanelRef}
         autoSaveId="insomnia-sidebar"
         id={WORKSPACE_CONTENT_WRAPPER}
-        className="new-sidebar relative h-full w-full text-(--color-font)"
+        className="new-sidebar h-full w-full text-(--color-font)"
         direction="horizontal"
       >
         {/* Design page has a collection view with legacy collection list */}

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
@@ -48,6 +48,7 @@ import { useRootLoaderData } from '~/root';
 import {
   type Child,
   useWorkspaceLoaderData,
+  WORKSPACE_CONTENT_WRAPPER,
 } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
 import { useDebugReorderActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.reorder';
 import { useRequestLoaderData } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId';
@@ -782,8 +783,8 @@ const Debug = () => {
       <PanelGroup
         ref={sidebarPanelRef}
         autoSaveId="insomnia-sidebar"
-        id="wrapper"
-        className="new-sidebar h-full w-full text-(--color-font)"
+        id={WORKSPACE_CONTENT_WRAPPER}
+        className="new-sidebar relative h-full w-full text-(--color-font)"
         direction="horizontal"
       >
         {/* Design page has a collection view with legacy collection list */}

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
@@ -771,23 +771,25 @@ const Debug = () => {
   const tabNavigate = useTabNavigate();
 
   return (
-    <PanelGroup
-      ref={sidebarPanelRef}
-      autoSaveId="insomnia-sidebar"
-      id="wrapper"
-      className="new-sidebar h-full w-full text-(--color-font)"
-      direction="horizontal"
-    >
-      <Panel className="flex flex-col">
+    <div className="new-sidebar h-full w-full text-(--color-font)">
+      <div className="flex flex-col">
         {/* Hide tabs when it's on the tutorial panel */}
         {!panel && <OrganizationTabList currentPage="debug" />}
         {!panel && !models.organization.isScratchpadOrganizationId(organizationId) && (
           <WorkspacePaneHeader hasSettings />
         )}
-        <PanelGroup autoSaveId="insomnia-panels" className="relative" id="workspace-wrapper" direction="horizontal">
-          {/* Design page has a collection view with legacy collection list */}
-          {isDesignWorkspace && (
-            <Panel id="sidebar" className="sidebar theme--sidebar" maxSize={40} minSize={10} collapsible>
+      </div>
+      <PanelGroup
+        ref={sidebarPanelRef}
+        autoSaveId="insomnia-sidebar"
+        id="wrapper"
+        className="new-sidebar h-full w-full text-(--color-font)"
+        direction="horizontal"
+      >
+        {/* Design page has a collection view with legacy collection list */}
+        {isDesignWorkspace && (
+          <>
+            <Panel id="sidebar" order={1} className="sidebar theme--sidebar" maxSize={40} minSize={10} collapsible>
               <div className="flex flex-1 flex-col divide-y divide-solid divide-(--hl-md) overflow-hidden">
                 <div className="flex flex-col items-start divide-y divide-solid divide-(--hl-md)">
                   {models.workspace.isDesign(activeWorkspace) && (
@@ -1132,8 +1134,10 @@ const Debug = () => {
                 )}
               </div>
             </Panel>
-          )}
-          <PanelResizeHandle className="h-full w-px bg-(--hl-md)" />
+            <PanelResizeHandle className="h-full w-px bg-(--hl-md)" />
+          </>
+        )}
+        <Panel order={2} className="flex flex-col">
           <PanelGroup autoSaveId="insomnia-panels" id="insomnia-panels" direction={direction}>
             <Routes>
               <RouteComponent
@@ -1206,9 +1210,9 @@ const Debug = () => {
               <RouteComponent path="runner" element={<Runner />} />
             </Routes>
           </PanelGroup>
-        </PanelGroup>
-      </Panel>
-    </PanelGroup>
+        </Panel>
+      </PanelGroup>
+    </div>
   );
 };
 

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.tsx
@@ -303,7 +303,7 @@ const Component = ({ loaderData, params }: Route.ComponentProps) => {
         ref={sidebarPanelRef}
         autoSaveId="insomnia-sidebar"
         id={WORKSPACE_CONTENT_WRAPPER}
-        className="new-sidebar relative w-full flex-1 text-(--color-font)"
+        className="new-sidebar w-full flex-1 text-(--color-font)"
         direction="horizontal"
       >
         <Panel

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.tsx
@@ -1,8 +1,6 @@
 import type { IconName, IconProp } from '@fortawesome/fontawesome-svg-core';
 import React, { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import {
-  Breadcrumb,
-  Breadcrumbs,
   Button,
   DropIndicator,
   GridList,
@@ -18,18 +16,19 @@ import {
   useDragAndDrop,
 } from 'react-aria-components';
 import { type ImperativePanelGroupHandle, Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
-import { NavLink } from 'react-router';
 
 import { DEFAULT_SIDEBAR_SIZE } from '~/common/constants';
 import { debounce } from '~/common/misc';
 import type { Environment, EnvironmentKvPairData } from '~/insomnia-data';
 import { EnvironmentKvPairDataType, EnvironmentType, models, services } from '~/insomnia-data';
-import { useWorkspaceLoaderData } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
+import {
+  useWorkspaceLoaderData,
+  WORKSPACE_CONTENT_WRAPPER,
+} from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
 import { useEnvironmentCreateActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.create';
 import { useEnvironmentDeleteActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.delete';
 import { useEnvironmentDuplicateActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.duplicate';
 import { useEnvironmentUpdateActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.update';
-import { WorkspaceDropdown } from '~/ui/components/dropdowns/workspace-dropdown';
 import { EditableInput } from '~/ui/components/editable-input';
 import {
   EnvironmentEditor,
@@ -44,7 +43,6 @@ import { AlertModal } from '~/ui/components/modals/alert-modal';
 import { InputVaultKeyModal } from '~/ui/components/modals/input-vault-key-modal';
 import { OrganizationTabList } from '~/ui/components/tabs/tab-list';
 import WorkspacePaneHeader from '~/ui/components/workspace/workspace-pane-header';
-import { INSOMNIA_TAB_HEIGHT } from '~/ui/constant';
 import { useOrganizationPermissions } from '~/ui/hooks/use-organization-features';
 import { useToggleEnvironmentType } from '~/ui/hooks/use-toggle-environment-type';
 import { getDataFromKVPair } from '~/utils/environment-utils';
@@ -304,7 +302,7 @@ const Component = ({ loaderData, params }: Route.ComponentProps) => {
       <PanelGroup
         ref={sidebarPanelRef}
         autoSaveId="insomnia-sidebar"
-        id="workspace-wrapper"
+        id={WORKSPACE_CONTENT_WRAPPER}
         className="new-sidebar relative w-full flex-1 text-(--color-font)"
         direction="horizontal"
       >

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.tsx
@@ -236,7 +236,7 @@ const Component = () => {
         ref={sidebarPanelRef}
         autoSaveId="insomnia-sidebar"
         id={WORKSPACE_CONTENT_WRAPPER}
-        className="new-sidebar relative w-full flex-1 text-(--color-font)"
+        className="new-sidebar w-full flex-1 text-(--color-font)"
         direction="horizontal"
       >
         <Panel

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.tsx
@@ -1,20 +1,9 @@
 import type { IconName } from '@fortawesome/fontawesome-svg-core';
 import React, { Suspense, useEffect, useLayoutEffect, useRef, useState } from 'react';
-import {
-  Breadcrumb,
-  Breadcrumbs,
-  Button,
-  GridList,
-  GridListItem,
-  Menu,
-  MenuItem,
-  MenuTrigger,
-  Popover,
-} from 'react-aria-components';
+import { Button, GridList, GridListItem, Menu, MenuItem, MenuTrigger, Popover } from 'react-aria-components';
 import { type ImperativePanelGroupHandle, Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import {
   href,
-  NavLink,
   redirect,
   Route as RouteComponent,
   Routes,
@@ -27,9 +16,11 @@ import { DEFAULT_SIDEBAR_SIZE } from '~/common/constants';
 import type { MockRoute } from '~/insomnia-data';
 import { services } from '~/insomnia-data';
 import { useRootLoaderData } from '~/root';
-import { useWorkspaceLoaderData } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
+import {
+  useWorkspaceLoaderData,
+  WORKSPACE_CONTENT_WRAPPER,
+} from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
 import { useMockRouteDeleteActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.mock-route.$mockRouteId.delete';
-import { WorkspaceDropdown } from '~/ui/components/dropdowns/workspace-dropdown';
 import { Icon } from '~/ui/components/icon';
 import { useDocBodyKeyboardShortcuts } from '~/ui/components/keydown-binder';
 import { showModal } from '~/ui/components/modals';
@@ -41,7 +32,6 @@ import { OrganizationTabList } from '~/ui/components/tabs/tab-list';
 import { formatMethodName } from '~/ui/components/tags/method-tag';
 import { showResourceNotFoundToast } from '~/ui/components/toast-notification';
 import WorkspacePaneHeader from '~/ui/components/workspace/workspace-pane-header';
-import { INSOMNIA_TAB_HEIGHT } from '~/ui/constant';
 import { useTabNavigate } from '~/ui/hooks/use-insomnia-tab';
 import { isPrimaryClickModifier } from '~/ui/utils';
 
@@ -245,7 +235,7 @@ const Component = () => {
       <PanelGroup
         ref={sidebarPanelRef}
         autoSaveId="insomnia-sidebar"
-        id="workspace-wrapper"
+        id={WORKSPACE_CONTENT_WRAPPER}
         className="new-sidebar relative w-full flex-1 text-(--color-font)"
         direction="horizontal"
       >

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx
@@ -468,7 +468,7 @@ const Component = ({ params }: Route.ComponentProps) => {
         ref={sidebarPanelRef}
         autoSaveId="insomnia-sidebar"
         id={WORKSPACE_CONTENT_WRAPPER}
-        className="new-sidebar relative w-full flex-1 text-(--color-font)"
+        className="new-sidebar w-full flex-1 text-(--color-font)"
         direction="horizontal"
       >
         <Panel

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx
@@ -3,8 +3,6 @@ import CodeMirror from 'codemirror';
 import type { OpenAPIV3 } from 'openapi-types';
 import { Fragment, type ReactNode, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
-  Breadcrumb,
-  Breadcrumbs,
   Button,
   GridList,
   GridListItem,
@@ -20,7 +18,7 @@ import {
   TooltipTrigger,
 } from 'react-aria-components';
 import { type ImperativePanelGroupHandle, Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
-import { href, NavLink, redirect, useLoaderData } from 'react-router';
+import { href, redirect, useLoaderData } from 'react-router';
 import * as reactUse from 'react-use';
 import { SwaggerUIBundle } from 'swagger-ui-dist';
 import YAML from 'yaml';
@@ -30,7 +28,10 @@ import { DEFAULT_SIDEBAR_SIZE } from '~/common/constants';
 import { debounce } from '~/common/misc';
 import { models, services } from '~/insomnia-data';
 import { useRootLoaderData } from '~/root';
-import { useWorkspaceLoaderData } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
+import {
+  useWorkspaceLoaderData,
+  WORKSPACE_CONTENT_WRAPPER,
+} from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
 import { useSpecGenerateRequestCollectionActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.generate-request-collection';
 import { useSpecUpdateActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.update';
 import { useStorageRulesLoaderFetcher } from '~/routes/organization.$organizationId.storage-rules';
@@ -38,7 +39,6 @@ import { SegmentEvent } from '~/ui/analytics';
 import { CodeEditor, type CodeEditorHandle } from '~/ui/components/.client/codemirror/code-editor';
 import { DesignEmptyState } from '~/ui/components/design-empty-state';
 import { DocumentTab } from '~/ui/components/document-tab';
-import { WorkspaceDropdown } from '~/ui/components/dropdowns/workspace-dropdown';
 import { Icon } from '~/ui/components/icon';
 import { useDocBodyKeyboardShortcuts } from '~/ui/components/keydown-binder';
 import { showError } from '~/ui/components/modals';
@@ -50,7 +50,6 @@ import { OrganizationTabList } from '~/ui/components/tabs/tab-list';
 import { formatMethodName } from '~/ui/components/tags/method-tag';
 import { showResourceNotFoundToast, showToast } from '~/ui/components/toast-notification';
 import WorkspacePaneHeader from '~/ui/components/workspace/workspace-pane-header';
-import { INSOMNIA_TAB_HEIGHT } from '~/ui/constant';
 import { useLoaderDeferData } from '~/ui/hooks/use-loader-defer-data';
 import { useAIFeatureStatus } from '~/ui/hooks/use-organization-features';
 import { useGitVCSVersion } from '~/ui/hooks/use-vcs-version';
@@ -468,7 +467,7 @@ const Component = ({ params }: Route.ComponentProps) => {
       <PanelGroup
         ref={sidebarPanelRef}
         autoSaveId="insomnia-sidebar"
-        id="workspace-wrapper"
+        id={WORKSPACE_CONTENT_WRAPPER}
         className="new-sidebar relative w-full flex-1 text-(--color-font)"
         direction="horizontal"
       >

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.tsx
@@ -283,7 +283,7 @@ const Component = () => {
         ref={sidebarPanelRef}
         autoSaveId="insomnia-sidebar"
         id={WORKSPACE_CONTENT_WRAPPER}
-        className="new-sidebar relative w-full flex-1 text-(--color-font)"
+        className="new-sidebar w-full flex-1 text-(--color-font)"
         direction="horizontal"
       >
         <Panel

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.tsx
@@ -1,8 +1,6 @@
 import type { IconName } from '@fortawesome/fontawesome-svg-core';
 import { Suspense, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import {
-  Breadcrumb,
-  Breadcrumbs,
   Button,
   DropIndicator,
   GridList,
@@ -15,7 +13,7 @@ import {
   useDragAndDrop,
 } from 'react-aria-components';
 import { type ImperativePanelGroupHandle, Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
-import { NavLink, Route as RouteComponent, Routes, useFetchers, useLoaderData, useParams } from 'react-router';
+import { Route as RouteComponent, Routes, useFetchers, useLoaderData, useParams } from 'react-router';
 
 import { DEFAULT_SIDEBAR_SIZE } from '~/common/constants';
 import { database } from '~/common/database';
@@ -28,7 +26,6 @@ import { TestRunStatus } from '~/routes/organization.$organizationId.project.$pr
 import { useTestSuiteUpdateActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.update';
 import { useTestSuiteNewActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.new';
 import { DocumentTab } from '~/ui/components/document-tab';
-import { WorkspaceDropdown } from '~/ui/components/dropdowns/workspace-dropdown';
 import { EditableInput } from '~/ui/components/editable-input';
 import { ErrorBoundary } from '~/ui/components/error-boundary';
 import { Icon } from '~/ui/components/icon';
@@ -41,13 +38,15 @@ import { CertificatesModal } from '~/ui/components/modals/workspace-certificates
 import { WorkspaceEnvironmentsEditModal } from '~/ui/components/modals/workspace-environments-edit-modal';
 import { OrganizationTabList } from '~/ui/components/tabs/tab-list';
 import WorkspacePaneHeader from '~/ui/components/workspace/workspace-pane-header';
-import { INSOMNIA_TAB_HEIGHT } from '~/ui/constant';
 import { useTabNavigate } from '~/ui/hooks/use-insomnia-tab';
 import { isPrimaryClickModifier } from '~/ui/utils';
 import { invariant } from '~/utils/invariant';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.test';
-import { useWorkspaceLoaderData } from './organization.$organizationId.project.$projectId.workspace.$workspaceId';
+import {
+  useWorkspaceLoaderData,
+  WORKSPACE_CONTENT_WRAPPER,
+} from './organization.$organizationId.project.$projectId.workspace.$workspaceId';
 import TestSuiteComponent from './organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId';
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
@@ -283,7 +282,7 @@ const Component = () => {
       <PanelGroup
         ref={sidebarPanelRef}
         autoSaveId="insomnia-sidebar"
-        id="workspace-wrapper"
+        id={WORKSPACE_CONTENT_WRAPPER}
         className="new-sidebar relative w-full flex-1 text-(--color-font)"
         direction="horizontal"
       >

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.tsx
@@ -393,6 +393,9 @@ export const revalidateWorkspaceActiveRequestByFolder = async (requestGroup: Req
   }
 };
 
+// This id is the wrapper element ID for workspace page content, representing the part of the workspace route component excluding tabs and breadcrumbs.
+export const WORKSPACE_CONTENT_WRAPPER = 'workspace-wrapper';
+
 const Component = () => {
   const navigate = useNavigate();
   const { organizationId, projectId, workspaceId } = useParams() as {
@@ -424,7 +427,7 @@ const Component = () => {
       return;
     }
 
-    setModalParent(document.getElementById('workspace-wrapper'));
+    setModalParent(document.getElementById(WORKSPACE_CONTENT_WRAPPER));
   }, [isIssueModalOpen, workspaceId]);
 
   return (

--- a/packages/insomnia/src/ui/components/mcp/mcp-pane.tsx
+++ b/packages/insomnia/src/ui/components/mcp/mcp-pane.tsx
@@ -29,7 +29,10 @@ import { fuzzyMatchAll } from '~/common/misc';
 import type { McpRequest, McpServerPrimitiveTypes } from '~/insomnia-data';
 import type { McpEvent, McpMessageEvent } from '~/main/mcp/types';
 import { useRootLoaderData } from '~/root';
-import { useWorkspaceLoaderData } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
+import {
+  useWorkspaceLoaderData,
+  WORKSPACE_CONTENT_WRAPPER,
+} from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
 import {
   type McpRequestLoaderData,
   useRequestLoaderData,
@@ -363,7 +366,7 @@ export const McpPane = () => {
       <PanelGroup
         ref={sidebarPanelRef}
         autoSaveId="insomnia-sidebar"
-        id="workspace-wrapper"
+        id={WORKSPACE_CONTENT_WRAPPER}
         className="new-sidebar relative min-h-0 w-full flex-1 text-(--color-font)"
         direction="horizontal"
       >

--- a/packages/insomnia/src/ui/components/mcp/mcp-pane.tsx
+++ b/packages/insomnia/src/ui/components/mcp/mcp-pane.tsx
@@ -367,7 +367,7 @@ export const McpPane = () => {
         ref={sidebarPanelRef}
         autoSaveId="insomnia-sidebar"
         id={WORKSPACE_CONTENT_WRAPPER}
-        className="new-sidebar relative min-h-0 w-full flex-1 text-(--color-font)"
+        className="new-sidebar min-h-0 w-full flex-1 text-(--color-font)"
         direction="horizontal"
       >
         <Panel id="sidebar" className="sidebar theme--sidebar" maxSize={40} minSize={10} collapsible>


### PR DESCRIPTION
## Background
For document design page, it should show old request list with request pane.
However, when click the `DocumentTab` to switch to collection view, no request list or request showed.
The root cause it that we should wrap `PanelGroup` with `Panel` when `PanelGroup` is nested in another `PanelGroup`.

## Fix
- Wrap the `PanelGroup` with `Panel` when necessary.
- Replace top level `PanelGroup` to `div` to make keyboard shortcut work.
- Fix duplicate `autoSaveId` property in `PanelGroup`.
- Conditionally showing the PanelResizeHandle.