### PR TITLE
fix: enhance deep link handling in insomniaFetch function in main

### DIFF
--- a/packages/insomnia/src/common/insomnia-fetch.ts
+++ b/packages/insomnia/src/common/insomnia-fetch.ts
@@ -13,9 +13,11 @@ export async function insomniaFetch<T = void>({
   origin,
   headers,
   timeout = INSOMNIA_FETCH_TIME_OUT,
+  onDeepLink,
 }: FetchConfig & {
   // It's not used at all, should be removed?
   retries?: number;
+  onDeepLink?: (uri: string) => void;
 }): Promise<T> {
   const config: RequestInit = {
     method,
@@ -39,8 +41,8 @@ export async function insomniaFetch<T = void>({
   try {
     const response = await fetch((origin || getApiBaseURL()) + path, config);
     const uri = response.headers.get('x-insomnia-command');
-    if (uri) {
-      window.main.openDeepLink(uri);
+    if (uri && onDeepLink) {
+      onDeepLink(uri);
     }
     const isJson = response.headers.get('content-type')?.includes('application/json') || path.match(/\.json$/);
     if (!response.ok) {

--- a/packages/insomnia/src/entry.client.tsx
+++ b/packages/insomnia/src/entry.client.tsx
@@ -38,7 +38,7 @@ initServices(window._dataServices);
 // Remove the global services reference after initialization to improve security by preventing unintended access from the global scope.
 delete window._dataServices;
 
-configureFetch(options => insomniaFetch({ ...options }));
+configureFetch(options => insomniaFetch({ ...options, onDeepLink: (uri: string) => window.main.openDeepLink(uri) }));
 
 await initPlugins();
 

--- a/packages/insomnia/src/entry.main.ts
+++ b/packages/insomnia/src/entry.main.ts
@@ -58,7 +58,10 @@ initializeSentry();
 
 registerInsomniaProtocols();
 
-configureFetch(options => insomniaFetch({ ...options }));
+let openDeepLinkUrl = async (url: string) => {
+  console.warn('[main] openDeepLinkUrl function not initialized yet, cannot open URL:', url);
+};
+configureFetch(options => insomniaFetch({ ...options, onDeepLink: (uri: string) => openDeepLinkUrl(uri) }));
 
 // Handle potential auto-update
 if (checkIfRestartNeeded()) {
@@ -245,7 +248,7 @@ const _launchApp = async () => {
       });
       window = windowUtils.createWindowsAndReturnMain();
 
-      const openDeepLinkUrl = async (url: string) => {
+      openDeepLinkUrl = async (url: string) => {
         console.log('[main] Open Deep Link URL', url);
         window = windowUtils.createWindowsAndReturnMain();
         if (window) {


### PR DESCRIPTION
## Background

Some of the requests are moved to be called in the main process, but when the requests return a deeplink, insomnia fetch still calls window.main.openDeepLink, which causes an incomprehensible error message: Cannot read properties of undefined (reading 'main')