### PR TITLE
fix: style tweaks in konnect integration empty state

### DIFF
--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/konnect-sync-intro/konnect-sync-intro.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/konnect-sync-intro/konnect-sync-intro.tsx
@@ -10,15 +10,17 @@ export const KonnectSyncIntro = ({ onConfigure }: KonnectSyncIntroProps) => {
   return (
     <div className="m-2 flex flex-col overflow-hidden rounded-md bg-black text-center text-white">
       <img src={bgUrl} alt="" className="w-full object-cover" />
-      <div className="flex flex-col items-center gap-3 px-4 pb-10">
+      <div className="flex flex-col items-center gap-5 px-4 pb-10">
         <span className="rounded-sm border border-[#b5f021] px-2 py-0.5 text-xs font-semibold text-[#b5f021]">NEW</span>
-        <h3 className="text-base leading-snug font-bold">Auto-sync your gateway service routes</h3>
-        <p className="text-sm text-[#aaa]">
-          Get right into testing your gateway configuration in Insomnia with the new Konnect platform integration.
-        </p>
+        <div className="flex flex-col gap-1">
+          <h3 className="text-base leading-snug font-bold">Auto-sync your gateway service routes</h3>
+          <p className="text-sm text-[#aaa]">
+            Get right into testing your gateway configuration in Insomnia with the new Konnect platform integration.
+          </p>
+        </div>
         <Button
           onPress={onConfigure}
-          className="mt-1 rounded-md border border-solid border-[#444] bg-[#1a1a1a] px-5 py-1.5 text-sm text-white transition-colors hover:bg-[#2a2a2a] focus:outline-none"
+          className="flex h-full items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) px-4 py-2 text-sm text-(--color-font) transition-colors hover:bg-(--hl-xs) aria-pressed:bg-(--hl-xs)"
         >
           Configure
         </Button>


### PR DESCRIPTION
These are some changes I am suggesting to slightly tweak the styles of the konnect empty state.

Changes that were made:
1. Adjusting spacing and proposing another wrapper around empty state content for spacing purposes.
2. Updating button classes to match other outline buttons that look like this in the app

Before:
<img width="632" height="616" alt="Screenshot 2026-05-27 at 2 47 29 PM" src="https://github.com/user-attachments/assets/872643c6-676b-4f33-961a-8fd136b022cb" />

After:
<img width="638" height="704" alt="Screenshot 2026-05-27 at 2 46 53 PM" src="https://github.com/user-attachments/assets/9fabd727-ff31-4900-9cc3-33e8d2601f6b" />

