### PR TITLE
feat: Add a hint when users are overriding the default host header 

### DIFF
--- a/packages/insomnia/src/ui/components/mcp/mcp-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/mcp/mcp-request-pane.tsx
@@ -60,8 +60,8 @@ const ModifyHostHeaderBanner = () => {
       }}
     >
       <p className="notice warning no-margin-top no-margin-bottom">
-        You are adding a new <strong>Host</strong> header which will override the default behavior. Uncheck or delete
-        the extra host restores automatic calculation from the URL.
+        You are adding a new <strong>Host</strong> header which will override the default behavior. Remove or disable
+        the new header to return to default behavior.
       </p>
     </div>
   );

--- a/packages/insomnia/src/ui/components/mcp/mcp-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/mcp/mcp-request-pane.tsx
@@ -50,6 +50,23 @@ const PaneReadOnlyBanner = () => {
   );
 };
 
+const ModifyHostHeaderBanner = () => {
+  return (
+    <div
+      style={{
+        paddingTop: 'var(--padding-md)',
+        paddingLeft: 'var(--padding-md)',
+        paddingRight: 'var(--padding-md)',
+      }}
+    >
+      <p className="notice warning no-margin-top no-margin-bottom">
+        You are adding a new <strong>Host</strong> header which will override the default behavior. Uncheck or delete
+        the extra host restores automatic calculation from the URL.
+      </p>
+    </div>
+  );
+};
+
 interface Props {
   environment: Environment | null;
   readyState: McpReadyState;
@@ -94,7 +111,9 @@ export const McpRequestPane: FC<Props> = ({
   const requestId = activeRequest._id;
   const isStdio = activeRequest.transportType === 'stdio';
 
-  const headersCount = activeRequest.headers.filter(h => !h.disabled).length + readOnlyHttpPairs.length;
+  const activeRequestHeaders = activeRequest.headers.filter(h => !h.disabled);
+  const headersCount = activeRequestHeaders.length + readOnlyHttpPairs.length;
+  const isModifyingHostHeader = activeRequestHeaders.some(h => h.name.toLowerCase() === 'host');
   const patchRequest = useRequestPatcher();
   const mcpPayloadPatcher = useRequestPayloadPatcher();
   const latestPayloadPatcherRef = useLatest(mcpPayloadPatcher);
@@ -397,6 +416,7 @@ export const McpRequestPane: FC<Props> = ({
         </TabPanel>
         <TabPanel className="w-full flex-1 overflow-y-auto" id="headers">
           {!isDisconnected && <PaneReadOnlyBanner />}
+          {isDisconnected && isModifyingHostHeader && <ModifyHostHeaderBanner />}
           <RequestHeadersEditor
             key={uniqueKey}
             headers={activeRequest.headers}


### PR DESCRIPTION
## Changes
For MCP request with customized `host` header specified by user, we will show extra banner to aware user about this.
<img width="437" height="378" alt="Screenshot 2026-05-26 at 12 03 20" src="https://github.com/user-attachments/assets/1e903d6e-167c-48d8-aab3-434a1f110dc9" />


[INS-2415](https://konghq.atlassian.net/browse/INS-2415)

[INS-2415]: https://konghq.atlassian.net/browse/INS-2415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