### PR TITLE
refactor: replace process.type inline checks with adapter pairs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,32 +55,32 @@ npm -v
 ## Repository Structure
 
 `packages/`
-  `insomnia/`                ← Main Electron app
-    `src/`
-      `common/`              ← Shared utils, settings types
-      `routes/`              ← React Router files (clientLoader/clientAction)
-      `ui/`                  ← React components, hooks, `insomnia-fetch.ts`
-      `main/`                ← Electron IPC handlers, `preload.ts`
-      `account/`             ← Auth, session, encryption
-      `sync/`                ← Git/VCS sync
-      `network/`             ← Request execution engine
-      `templating/`          ← Nunjucks rendering (Web Worker)
-  `insomnia-data/`           ← Data models, services, NeDB implementation, shared data utilities
-  `insomnia-api/`            ← Cloud API client
-  `insomnia-inso/`           ← CLI tool
-  `insomnia-testing/`        ← Test framework
+`insomnia/` ← Main Electron app
+`src/`
+`common/` ← Shared utils, settings types
+`routes/` ← React Router files (clientLoader/clientAction)
+`ui/` ← React components, hooks, `insomnia-fetch.ts`
+`main/` ← Electron IPC handlers, `preload.ts`
+`account/` ← Auth, session, encryption
+`sync/` ← Git/VCS sync
+`network/` ← Request execution engine
+`templating/` ← Nunjucks rendering (Web Worker)
+`insomnia-data/` ← Data models, services, NeDB implementation, shared data utilities
+`insomnia-api/` ← Cloud API client
+`insomnia-inso/` ← CLI tool
+`insomnia-testing/` ← Test framework
 
 ## Data Model Hierarchy
 
 Organization
-  → Project (local | remote/cloud | git-backed)
-    → Workspace (scope: 'collection' | 'design')
-      → Base Environment (auto-created: use `models.environment.getOrCreateForParentId(workspaceId)`)
-        → Sub-Environments
-      → Cookie Jar (auto-created)
-      → Request Group (folders)
-        → Request (HTTP, GraphQL, gRPC, WebSocket, Socket.IO)
-      → Request (can be direct child of workspace)
+→ Project (local | remote/cloud | git-backed)
+→ Workspace (scope: 'collection' | 'design')
+→ Base Environment (auto-created: use `models.environment.getOrCreateForParentId(workspaceId)`)
+→ Sub-Environments
+→ Cookie Jar (auto-created)
+→ Request Group (folders)
+→ Request (HTTP, GraphQL, gRPC, WebSocket, Socket.IO)
+→ Request (can be direct child of workspace)
 **Note:** A Workspace with `scope: 'collection'` IS the collection.
 
 ## Key Patterns
@@ -90,6 +90,7 @@ Organization
 - **Database Buffering:** Always buffer bulk writes (`database.bufferChangesIndefinitely()`, then `flushChanges()`). Unbuffered writes fire UI revalidation per operation, causing severe lag.
 - **State Management:** Use Router loaders/actions and NeDB for persistent state. Use React `useState`/context for ephemeral UI state (No Redux/Zustand).
 - **Electron IPC:** For main↔renderer communication, define handlers in `src/main/ipc/`, expose in `src/main/preload.ts`, and update `window.main` in `src/global.d.ts`.
