### PR TITLE
fix(e2e): remove pat seeding from flaky windows test

### DIFF
--- a/packages/insomnia-smoke-test/playwright/test.ts
+++ b/packages/insomnia-smoke-test/playwright/test.ts
@@ -159,9 +159,6 @@ export const test = baseTest.extend<{
 
     await page.waitForLoadState();
 
-    // Seed a fake Konnect PAT so konnect-enabled UI renders in all tests
-    await page.evaluate(() => (window as any).main.secretStorage.setSecret('konnectPat', 'kpat_test'));
-
     await use(page);
   },
   dataPath: async ({}, use) => {


### PR DESCRIPTION
An attempt to clear up the flaky Windows e2e, since we only run the critical paths, we don't test the Konnect integration