### PR TITLE
feat: align list and onboarding UX to unified space model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3539,9 +3539,9 @@
       }
     },
     "node_modules/@getinsomnia/insomnia-v3-fetch": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@getinsomnia/insomnia-v3-fetch/-/insomnia-v3-fetch-1.0.1.tgz",
-      "integrity": "sha512-v/0lZ6Fz700xLd+YgqqsAi50HTuZ6l/klc2z8G4v7PgWAtEG2O4tIUY/9yn1WtdH21SQtgBz9kWxIxTPUGtzUQ==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@getinsomnia/insomnia-v3-fetch/-/insomnia-v3-fetch-1.0.16.tgz",
+      "integrity": "sha512-ukYo8HJGZJK5rGH6SnzJDQSeFMPvd2N48F1hbNzgJTvzQtUxhckoIPI9VmMT4QRFGw0+NHZ00sRubMl3I130PA==",
       "license": "Apache-2.0"
     },
     "node_modules/@getinsomnia/node-libcurl": {
@@ -29254,7 +29254,7 @@
       "version": "12.5.1-alpha.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@getinsomnia/insomnia-v3-fetch": "^1.0.1"
+        "@getinsomnia/insomnia-v3-fetch": "^1.0.16"
       }
     },
     "packages/insomnia-data": {

--- a/packages/insomnia-api/package.json
+++ b/packages/insomnia-api/package.json
@@ -26,6 +26,6 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@getinsomnia/insomnia-v3-fetch": "^1.0.1"
+    "@getinsomnia/insomnia-v3-fetch": "^1.0.16"
   }
 }

