### PR TITLE
fix: shell:open auth redirect and TrailLines height growth bug

### DIFF
--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -91,6 +91,54 @@ const sanitizeUrlAndExtractOrigin = (url: string) => {
 };
 export const clientMiddleware: Route.ClientMiddlewareFunction[] = [locationHistoryMiddleware];
 
+// Shared URL-parsing utility used by both useAuthDeepLinkHandler and Root's
+// full deep-link handler to avoid duplicating the try/catch and dev-protocol
+// normalisation logic.
+const parseDeepLinkUrl = (url: string) => {
+  // Get the url without params
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    console.log('[deep-link] Invalid args, expected insomnia://x/y/z', url);
+    return;
+  }
+  let urlWithoutParams = url.slice(0, Math.max(0, url.indexOf('?'))) || url;
+  const params = Object.fromEntries(parsedUrl.searchParams);
+
+  // Change protocol for dev redirects to match switch case
+  if (isDevelopment()) {
+    urlWithoutParams = urlWithoutParams.replace('insomniadev://', 'insomnia://');
+  }
+  return { urlWithoutParams, params };
+};
+
+// Handles the auth/logout deep-link (insomnia://app/auth/login) independently
+// of the Root component so that it continues to work even when Root is replaced
+// by ErrorBoundary. Without this, an invalid session that causes an error before
+// Root mounts would leave the IPC listener unregistered, blocking the API-
+// triggered redirect to the logout page.
+// Root calls this hook too, but skips the auth/login case in its own handler
+// (see the early return below) to avoid double-handling.
+const useAuthDeepLinkHandler = () => {
+  const { submit: logoutSubmit } = useLogoutFetcher();
+  useEffect(() => {
+    return window.main.on('shell:open', async (_, url: string) => {
+      const parsed = parseDeepLinkUrl(url);
+      if (!parsed) return;
+      const { urlWithoutParams, params } = parsed;
+
+      if (urlWithoutParams === 'insomnia://app/auth/login') {
+        if (params.message) {
+          window.localStorage.setItem('logoutMessage', params.message);
+        }
+
+        return logoutSubmit();
+      }
+    });
+  }, [logoutSubmit]);
+};
+
 export const ErrorBoundary: FC<Route.ErrorBoundaryProps> = ({ error }) => {
   const getErrorMessage = (err: any) => {
     if (isRouteErrorResponse(err)) {
@@ -108,6 +156,7 @@ export const ErrorBoundary: FC<Route.ErrorBoundaryProps> = ({ error }) => {
 
   const errorMessage = getErrorMessage(error);
   const logoutFetcher = useLogoutFetcher();
+  useAuthDeepLinkHandler();
 
   return (
     <div className="flex h-full w-full flex-col items-center justify-center gap-2 overflow-hidden">
@@ -322,12 +371,12 @@ const Root = () => {
   const [importObject, setImportObject] = useState<ImportSource>({ type: 'clipboard', defaultValue: '' });
   const { submit: createCloudCredentials } = useCreateCloudCredentialActionFetcher();
   const { submit: authorizeSubmit } = useAuthorizeActionFetcher();
-  const { submit: logoutSubmit } = useLogoutFetcher();
   const { submit: redirectToDefaultBrowserSubmit } = useDefaultBrowserRedirectActionFetcher();
   const { submit: gitProviderCompleteSignInSubmit } = useGitProviderCompleteSignInFetcher({
     key: GIT_PROVIDER_COMPLETE_SIGN_IN_FETCHER_KEY,
   });
   const navigate = useNavigate();
+  useAuthDeepLinkHandler();
 
   const { revalidate } = useRevalidator();
   const inflightFetchers = useFetchers();
@@ -358,32 +407,20 @@ const Root = () => {
 
   useEffect(() => {
     return window.main.on('shell:open', async (_: IpcRendererEvent, url: string) => {
-      // Get the url without params
-      let parsedUrl;
-      try {
-        parsedUrl = new URL(url);
-      } catch {
-        console.log('[deep-link] Invalid args, expected insomnia://x/y/z', url);
+      const parsed = parseDeepLinkUrl(url);
+      if (!parsed) {
         return;
       }
-      let urlWithoutParams = url.slice(0, Math.max(0, url.indexOf('?'))) || url;
-      const params = Object.fromEntries(parsedUrl.searchParams);
-      // Change protocol for dev redirects to match switch case
-      if (isDevelopment()) {
-        urlWithoutParams = urlWithoutParams.replace('insomniadev://', 'insomnia://');
+      const { urlWithoutParams, params } = parsed;
+      // Handled by useAuthDeepLinkHandler (registered in both Root and ErrorBoundary)
+      if (urlWithoutParams === 'insomnia://app/auth/login') {
+        return;
       }
       if (urlWithoutParams === 'insomnia://app/alert') {
         return showModal(AlertModal, {
           title: params.title,
           message: params.message,
         });
-      }
-      if (urlWithoutParams === 'insomnia://app/auth/login') {
-        if (params.message) {
-          window.localStorage.setItem('logoutMessage', params.message);
-        }
-
-        return logoutSubmit();
       }
       // Supports params: uri, curl, origin
       if (urlWithoutParams === 'insomnia://app/import') {
@@ -556,11 +593,11 @@ const Root = () => {
       if (urlWithoutParams === 'insomnia://oauth/azure/authenticate') {
         const { code, ...restParams } = params;
         if (code && typeof code === 'string') {
-          const authResult = await plugins.executePluginMainAction({
+          const authResult = (await plugins.executePluginMainAction({
             pluginName: EXTERNAL_VAULT_PLUGIN_NAME,
             actionName: 'exchangeCode',
             params: { provider: 'azure', code },
-          }) as any;
+          })) as any;
           const { success, result, error } = authResult;
           if (success) {
             const { account, uniqueId } = result!;
@@ -636,7 +673,6 @@ const Root = () => {
     authorizeSubmit,
     createCloudCredentials,
     gitProviderCompleteSignInSubmit,
-    logoutSubmit,
     navigate,
     organizationId,
     projectId,

--- a/packages/insomnia/src/ui/components/trail-lines.tsx
+++ b/packages/insomnia/src/ui/components/trail-lines.tsx
@@ -91,7 +91,16 @@ const TrailLines = forwardRef<TrailsLineHandle, Props>(
     useImperativeHandle(
       ref,
       () => ({
+        // Synchronously set display style via DOM instead of relying solely on React
+        // state (setShowPaths). Without this, callers that measure containerRef
+        // dimensions immediately after toggle(false) would still read the old
+        // inflated SVG height because the React re-render hasn't flushed yet —
+        // causing a one-directional height growth bug where the container can
+        // grow on resize but never shrink.
         toggle: (show: boolean) => {
+          if (refRoot.current) {
+            refRoot.current.style.display = show ? '' : 'none';
+          }
           setShowPaths(show);
         },
       }),


### PR DESCRIPTION
## Background

1. shell:open auth redirect lost when ErrorBoundary is shown (root.tsx)

   When a session is invalid and an error is thrown before Root mounts, React Router renders ErrorBoundary instead of Root. The window.main 'shell:open' IPC listener registered inside Root's useEffect is never set up, so the API-triggered insomnia://app/auth/login deep link that should redirect the user to logout is silently ignored, leaving the app stuck on the error screen.

2. TrailLines SVG height can only grow, never shrink on window resize (trail-lines.tsx)

   toggle(false) queues a React state update (async), but containerRef.clientHeight is read synchronously right after in updateDimensions. The SVG is still in the DOM with its old height at measurement time, so the container always reports the inflated height. When the window shrinks, the next measurement reads the old inflated SVG height and the cycle repeats — height is locked and can only grow.

[INS-2683](https://konghq.atlassian.net/browse/INS-2683)

[INS-2683]: https://konghq.atlassian.net/browse/INS-2683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