### PR TITLE
fix: preserve equals in curl form imports

### DIFF
--- a/packages/insomnia/src/main/importers/importers/curl.test.ts
+++ b/packages/insomnia/src/main/importers/importers/curl.test.ts
@@ -186,6 +186,16 @@ describe('curl', () => {
       curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode '%3D'",
       expected: { body: { params: [{ name: '', value: '%3D' }] } },
     },
+    {
+      name: 'should handle multipart text fields with multiple equals signs',
+      curl: "curl -X POST https://example.com -F 'token=abc=def=='",
+      expected: { body: { params: [{ name: 'token', value: 'abc=def==', type: 'text' }] } },
+    },
+    {
+      name: 'should handle multipart file fields with equals signs in the file path',
+      curl: "curl -X POST https://example.com -F 'file=@/tmp/a=b.txt'",
+      expected: { body: { params: [{ name: 'file', fileName: '/tmp/a=b.txt', type: 'file' }] } },
+    },
 
     // --data flags without urlencoded content type
     {

--- a/packages/insomnia/src/main/importers/importers/curl.ts
+++ b/packages/insomnia/src/main/importers/importers/curl.ts
@@ -168,7 +168,9 @@ const extractBody = (
     ...((pairsByName.form as string[] | undefined) || []),
     ...((pairsByName.F as string[] | undefined) || []),
   ].map(str => {
-    const [name, value] = str.split('=');
+    const equalIndex = str.indexOf('=');
+    const name = equalIndex === -1 ? str : str.slice(0, equalIndex);
+    const value = equalIndex === -1 ? '' : str.slice(equalIndex + 1);
     const item: Parameter = {
       name,
     };


### PR DESCRIPTION
Related: #9412, #9434, #9198

This is a small follow-up for cURL import.
`-d` style payloads were fixed already, but `-F/--form` was still kinda busted. The form parser used `split('=')`, so multipart values and file paths got chopped after the first extra `=`.

Repro
1. Create -> Import From cURL
2. Paste `curl -X POST https://example.com -F 'token=abc=def=='`
3. Or paste `curl -X POST https://example.com -F 'file=@/tmp/a=b.txt'`
4. Import

Before
- `token` becomes `abc`
- file path becomes `/tmp/a`

After
- `token` stays `abc=def==`
- file path stays `/tmp/a=b.txt`

This is real-world enough, not some unicorn edge case. base64-ish fields and odd file names happen all the time.

Tests
- added 2 regression tests for multipart text/file fields with extra `=`
- `npm test --silent -w packages/insomnia -- src/main/importers/importers/curl.test.ts`
- `npm run type-check`
- `npm test`
- `npm run lint` still reports existing warnings in untouched files, same as before
