### PR TITLE
Streamline workspace create & settings form [INS-2621]

### DIFF
--- a/packages/insomnia/src/ui/components/modals/new-workspace-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/new-workspace-modal.tsx
@@ -272,7 +272,7 @@ export const NewWorkspaceModal = ({
                             placeholder={workspaceData.name ? safeToUseInsomniaFileName(workspaceData.name) : 'name'}
                             className="w-full outline-hidden [grid-area:input] placeholder:italic focus:outline-hidden"
                           />
-                          <span className="pointer-events-none w-min truncate opacity-0 [grid-area:input]">
+                          <span className="pointer-events-none truncate opacity-0 [grid-area:input]">
                             {safeToUseInsomniaFileName(workspaceData.fileName || workspaceData.name || 'name')}
                           </span>
                           <span className="text-(--hl) [grid-area:extension]">.yaml</span>

--- a/packages/insomnia/src/ui/components/modals/new-workspace-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/new-workspace-modal.tsx
@@ -267,7 +267,7 @@ export const NewWorkspaceModal = ({
                       <Label className="group relative flex flex-col gap-2 overflow-hidden">
                         <span className="text-sm text-(--hl)">File name</span>
 
-                        <div className="grid w-full grid-cols-[min-content_auto] overflow-hidden rounded-xs border border-solid border-(--hl-sm) bg-(--color-bg) py-1 pr-7 pl-2 text-(--color-font) transition-colors [grid-template-areas:'input_extension'] focus:ring-1 focus:ring-(--hl-md) focus:outline-hidden">
+                        <div className="grid w-full grid-cols-[min-content_auto] overflow-hidden rounded-xs border border-solid border-(--hl-sm) bg-(--color-bg) py-1 pr-2 pl-2 text-(--color-font) transition-colors [grid-template-areas:'input_extension'] focus:ring-1 focus:ring-(--hl-md) focus:outline-hidden">
                           <Input
                             placeholder={workspaceData.name ? safeToUseInsomniaFileName(workspaceData.name) : 'name'}
                             className="w-full outline-hidden [grid-area:input] placeholder:italic focus:outline-hidden"

--- a/packages/insomnia/src/ui/components/modals/new-workspace-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/new-workspace-modal.tsx
@@ -270,9 +270,9 @@ export const NewWorkspaceModal = ({
                         <div className="grid w-full grid-cols-[min-content_auto] overflow-hidden rounded-xs border border-solid border-(--hl-sm) bg-(--color-bg) py-1 pr-7 pl-2 text-(--color-font) transition-colors [grid-template-areas:'input_extension'] focus:ring-1 focus:ring-(--hl-md) focus:outline-hidden">
                           <Input
                             placeholder={workspaceData.name ? safeToUseInsomniaFileName(workspaceData.name) : 'name'}
-                            className="w-full min-w-[3ch] outline-hidden [grid-area:input] placeholder:italic focus:outline-hidden"
+                            className="w-full outline-hidden [grid-area:input] placeholder:italic focus:outline-hidden"
                           />
-                          <span className="-z-10 w-min truncate opacity-0 [grid-area:input]">
+                          <span className="pointer-events-none w-min truncate opacity-0 [grid-area:input]">
                             {safeToUseInsomniaFileName(workspaceData.fileName || workspaceData.name || 'name')}
                           </span>
                           <span className="text-(--hl) [grid-area:extension]">.yaml</span>

--- a/packages/insomnia/src/ui/components/modals/workspace-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-settings-modal.tsx
@@ -144,11 +144,11 @@ export const WorkspaceSettingsModal = ({ workspace, gitFilePath, project, mockSe
                     <TextField
                       name="fileName"
                       isRequired
-                      validate={fileName => {
+                      validate={inputValue => {
                         if (
                           selectedFolderChildren
                             .filter(name => name !== fileName)
-                            .includes(safeToUseInsomniaFileNameWithExt(fileName))
+                            .includes(safeToUseInsomniaFileNameWithExt(inputValue))
                         ) {
                           return 'A file with the same name already exists in the selected folder';
                         }

--- a/packages/insomnia/src/ui/components/modals/workspace-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-settings-modal.tsx
@@ -167,9 +167,9 @@ export const WorkspaceSettingsModal = ({ workspace, gitFilePath, project, mockSe
                         <div className="grid w-full grid-cols-[min-content_auto] overflow-hidden rounded-xs border border-solid border-(--hl-sm) bg-(--color-bg) py-1 pr-2 pl-2 text-(--color-font) transition-colors [grid-template-areas:'input_extension'] focus:ring-1 focus:ring-(--hl-md) focus:outline-hidden">
                           <Input
                             placeholder={workspace.name ? safeToUseInsomniaFileName(workspace.name) : 'name'}
-                            className="w-full min-w-[3ch] outline-hidden [grid-area:input] placeholder:italic focus:outline-hidden"
+                            className="w-full outline-hidden [grid-area:input] placeholder:italic focus:outline-hidden"
                           />
-                          <span className="-z-10 w-min truncate opacity-0 [grid-area:input]">
+                          <span className="pointer-events-none truncate opacity-0 [grid-area:input]">
                             {fileNameValue || (workspace.name ? safeToUseInsomniaFileName(workspace.name) : 'name')}
                           </span>
                           <span className="text-(--hl) [grid-area:extension]">.yaml</span>

--- a/packages/insomnia/src/ui/components/modals/workspace-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-settings-modal.tsx
@@ -146,7 +146,7 @@ export const WorkspaceSettingsModal = ({ workspace, gitFilePath, project, mockSe
                     <TextField
                       name="fileName"
                       isRequired
-                      value={fileNameValue}
+                      value={safeToUseInsomniaFileName(fileNameValue || '')}
                       onChange={setFileNameValue}
                       validate={inputValue => {
                         if (
@@ -170,7 +170,7 @@ export const WorkspaceSettingsModal = ({ workspace, gitFilePath, project, mockSe
                             className="w-full outline-hidden [grid-area:input] placeholder:italic focus:outline-hidden"
                           />
                           <span className="pointer-events-none truncate opacity-0 [grid-area:input]">
-                            {fileNameValue || (workspace.name ? safeToUseInsomniaFileName(workspace.name) : 'name')}
+                            {safeToUseInsomniaFileName(fileNameValue) || (workspace.name ? safeToUseInsomniaFileName(workspace.name) : 'name')}
                           </span>
                           <span className="text-(--hl) [grid-area:extension]">.yaml</span>
                         </div>

--- a/packages/insomnia/src/ui/components/modals/workspace-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-settings-modal.tsx
@@ -83,6 +83,8 @@ export const WorkspaceSettingsModal = ({ workspace, gitFilePath, project, mockSe
   const fileName = gitFilePath?.split('/').pop() || '';
   const selectedFolderChildren = gitRepoTreeFetcher.data?.folderList[selectedFolder] || [];
 
+  const [fileNameValue, setFileNameValue] = useState<string>(safeToUseInsomniaFileName(fileName || ''));
+
   return (
     <ModalOverlay
       isOpen
@@ -144,6 +146,8 @@ export const WorkspaceSettingsModal = ({ workspace, gitFilePath, project, mockSe
                     <TextField
                       name="fileName"
                       isRequired
+                      value={fileNameValue}
+                      onChange={setFileNameValue}
                       validate={inputValue => {
                         if (
                           selectedFolderChildren
@@ -155,19 +159,18 @@ export const WorkspaceSettingsModal = ({ workspace, gitFilePath, project, mockSe
 
                         return null;
                       }}
-                      defaultValue={safeToUseInsomniaFileName(fileName || '')}
                       className="group relative flex w-full max-w-full shrink-0 flex-col gap-2 overflow-hidden"
                     >
                       <Label className="group relative flex flex-col gap-2 overflow-hidden">
                         <span className="text-sm text-(--hl)">File name</span>
 
-                        <div className="grid w-full grid-cols-[min-content_auto] overflow-hidden rounded-xs border border-solid border-(--hl-sm) bg-(--color-bg) py-1 pr-7 pl-2 text-(--color-font) transition-colors [grid-template-areas:'input_extension'] focus:ring-1 focus:ring-(--hl-md) focus:outline-hidden">
+                        <div className="grid w-full grid-cols-[min-content_auto] overflow-hidden rounded-xs border border-solid border-(--hl-sm) bg-(--color-bg) py-1 pr-2 pl-2 text-(--color-font) transition-colors [grid-template-areas:'input_extension'] focus:ring-1 focus:ring-(--hl-md) focus:outline-hidden">
                           <Input
                             placeholder={workspace.name ? safeToUseInsomniaFileName(workspace.name) : 'name'}
                             className="w-full min-w-[3ch] outline-hidden [grid-area:input] placeholder:italic focus:outline-hidden"
                           />
                           <span className="-z-10 w-min truncate opacity-0 [grid-area:input]">
-                            {safeToUseInsomniaFileName(fileName || workspace.name || 'name')}
+                            {fileNameValue || (workspace.name ? safeToUseInsomniaFileName(workspace.name) : 'name')}
                           </span>
                           <span className="text-(--hl) [grid-area:extension]">.yaml</span>
                         </div>


### PR DESCRIPTION
This PR addresses a few usability issues in the "Create a new *" and "* Settings" modals for Git Sync projects:
1. Editing just the name and leaving the filename untouched in the Settings modal still leads to a validation error for the filename, preventing the user from saving the new name.
2. Filename input width is virtually restricted to the width of the original name and causes unintuitive scrolling & clipping when entering a longer filename.

|  | 1 | 2 |
|---|---|---|
| Before | <img width="366" height="280" alt="image" src="https://github.com/user-attachments/assets/c2d2954d-9614-43a5-921f-b0d37e07330e" /> | <img width="349" height="265" alt="image" src="https://github.com/user-attachments/assets/433bc668-1d0f-4081-9a94-ba6bf09a2e76" /> |
| After | <img width="336" height="252" alt="Kapture 2026-05-20 at 19 35 45" src="https://github.com/user-attachments/assets/1184ef9a-3bb4-42ff-9e4c-2aa04c8c4c7f" /> | <img width="336" height="252" alt="ws-settings-filename-adaptive-length" src="https://github.com/user-attachments/assets/ea123711-eeac-480e-be09-3284b3a7113e" /> |

Changes were manually tested by comparing v12.6.0-beta.0 and a local dev build. Automated tests were not added for these because unit tests wouldn't effectively test either case and the cost of failure seems too low to add e2e/smoke tests for these. Happy to give the tests a go if that assessment doesn't feel right though.