--- a/packages/insomnia-data/node-src/services/organization.ts
+++ b/packages/insomnia-data/node-src/services/organization.ts
@@ -4,34 +4,13 @@ import { models } from 'insomnia-data';
 import * as userSessionService from './user-session';
 
 function sortOrganizations(accountId: string, organizations: Organization[]): Organization[] {
-  const home = organizations.find(
-    organization =>
-      models.organization.isPersonalOrganization(organization) &&
-      models.organization.isOwnerOfOrganization({
-        organization,
-        accountId,
-      }),
-  );
-  const myOrgs = organizations
-    .filter(
-      organization =>
-        !models.organization.isPersonalOrganization(organization) &&
-        models.organization.isOwnerOfOrganization({
-          organization,
-          accountId,
-        }),
-    )
-    .sort((a, b) => a.name.localeCompare(b.name));
-  const notMyOrgs = organizations
-    .filter(
-      organization =>
-        !models.organization.isOwnerOfOrganization({
-          organization,
-          accountId,
-        }),
-    )
-    .sort((a, b) => a.name.localeCompare(b.name));
-  return [...(home ? [home] : []), ...myOrgs, ...notMyOrgs];
+  const owned = organizations
+    .filter(organization => models.organization.isOwnerOfOrganization({ organization, accountId }))
+    .sort((a, b) => a.display_name.localeCompare(b.display_name));
+  const notOwned = organizations
+    .filter(organization => !models.organization.isOwnerOfOrganization({ organization, accountId }))
+    .sort((a, b) => a.display_name.localeCompare(b.display_name));
+  return [...owned, ...notOwned];
 }
 
 /**

--- a/packages/insomnia-data/src/models/organization.ts
+++ b/packages/insomnia-data/src/models/organization.ts
@@ -2,20 +2,8 @@ import type { Organization, PersonalPlanType } from 'insomnia-api';
 
 export const SCRATCHPAD_ORGANIZATION_ID = 'org_scratchpad';
 export const isScratchpadOrganizationId = (organizationId: string) => organizationId === SCRATCHPAD_ORGANIZATION_ID;
-export const isPersonalOrganization = (organization: Organization) =>
-  organization.metadata.organizationType === 'personal';
-
 export const isOwnerOfOrganization = ({ organization, accountId }: { organization: Organization; accountId: string }) =>
   organization.metadata.ownerAccountId === accountId;
-
-export const findPersonalOrganization = (organizations: Organization[], accountId: string) => {
-  return organizations.filter(isPersonalOrganization).find(organization =>
-    isOwnerOfOrganization({
-      organization,
-      accountId,
-    }),
-  );
-};
 
 export const formatCurrentPlanType = (type: PersonalPlanType) => {
   switch (type) {

--- a/packages/insomnia-smoke-test/server/insomnia-api.ts
+++ b/packages/insomnia-smoke-test/server/insomnia-api.ts
@@ -70,7 +70,7 @@ const organizations = [
     },
     metadata: {
       organizationType: 'team',
-      ownerAccountId: 'acct_64a477e6b59d43a5a607f84b4f73e3ce',
+      ownerAccountId: 'acct_other-team-owner',
     },
   },
   // User B personal organization — required by cloud-sync multi-user smoke

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
@@ -145,7 +145,6 @@ const Component = ({ loaderData }: Route.ComponentProps) => {
     organization &&
     userSession.accountId &&
     models.organization.isOwnerOfOrganization({ organization, accountId: userSession.accountId });
-  const isPersonalOrg = organization && models.organization.isPersonalOrganization(organization);
   const greetingName = userSession.firstName || userSession.email.split('@')[0] || 'there';
   const collectionItems = useMemo(
     () =>
@@ -397,8 +396,8 @@ const Component = ({ loaderData }: Route.ComponentProps) => {
                   <p className="text-base">
                     <Icon icon="exclamation-triangle" className="mr-2" />
                     {isUserOwner
-                      ? `Your ${isPersonalOrg ? 'personal account' : 'organization'} has unpaid past invoices. Please enter a new payment method to continue using Insomnia.`
-                      : 'This organization has unpaid past invoices. Please ask the organization owner to enter a new payment method to continue using Insomnia.'}
+                      ? 'Your space has unpaid past invoices. Please enter a new payment method to continue using Insomnia.'
+                      : 'This space has unpaid past invoices. Please ask the space owner to enter a new payment method to continue using Insomnia.'}
                   </p>
                   {isUserOwner && (
                     <a

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.tsx
@@ -97,17 +97,15 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   }
 
   try {
-    const organization = await services.organization.get(organizationId);
+    if (accountId) {
+      const firstAccountLandingKey = `firstAccountLandingHandled:${accountId}`;
 
-    if (accountId && organization && models.organization.isPersonalOrganization(organization)) {
-      const firstPersonalOrgLandingKey = `firstPersonalOrgLandingHandled:${accountId}`;
-
-      if (!window.localStorage.getItem(firstPersonalOrgLandingKey)) {
-        window.localStorage.setItem(firstPersonalOrgLandingKey, 'true');
+      if (!window.localStorage.getItem(firstAccountLandingKey)) {
+        window.localStorage.setItem(firstAccountLandingKey, 'true');
       }
     }
   } catch (error) {
-    console.log('[organizations] Failed to load Organizations', error);
+    console.log('[organizations] Failed to set first account landing flag', error);
   }
 
   const fallbackLearningFeature = {

--- a/packages/insomnia/src/routes/organization.$organizationId.project._index.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project._index.tsx
@@ -23,29 +23,21 @@ export interface ProjectIndexLoaderData {
 }
 
 const shouldAutoCreateInitialProject = async ({
-  organizationId,
   accountId,
 }: {
-  organizationId: string;
   accountId: string | null | undefined;
 }) => {
   if (!accountId) {
     return false;
   }
 
-  try {
-    const organization = await services.organization.get(organizationId);
-    if (!organization || !models.organization.isPersonalOrganization(organization)) {
-      return false;
-    }
-  } catch (error) {
-    console.log('[organizations] Failed to load Organizations', error);
-    return false;
-  }
+  const firstAccountLandingKey = `firstAccountLandingHandled:${accountId}`;
+  const legacyFirstPersonalOrgLandingKey = `firstPersonalOrgLandingHandled:${accountId}`;
 
-  const firstPersonalOrgLandingKey = `firstPersonalOrgLandingHandled:${accountId}`;
-
-  return !window.localStorage.getItem(firstPersonalOrgLandingKey);
+  return (
+    !window.localStorage.getItem(firstAccountLandingKey) &&
+    !window.localStorage.getItem(legacyFirstPersonalOrgLandingKey)
+  );
 };
 
 export async function clientLoader({ params }: LoaderFunctionArgs) {
@@ -66,15 +58,15 @@ export async function clientLoader({ params }: LoaderFunctionArgs) {
     return redirect(`/organization/${organizationId}/project/${projects[0]._id}`);
   }
 
-  let isFirstPersonalOrgLanding = false;
+  let isFirstAccountLanding = false;
 
   try {
-    isFirstPersonalOrgLanding = await shouldAutoCreateInitialProject({ organizationId, accountId });
+    isFirstAccountLanding = await shouldAutoCreateInitialProject({ accountId });
   } catch (error) {
-    console.warn('[project] Failed to evaluate first personal org landing state', error);
+    console.warn('[project] Failed to evaluate first account landing state', error);
   }
 
-  if (isFirstPersonalOrgLanding) {
+  if (isFirstAccountLanding) {
     try {
       const project = await services.project.create({
         name: 'Drafts',

--- a/packages/insomnia/src/routes/organization._index.tsx
+++ b/packages/insomnia/src/routes/organization._index.tsx
@@ -1,5 +1,5 @@
 import type { Organization } from 'insomnia-api';
-import { models, services } from 'insomnia-data';
+import { services } from 'insomnia-data';
 import { href, redirect } from 'react-router';
 
 import { invariant } from '~/common/utils/invariant';
@@ -16,13 +16,10 @@ export async function clientLoader(_args: Route.ClientLoaderArgs) {
     const organizations = JSON.parse(localStorage.getItem(`${accountId}:organizations`) || '[]') as Organization[];
     invariant(organizations.length, 'Failed to fetch organizations. Check your network connection and try again.');
 
-    const personalOrganization = models.organization.findPersonalOrganization(organizations, accountId);
-    invariant(
-      personalOrganization,
-      'Failed to find personal organization your account appears to be in an invalid state. Please contact support if this is a recurring issue.',
-    );
-    const personalOrganizationId = personalOrganization.id;
-    await migrateProjectsUnderOrganization(personalOrganizationId, sessionId);
+    const landingOrganizationId = organizations[0].id;
+    // TODO: when migrating to /v3/users/me/spaces, target the owned space with total_members === 1
+    // so legacy orphan local projects land in the user's solo space rather than a shared owned space.
+    await migrateProjectsUnderOrganization(landingOrganizationId, sessionId);
 
     const specificOrgRedirectAfterAuthorize = window.localStorage.getItem('specificOrgRedirectAfterAuthorize');
     if (specificOrgRedirectAfterAuthorize && specificOrgRedirectAfterAuthorize !== '') {
@@ -30,13 +27,7 @@ export async function clientLoader(_args: Route.ClientLoaderArgs) {
       return redirect(`/organization/${specificOrgRedirectAfterAuthorize}`);
     }
 
-    if (personalOrganization) {
-      return redirect(`/organization/${personalOrganizationId}`);
-    }
-
-    if (organizations.length > 0) {
-      return redirect(`/organization/${organizations[0].id}`);
-    }
+    return redirect(`/organization/${landingOrganizationId}`);
   }
 
   await session.logout();

--- a/packages/insomnia/src/routes/organization.sync-organizations-and-projects.tsx
+++ b/packages/insomnia/src/routes/organization.sync-organizations-and-projects.tsx
@@ -34,12 +34,11 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
 
     if (asyncTaskList.includes(AsyncTask.MigrateProjects)) {
       const organizations = JSON.parse(localStorage.getItem(`${accountId}:organizations`) || '[]') as Organization[];
-      invariant(organizations, 'Failed to fetch organizations.');
-      const personalOrganization = models.organization.findPersonalOrganization(organizations, accountId);
-      invariant(personalOrganization, 'personalOrganization is required');
-      invariant(personalOrganization.id, 'personalOrganizationId is required');
+      invariant(organizations.length, 'Failed to fetch organizations.');
       invariant(sessionId, 'sessionId is required');
-      taskPromiseList.push(migrateProjectsUnderOrganization(personalOrganization.id, sessionId));
+      // TODO: when migrating to /v3/users/me/spaces, target the owned space with total_members === 1
+      // so legacy orphan local projects land in the user's solo space rather than a shared owned space.
+      taskPromiseList.push(migrateProjectsUnderOrganization(organizations[0].id, sessionId));
     }
 
     if (asyncTaskList.includes(AsyncTask.SyncProjects)) {

--- a/packages/insomnia/src/ui/utils/router.ts
+++ b/packages/insomnia/src/ui/utils/router.ts
@@ -123,13 +123,12 @@ export const getInitialEntry = async () => {
       const organizations = JSON.parse(
         localStorage.getItem(`${user.accountId}:organizations`) || '[]',
       ) as Organization[];
-      const personalOrganization = models.organization.findPersonalOrganization(organizations, user.accountId);
-      // If the personal org is not found in local storage go fetch from org index loader
-      if (!personalOrganization) {
+      // If no organizations are in local storage, go fetch from org index loader
+      if (organizations.length === 0) {
         return href('/organization');
       }
 
-      let organizationId = personalOrganization.id;
+      let organizationId = organizations[0].id;
 
       // Check if the user has a last visited organization
       try {


### PR DESCRIPTION
Preparing to migrate from `/v1/organizations` to `/v3/users/me/spaces` by unifying org -> space model where "a space is a space". This means all spaces are treated equally going forward, we will sort by if user is the owner of the space and then by name, instead of by type of space (org).

Also update insomnia-v3-fetch import