### PR TITLE
Replace HTML preview webview with iframe

### DIFF
--- a/packages/insomnia/src/entry.main.ts
+++ b/packages/insomnia/src/entry.main.ts
@@ -90,6 +90,11 @@ app.on('web-contents-created', (_, contents) => {
   } else {
     contextMenu();
   }
+  // Stopgap: unconditionally deny future webview attachments. The HTML preview
+  // was migrated to a sandboxed <iframe>; webviewTag is no longer enabled.
+  contents.on('will-attach-webview', event => {
+    event.preventDefault();
+  });
 });
 
 // When the app is first launched

--- a/packages/insomnia/src/main/window-security.test.ts
+++ b/packages/insomnia/src/main/window-security.test.ts
@@ -35,5 +35,7 @@ describe('main window security posture', () => {
     // ...and must not re-introduce a weakening override.
     expect(mainWindowBlock).not.toMatch(/nodeIntegration\s*:\s*true/);
     expect(mainWindowBlock).not.toMatch(/contextIsolation\s*:\s*false/);
+    // webviewTag must not be re-enabled; the HTML preview now uses a sandboxed <iframe>.
+    expect(mainWindowBlock).not.toMatch(/webviewTag\s*:\s*true/);
   });
 });

--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -205,7 +205,6 @@ export function createWindow(): ElectronBrowserWindow {
     webPreferences: {
       preload: path.join(__dirname, 'entry.preload.min.js'),
       zoomFactor: getZoomFactor(),
-      webviewTag: true,
       disableBlinkFeatures: 'Auxclick',
       // Security-critical flags (nodeIntegration/contextIsolation). Pinned by window-security.test.ts.
       // Spread last so nothing below can override them. Do not weaken — see ./window-security.

--- a/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
@@ -300,7 +300,7 @@ export const ResponseViewer = ({
         body={getBodyAsString()}
         key={disableHtmlPreviewJs ? 'no-js' : 'yes-js'}
         url={url}
-        webpreferences={`disableDialogs=true, javascript=${disableHtmlPreviewJs ? 'no' : 'yes'}`}
+        disableHtmlPreviewJs={disableHtmlPreviewJs}
       />
     );
   }

--- a/packages/insomnia/src/ui/components/viewers/response-web-view.test.ts
+++ b/packages/insomnia/src/ui/components/viewers/response-web-view.test.ts
@@ -9,6 +9,12 @@ describe('response-web-view', () => {
     );
   });
 
+  it('escapes HTML-significant characters in the injected base href', () => {
+    expect(getResponsePreviewHtml('<head></head>', 'https://example.com/"><script>alert(1)</script>')).toBe(
+      '<head><base href="https://example.com/&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;"></head>',
+    );
+  });
+
   it('keeps scripts disabled when HTML preview JS is turned off', () => {
     expect(getResponsePreviewSandbox(true)).toBe('');
   });

--- a/packages/insomnia/src/ui/components/viewers/response-web-view.test.ts
+++ b/packages/insomnia/src/ui/components/viewers/response-web-view.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { getResponsePreviewHtml, getResponsePreviewSandbox } from './response-web-view';
+
+describe('response-web-view', () => {
+  it('injects a base tag into the document head', () => {
+    expect(getResponsePreviewHtml('<html><head></head><body>Hello</body></html>', 'https://example.com/path/')).toBe(
+      '<html><head><base href="https://example.com/path/"></head><body>Hello</body></html>',
+    );
+  });
+
+  it('keeps scripts disabled when HTML preview JS is turned off', () => {
+    expect(getResponsePreviewSandbox(true)).toBe('');
+  });
+
+  it('allows scripts when HTML preview JS is enabled', () => {
+    expect(getResponsePreviewSandbox(false)).toBe('allow-scripts');
+  });
+});

--- a/packages/insomnia/src/ui/components/viewers/response-web-view.test.ts
+++ b/packages/insomnia/src/ui/components/viewers/response-web-view.test.ts
@@ -22,4 +22,9 @@ describe('response-web-view', () => {
   it('allows scripts when HTML preview JS is enabled', () => {
     expect(getResponsePreviewSandbox(false)).toBe('allow-scripts');
   });
+
+  it('never grants allow-same-origin in any sandbox state', () => {
+    expect(getResponsePreviewSandbox(true)).not.toContain('allow-same-origin');
+    expect(getResponsePreviewSandbox(false)).not.toContain('allow-same-origin');
+  });
 });

--- a/packages/insomnia/src/ui/components/viewers/response-web-view.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-web-view.tsx
@@ -20,7 +20,11 @@ export const getResponsePreviewSandbox = (disableHtmlPreviewJs: boolean) =>
 export const ResponseWebView: FC<Props> = ({ body, disableHtmlPreviewJs, url }) => {
   return (
     <iframe
-      className="h-full w-full border-0"
+      // bg-white preserves the previous <webview> rendering (main.css set
+      // `webview { background-color: #fff }`). Without it the transparent
+      // iframe shows the app theme behind pages that declare no background,
+      // making dark-theme HTML previews unreadable.
+      className="h-full w-full border-0 bg-white"
       data-testid="ResponseWebView"
       sandbox={getResponsePreviewSandbox(disableHtmlPreviewJs)}
       srcDoc={getResponsePreviewHtml(body, url)}

--- a/packages/insomnia/src/ui/components/viewers/response-web-view.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-web-view.tsx
@@ -1,30 +1,24 @@
-import React, { type FC, useEffect, useRef } from 'react';
+import React, { type FC } from 'react';
 
 interface Props {
   body: string;
   url: string;
-  webpreferences: string;
+  disableHtmlPreviewJs: boolean;
 }
-export const ResponseWebView: FC<Props> = ({ webpreferences, body, url }) => {
-  const webviewRef = useRef<Electron.WebviewTag>(null);
 
-  useEffect(() => {
-    const webview = webviewRef.current;
-    const handleDOMReady = () => {
-      if (webview) {
-        webview.removeEventListener('dom-ready', handleDOMReady);
-        const bodyWithBase = body.replace('<head>', `<head><base href="${url}">`);
-        webview.loadURL(`data:text/html; charset=utf-8,${encodeURIComponent(bodyWithBase)}`);
-      }
-    };
-    if (webview) {
-      webview.addEventListener('dom-ready', handleDOMReady);
-    }
-    return () => {
-      if (webview) {
-        webview.removeEventListener('dom-ready', handleDOMReady);
-      }
-    };
-  }, [body, url]);
-  return <webview data-testid="ResponseWebView" ref={webviewRef} src="about:blank" webpreferences={webpreferences} />;
+export const getResponsePreviewHtml = (body: string, url: string) => body.replace('<head>', `<head><base href="${url}">`);
+
+export const getResponsePreviewSandbox = (disableHtmlPreviewJs: boolean) =>
+  disableHtmlPreviewJs ? '' : 'allow-scripts';
+
+export const ResponseWebView: FC<Props> = ({ body, disableHtmlPreviewJs, url }) => {
+  return (
+    <iframe
+      className="h-full w-full border-0"
+      data-testid="ResponseWebView"
+      sandbox={getResponsePreviewSandbox(disableHtmlPreviewJs)}
+      srcDoc={getResponsePreviewHtml(body, url)}
+      title="HTML response preview"
+    />
+  );
 };

--- a/packages/insomnia/src/ui/components/viewers/response-web-view.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-web-view.tsx
@@ -6,14 +6,14 @@ interface Props {
   disableHtmlPreviewJs: boolean;
 }
 
-const escapeHtmlAttribute = (value: string) => value
-  .replace(/&/g, '&amp;')
-  .replace(/"/g, '&quot;')
-  .replace(/</g, '&lt;')
-  .replace(/>/g, '&gt;');
+const escapeHtmlAttribute = (value: string) =>
+  value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
-export const getResponsePreviewHtml = (body: string, url: string) => body.replace('<head>', `<head><base href="${escapeHtmlAttribute(url)}">`);
+export const getResponsePreviewHtml = (body: string, url: string) =>
+  body.replace('<head>', `<head><base href="${escapeHtmlAttribute(url)}">`);
 
+// NOTE: allow-same-origin must never appear here. Combined with allow-scripts it
+// defeats the sandbox (the iframe can remove its own sandbox attribute).
 export const getResponsePreviewSandbox = (disableHtmlPreviewJs: boolean) =>
   disableHtmlPreviewJs ? '' : 'allow-scripts';
 

--- a/packages/insomnia/src/ui/components/viewers/response-web-view.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-web-view.tsx
@@ -6,7 +6,13 @@ interface Props {
   disableHtmlPreviewJs: boolean;
 }
 
-export const getResponsePreviewHtml = (body: string, url: string) => body.replace('<head>', `<head><base href="${url}">`);
+const escapeHtmlAttribute = (value: string) => value
+  .replace(/&/g, '&amp;')
+  .replace(/"/g, '&quot;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;');
+
+export const getResponsePreviewHtml = (body: string, url: string) => body.replace('<head>', `<head><base href="${escapeHtmlAttribute(url)}">`);
 
 export const getResponsePreviewSandbox = (disableHtmlPreviewJs: boolean) =>
   disableHtmlPreviewJs ? '' : 'allow-scripts';


### PR DESCRIPTION
## Summary
- replace the HTML response preview `webview` with a sandboxed `iframe` using `srcDoc`
- preserve the existing base-URL injection and HTML preview JS toggle through explicit helper logic
- remove the main window's `webviewTag: true` requirement and add focused coverage for the preview helpers

## Notes
- the changed-file lint step passed and the focused `response-web-view` test passed
- the repo-wide `type-check` script still reports existing unrelated baseline issues in `src/main/ipc/grpc.ts` and `src/ui/components/keydown-binder.ts`