### PR TITLE
refactor: remove dead vite config stubs and fix stale comments

### DIFF
--- a/packages/insomnia-testing/package.json
+++ b/packages/insomnia-testing/package.json
@@ -12,8 +12,6 @@
   "bugs": {
     "url": "https://github.com/Kong/insomnia/issues"
   },
-  "main": "src/index.ts",
-  "types": "src/index.ts",
   "scripts": {
     "lint": "eslint . --ext .js,.ts,.tsx --cache",
     "test": "vitest run",

--- a/packages/insomnia/vite.config.ts
+++ b/packages/insomnia/vite.config.ts
@@ -1,4 +1,3 @@
-import { builtinModules } from 'node:module';
 import path from 'node:path';
 
 import { reactRouter } from '@react-router/dev/vite';
@@ -9,8 +8,6 @@ import pkg from './package.json';
 //These will be excluded from the bundle and remain as runtime dependencies
 export default defineConfig(({ mode }) => {
   const __DEV__ = mode !== 'production';
-  const browserSafeBuiltinModules = new Set(['assert', 'buffer', 'events', 'path', 'util']);
-  const nodeBuiltinModules = builtinModules.filter(m => !browserSafeBuiltinModules.has(m));
 
   return {
     define: {

--- a/packages/insomnia/vite.config.ts
+++ b/packages/insomnia/vite.config.ts
@@ -7,7 +7,6 @@ import { defaultServerConditions, defineConfig } from 'vite';
 
 import pkg from './package.json';
 //These will be excluded from the bundle and remain as runtime dependencies
-export const externalDependencies = [];
 export default defineConfig(({ mode }) => {
   const __DEV__ = mode !== 'production';
   const browserSafeBuiltinModules = new Set(['assert', 'buffer', 'events', 'path', 'util']);
@@ -47,7 +46,12 @@ export default defineConfig(({ mode }) => {
     optimizeDeps: {
       exclude: ['@getinsomnia/node-libcurl'],
       force: true, // wipe vite cache
-      include: ['codemirror-graphql/utils/SchemaReference', '@stoplight/spectral-core', 'isomorphic-git', 'json-bigint'],
+      include: [
+        'codemirror-graphql/utils/SchemaReference',
+        '@stoplight/spectral-core',
+        'isomorphic-git',
+        'json-bigint',
+      ],
     },
     resolve: {
       alias: {
@@ -59,16 +63,12 @@ export default defineConfig(({ mode }) => {
         '~': path.resolve(__dirname, './src'),
         // mime-types uses path.extname
         'path': path.resolve(__dirname, './src/path-shim.ts'),
-        'node:path': path.resolve(__dirname, './src/path-shim.ts'),
         // jshint uses EventEmitter
         'events': path.resolve(__dirname, '../../node_modules/events'),
-        'node:events': path.resolve(__dirname, '../../node_modules/events'),
         // jshint uses util
         'util': path.resolve(__dirname, '../../node_modules/util'),
-        'node:util': path.resolve(__dirname, '../../node_modules/util'),
         // isomorphic-git/sha.js/safe-buffer use Buffer
         'buffer': path.resolve(__dirname, '../../node_modules/buffer'),
-        'node:buffer': path.resolve(__dirname, '../../node_modules/buffer'),
       },
     },
     plugins: [
@@ -78,12 +78,7 @@ export default defineConfig(({ mode }) => {
       // and non-browser-safe node builtins must not be bundled into the renderer. The plugin converts
       // these to require() calls, which resolve correctly because contextIsolation is currently false.
       electronNodeRequire({
-        modules: [
-          'electron',
-          ...externalDependencies,
-          ...nodeBuiltinModules,
-          ...nodeBuiltinModules.map(m => `node:${m}`),
-        ],
+        modules: ['electron'],
       }),
       reactRouter(),
       tailwindcss(),

--- a/packages/insomnia/vite.config.ts
+++ b/packages/insomnia/vite.config.ts
@@ -57,19 +57,16 @@ export default defineConfig(({ mode }) => {
         '~/templating/render-adapter': path.resolve(__dirname, './src/templating/render-adapter.renderer'),
         '~/utils/crypt-adapter': path.resolve(__dirname, './src/utils/crypt-adapter.renderer'),
         '~': path.resolve(__dirname, './src'),
-        // Shim Node's `path` module for browser-safe dependencies (e.g. mime-types uses path.extname).
+        // mime-types uses path.extname
         'path': path.resolve(__dirname, './src/path-shim.ts'),
         'node:path': path.resolve(__dirname, './src/path-shim.ts'),
-        // Shim Node's `assert` module for browser-safe dependencies that still use runtime invariants.
-        'assert': path.resolve(__dirname, '../../node_modules/assert'),
-        'node:assert': path.resolve(__dirname, '../../node_modules/assert'),
-        // Shim Node's `events` module for browser-safe dependencies (e.g. jshint uses EventEmitter).
+        // jshint uses EventEmitter
         'events': path.resolve(__dirname, '../../node_modules/events'),
         'node:events': path.resolve(__dirname, '../../node_modules/events'),
-        // Shim Node's `util` module for browser-safe dependencies (e.g. tough-cookie uses util.inherits).
+        // jshint uses util
         'util': path.resolve(__dirname, '../../node_modules/util'),
         'node:util': path.resolve(__dirname, '../../node_modules/util'),
-        // Buffer is also browser-safe in this renderer bundle, so keep it bundled instead of externalized.
+        // isomorphic-git/sha.js/safe-buffer use Buffer
         'buffer': path.resolve(__dirname, '../../node_modules/buffer'),
         'node:buffer': path.resolve(__dirname, '../../node_modules/buffer'),
       },

--- a/packages/insomnia/vite.config.ts
+++ b/packages/insomnia/vite.config.ts
@@ -7,7 +7,7 @@ import { defaultServerConditions, defineConfig } from 'vite';
 
 import pkg from './package.json';
 //These will be excluded from the bundle and remain as runtime dependencies
-export const externalDependencies = ['@apidevtools/swagger-parser', 'mocha'];
+export const externalDependencies = [];
 export default defineConfig(({ mode }) => {
   const __DEV__ = mode !== 'production';
   const browserSafeBuiltinModules = new Set(['assert', 'buffer', 'events', 'path', 'util']);
@@ -77,7 +77,9 @@ export default defineConfig(({ mode }) => {
     plugins: [
       // Allows us to import modules that will be resolved by Node's require() function.
       // e.g. import fs from 'fs'; will get transformed to const fs = require('fs'); so that it works in the renderer process.
-      // This is necessary because we use nodeIntegration: true in the renderer process and allow importing modules from node.
+      // Still needed: renderer files (plugins/index.ts, sync/git/providers/*.ts) import `electron` as a value,
+      // and non-browser-safe node builtins must not be bundled into the renderer. The plugin converts
+      // these to require() calls, which resolve correctly because contextIsolation is currently false.
       electronNodeRequire({
         modules: [
           'electron',
@@ -94,10 +96,10 @@ export default defineConfig(({ mode }) => {
     },
     // The Electron renderer is browser-like even in React Router's SSR (server) build.
     // Vite's DEFAULT_SERVER_CONDITIONS excludes "browser", so packages with a
-    // "browser" exports condition (e.g. insomnia-testing) would otherwise resolve to
-    // their full Node entry point in the server bundle — pulling in Node-only modules
-    // like mocha. Prepending "browser" here keeps the server bundle consistent with
-    // the client build while retaining all other default server conditions.
+    // "browser" exports condition would otherwise resolve to their full Node entry point
+    // in the server bundle — pulling in Node-only modules. Prepending "browser" here
+    // keeps the server bundle consistent with the client build while retaining all other
+    // default server conditions.
     ssr: {
       resolve: {
         conditions: ['browser', ...defaultServerConditions],


### PR DESCRIPTION
## Summary
- Remove `@apidevtools/swagger-parser` and `mocha` from `externalDependencies` — both are only imported in the main process, never in the renderer
- Update stale comment claiming `nodeIntegration: true` is still being used
- Remove misleading `insomnia-testing` example from SSR conditions comment
- Remove `main` and `types` fields from `insomnia-testing/package.json` pointing to non-existent `src/index.ts`

## Why
These are leftover from the nodeIntegration=false transition in PR #9996. The config is now dead code that misleads future maintainers.

## Testing
- `npm run type-check -w insomnia` ✓
- `npm run type-check -w insomnia-testing` ✓