### PR TITLE
feat(analytics): add source field to creation and execution events [INS-2427]

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
@@ -558,7 +558,7 @@ const Component = () => {
                     <div className="flex w-full flex-col items-center justify-center gap-4">
                       <ProjectEmptyView
                         onCreateRequestCollectionWithRequest={createNewCollectionWithRequest}
-                        onCreateDesignDocument={createNewDocument}
+                        onCreateDesignDocument={() => createNewDocument('empty-state')}
                         onImportFrom={() => setImportModalType('file')}
                       />
                       {createNewWorkspaceFetcher.data?.error && (

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
@@ -287,19 +287,19 @@ const Component = () => {
       id: 'new-collection',
       name: 'Request collection',
       icon: 'bars',
-      action: createNewCollection,
+      action: () => createNewCollection('navbar'),
     },
     {
       id: 'new-document',
       name: 'Design document',
       icon: 'file',
-      action: createNewDocument,
+      action: () => createNewDocument('navbar'),
     },
     {
       id: 'new-mcp-client',
       name: 'MCP Client',
       icon: ['fac', 'mcp'] as unknown as IconProp,
-      action: createNewMcpClient,
+      action: () => createNewMcpClient('navbar'),
     },
     ...(canCreateMockServer
       ? [
@@ -307,7 +307,7 @@ const Component = () => {
             id: 'new-mock-server',
             name: 'Mock Server',
             icon: 'server' as IconName,
-            action: createNewMockServer,
+            action: () => createNewMockServer('navbar'),
           },
         ]
       : []),
@@ -315,7 +315,7 @@ const Component = () => {
       id: 'new-environment',
       name: 'Environment',
       icon: 'code',
-      action: createNewGlobalEnvironment,
+      action: () => createNewGlobalEnvironment('navbar'),
     },
   ];
 
@@ -712,6 +712,7 @@ const Component = () => {
               }
             }}
             redirectAfterCreate={newWorkspaceModalState.redirect}