+- **Renderer/Node Adapter:** When an API must behave differently in the renderer vs node/inso, create a `.renderer.ts` + `.node.ts` file pair and a `.ts` shim that re-exports from `.renderer`. Add a Vite alias in `vite.config.ts` pointing the `~/path/foo-adapter` import at the `.renderer` file. The esbuild node build automatically rewrites `.renderer` → `.node` via the existing `renderer-to-node` plugin — no per-adapter esbuild config needed. Do **not** use `process.type` checks: they bundle both variants and `process.type` is `undefined` in inso. Examples: `src/network/network-adapter.*`, `src/utils/crypt-adapter.*`.
 - **Templates:** Nunjucks runs in a Web Worker (`src/templating/`). Use `{{ _.variable_name }}`.
 - **Models:** Follow CRUD via `models.<type>` (e.g., `create()`, `update()`).
 - **HTTP Calls:** Use `insomniaFetch()` for Insomnia backend APIs. Use plain `fetch()` for external/third-party APIs.

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -91,12 +91,8 @@ export async function fetchImportContentFromURI({ uri }: { uri: string }) {
     return content;
   } else if (uri.match(/^(file):\/\//)) {
     const path = uri.replace(/^(file):\/\//, '');
-    const readFileProcessFork = async (path: string) =>
-      process.type === 'renderer'
-        ? window.main.insecureReadFile({ path })
-        : (await import('../main/secure-read-file')).insecureReadFile(path);
-
-    return readFileProcessFork(path);
+    const { insecureReadFile } = await import('~/utils/read-file-adapter');
+    return insecureReadFile(path);
   }
   // Treat everything else as raw text
   const content = decodeURIComponent(uri);

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -23,11 +23,13 @@ import type { InsomniaImporter } from '../main/importers/convert';
 import type { ImportEntry } from '../main/importers/entities';
 import { id as postmanEnvImporterId } from '../main/importers/importers/postman-env';
 import { invariant } from '../utils/invariant';
+import { insecureReadFile } from '../utils/read-file-adapter';
 import { parseApiSpec, type ParsedApiSpec } from './api-specs';
 import { JSON_ORDER_PREFIX, JSON_ORDER_SEPARATOR } from './constants';
 import { database as db } from './database';
 import { tryImportV5Data } from './insomnia-v5';
 import { generateId } from './misc';
+import { parseImport } from './parse-import-adapter';
 import { pathWithParamsAsPathParameters } from './path-with-params';
 
 const { isRequest } = models.request;
@@ -91,7 +93,6 @@ export async function fetchImportContentFromURI({ uri }: { uri: string }) {
     return content;
   } else if (uri.match(/^(file):\/\//)) {
     const path = uri.replace(/^(file):\/\//, '');
-    const { insecureReadFile } = await import('~/utils/read-file-adapter');
     return insecureReadFile(path);
   }
   // Treat everything else as raw text
@@ -190,22 +191,19 @@ export async function scanResources(importEntries: ImportEntry[]): Promise<ScanR
           insomnia5Import = data as ExportedModel[];
           v5Error = error;
         }
-        if (insomnia5Import.length > 0) {
-          result = {
-            type: {
-              id: 'insomnia-5',
-              name: 'Insomnia v5',
-              description: 'Insomnia v5',
-            },
-            data: {
-              resources: insomnia5Import,
-            },
-          };
-        } else {
-          const convertProcessFork =
-            process.type === 'renderer' ? window.main.parseImport : (await import('../main/importers/convert')).convert;
-          result = (await convertProcessFork(importEntry)) as unknown as ConvertResult;
-        }
+        result =
+          insomnia5Import.length > 0
+            ? {
+                type: {
+                  id: 'insomnia-5',
+                  name: 'Insomnia v5',
+                  description: 'Insomnia v5',
+                },
+                data: {
+                  resources: insomnia5Import,
+                },
+              }
+            : ((await parseImport(importEntry)) as unknown as ConvertResult);
       } catch (err: unknown) {
         if (v5Error) {
           const messages = extractErrorMessages(v5Error);

--- a/packages/insomnia/src/common/parse-import-adapter.node.ts
+++ b/packages/insomnia/src/common/parse-import-adapter.node.ts
@@ -1,0 +1,1 @@
+export { convert as parseImport } from '../main/importers/convert';

--- a/packages/insomnia/src/common/parse-import-adapter.renderer.ts
+++ b/packages/insomnia/src/common/parse-import-adapter.renderer.ts
@@ -1,0 +1,1 @@
+export const parseImport = window.main.parseImport;

--- a/packages/insomnia/src/common/parse-import-adapter.ts
+++ b/packages/insomnia/src/common/parse-import-adapter.ts
@@ -1,0 +1,3 @@
+// Imports the renderer implementation by default.
+// esbuild node builds alias this to parse-import-adapter.node via the renderer-to-node plugin.
+export { parseImport } from './parse-import-adapter.renderer';

--- a/packages/insomnia/src/network/curl-request-adapter.node.ts
+++ b/packages/insomnia/src/network/curl-request-adapter.node.ts
@@ -1,0 +1,1 @@
+export { curlRequest } from '../main/network/libcurl-promise';

--- a/packages/insomnia/src/network/curl-request-adapter.renderer.ts
+++ b/packages/insomnia/src/network/curl-request-adapter.renderer.ts
@@ -1,0 +1,1 @@
+export const curlRequest = window.main.curlRequest;

--- a/packages/insomnia/src/network/curl-request-adapter.ts
+++ b/packages/insomnia/src/network/curl-request-adapter.ts
@@ -1,0 +1,3 @@
+// Imports the renderer implementation by default.
+// esbuild node builds alias this to curl-request-adapter.node via the renderer-to-node plugin.
+export { curlRequest } from './curl-request-adapter.renderer';

--- a/packages/insomnia/src/plugins/context/network.ts
+++ b/packages/insomnia/src/plugins/context/network.ts
@@ -57,11 +57,7 @@ export function init(): {
         const settings = await services.settings.get();
         const settingFollowRedirects = settings?.followRedirects ? 'on' : 'off';
         const { request: originRequest, caCertficatePath = null } = options;
-        const curlRequest =
-          process.type === 'renderer' || process.type === 'worker'
-            ? window.main.curlRequest
-            : // when exeucted in Inso;
-              (await import('../../main/network/libcurl-promise')).curlRequest;
+        const { curlRequest } = await import('~/network/curl-request-adapter');
         const response = await curlRequest({
           requestId: `no-sideEffects-request-${requestId}`,
           req: {

--- a/packages/insomnia/src/plugins/context/network.ts
+++ b/packages/insomnia/src/plugins/context/network.ts
@@ -2,6 +2,7 @@ import { services } from 'insomnia-data';
 import { v4 as uuidv4 } from 'uuid';
 
 import { RESPONSE_CODE_REASONS } from '../../common/constants';
+import { curlRequest } from '../../network/curl-request-adapter';
 import {
   fetchRequestData,
   responseTransform,
@@ -57,7 +58,6 @@ export function init(): {
         const settings = await services.settings.get();
         const settingFollowRedirects = settings?.followRedirects ? 'on' : 'off';
         const { request: originRequest, caCertficatePath = null } = options;
-        const { curlRequest } = await import('~/network/curl-request-adapter');
         const response = await curlRequest({
           requestId: `no-sideEffects-request-${requestId}`,
           req: {

--- a/packages/insomnia/src/utils/read-file-adapter.node.ts
+++ b/packages/insomnia/src/utils/read-file-adapter.node.ts
@@ -1,0 +1,1 @@
+export { insecureReadFile } from '../main/secure-read-file';

--- a/packages/insomnia/src/utils/read-file-adapter.renderer.ts
+++ b/packages/insomnia/src/utils/read-file-adapter.renderer.ts
@@ -1,0 +1,1 @@
+export const insecureReadFile = (path: string): Promise<string> => window.main.insecureReadFile({ path });

--- a/packages/insomnia/src/utils/read-file-adapter.ts
+++ b/packages/insomnia/src/utils/read-file-adapter.ts
@@ -1,0 +1,3 @@
+// Imports the renderer implementation by default.
+// esbuild node builds alias this to read-file-adapter.node via the renderer-to-node plugin.
+export { insecureReadFile } from './read-file-adapter.renderer';

--- a/packages/insomnia/vite.config.ts
+++ b/packages/insomnia/vite.config.ts
@@ -55,8 +55,10 @@ export default defineConfig(({ mode }) => {
         // Short-circuit the adapter wrappers to the renderer implementation directly.
         // These must appear before the '~' catch-all so the specific path wins.
         '~/network/network-adapter': path.resolve(__dirname, './src/network/network-adapter.renderer'),
+        '~/network/curl-request-adapter': path.resolve(__dirname, './src/network/curl-request-adapter.renderer'),
         '~/templating/render-adapter': path.resolve(__dirname, './src/templating/render-adapter.renderer'),
         '~/utils/crypt-adapter': path.resolve(__dirname, './src/utils/crypt-adapter.renderer'),
+        '~/utils/read-file-adapter': path.resolve(__dirname, './src/utils/read-file-adapter.renderer'),
         '~': path.resolve(__dirname, './src'),
         // mime-types uses path.extname
         'path': path.resolve(__dirname, './src/path-shim.ts'),

--- a/packages/insomnia/vite.config.ts
+++ b/packages/insomnia/vite.config.ts
@@ -59,6 +59,7 @@ export default defineConfig(({ mode }) => {
         '~/templating/render-adapter': path.resolve(__dirname, './src/templating/render-adapter.renderer'),
         '~/utils/crypt-adapter': path.resolve(__dirname, './src/utils/crypt-adapter.renderer'),
         '~/utils/read-file-adapter': path.resolve(__dirname, './src/utils/read-file-adapter.renderer'),
+        '~/common/parse-import-adapter': path.resolve(__dirname, './src/common/parse-import-adapter.renderer'),
         '~': path.resolve(__dirname, './src'),
         // mime-types uses path.extname
         'path': path.resolve(__dirname, './src/path-shim.ts'),


### PR DESCRIPTION
## Summary

- Replaces two `process.type === 'renderer'` inline ternaries with the established `.renderer.ts`/`.node.ts` file-suffix adapter pattern
- New `src/utils/read-file-adapter.*` wraps `insecureReadFile` (was in `common/import.ts`)
- New `src/network/curl-request-adapter.*` wraps `curlRequest` (was in `plugins/context/network.ts`) — also drops the dead `|| process.type === 'worker'` branch (workers never import this file; they use `liquid-extension-worker.ts` instead)
- Adds Vite aliases for both new adapters in `vite.config.ts`
- Documents the canonical adapter pattern in `AGENTS.md` to prevent reintroduction

## Why

`process.type` checks bundle both the renderer and node variants into every output, and `process.type` is `undefined` in inso — making the node branch work only by accident. The file-suffix pattern is tree-shaken at build time and is already used by `network-adapter`, `render-adapter`, and `crypt-adapter`.
Related deep dive : https://gist.github.com/jackkav/0458860e3def9f074fa0f8b709a253b1

## Test plan

- [x] `npm run type-check -w insomnia` — clean
- [x] `npm test -w insomnia` — 101 files, 1743 tests pass
- [ ] Manual: import a collection from a `file://` URI to exercise `read-file-adapter`
- [ ] Manual: use a plugin template tag that calls `network.sendRequestWithoutSideEffects` to exercise `curl-request-adapter`