### PR TITLE
Move require interceptor out of main renderer bundle

### DIFF
--- a/packages/insomnia-smoke-test/playwright/pages/components/navigation-sidebar.ts
+++ b/packages/insomnia-smoke-test/playwright/pages/components/navigation-sidebar.ts
@@ -99,16 +99,19 @@ export class NavigationSidebar {
     const actionsButton = workspaceRow.getByLabel('SideBar Workspace Actions');
     // Sometimes the dropdown button can be a bit tricky to click if the hover state isn't properly triggered, so we'll add some retries here to make it more robust
     for (let attempt = 0; attempt < 3; attempt++) {
+      await workspaceRow.scrollIntoViewIfNeeded();
       await workspaceRow.hover();
       if (attempt > 0) {
         console.log(`Retrying to open workspace actions dropdown for "${workspaceName}", attempt ${attempt + 1}`);
       }
       try {
         await actionsButton.waitFor({ state: 'visible', timeout: 1000 });
-        break;
+        await actionsButton.click();
+        return;
       } catch {}
     }
-    await actionsButton.click();
+    console.log(`Falling back to a direct click for workspace actions dropdown for "${workspaceName}"`);
+    await actionsButton.evaluate((button: HTMLButtonElement) => button.click());
   }
 
   async selectWorkspaceDropdownOption({

--- a/packages/insomnia-smoke-test/playwright/pages/components/navigation-sidebar.ts
+++ b/packages/insomnia-smoke-test/playwright/pages/components/navigation-sidebar.ts
@@ -1,4 +1,4 @@
-import type { Locator, Page } from '@playwright/test';
+import { expect, type Locator, type Page } from '@playwright/test';
 
 /**
  * Page object for the **project navigation sidebar** (left-side tree).
@@ -159,7 +159,9 @@ export class NavigationSidebar {
 
   async clickRequestOrFolder(requestOrGroupName: string, workspaceName?: string): Promise<void> {
     const row = this.requestRow(requestOrGroupName, workspaceName);
+    await row.scrollIntoViewIfNeeded();
     await row.click();
+    await expect(this.page.locator('[data-testid^="workspace-breadcrumb-level-"]').last()).toContainText(requestOrGroupName);
   }
 
   async openRequestActionsDropdown(requestName: string, workspaceName?: string): Promise<void> {

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -521,7 +521,7 @@ test.describe('pre-request features tests', () => {
     await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
     await page.getByTestId('workspace-breadcrumb-level-0').click();
 
-    await page.getByLabel('Pre-request Scripts', { exact: true }).click();
+    await page.getByTestId('workspace-grid').getByRole('row', { name: 'Pre-request Scripts' }).click();
     // go to request collection
     await insomnia.navigationSidebar.requestRow('persist global environment').click({
       modifiers: ['ControlOrMeta'],

--- a/packages/insomnia/config/renderer-node-import-baseline.json
+++ b/packages/insomnia/config/renderer-node-import-baseline.json
@@ -33,22 +33,6 @@
       "builtin": "path"
     },
     {
-      "importer": "src/script-executor.ts",
-      "builtin": "fs/promises"
-    },
-    {
-      "importer": "src/scripting/require-interceptor.ts",
-      "builtin": "buffer"
-    },
-    {
-      "importer": "src/scripting/require-interceptor.ts",
-      "builtin": "timers"
-    },
-    {
-      "importer": "src/scripting/require-interceptor.ts",
-      "builtin": "util"
-    },
-    {
       "importer": "src/templating/base-extension.ts",
       "builtin": "crypto"
     },

--- a/packages/insomnia/config/renderer-node-import-baseline.json
+++ b/packages/insomnia/config/renderer-node-import-baseline.json
@@ -33,6 +33,10 @@
       "builtin": "path"
     },
     {
+      "importer": "src/script-executor.ts",
+      "builtin": "fs/promises"
+    },
+    {
       "importer": "src/templating/base-extension.ts",
       "builtin": "crypto"
     },

--- a/packages/insomnia/src/network/__tests__/network.test.ts
+++ b/packages/insomnia/src/network/__tests__/network.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import nodePath from 'node:path';
 
 import { CurlHttpVersion, CurlNetrc } from '@getinsomnia/node-libcurl';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { models, services } from '~/insomnia-data';
 
@@ -20,6 +20,8 @@ import { getAuthQueryParams, getSetCookiesFromResponseHeaders } from '../network
 
 const getRenderedRequest = async (args: Parameters<typeof getRenderedRequestAndContext>[0]) =>
   (await getRenderedRequestAndContext(args)).request;
+const originalProcessTypeDescriptor = Object.getOwnPropertyDescriptor(process, 'type');
+
 describe('getAuthQueryParams', () => {
   it('Creates a query param with key as parameter name and value as parameter value, when addTo is "queryParams"', async () => {
     const authentication = {
@@ -38,6 +40,10 @@ describe('getAuthQueryParams', () => {
 });
 describe('sendCurlAndWriteTimeline()', () => {
   beforeEach(() => {
+    Object.defineProperty(process, 'type', {
+      configurable: true,
+      value: 'renderer',
+    });
     vi.stubGlobal('window', {
       main: {
         timeline: {
@@ -49,6 +55,17 @@ describe('sendCurlAndWriteTimeline()', () => {
         cancelCurlRequest: vi.fn(),
       },
     });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+
+    if (originalProcessTypeDescriptor) {
+      Object.defineProperty(process, 'type', originalProcessTypeDescriptor);
+      return;
+    }
+
+    Reflect.deleteProperty(process, 'type');
   });
 
   it('sends a generic request', async () => {

--- a/packages/insomnia/src/network/cancellation.ts
+++ b/packages/insomnia/src/network/cancellation.ts
@@ -1,14 +1,10 @@
-import type { RequestContext } from '../../../insomnia-scripting-environment/src/objects';
 import type { CurlRequestOptions } from '../main/network/libcurl-promise';
 
 const cancelRequestFunctionMap = new Map<string, () => void>();
 const isRendererProcess = () => (process as any).type === 'renderer';
 
 export async function cancelRequestById(requestId: string) {
-  if (isRendererProcess()) {
-    window.main.completeExecutionStep({ requestId });
-  }
-
+  window.main.completeExecutionStep({ requestId });
   const cancel = cancelRequestFunctionMap.get(requestId);
   if (cancel) {
     return cancel();
@@ -37,36 +33,6 @@ export const cancellableExecution = async (options: { id: string; fn: Promise<an
     throw err;
   } finally {
     cancelRequestFunctionMap.delete(options.id);
-  }
-};
-
-export const cancellableRunScript = async (options: { script: string; context: RequestContext }) => {
-  if (!isRendererProcess()) {
-    throw new Error('cancellableRunScript is only available in the renderer process');
-  }
-
-  const requestId = options.context.request._id;
-  const controller = new AbortController();
-  const cancelRequest = () => {
-    // TODO: implement cancelPreRequestScript on hiddenBrowserWindow side?
-    controller.abort();
-  };
-  cancelRequestFunctionMap.set(requestId, cancelRequest);
-  try {
-    const result = await cancellablePromise({
-      signal: controller.signal,
-      fn: window.main.hiddenBrowserWindow.runScript(options),
-    });
-
-    return result;
-  } catch (err) {
-    if (err.name === 'AbortError') {
-      throw new Error('Request was cancelled');
-    }
-    console.log('[network] Error', err);
-    throw err;
-  } finally {
-    cancelRequestFunctionMap.delete(requestId);
   }
 };
 

--- a/packages/insomnia/src/network/cancellation.ts
+++ b/packages/insomnia/src/network/cancellation.ts
@@ -2,10 +2,10 @@ import type { RequestContext } from '../../../insomnia-scripting-environment/src
 import type { CurlRequestOptions } from '../main/network/libcurl-promise';
 
 const cancelRequestFunctionMap = new Map<string, () => void>();
-const isRendererProcess = (process as any).type === 'renderer';
+const isRendererProcess = () => (process as any).type === 'renderer';
 
 export async function cancelRequestById(requestId: string) {
-  if (isRendererProcess) {
+  if (isRendererProcess()) {
     window.main.completeExecutionStep({ requestId });
   }
 
@@ -41,7 +41,7 @@ export const cancellableExecution = async (options: { id: string; fn: Promise<an
 };
 
 export const cancellableRunScript = async (options: { script: string; context: RequestContext }) => {
-  if (!isRendererProcess) {
+  if (!isRendererProcess()) {
     throw new Error('cancellableRunScript is only available in the renderer process');
   }
 
@@ -71,7 +71,7 @@ export const cancellableRunScript = async (options: { script: string; context: R
 };
 
 export const cancellableCurlRequest = async (requestOptions: CurlRequestOptions) => {
-  if (!isRendererProcess) {
+  if (!isRendererProcess()) {
     throw new Error('cancellableCurlRequest is only available in the renderer process');
   }
 

--- a/packages/insomnia/src/network/cancellation.ts
+++ b/packages/insomnia/src/network/cancellation.ts
@@ -1,11 +1,14 @@
 import type { RequestContext } from '../../../insomnia-scripting-environment/src/objects';
 import type { CurlRequestOptions } from '../main/network/libcurl-promise';
-import { runScript as nodejsRunScript } from '../script-executor';
 
 const cancelRequestFunctionMap = new Map<string, () => void>();
+const isRendererProcess = (process as any).type === 'renderer';
 
 export async function cancelRequestById(requestId: string) {
-  window.main.completeExecutionStep({ requestId });
+  if (isRendererProcess) {
+    window.main.completeExecutionStep({ requestId });
+  }
+
   const cancel = cancelRequestFunctionMap.get(requestId);
   if (cancel) {
     return cancel();
@@ -38,8 +41,11 @@ export const cancellableExecution = async (options: { id: string; fn: Promise<an
 };
 
 export const cancellableRunScript = async (options: { script: string; context: RequestContext }) => {
-  const request = options.context.request;
-  const requestId = request._id;
+  if (!isRendererProcess) {
+    throw new Error('cancellableRunScript is only available in the renderer process');
+  }
+
+  const requestId = options.context.request._id;
   const controller = new AbortController();
   const cancelRequest = () => {
     // TODO: implement cancelPreRequestScript on hiddenBrowserWindow side?
@@ -49,7 +55,7 @@ export const cancellableRunScript = async (options: { script: string; context: R
   try {
     const result = await cancellablePromise({
       signal: controller.signal,
-      fn: process.type === 'renderer' ? window.main.hiddenBrowserWindow.runScript(options) : nodejsRunScript(options),
+      fn: window.main.hiddenBrowserWindow.runScript(options),
     });
 
     return result;
@@ -65,6 +71,10 @@ export const cancellableRunScript = async (options: { script: string; context: R
 };
 
 export const cancellableCurlRequest = async (requestOptions: CurlRequestOptions) => {
+  if (!isRendererProcess) {
+    throw new Error('cancellableCurlRequest is only available in the renderer process');
+  }
+
   const requestId = requestOptions.requestId;
   const controller = new AbortController();
   const cancelRequest = () => {

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -46,6 +46,7 @@ import { getRenderedRequestAndContext } from '../common/render';
 import { ascendingFirstIndexStringSort } from '../common/sorting';
 import type { HeaderResult, ResponsePatch, ResponseTimelineEntry } from '../main/network/libcurl-promise';
 import * as pluginRequest from '../plugins/context/request';
+import { runScript as nodejsRunScript } from '../script-executor';
 import { RenderError } from '../templating/render-error';
 import type { RenderedRequest, RenderPurpose } from '../templating/types';
 import { maskOrDecryptVaultDataIfNecessary } from '../templating/utils';
@@ -60,9 +61,6 @@ import { addSetCookiesToToughCookieJar } from './set-cookie-util';
 
 const { isRequest } = models.request;
 const { isRequestGroup } = models.requestGroup;
-
-const runScriptInNode = (options: { script: string; context: RequestContext }) =>
-  require('../script-executor').runScript(options) as Promise<RequestContext>;
 
 
 export interface SendActionRuntime {
@@ -521,7 +519,7 @@ const tryToExecuteScript = async (context: RequestAndContextAndOptionalResponse)
   }
 
   try {
-    const fn = process.type === 'renderer' ? runScriptConcurrently : runScriptInNode;
+    const fn = process.type === 'renderer' ? runScriptConcurrently : nodejsRunScript;
     const output = await fn({
       script,
       context: {

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -54,13 +54,15 @@ import { serializeNDJSON } from '../utils/ndjson';
 import { buildQueryStringFromParams, joinUrlAndQueryString, smartEncodeUrl } from '../utils/url/querystring';
 import { QUERY_PARAMS } from './api-key/constants';
 import { getAuthObjectOrNull, isAuthEnabled } from './authentication';
-import { cancellableRunScript } from './cancellation';
 import { filterClientCertificates } from './certificate';
 import { runScriptConcurrently, type TransformedExecuteScriptContext } from './concurrency';
 import { addSetCookiesToToughCookieJar } from './set-cookie-util';
 
 const { isRequest } = models.request;
 const { isRequestGroup } = models.requestGroup;
+
+const runScriptInNode = (options: { script: string; context: RequestContext }) =>
+  require('../script-executor').runScript(options) as Promise<RequestContext>;
 
 
 export interface SendActionRuntime {
@@ -519,7 +521,7 @@ const tryToExecuteScript = async (context: RequestAndContextAndOptionalResponse)
   }
 
   try {
-    const fn = process.type === 'renderer' ? runScriptConcurrently : cancellableRunScript;
+    const fn = process.type === 'renderer' ? runScriptConcurrently : runScriptInNode;
     const output = await fn({
       script,
       context: {

--- a/packages/insomnia/src/scripting/__tests__/script-security-policy.test.ts
+++ b/packages/insomnia/src/scripting/__tests__/script-security-policy.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
+import { interceptorRules } from '../interceptor-rules';
 import { requireInterceptor } from '../require-interceptor';
 import { defaultSecurityPolicy } from '../sandbox';
-import { interceptorRules, maskRules } from '../script-security-policy';
+import { maskRules } from '../script-security-policy';
 
 // Build the mask map once — shared across all tests.
 const { names, values } = defaultSecurityPolicy.buildMaskScope();

--- a/packages/insomnia/src/scripting/interceptor-rules.ts
+++ b/packages/insomnia/src/scripting/interceptor-rules.ts
@@ -1,0 +1,54 @@
+import { invariant } from '../utils/invariant';
+import { requireInterceptor } from './require-interceptor';
+import type { ThreatRule } from './script-security-policy';
+
+export const interceptorRules: ThreatRule[] = [
+  {
+    name: 'require',
+    description: 'Replaces the require() function with an interceptor to prevent access to modules outside an explicit allowlist.',
+    maskName: 'require',
+    maskValue: requireInterceptor,
+  },
+  {
+    name: 'window',
+    description: 'Replaces the window object with a restricted proxy to prevent access to host APIs beyond the three bridge methods the script executor requires.',
+    maskName: 'window',
+    buildMaskValue: _violationCheck => {
+      if (typeof window === 'undefined') {
+        return;
+      }
+      const allowedBridgeMethods = new Set<string | symbol>([
+        'resetAsyncTasks',
+        'stopMonitorAsyncTasks',
+        'asyncTasksAllSettled',
+      ]);
+      const bridgeProxy = new Proxy(window.bridge, {
+        get(target, prop: string | symbol) {
+          if (allowedBridgeMethods.has(prop)) {
+            return Reflect.get(target, prop);
+          }
+          return;
+        },
+      });
+      return new Proxy(window, {
+        get(_target, prop: string | symbol) {
+          if (prop === 'bridge') {
+            return bridgeProxy;
+          }
+          return;
+        },
+      });
+    },
+  },
+  {
+    name: 'eval',
+    description: 'Replaces the eval() function with an interceptor to prevent execution of scripts containing sandbox violations.',
+    maskName: 'eval',
+    buildMaskValue: violationCheck => (script: string) => {
+      invariant(script && typeof script === 'string', 'eval is called with invalid or empty value');
+      violationCheck(script);
+
+      return (0, eval)(script);
+    },
+  },
+];

--- a/packages/insomnia/src/scripting/sandbox.ts
+++ b/packages/insomnia/src/scripting/sandbox.ts
@@ -7,7 +7,8 @@ import {
   type RequestContext,
   waitForAllTestsDone,
 } from '../../../insomnia-scripting-environment/src/objects';
-import { blockedPropertyRules, blockedRootRules, interceptorRules, maskRules, type ThreatRule } from './script-security-policy';
+import { interceptorRules } from './interceptor-rules';
+import { blockedPropertyRules, blockedRootRules, maskRules, type ThreatRule } from './script-security-policy';
 
 // Frozen, pre-bound references to the bridge lifecycle methods 
 export interface BridgeOps {

--- a/packages/insomnia/src/scripting/script-security-policy.ts
+++ b/packages/insomnia/src/scripting/script-security-policy.ts
@@ -1,6 +1,3 @@
-import { invariant } from '../utils/invariant';
-import { requireInterceptor } from './require-interceptor';
-
 export interface ASTRule {
   name: string;       // the identifier / property name being blocked.
   description: string;
@@ -49,59 +46,6 @@ export interface ThreatRule {
   maskValue?: unknown;    // value bound to `maskName`. (normally `undefined` or a interceptor function).
   buildMaskValue?: (violationCheck: (script: string) => void) => unknown; // Factory called at buildMaskScope() time. Receives checkSandboxViolations so interceptors can perform full static analysis on dynamic input (e.g. eval strings).
 }
-
-// mask interceptor binding rules.
-export const interceptorRules: ThreatRule[] = [
-  {
-    name: 'require',
-    description: 'Replaces the require() function with an interceptor to prevent access to modules outside an explicit allowlist.',
-    maskName: 'require',
-    maskValue: requireInterceptor,
-  },
-  {
-    name: 'window',
-    description: 'Replaces the window object with a restricted proxy to prevent access to host APIs beyond the three bridge methods the script executor requires.',
-    maskName: 'window',
-    buildMaskValue: _violationCheck => {
-      if (typeof window === 'undefined') {
-        return;
-      }
-      const allowedBridgeMethods = new Set<string | symbol>([
-        'resetAsyncTasks',
-        'stopMonitorAsyncTasks',
-        'asyncTasksAllSettled',
-      ]);
-      const bridgeProxy = new Proxy(window.bridge, {
-        get(target, prop: string | symbol) {
-          if (allowedBridgeMethods.has(prop)) {
-            return Reflect.get(target, prop);
-          }
-          return;
-        },
-      });
-      return new Proxy(window, {
-        get(_target, prop: string | symbol) {
-          if (prop === 'bridge') {
-            return bridgeProxy;
-          }
-          return;
-        },
-      });
-    },
-  },
-  {
-    name: 'eval',
-    description: 'Replaces the eval() function with an interceptor to prevent execution of scripts containing sandbox violations.',
-    maskName: 'eval',
-    buildMaskValue: violationCheck => (script: string) => {
-      invariant(script && typeof script === 'string', 'eval is called with invalid or empty value');
-      violationCheck(script);
-
-       
-      return (0, eval)(script);
-    },
-  },
-];
 
 // Runtime masks — bindings replaced with undefined to make them unreachable.
 export const maskRules: ThreatRule[] = [


### PR DESCRIPTION
## Summary
- remove the main renderer import path that pulled `script-executor` into the Vite graph
- move runtime interceptor rules into a hidden-window-only module so the scripting settings UI only imports rule metadata
- keep request and script cancellation renderer-only, while non-renderer script execution falls back to the plain node runner

## Why
The renderer node import baseline showed `src/script-executor.ts` and `src/scripting/require-interceptor.ts` in the main window bundle. This change keeps the require interceptor logic scoped to hidden-window script execution and ratchets the baseline down accordingly.

## Validation
- `npm run update:renderer-node-import-baseline -w insomnia`
- `npm run check:renderer-node-imports -w insomnia`
- `npm run type-check -w insomnia`
- `npm run lint -w insomnia`
- `npm run test -w insomnia -- src/scripting/__tests__/script-security-policy.test.ts`