### PR TITLE
fix: route Request Created to Customer.io via identified profile to stop email-less profiles [INS-2678]

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new.tsx
@@ -12,6 +12,7 @@ import {
 import { invariant } from '~/common/utils/invariant';
 import type { RequestCreatedMetricsProperties } from '~/ui/analytics';
 import { AnalyticsEvent } from '~/ui/analytics';
+import { trackCioEvent } from '~/ui/hooks/use-cio';
 import type { CreateRequestType } from '~/ui/hooks/use-request';
 import { createFetcherSubmitHook } from '~/ui/utils/router';
 
@@ -119,34 +120,40 @@ export async function clientAction({ params, request }: Route.ClientActionArgs) 
 
   const certificates = await services.clientCertificate.findByParentId(workspaceId);
 
+  const requestCreatedProperties = {
+    requestType,
+    protocol: requestType,
+    project_id: projectId,
+    collection_id: workspaceId,
+    request_key_id: activeRequestId,
+    has_prescript: !!req?.preRequestScript,
+    has_postscript: !!req?.afterResponseScript,
+    request_header_names: req?.headers?.map(h => h.name) || [],
+    count_cookies: req?.headers?.find(h => h.name.toLowerCase() === 'cookie')
+      ? req.headers?.find(h => h.name.toLowerCase() === 'cookie')?.value.split(';').length
+      : 0,
+    count_certificates: certificates.length,
+    count_headers: req?.headers?.length || 0,
+    count_query_parameters: req?.parameters?.length || 0,
+    count_path_parameters: req?.pathParameters?.length || 0,
+    count_prescript_lines: req?.preRequestScript ? req.preRequestScript.split('\n').length : 0,
+    count_postscript_lines: req?.afterResponseScript ? req.afterResponseScript.split('\n').length : 0,
+    auth_type:
+      req?.authentication && typeof req.authentication === 'object' && 'type' in req.authentication
+        ? req.authentication.type
+        : 'none',
+    has_docs: !!req?.description,
+    source: metrics?.source,
+  };
+
   window.main.trackAnalyticsEvent({
     event: AnalyticsEvent.requestCreated,
-    properties: {
-      requestType,
-      protocol: requestType,
-      project_id: projectId,
-      collection_id: workspaceId,
-      request_key_id: activeRequestId,
-      has_prescript: !!req?.preRequestScript,
-      has_postscript: !!req?.afterResponseScript,
-      request_header_names: req?.headers?.map(h => h.name) || [],
-      count_cookies: req?.headers?.find(h => h.name.toLowerCase() === 'cookie')
-        ? req.headers?.find(h => h.name.toLowerCase() === 'cookie')?.value.split(';').length
-        : 0,
-      count_certificates: certificates.length,
-      count_headers: req?.headers?.length || 0,
-      count_query_parameters: req?.parameters?.length || 0,
-      count_path_parameters: req?.pathParameters?.length || 0,
-      count_prescript_lines: req?.preRequestScript ? req.preRequestScript.split('\n').length : 0,
-      count_postscript_lines: req?.afterResponseScript ? req.afterResponseScript.split('\n').length : 0,
-      auth_type:
-        req?.authentication && typeof req.authentication === 'object' && 'type' in req.authentication
-          ? req.authentication.type
-          : 'none',
-      has_docs: !!req?.description,
-      source: metrics?.source,
-    },
+    properties: requestCreatedProperties,
   });
+
+  // Send to Customer.io directly so the event is tied to the identified user's
+  // email-bearing profile (only fires when logged in). See INS-2678.
+  trackCioEvent(AnalyticsEvent.requestCreated, requestCreatedProperties);
 
   return redirect(
     href(`/organization/:organizationId/project/:projectId/workspace/:workspaceId/debug/request/:requestId`, {

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
@@ -10,6 +10,7 @@ import { invariant } from '~/common/utils/invariant';
 import { safeToUseInsomniaFileNameWithExt } from '~/sync/git/insomnia-filename';
 import { AnalyticsEvent } from '~/ui/analytics';
 import { showToast } from '~/ui/components/toast-notification';
+import { trackCioEvent } from '~/ui/hooks/use-cio';
 import { createFetcherSubmitHook } from '~/ui/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.new';
@@ -199,10 +200,18 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
         })
       )._id;
 
+      const requestCreatedProperties = {
+        requestType: 'HTTP',
+        ...(workspaceData.source && { source: workspaceData.source }),
+      };
       window.main.trackAnalyticsEvent({
         event: AnalyticsEvent.requestCreated,
-        properties: { requestType: 'HTTP', ...(workspaceData.source && { source: workspaceData.source }) },
+        properties: requestCreatedProperties,
       });
+
+      // Send to Customer.io directly so the event is tied to the identified
+      // user's email-bearing profile (only fires when logged in). See INS-2678.
+      trackCioEvent(AnalyticsEvent.requestCreated, requestCreatedProperties);
 
       if (!redirectAfterCreate) {
         return {

--- a/packages/insomnia/src/ui/hooks/use-cio.tsx
+++ b/packages/insomnia/src/ui/hooks/use-cio.tsx
@@ -85,11 +85,16 @@ export const useCio = () => {
     // Logged out (or not yet logged in): clear any prior Customer.io identity so
     // later events aren't attributed to the previous account (INS-2678).
     if (!currentUserId) {
-      if (identifiedUserId) {
+      // A queued identify must be dropped too, otherwise logging out before the
+      // SDK finishes initializing would re-identify the previous user once it
+      // loads. Always clear the markers; only reset the SDK if there was an
+      // active or queued identity to clear.
+      const hadIdentity = Boolean(identifiedUserId || pendingIdentify);
+      lastIdentifiedUser.current = null;
+      identifiedUserId = null;
+      pendingIdentify = null;
+      if (hadIdentity) {
         globalAnalyticsInstance?.reset();
-        lastIdentifiedUser.current = null;
-        identifiedUserId = null;
-        pendingIdentify = null;
       }
       return;
     }

--- a/packages/insomnia/src/ui/hooks/use-cio.tsx
+++ b/packages/insomnia/src/ui/hooks/use-cio.tsx
@@ -8,6 +8,25 @@ import { useRootLoaderData } from '~/root';
 let globalAnalyticsInstance: AnalyticsBrowser | null = null;
 let isInitializing = false;
 let pendingIdentify: (() => void) | null = null;
+// The raw accountId of the currently identified user, or null when anonymous.
+// We only send Customer.io events for identified users so we never create
+// anonymous, email-less profiles (INS-2678).
+let identifiedUserId: string | null = null;
+
+/**
+ * Track an event directly through the Customer.io browser SDK, tied to the
+ * already-identified user (keyed by the raw accountId used in `identify`).
+ *
+ * No-ops for anonymous users and before the SDK has initialized/identified, so
+ * it can never create email-less Customer.io profiles. This is intentionally
+ * separate from the Segment `track()` pipeline in `main/analytics.ts`.
+ */
+export function trackCioEvent(event: string, properties?: Record<string, unknown>): void {
+  if (!globalAnalyticsInstance || !identifiedUserId) {
+    return;
+  }
+  globalAnalyticsInstance.track(event, properties);
+}
 
 export const useCio = () => {
   const { userSession } = useRootLoaderData()!;
@@ -62,7 +81,20 @@ export const useCio = () => {
   // Handle user identification
   useEffect(() => {
     const currentUserId = userSession?.accountId;
-    if (!currentUserId || currentUserId === lastIdentifiedUser.current) {
+
+    // Logged out (or not yet logged in): clear any prior Customer.io identity so
+    // later events aren't attributed to the previous account (INS-2678).
+    if (!currentUserId) {
+      if (identifiedUserId) {
+        globalAnalyticsInstance?.reset();
+        lastIdentifiedUser.current = null;
+        identifiedUserId = null;
+        pendingIdentify = null;
+      }
+      return;
+    }
+
+    if (currentUserId === lastIdentifiedUser.current) {
       return;
     }
 
@@ -74,6 +106,7 @@ export const useCio = () => {
       });
       globalAnalyticsInstance?.page();
       lastIdentifiedUser.current = currentUserId;
+      identifiedUserId = currentUserId;
     };
 
     if (globalAnalyticsInstance) {

--- a/packages/insomnia/src/ui/hooks/use-cio.tsx
+++ b/packages/insomnia/src/ui/hooks/use-cio.tsx
@@ -89,13 +89,13 @@ export const useCio = () => {
       // SDK finishes initializing would re-identify the previous user once it
       // loads. Always clear the markers; only reset the SDK if there was an
       // active or queued identity to clear.
-      const hadIdentity = Boolean(identifiedUserId || pendingIdentify);
-      lastIdentifiedUser.current = null;
-      identifiedUserId = null;
-      pendingIdentify = null;
+      const hadIdentity = Boolean(pendingIdentify || lastIdentifiedUser.current || identifiedUserId);
       if (hadIdentity) {
         globalAnalyticsInstance?.reset();
       }
+      lastIdentifiedUser.current = null;
+      identifiedUserId = null;
+      pendingIdentify = null;
       return;
     }
 


### PR DESCRIPTION
## Problem

The `Request Created` event was wired through Segment → Customer.io as a destination.
This created several thousand Customer.io profiles in a few hours, the vast majority
**without an email**. We pay per profile in Customer.io, so this is costly garbage.

### Root cause

The app has two separate analytics pipelines keyed by different identifiers:

- **Segment** (`main/analytics.ts`): only ever calls `track()` / `page()` — never
  `identify()`. Its `userId` is a **SHA-256 hash** of the account ID and its
  `anonymousId` is the device ID. It also fires for **not-logged-in users**
  (the gate is `enableAnalytics || hashedAccountId`, and `enableAnalytics`
  defaults to `true`).
- **Customer.io browser SDK** (`use-cio.tsx`): the only place an email reaches
  Customer.io, via `identify(accountId, { email, ... })`, keyed by the **raw**
  `accountId`, and only for logged-in users.

So when Segment forwarded `Request Created` to Customer.io:
1. Anonymous/not-logged-in users created brand-new email-less profiles (the bulk).
2. Logged-in users created duplicate profiles keyed by the hash, which never
   reconciles with the raw-`accountId` email profile.

## Fix

Stop relying on the Segment → Customer.io destination and emit `Request Created`
through the Customer.io browser SDK directly, tied to the already-identified,
email-bearing profile:

- Added a module-level `trackCioEvent()` helper in `use-cio.tsx` that reuses the
  existing global SDK singleton. It **no-ops unless a user is identified**, so it
  can never create anonymous, email-less profiles.
- Track `identifiedUserId` on `identify()`, and `reset()` it on logout so events
  aren't misattributed to a previous account on shared machines / account switches.
- Both `Request Created` call sites now send to Customer.io directly alongside the
  existing Segment `track()` (Segment still feeds the warehouse/other destinations).

## Follow-ups (outside this repo)

- [ ] Disable the Segment → Customer.io destination for `Request Created` in the Segment dashboard.
- [ ] Notify Cam before re-enabling anything for testing, and clean up the existing email-less profiles in Customer.io.
