### PR TITLE
fix(git): default file name from name on create & show file name for MCP in settings [INS-2630]

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/git-sync.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/git-sync.test.ts
@@ -39,9 +39,9 @@ test.describe('Git Sync', () => {
     await page.getByRole('textbox', { name: 'Name', exact: true }).click();
     await page.getByRole('textbox', { name: 'Name', exact: true }).press('ControlOrMeta+a');
     await page.getByRole('textbox', { name: 'Name', exact: true }).fill('Collection 1');
-    await page.getByRole('textbox', { name: 'File name my_collection' }).click();
-    await page.getByRole('textbox', { name: 'File name my_collection' }).press('ControlOrMeta+a');
-    await page.getByRole('textbox', { name: 'File name my_collection' }).fill('collection_1');
+    await page.getByRole('textbox', { name: 'File name' }).click();
+    await page.getByRole('textbox', { name: 'File name' }).press('ControlOrMeta+a');
+    await page.getByRole('textbox', { name: 'File name' }).fill('collection_1');
     await page.getByRole('button', { name: 'Create', exact: true }).click();
     await page.getByTestId('git-dropdown').click();
     await expect.soft(page.getByRole('menuitemradio', { name: 'Commit' })).toBeVisible();
@@ -79,9 +79,9 @@ test.describe('Git Sync', () => {
     await page.getByRole('textbox', { name: 'Name', exact: true }).click();
     await page.getByRole('textbox', { name: 'Name', exact: true }).press('ControlOrMeta+a');
     await page.getByRole('textbox', { name: 'Name', exact: true }).fill('collection 1');
-    await page.getByRole('textbox', { name: 'File name my_collection' }).click();
-    await page.getByRole('textbox', { name: 'File name my_collection' }).press('ControlOrMeta+a');
-    await page.getByRole('textbox', { name: 'File name my_collection' }).fill('collection_1');
+    await page.getByRole('textbox', { name: 'File name' }).click();
+    await page.getByRole('textbox', { name: 'File name' }).press('ControlOrMeta+a');
+    await page.getByRole('textbox', { name: 'File name' }).fill('collection_1');
     await page.getByRole('button', { name: 'Create', exact: true }).click();
     await page.getByText('Create a new Request Collection').waitFor({ state: 'hidden' });
     await insomnia.navigationSidebar.selectProject(GIT_PROJECT_NAME);
@@ -113,9 +113,9 @@ test.describe('Git Sync', () => {
     await page.getByRole('textbox', { name: 'Name', exact: true }).click();
     await page.getByRole('textbox', { name: 'Name', exact: true }).press('ControlOrMeta+a');
     await page.getByRole('textbox', { name: 'Name', exact: true }).fill('Push Test Collection');
-    await page.getByRole('textbox', { name: 'File name my_collection' }).click();
-    await page.getByRole('textbox', { name: 'File name my_collection' }).press('ControlOrMeta+a');
-    await page.getByRole('textbox', { name: 'File name my_collection' }).fill('push_test_collection');
+    await page.getByRole('textbox', { name: 'File name' }).click();
+    await page.getByRole('textbox', { name: 'File name' }).press('ControlOrMeta+a');
+    await page.getByRole('textbox', { name: 'File name' }).fill('push_test_collection');
     await page.getByRole('button', { name: 'Create', exact: true }).click();
 
     await page.getByTestId('git-dropdown').click();
@@ -164,9 +164,9 @@ test.describe('Git Sync', () => {
     await page.getByRole('textbox', { name: 'Name', exact: true }).click();
     await page.getByRole('textbox', { name: 'Name', exact: true }).press('ControlOrMeta+a');
     await page.getByRole('textbox', { name: 'Name', exact: true }).fill('Discard Test Collection');
-    await page.getByRole('textbox', { name: 'File name my_collection' }).click();
-    await page.getByRole('textbox', { name: 'File name my_collection' }).press('ControlOrMeta+a');
-    await page.getByRole('textbox', { name: 'File name my_collection' }).fill('discard_test_collection');
+    await page.getByRole('textbox', { name: 'File name' }).click();
+    await page.getByRole('textbox', { name: 'File name' }).press('ControlOrMeta+a');
+    await page.getByRole('textbox', { name: 'File name' }).fill('discard_test_collection');
     await page.getByRole('button', { name: 'Create', exact: true }).click();
     await page.getByText('Create a new Request Collection').waitFor({ state: 'hidden' });
 

--- a/packages/insomnia/src/ui/components/modals/new-workspace-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/new-workspace-modal.tsx
@@ -1,7 +1,7 @@
 import type { StorageRules } from 'insomnia-api';
 import type { ApiSpec, Project, WorkspaceScope } from 'insomnia-data';
 import { models } from 'insomnia-data';
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Button,
   Collection,
@@ -104,6 +104,9 @@ export const NewWorkspaceModal = ({
     mockServerAdditionalFiles: [],
     mockServerDynamicResponses: false,
   });
+
+  // Once the user manually edits the file name we stop deriving it from the name.
+  const [hasEditedFileName, setHasEditedFileName] = useState(false);
 
   const createNewWorkspaceFetcher = useWorkspaceNewActionFetcher();
   const prevCreateNewWorkspaceFetcherState = useRef(createNewWorkspaceFetcher.state);

--- a/packages/insomnia/src/ui/components/modals/new-workspace-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/new-workspace-modal.tsx
@@ -264,7 +264,12 @@ export const NewWorkspaceModal = ({
                     name="name"
                     value={workspaceData.name}
                     isRequired
-                    onChange={name => setWorkspaceData({ ...workspaceData, name })}
+                    onChange={name => setWorkspaceData({
+                      ...workspaceData,
+                      name,
+                      // Keep the file name in sync with the name until the user edits it themselves.
+                      ...(hasEditedFileName ? {} : { fileName: name }),
+                    })}
                     className="group relative flex flex-col gap-2"
                   >
                     <Label className="text-sm text-(--hl)">Name</Label>
@@ -287,7 +292,10 @@ export const NewWorkspaceModal = ({
                           return null;
                         }}
                         value={safeToUseInsomniaFileName(workspaceData.fileName || '')}
-                        onChange={fileName => setWorkspaceData({ ...workspaceData, fileName })}
+                        onChange={fileName => {
+                          setHasEditedFileName(true);
+                          setWorkspaceData({ ...workspaceData, fileName });
+                        }}
                         className="group relative flex max-w-full flex-col gap-2 overflow-hidden"
                       >
                         <Label className="group relative flex flex-col gap-2 overflow-hidden">

--- a/packages/insomnia/src/ui/components/modals/workspace-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-settings-modal.tsx
@@ -176,18 +176,20 @@ export const WorkspaceSettingsModal = ({ workspace, gitFilePath, project, mockSe
                   </TextField>
                   {project &&
                     models.project.isGitProject(project) &&
-                    gitRepoTreeFetcher.data &&
-                    !models.workspace.isMcp(workspace) && (
+                    gitRepoTreeFetcher.data && (
                       <TextField
                         name="fileName"
                         isRequired
                         value={safeToUseInsomniaFileName(fileNameValue || '')}
                         onChange={setFileNameValue}
                         validate={inputValue => {
+                          const candidateFileName = safeToUseInsomniaFileNameWithExt(inputValue);
+                          // Exclude the current file (normalized) so renaming to its own name isn't flagged as a collision.
+                          const currentFileName = safeToUseInsomniaFileNameWithExt(fileName);
                           if (
                             selectedFolderChildren
-                              .filter(name => name !== fileName)
-                              .includes(safeToUseInsomniaFileNameWithExt(inputValue))
+                              .filter(name => name !== currentFileName)
+                              .includes(candidateFileName)
                           ) {
                             return 'A file with the same name already exists in the selected folder';
                           }

--- a/packages/insomnia/src/ui/components/modals/workspace-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-settings-modal.tsx
@@ -57,6 +57,27 @@ export const WorkspaceSettingsModal = ({ workspace, gitFilePath, project, mockSe
     }
   }, [project, gitRepoTreeFetcher]);
 
+  // When the modal is opened without a gitFilePath prop (e.g. from the project
+  // sidebar), resolve it from the workspace meta so the File name field is populated.
+  const [metaGitFilePath, setMetaGitFilePath] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (gitFilePath || !project || !models.project.isGitProject(project)) {
+      return;
+    }
+
+    let isMounted = true;
+    services.workspaceMeta.getByParentId(workspace._id).then(meta => {
+      if (isMounted && meta?.gitFilePath) {
+        setMetaGitFilePath(meta.gitFilePath);
+      }
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [gitFilePath, project, workspace._id]);
+
   const isScratchpadWorkspace = models.workspace.isScratchpad(workspace);
 
   const workspaceFetcher = useWorkspaceUpdateActionFetcher();
@@ -80,8 +101,9 @@ export const WorkspaceSettingsModal = ({ workspace, gitFilePath, project, mockSe
 
   // From the folderPath we need to get the folder children and validate that there is no file with the same name
   // Get the folder from the gitFilePath
-  const selectedFolder = gitFilePath?.split('/').slice(1).join('/') || '';
-  const fileName = gitFilePath?.split('/').pop() || '';
+  const effectiveGitFilePath = gitFilePath || metaGitFilePath || '';
+  const selectedFolder = effectiveGitFilePath.split('/').slice(1).join('/') || '';
+  const fileName = effectiveGitFilePath.split('/').pop() || '';
   const selectedFolderChildren = gitRepoTreeFetcher.data?.folderList[selectedFolder] || [];
 
   const [fileNameValue, setFileNameValue] = useState<string>(safeToUseInsomniaFileName(fileName || ''));
@@ -92,6 +114,14 @@ export const WorkspaceSettingsModal = ({ workspace, gitFilePath, project, mockSe
     description !== workspace.description,
     mockServerUrlValue !== (mockServer?.url || ''),
   ].filter(Boolean).length;
+
+  // Keep the controlled file name in sync once the git file path resolves - it may
+  // arrive asynchronously when loaded from the workspace meta (e.g. opened from the sidebar).
+  useEffect(() => {
+    if (fileName) {
+      setFileNameValue(safeToUseInsomniaFileName(fileName));
+    }
+  }, [fileName]);
 
   return (
     <UnsavedChangesGuard hasUnsavedChanges={changedFieldCount > 1} onClose={onClose}>


### PR DESCRIPTION
## What

When creating a workspace (collection, doc, mock server, environment, MCP client) in a Git-backed project, the form asks for both a **Name** and a **File name**. Previously the File name didn't follow the Name, so users had to type the same thing twice.

This PR:
- **Defaults the File name from the Name** in the create modal. As you type the Name, the File name follows it (run through the existing `safeToUseInsomniaFileName` sanitizer, e.g. `My Collection` → `my_collection.yaml`). Once you manually edit the File name, we stop overriding it so your custom value sticks.
- **Shows the File name field for MCP clients in the Workspace Settings modal.** It was the only Git-backed type where the field was hidden (`!isMcp`), even though the create modal collects a file name for it and the update route already stores `gitFilePath` generically. This makes create/settings consistent and lets you rename the MCP file.

The File name field stays fully editable and we don't lock it down or block on duplicates — we're only defaulting it. This applies to all five workspace types via the shared Name field; no per-type handling.

## How to test

1. Open a Git-backed project.
2. Create a Collection / Doc / Mock Server / Environment / MCP Client.
3. Type a Name → the File name updates to match (sanitized).
4. Manually edit the File name → it no longer follows the Name.
5. Open Settings on an MCP client in a Git project → the File name field is now shown and editable.

## Notes

- Mock servers already showed the File name in both modals; the only type-based hiding was MCP-in-Settings, which this PR removes.
- Import/clone flows are unaffected (the file name comes from the imported file).
