### PR TITLE
fix: new sidebar navigation header tabs styles

### DIFF
--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar-header.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar-header.tsx
@@ -26,13 +26,13 @@ export const SidebarHeader = ({
   actionButton,
 }: SidebarHeaderProps) => (
   <>
-    <div className="flex shrink-0 border-b border-solid border-b-(--hl-md)">
+    <div className="flex h-[41px] shrink-0 border-b border-solid border-b-(--hl-md)">
       {!isScratchPad &&
         tabs.map(({ name, label }) => (
           <button
             type="button"
             key={name}
-            className={`border-b-2 border-solid px-4 py-2 text-xs ${activeTab === name ? 'border-(--color-surprise) text-(--color-font)' : 'border-b-transparent text-(--hl) hover:bg-(--hl-xs)'}`}
+            className={`px-3 py-1 ${activeTab === name ? 'bg-(--hl-xs) text-(--color-font)' : 'text-(--hl) hover:bg-(--hl-sm) hover:text-(--color-font)'}`}
             data-testid={`sidebar-tab-${name}`}
             onClick={() => onTabChange(name)}
           >

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar-header.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar-header.tsx
@@ -26,7 +26,7 @@ export const SidebarHeader = ({
   actionButton,
 }: SidebarHeaderProps) => (
   <>
-    <div className="flex h-[41px] shrink-0 border-b border-solid border-b-(--hl-md)">
+    <div className="flex h-12 shrink-0 border-b border-solid border-b-(--hl-md)">
       {!isScratchPad &&
         tabs.map(({ name, label }) => (
           <button

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
@@ -745,7 +745,7 @@ export const ProjectNavigationSidebar = ({
           {
             name: 'konnect',
             label: (
-              <span className="flex items-center gap-1">
+              <span className="flex items-center gap-2">
                 <KongLogo />
                 Konnect ({konnectProjects.length})
               </span>

--- a/packages/insomnia/src/ui/components/tabs/tab-list.tsx
+++ b/packages/insomnia/src/ui/components/tabs/tab-list.tsx
@@ -20,7 +20,6 @@ import { useInsomniaTab } from '~/ui/hooks/use-insomnia-tab';
 
 import { type ChangeBufferEvent, type ChangeType, database } from '../../../common/database';
 import { debounce } from '../../../common/misc';
-import { INSOMNIA_TAB_HEIGHT } from '../../constant';
 import { useInsomniaTabContext } from '../../context/app/insomnia-tab-context';
 import { type Size, useResizeObserver } from '../../hooks/use-resize-observer';
 import { Icon } from '../icon';
@@ -373,7 +372,7 @@ export const OrganizationTabList = ({ showActiveStatus = true, currentPage = '' 
   if (!tabList.length) return null;
 
   return (
-    <div className="box-content flex bg-(--color-bg)" style={{ height: `${INSOMNIA_TAB_HEIGHT + 1}px` }}>
+    <div className="box-content flex h-12 bg-(--color-bg)">
       <Button
         onPress={scrollLeft}
         isDisabled={leftScrollDisable}
@@ -393,7 +392,7 @@ export const OrganizationTabList = ({ showActiveStatus = true, currentPage = '' 
           disallowEmptySelection
           selectionMode="single"
           selectionBehavior="replace"
-          className="flex h-[41px] w-fit"
+          className="flex h-12 w-fit"
           dragAndDropHooks={dragAndDropHooks}
           items={tabList}
           dependencies={[issuesByWorkspaceId]}


### PR DESCRIPTION
This PR makes subtle style edits in order to make the sidebar header tabs pattern visually more consistent with other tabs that exist in the Insomnia app.

Before:
<img width="536" height="340" alt="Screenshot 2026-05-26 at 11 55 16 AM" src="https://github.com/user-attachments/assets/41da5c91-84fb-4a5c-bcda-87332cf2e0ff" />

After:
<img width="518" height="337" alt="Screenshot 2026-05-26 at 11 55 28 AM" src="https://github.com/user-attachments/assets/200e6512-1f91-49dc-8d90-f606de56c599" />

