### PR TITLE
chore: add konnect smoke tests

### DIFF
--- a/packages/insomnia-smoke-test/playwright/test.ts
+++ b/packages/insomnia-smoke-test/playwright/test.ts
@@ -41,6 +41,7 @@ interface EnvOptions {
   INSOMNIA_VAULT_KEY: string;
   INSOMNIA_VAULT_SALT: string;
   INSOMNIA_VAULT_SRP_SECRET: string;
+  KONNECT_API_URL: string;
 }
 
 interface AESMessage {
@@ -95,6 +96,7 @@ export const test = baseTest.extend<{
       INSOMNIA_VAULT_KEY: userConfig.vaultKey || '',
       INSOMNIA_VAULT_SALT: userConfig.vaultSalt || '',
       INSOMNIA_VAULT_SRP_SECRET: userConfig.vaultSrpSecret || '',
+      KONNECT_API_URL: echoServer,
       ...(userConfig.session ? { INSOMNIA_SESSION: JSON.stringify(userConfig.session) } : {}),
     };
     const { ELECTRON_RUN_AS_NODE: _ignored, ...launchEnv } = process.env;

--- a/packages/insomnia-smoke-test/server/insomnia-api.ts
+++ b/packages/insomnia-smoke-test/server/insomnia-api.ts
@@ -653,4 +653,8 @@ export default function setup(app: Application) {
       isAllowed: true,
     });
   });
+
+  app.get('/v2/control-planes', (_req, res) => {
+    res.status(200).json({ data: [] });
+  });
 }

--- a/packages/insomnia-smoke-test/tests/smoke/konnect.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/konnect.test.ts
@@ -19,15 +19,22 @@ test.describe('Konnect sidebar tab', () => {
     await expect.soft(page.getByRole('button', { name: 'Create new Project' })).toBeVisible();
   });
 
-  test('hidden when konnectSync feature flag is disabled', async ({ page, insomnia, request }) => {
-    await request.post('http://127.0.0.1:4010/v1/test-utils/organizations/features', {
-      data: { features: { gitSync: { enabled: true }, konnectSync: { enabled: false } } },
+  test.describe('with konnectSync feature flag disabled', () => {
+    test.beforeEach(async ({ request }) => {
+      await request.post('http://127.0.0.1:4010/v1/test-utils/organizations/features', {
+        data: { features: { gitSync: { enabled: true }, konnectSync: { enabled: false } } },
+      });
     });
-    await page.reload();
-    await expect.soft(page.getByTestId('sidebar-tab-konnect')).toBeHidden();
 
-    await request.post('http://127.0.0.1:4010/v1/test-utils/organizations/features', {
-      data: { features: { gitSync: { enabled: true }, konnectSync: { enabled: true } } },
+    test.afterEach(async ({ request }) => {
+      await request.post('http://127.0.0.1:4010/v1/test-utils/organizations/features', {
+        data: { features: { gitSync: { enabled: true }, konnectSync: { enabled: true } } },
+      });
+    });
+
+    test('hides the Konnect tab', async ({ page }) => {
+      await page.reload();
+      await expect.soft(page.getByTestId('sidebar-tab-konnect')).toBeHidden();
     });
   });
 });

--- a/packages/insomnia-smoke-test/tests/smoke/konnect.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/konnect.test.ts
@@ -5,18 +5,18 @@ import { test } from '../../playwright/test';
 test.describe('Konnect sidebar tab', () => {
   test('shows intro card without a PAT, configure it, then sync', async ({ page, insomnia }) => {
     await page.getByTestId('sidebar-tab-konnect').click();
-    await expect(page.getByText('Auto-sync your gateway service routes')).toBeVisible();
+    await expect.soft(page.getByText('Auto-sync your gateway service routes')).toBeVisible();
 
     await page.getByRole('button', { name: 'Configure' }).click();
     await page.getByLabel('Personal Access Token').fill('kpat_test');
     await page.getByRole('button', { name: 'Connect & Sync' }).click();
-    await expect(page.getByText('Connected')).toBeVisible();
+    await expect.soft(page.getByText('Connected')).toBeVisible();
     await page.getByRole('button', { name: 'Close' }).click();
 
-    await expect(page.getByRole('button', { name: 'Sync Konnect' })).toBeVisible();
+    await expect.soft(page.getByRole('button', { name: 'Sync Konnect' })).toBeVisible();
 
     await page.getByTestId('sidebar-tab-projects').click();
-    await expect(page.getByRole('button', { name: 'Create new Project' })).toBeVisible();
+    await expect.soft(page.getByRole('button', { name: 'Create new Project' })).toBeVisible();
   });
 
   test('hidden when konnectSync feature flag is disabled', async ({ page, insomnia, request }) => {
@@ -24,7 +24,7 @@ test.describe('Konnect sidebar tab', () => {
       data: { features: { gitSync: { enabled: true }, konnectSync: { enabled: false } } },
     });
     await page.reload();
-    await expect(page.getByTestId('sidebar-tab-konnect')).toBeHidden();
+    await expect.soft(page.getByTestId('sidebar-tab-konnect')).toBeHidden();
 
     await request.post('http://127.0.0.1:4010/v1/test-utils/organizations/features', {
       data: { features: { gitSync: { enabled: true }, konnectSync: { enabled: true } } },

--- a/packages/insomnia-smoke-test/tests/smoke/konnect.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/konnect.test.ts
@@ -1,0 +1,33 @@
+import { expect } from '@playwright/test';
+
+import { test } from '../../playwright/test';
+
+test.describe('Konnect sidebar tab', () => {
+  test('shows intro card without a PAT, configure it, then sync', async ({ page, insomnia }) => {
+    await page.getByTestId('sidebar-tab-konnect').click();
+    await expect(page.getByText('Auto-sync your gateway service routes')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Configure' }).click();
+    await page.getByLabel('Personal Access Token').fill('kpat_test');
+    await page.getByRole('button', { name: 'Connect & Sync' }).click();
+    await expect(page.getByText('Connected')).toBeVisible();
+    await page.getByRole('button', { name: 'Close' }).click();
+
+    await expect(page.getByRole('button', { name: 'Sync Konnect' })).toBeVisible();
+
+    await page.getByTestId('sidebar-tab-projects').click();
+    await expect(page.getByRole('button', { name: 'Create new Project' })).toBeVisible();
+  });
+
+  test('hidden when konnectSync feature flag is disabled', async ({ page, insomnia, request }) => {
+    await request.post('http://127.0.0.1:4010/v1/test-utils/organizations/features', {
+      data: { features: { gitSync: { enabled: true }, konnectSync: { enabled: false } } },
+    });
+    await page.reload();
+    await expect(page.getByTestId('sidebar-tab-konnect')).toBeHidden();
+
+    await request.post('http://127.0.0.1:4010/v1/test-utils/organizations/features', {
+      data: { features: { gitSync: { enabled: true }, konnectSync: { enabled: true } } },
+    });
+  });
+});

--- a/packages/insomnia/src/ui/components/modals/konnect-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/konnect-settings-modal.tsx
@@ -114,6 +114,7 @@ export const KonnectSettingsModal = ({
                   {showDisconnectConfirm ? 'Disconnect Kong Konnect?' : 'Kong Konnect settings'}
                 </Heading>
                 <Button
+                  aria-label="Close"
                   className="flex aspect-square h-6 shrink-0 items-center justify-center rounded-sm text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset"
                   onPress={close}
                 >


### PR DESCRIPTION
Adds dedicated smoke tests to ensure the Konnect project sidecar renders when the Konnect feature is enabled.