+            source={newWorkspaceModalState.source}
             onOpenChange={isOpen => {
               setNewWorkspaceModalState({
                 scope: newWorkspaceModalState.scope,

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
@@ -159,6 +159,7 @@ const Component = () => {
     scope: WorkspaceScope;
     isOpen: boolean;
     redirect?: boolean;
+    source?: string;
   } | null>({
     scope: 'collection',
     isOpen: false,
@@ -250,12 +251,14 @@ const Component = () => {
       },
     }));
 
-  const createNewCollection = () => setNewWorkspaceModalState({ scope: 'collection', isOpen: true });
-  const createNewDocument = () => setNewWorkspaceModalState({ scope: 'design', isOpen: true });
-  const createNewMockServer = () =>
-    canCreateMockServer && setNewWorkspaceModalState({ scope: 'mock-server', isOpen: true });
-  const createNewGlobalEnvironment = () => setNewWorkspaceModalState({ scope: 'environment', isOpen: true });
-  const createNewMcpClient = () => setNewWorkspaceModalState({ scope: 'mcp', isOpen: true });
+  const createNewCollection = (source: string) =>
+    setNewWorkspaceModalState({ scope: 'collection', isOpen: true, source });
+  const createNewDocument = (source: string) => setNewWorkspaceModalState({ scope: 'design', isOpen: true, source });
+  const createNewMockServer = (source: string) =>
+    canCreateMockServer && setNewWorkspaceModalState({ scope: 'mock-server', isOpen: true, source });
+  const createNewGlobalEnvironment = (source: string) =>
+    setNewWorkspaceModalState({ scope: 'environment', isOpen: true, source });
+  const createNewMcpClient = (source: string) => setNewWorkspaceModalState({ scope: 'mcp', isOpen: true, source });
 
   const createNewCollectionWithRequest = () => {
     if (!activeProject) {
@@ -268,6 +271,7 @@ const Component = () => {
       name: 'My first collection',
       scope: 'collection',
       withRequest: true,
+      source: 'home-page',
     });
   };
 

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
@@ -342,7 +342,7 @@ const Component = () => {
             selectedCollectionId={selectedCollectionId}
             onSelectedCollectionChange={setSelectedCollectionId}
             onCreateCollection={() => {
-              setNewWorkspaceModalState({ scope: 'collection', isOpen: true, redirect: false });
+              setNewWorkspaceModalState({ scope: 'collection', isOpen: true, redirect: false, source: 'home-page' });
             }}
           />
         </div>

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx
@@ -403,6 +403,7 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
               has_docs: !!activeRequest.description,
               count_certificates: clientCertificates.length,
               request_type: requestType,
+              source: 'request-pane',
             },
           });
 

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new.tsx
@@ -18,8 +18,6 @@ import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new';
 
-
-
 export async function clientAction({ params, request }: Route.ClientActionArgs) {
   const { organizationId, projectId, workspaceId } = params;
 

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
@@ -483,7 +483,6 @@ const Debug = () => {
     requestType: CreateRequestType;
     parentId: string;
     req?: Partial<Request>;
-    source?: string;
   }) =>
     createRequestFetcher.submit({
       organizationId,

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
@@ -51,11 +51,11 @@ import {
   WORKSPACE_CONTENT_WRAPPER,
 } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
 import { useDebugReorderActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.reorder';
+import { useRequestGroupNewActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.new';
 import { useRequestLoaderData } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId';
 import { useRequestDuplicateActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.duplicate';
 import { useRequestDeleteActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.delete';
 import { useRequestNewActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new';
-import { useRequestGroupNewActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.new';
 import Runner from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.runner';
 import { useToggleExpandAllActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.toggle-expand-all';
 import { AnalyticsEvent } from '~/ui/analytics';
@@ -483,6 +483,7 @@ const Debug = () => {
     requestType: CreateRequestType;
     parentId: string;
     req?: Partial<Request>;
+    source?: string;
   }) =>
     createRequestFetcher.submit({
       organizationId,
@@ -493,7 +494,7 @@ const Debug = () => {
       req,
       metrics: {
         source: 'sidebar',
-      }
+      },
     });
 
   const reorderFetcher = useDebugReorderActionFetcher();

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
@@ -51,11 +51,11 @@ import {
   WORKSPACE_CONTENT_WRAPPER,
 } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
 import { useDebugReorderActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.reorder';
-import { useRequestGroupNewActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.new';
 import { useRequestLoaderData } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId';
 import { useRequestDuplicateActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.duplicate';
 import { useRequestDeleteActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.delete';
 import { useRequestNewActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new';
+import { useRequestGroupNewActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.new';
 import Runner from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.runner';
 import { useToggleExpandAllActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.toggle-expand-all';
 import { AnalyticsEvent } from '~/ui/analytics';

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.create.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.create.tsx
@@ -10,7 +10,7 @@ import type { Route } from './+types/organization.$organizationId.project.$proje
 export async function clientAction({ request, params }: Route.ClientActionArgs) {
   const { workspaceId } = params;
 
-  const { isPrivate, environmentType = EnvironmentType.KVPAIR } = await request.json();
+  const { isPrivate, environmentType = EnvironmentType.KVPAIR, source } = await request.json();
 
   const baseEnvironment = await services.environment.getByParentId(workspaceId);
 
@@ -24,7 +24,7 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
 
   window.main.trackAnalyticsEvent({
     event: AnalyticsEvent.environmentCreate,
-    properties: { type: isPrivate ? 'private' : 'global' },
+    properties: { type: isPrivate ? 'private' : 'global', ...(source && { source }) },
   });
 
   return environment;
@@ -41,7 +41,7 @@ export const useEnvironmentCreateActionFetcher = createFetcherSubmitHook(
       organizationId: string;
       projectId: string;
       workspaceId: string;
-      params: { isPrivate: boolean; environmentType?: string };
+      params: { isPrivate: boolean; environmentType?: string; source?: string };
     }) => {
       return submit(JSON.stringify(params), {
         method: 'POST',

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.tsx
@@ -164,6 +164,7 @@ const Component = ({ loaderData, params }: Route.ComponentProps) => {
           workspaceId,
           params: {
             isPrivate: false,
+            source: 'environment-editor',
           },
         });
       },
@@ -180,6 +181,7 @@ const Component = ({ loaderData, params }: Route.ComponentProps) => {
           workspaceId,
           params: {
             isPrivate: true,
+            source: 'environment-editor',
           },
         });
       },

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx
@@ -1043,6 +1043,7 @@ const Component = ({ params }: Route.ComponentProps) => {
                 storageRules={storageRules}
                 scope="mock-server"
                 sourceApiSpec={apiSpec}
+                source="design-view"
                 onOpenChange={setNewMockServerModalOpen}
               />
             )}

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
@@ -32,6 +32,7 @@ interface NewWorkspaceData {
   fileName?: string;
   withRequest?: boolean;
   mockServerDynamicResponses?: boolean;
+  source?: string;
 }
 
 export async function clientAction({ request, params }: Route.ClientActionArgs) {
@@ -118,6 +119,7 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
         organizationId,
         projectId,
         name,
+        workspaceData.source,
       );
 
       if (mockServerError) {
@@ -185,11 +187,10 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
 
     window.main.trackAnalyticsEvent({
       event: event,
-      ...(environmentType && {
-        properties: {
-          type: environmentType,
-        },
-      }),
+      properties: {
+        ...(environmentType && { type: environmentType }),
+        ...(workspaceData.source && { source: workspaceData.source }),
+      },
     });
 
     if (workspaceData.withRequest) {
@@ -214,7 +215,10 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
         })
       )._id;
 
-      window.main.trackAnalyticsEvent({ event: AnalyticsEvent.requestCreated, properties: { requestType: 'HTTP' } });
+      window.main.trackAnalyticsEvent({
+        event: AnalyticsEvent.requestCreated,
+        properties: { requestType: 'HTTP', ...(workspaceData.source && { source: workspaceData.source }) },
+      });
 
       if (!redirectAfterCreate) {
         return {
@@ -289,6 +293,7 @@ async function createMockServer(
   organizationId: string,
   projectId: string,
   name: string,
+  source?: string,
 ): Promise<string | undefined> {
   try {
     const mockServerType = workspaceData.mockServerType!;
@@ -384,7 +389,7 @@ async function createMockServer(
         generation_from: workspaceData.apiSpecContents ? 'design_doc' : workspaceData.mockServerSpecSource || '',
         dynamic_responses: workspaceData.mockServerDynamicResponses ? 'yes' : 'no',
         generation_duration_seconds: generationDurationMs / 1000,
-        source: 'menu',
+        source: source || 'menu',
       },
     });
 

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
@@ -389,7 +389,7 @@ async function createMockServer(
         generation_from: workspaceData.apiSpecContents ? 'design_doc' : workspaceData.mockServerSpecSource || '',
         dynamic_responses: workspaceData.mockServerDynamicResponses ? 'yes' : 'no',
         generation_duration_seconds: generationDurationMs / 1000,
-        source: source || 'menu',
+        ...(source && { source }),
       },
     });
 

--- a/packages/insomnia/src/ui/components/dropdowns/request-group-actions-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/request-group-actions-dropdown.tsx
@@ -8,10 +8,10 @@ import { services } from '~/insomnia-data';
 import type { PlatformKeyCombinations } from '~/insomnia-data/common';
 import { plugins } from '~/plugins/renderer-bridge';
 import { useRootLoaderData } from '~/root';
-import { useRequestNewActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new';
 import { useRequestGroupDeleteActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.delete';
 import { useRequestGroupDuplicateActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.duplicate';
 import { useRequestGroupNewActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.new';
+import { useRequestNewActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new';
 import { useTabNavigate } from '~/ui/hooks/use-insomnia-tab';
 
 import { toKebabCase } from '../../../common/misc';
@@ -81,7 +81,7 @@ export const RequestGroupActionsDropdown = ({
       req,
       metrics: {
         source: 'sidebar',
-      }
+      },
     });
 
   const onOpen = async () => {

--- a/packages/insomnia/src/ui/components/dropdowns/request-group-actions-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/request-group-actions-dropdown.tsx
@@ -8,10 +8,10 @@ import { services } from '~/insomnia-data';
 import type { PlatformKeyCombinations } from '~/insomnia-data/common';
 import { plugins } from '~/plugins/renderer-bridge';
 import { useRootLoaderData } from '~/root';
+import { useRequestNewActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new';
 import { useRequestGroupDeleteActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.delete';
 import { useRequestGroupDuplicateActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.duplicate';
 import { useRequestGroupNewActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.new';
-import { useRequestNewActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new';
 import { useTabNavigate } from '~/ui/hooks/use-insomnia-tab';
 
 import { toKebabCase } from '../../../common/misc';

--- a/packages/insomnia/src/ui/components/dropdowns/sidebar-project-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/sidebar-project-dropdown.tsx
@@ -65,6 +65,7 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId, storageRul
   const [newWorkspaceModalState, setNewWorkspaceModalState] = useState<{
     scope: WorkspaceScope;
     isOpen: boolean;
+    source?: string;
   } | null>({
     scope: 'collection',
     isOpen: false,
@@ -79,13 +80,13 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId, storageRul
   const isGitProjectInconsistent = models.project.isGitProject(project) && !storageRules.enableGitSync;
   const isProjectInconsistent = isRemoteProjectInconsistent || isLocalProjectInconsistent || isGitProjectInconsistent;
 
-  const createNewCollection = () => setNewWorkspaceModalState({ scope: 'collection', isOpen: true });
-  const createNewDocument = () => setNewWorkspaceModalState({ scope: 'design', isOpen: true });
+  const createNewCollection = () => setNewWorkspaceModalState({ scope: 'collection', isOpen: true, source: 'sidebar-dropdown' });
+  const createNewDocument = () => setNewWorkspaceModalState({ scope: 'design', isOpen: true, source: 'sidebar-dropdown' });
   const canCreateMockServer = project?._id;
   const createNewMockServer = () =>
-    canCreateMockServer && setNewWorkspaceModalState({ scope: 'mock-server', isOpen: true });
-  const createNewGlobalEnvironment = () => setNewWorkspaceModalState({ scope: 'environment', isOpen: true });
-  const createNewMcpClient = () => setNewWorkspaceModalState({ scope: 'mcp', isOpen: true });
+    canCreateMockServer && setNewWorkspaceModalState({ scope: 'mock-server', isOpen: true, source: 'sidebar-dropdown' });
+  const createNewGlobalEnvironment = () => setNewWorkspaceModalState({ scope: 'environment', isOpen: true, source: 'sidebar-dropdown' });
+  const createNewMcpClient = () => setNewWorkspaceModalState({ scope: 'mcp', isOpen: true, source: 'sidebar-dropdown' });
 
   const projectActionList: ProjectActionItem[] = [
     {
@@ -341,6 +342,7 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId, storageRul
           project={project}
           storageRules={storageRules}
           scope={newWorkspaceModalState.scope}
+          source={newWorkspaceModalState.source}
           onOpenChange={isOpen => {
             setNewWorkspaceModalState({
               scope: newWorkspaceModalState.scope,

--- a/packages/insomnia/src/ui/components/modals/new-workspace-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/new-workspace-modal.tsx
@@ -1,5 +1,5 @@
 import type { StorageRules } from 'insomnia-api';
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Button,
   Collection,
@@ -57,6 +57,7 @@ export const NewWorkspaceModal = ({
   sourceApiSpec,
   onCreateWorkspace,
   redirectAfterCreate = true,
+  source,
 }: {
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
@@ -66,6 +67,7 @@ export const NewWorkspaceModal = ({
   redirectAfterCreate?: boolean;
   scope: WorkspaceScope;
   sourceApiSpec?: ApiSpec;
+  source?: string;
 }) => {
   const { organizationId } = useParams() as { organizationId: string; projectId: string };
 
@@ -172,6 +174,7 @@ export const NewWorkspaceModal = ({
         apiSpecContents: sourceApiSpec.contents,
       }),
       redirectAfterCreate,
+      ...(source && { source }),
     });
   };
 

--- a/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
@@ -145,6 +145,7 @@ export const WorkspaceEnvironmentsEditModal = ({ onClose }: { onClose: () => voi
           workspaceId,
           params: {
             isPrivate: false,
+            source: 'environment-editor',
           },
         });
       },
@@ -161,6 +162,7 @@ export const WorkspaceEnvironmentsEditModal = ({ onClose }: { onClose: () => voi
           workspaceId,
           params: {
             isPrivate: true,
+            source: 'environment-editor',
           },
         });
       },

--- a/packages/insomnia/src/ui/components/panes/placeholder-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/placeholder-request-pane.tsx
@@ -1,4 +1,4 @@
-import React, { type FC, useCallback } from 'react';
+import { type FC, useCallback } from 'react';
 import { useParams } from 'react-router';
 
 import { useRootLoaderData } from '~/root';
@@ -26,7 +26,7 @@ export const PlaceholderRequestPane: FC = () => {
         parentId: workspaceId,
         metrics: {
           source: 'placeholder-request-pane',
-        }
+        },
       }),
     [requestFetcher, organizationId, projectId, workspaceId],
   );

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/empty-node.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/empty-node.tsx
@@ -32,15 +32,16 @@ export const EmptyNode = ({ item, storageRules }: EmptyNodeProps) => {
   const [newWorkspaceModalState, setNewWorkspaceModalState] = useState<{
     scope: WorkspaceScope;
     isOpen: boolean;
+    source?: string;
   } | null>({
     scope: 'collection',
     isOpen: false,
   });
-  const createNewCollection = () => setNewWorkspaceModalState({ scope: 'collection', isOpen: true });
-  const createNewDocument = () => setNewWorkspaceModalState({ scope: 'design', isOpen: true });
-  const createNewMockServer = () => setNewWorkspaceModalState({ scope: 'mock-server', isOpen: true });
-  const createNewGlobalEnvironment = () => setNewWorkspaceModalState({ scope: 'environment', isOpen: true });
-  const createNewMcpClient = () => setNewWorkspaceModalState({ scope: 'mcp', isOpen: true });
+  const createNewCollection = () => setNewWorkspaceModalState({ scope: 'collection', isOpen: true, source: 'sidebar' });
+  const createNewDocument = () => setNewWorkspaceModalState({ scope: 'design', isOpen: true, source: 'sidebar' });
+  const createNewMockServer = () => setNewWorkspaceModalState({ scope: 'mock-server', isOpen: true, source: 'sidebar' });
+  const createNewGlobalEnvironment = () => setNewWorkspaceModalState({ scope: 'environment', isOpen: true, source: 'sidebar' });
+  const createNewMcpClient = () => setNewWorkspaceModalState({ scope: 'mcp', isOpen: true, source: 'sidebar' });
 
   const newRequestFetcher = useRequestNewActionFetcher();
   const newRequestGroupFetcher = useRequestGroupNewActionFetcher();
@@ -268,6 +269,7 @@ export const EmptyNode = ({ item, storageRules }: EmptyNodeProps) => {
           project={project}
           storageRules={storageRules}
           scope={newWorkspaceModalState.scope}
+          source={newWorkspaceModalState.source}
           onOpenChange={isOpen => {
             setNewWorkspaceModalState({
               scope: newWorkspaceModalState.scope,

--- a/packages/insomnia/src/ui/components/tabs/tab-list.tsx
+++ b/packages/insomnia/src/ui/components/tabs/tab-list.tsx
@@ -261,7 +261,7 @@ export const OrganizationTabList = ({ showActiveStatus = true, currentPage = '' 
         parentId: workspaceId,
         metrics: {
           source: 'tab-list',
-        }
+        },
       });
     }
   };


### PR DESCRIPTION
## Summary

- Adds a `source` property to analytics creation and execution events to
  differentiate where users trigger actions from (home page, sidebar, navbar, etc.)
- Covers: Request Created, Request Executed, Collection Created, Document Created,
  Mock Created, MCP Client Workspace Created, and Environment Created
- Import Started already had `source` on all call sites — no change needed

## Analytics Events

### `requestExecuted` — added `source` property
| Source | Trigger |
|---|---|
| `request-pane` | Send button in the request pane |

### `environmentCreate` — added `source` property
| Source | Trigger |
|---|---|
| `environment-editor` | "Add environment" in the environment editor route |
| `environment-editor` | "Add environment" in the workspace environments modal |

### `workspaceCreate` — added `source` property _(all scopes: collection, design, environment, mcp, mock-server)_
| Source | Trigger |
|---|---|
| `navbar` | Top-bar "New" dropdown on the project home page |
| `empty-state` | Empty state card on the project home page _(design doc only)_ |
| `home-page` | First request creation button on the project home page |
| `sidebar-dropdown` | Project context menu in the sidebar |
| `sidebar` | Empty-node actions inside the sidebar navigation tree |
| `design-view` | "Create mock server" button in the API spec/design tab _(mock-server only)_ |

### `requestCreated` — new event
Fired when a collection is created together with a first HTTP request.

| Source | Trigger |
|---|---|
| `home-page` | Create collection with first request on the project home page |

### `mockCreate` — `source` now dynamic
Previously hardcoded as `menu`. Now inherits the same source values as `workspaceCreate` (`navbar`, `sidebar-dropdown`, `sidebar`, `design-view`). Omitted entirely when no source is provided.

