### PR TITLE
refactor(runtime): extend IoC runtime to crypto and templating

### DIFF
--- a/packages/insomnia-inso/vitest.config.ts
+++ b/packages/insomnia-inso/vitest.config.ts
@@ -4,8 +4,6 @@ export default defineConfig({
   test: {
     hideSkippedTests: true,
     alias: {
-      '~/templating/render-adapter': new URL('../insomnia/src/templating/render-adapter.node.ts', import.meta.url)
-        .pathname,
       '~/': new URL('../insomnia/src/', import.meta.url).pathname,
     },
     env: {

--- a/packages/insomnia/src/common/__tests__/har.test.ts
+++ b/packages/insomnia/src/common/__tests__/har.test.ts
@@ -14,11 +14,15 @@ vi.mock('~/common/runtime', () => ({
       applyRequestHooks: (request: any) => Promise.resolve(request),
       applyResponseHooks: (response: any) => Promise.resolve(response),
     },
+    crypto: {
+      decryptSecretValue: (value: any) => Promise.resolve(value),
+      encryptSecretValue: (value: any) => Promise.resolve(value),
+      decryptAES: (_symmetricKey: any, encryptedResult: any) => Promise.resolve(encryptedResult),
+    },
+    templating: {
+      renderTemplate: async (input: any) => typeof input.input === 'string' ? input.input : null,
+    },
   }),
-}));
-vi.mock('~/utils/crypt-adapter', () => ({
-  decryptSecretValue: (value: any) => value,
-  encryptSecretValue: (value: any) => value,
 }));
 
 import type { Cookie, Request, Response } from 'insomnia-data';

--- a/packages/insomnia/src/common/render.ts
+++ b/packages/insomnia/src/common/render.ts
@@ -14,8 +14,6 @@ import type {
 import { models, services } from 'insomnia-data';
 import orderedJSON from 'json-order';
 
-import { renderTemplate } from '~/templating/render-adapter';
-
 import { getOrInheritAuthentication, getOrInheritHeaders } from '../network/network';
 import { NUNJUCKS_TEMPLATE_GLOBAL_PROPERTY_NAME } from '../templating/constants';
 import { RenderError } from '../templating/render-error';
@@ -31,6 +29,7 @@ import { maskOrDecryptVaultDataIfNecessary } from '../templating/utils';
 import { setDefaultProtocol } from '../utils/url/protocol';
 import { CONTENT_TYPE_GRAPHQL, JSON_ORDER_SEPARATOR } from './constants';
 import { database as db } from './database';
+import { getRuntime } from './runtime';
 
 const { PATH_PARAMETER_REGEX } = models.request;
 const { isRequestGroup } = models.requestGroup;
@@ -283,7 +282,7 @@ export async function render<T>(
 
       try {
         // @ts-expect-error -- TSCONVERSION
-        input = await renderTemplate({ input, context, path, ignoreUndefinedEnvVariable });
+        input = await getRuntime().templating.renderTemplate({ input, context, path, ignoreUndefinedEnvVariable });
 
         // If the variable outputs a tag, render it again. This is a common use
         // case for environment variables:
@@ -291,7 +290,7 @@ export async function render<T>(
         // @ts-expect-error -- TSCONVERSION
         if (input.includes('{%')) {
           // @ts-expect-error -- TSCONVERSION
-          input = await renderTemplate({ input, context, path, ignoreUndefinedEnvVariable });
+          input = await getRuntime().templating.renderTemplate({ input, context, path, ignoreUndefinedEnvVariable });
         }
       } catch (err) {
         console.log(`Failed to render element ${path}`, input);

--- a/packages/insomnia/src/common/runtime/runtime.node.ts
+++ b/packages/insomnia/src/common/runtime/runtime.node.ts
@@ -1,6 +1,10 @@
 import * as networkAdapter from '../../network/network-adapter.node';
+import * as renderAdapter from '../../templating/render-adapter.node';
+import * as cryptAdapter from '../../utils/crypt-adapter.node';
 import type { RuntimeCapabilities } from './types';
 
 export const nodeRuntime = {
   network: networkAdapter,
+  crypto: cryptAdapter,
+  templating: renderAdapter,
 } satisfies RuntimeCapabilities;

--- a/packages/insomnia/src/common/runtime/runtime.renderer.ts
+++ b/packages/insomnia/src/common/runtime/runtime.renderer.ts
@@ -1,6 +1,6 @@
-import * as cryptAdapter from '../../utils/crypt-adapter.renderer';
 import * as networkAdapter from '../../network/network-adapter.renderer';
 import * as renderAdapter from '../../templating/render-adapter.renderer';
+import * as cryptAdapter from '../../utils/crypt-adapter.renderer';
 import type { RuntimeCapabilities } from './types';
 
 export const rendererRuntime = {

--- a/packages/insomnia/src/common/runtime/runtime.renderer.ts
+++ b/packages/insomnia/src/common/runtime/runtime.renderer.ts
@@ -1,6 +1,10 @@
+import * as cryptAdapter from '../../utils/crypt-adapter.renderer';
 import * as networkAdapter from '../../network/network-adapter.renderer';
+import * as renderAdapter from '../../templating/render-adapter.renderer';
 import type { RuntimeCapabilities } from './types';
 
 export const rendererRuntime = {
   network: networkAdapter,
+  crypto: cryptAdapter,
+  templating: renderAdapter,
 } satisfies RuntimeCapabilities;

--- a/packages/insomnia/src/common/runtime/types.ts
+++ b/packages/insomnia/src/common/runtime/types.ts
@@ -1,8 +1,8 @@
-import type { Cookie, RequestHeader } from 'insomnia-data';
+import type { AESMessage, Cookie, RequestHeader } from 'insomnia-data';
 
 import type { RequestContext } from '../../../../insomnia-scripting-environment/src/objects';
 import type { CurlRequestOptions, CurlRequestOutput, ResponsePatch } from '../../main/network/libcurl-promise';
-import type { RenderedRequest } from '../../templating/types';
+import type { RenderedRequest, RenderInputType } from '../../templating/types';
 
 interface CurlRequestErrorOutput {
   statusMessage: string;
@@ -33,6 +33,18 @@ export interface NetworkRuntime {
   ) => Promise<ResponsePatch>;
 }
 
+export interface CryptoRuntime {
+  decryptAES: (symmetricKey: string | JsonWebKey, encryptedResult: AESMessage) => Promise<string>;
+  encryptSecretValue: (rawValue: string, symmetricKey: JsonWebKey) => Promise<string>;
+  decryptSecretValue: (encryptedValue: string, symmetricKey: JsonWebKey) => Promise<string>;
+}
+
+export interface TemplatingRuntime {
+  renderTemplate: (input: RenderInputType) => Promise<string | null>;
+}
+
 export interface RuntimeCapabilities {
   network: NetworkRuntime;
+  crypto: CryptoRuntime;
+  templating: TemplatingRuntime;
 }

--- a/packages/insomnia/src/network/__tests__/network.test.ts
+++ b/packages/insomnia/src/network/__tests__/network.test.ts
@@ -18,11 +18,6 @@ import { DEFAULT_BOUNDARY } from '../multipart-constants';
 import * as networkUtils from '../network';
 import { getAuthQueryParams, getSetCookiesFromResponseHeaders } from '../network';
 
-vi.mock('~/utils/crypt-adapter', () => ({
-  decryptSecretValue: (value: any) => value,
-  encryptSecretValue: (value: any) => value,
-}));
-
 const getRenderedRequest = async (args: Parameters<typeof getRenderedRequestAndContext>[0]) =>
   (await getRenderedRequestAndContext(args)).request;
 describe('getAuthQueryParams', () => {

--- a/packages/insomnia/src/templating/utils.ts
+++ b/packages/insomnia/src/templating/utils.ts
@@ -1,7 +1,7 @@
 import type { EditorFromTextArea, MarkerRange } from 'codemirror';
 import { models, services } from 'insomnia-data';
 
-import { decryptSecretValue } from '~/utils/crypt-adapter';
+import { getRuntime } from '../common/runtime';
 import { base64ToUtf8, utf8ToBase64 } from '~/utils/utf8-bytes';
 
 import type { NunjucksParsedTag, NunjucksParsedTagArg, RenderPurpose } from '../templating/types';
@@ -161,7 +161,7 @@ export async function maskOrDecryptVaultDataIfNecessary(vaultEnvironmentData: an
         // decrypt all secret values under vaultEnvironmentPath property in context
         for (const vaultContextKey of Object.keys(vaultEnvironmentData)) {
           const encryptedValue = vaultEnvironmentData[vaultContextKey];
-          vaultEnvironmentData[vaultContextKey] = await decryptSecretValue(encryptedValue, symmetricKey);
+          vaultEnvironmentData[vaultContextKey] = await getRuntime().crypto.decryptSecretValue(encryptedValue, symmetricKey);
         }
       } else if (isVaultEnabled && !vaultKey) {
         // remove all values under vaultEnvironmentPath if no vault key found

--- a/packages/insomnia/src/templating/utils.ts
+++ b/packages/insomnia/src/templating/utils.ts
@@ -1,9 +1,9 @@
 import type { EditorFromTextArea, MarkerRange } from 'codemirror';
 import { models, services } from 'insomnia-data';
 
-import { getRuntime } from '../common/runtime';
 import { base64ToUtf8, utf8ToBase64 } from '~/utils/utf8-bytes';
 
+import { getRuntime } from '../common/runtime';
 import type { NunjucksParsedTag, NunjucksParsedTagArg, RenderPurpose } from '../templating/types';
 import { decryptVaultKeyFromSession } from '../utils/vault';
 import { tokenizeArgs } from './tokenize-args';
@@ -161,7 +161,10 @@ export async function maskOrDecryptVaultDataIfNecessary(vaultEnvironmentData: an
         // decrypt all secret values under vaultEnvironmentPath property in context
         for (const vaultContextKey of Object.keys(vaultEnvironmentData)) {
           const encryptedValue = vaultEnvironmentData[vaultContextKey];
-          vaultEnvironmentData[vaultContextKey] = await getRuntime().crypto.decryptSecretValue(encryptedValue, symmetricKey);
+          vaultEnvironmentData[vaultContextKey] = await getRuntime().crypto.decryptSecretValue(
+            encryptedValue,
+            symmetricKey,
+          );
         }
       } else if (isVaultEnabled && !vaultKey) {
         // remove all values under vaultEnvironmentPath if no vault key found

--- a/packages/insomnia/vite.config.ts
+++ b/packages/insomnia/vite.config.ts
@@ -53,10 +53,6 @@ export default defineConfig(({ mode }) => {
     },
     resolve: {
       alias: {
-        // Short-circuit the adapter wrappers to the renderer implementation directly.
-        // These must appear before the '~' catch-all so the specific path wins.
-        '~/templating/render-adapter': path.resolve(__dirname, './src/templating/render-adapter.renderer'),
-        '~/utils/crypt-adapter': path.resolve(__dirname, './src/utils/crypt-adapter.renderer'),
         '~': path.resolve(__dirname, './src'),
         // mime-types uses path.extname
         'path': path.resolve(__dirname, './src/path-shim.ts'),

--- a/packages/insomnia/vitest.config.ts
+++ b/packages/insomnia/vitest.config.ts
@@ -14,7 +14,6 @@ export default defineConfig({
     },
     exclude: ['src/routes/**.*.tsx', '.react-router', 'node_modules'],
     alias: {
-      '~/templating/render-adapter': path.resolve(__dirname, './src/templating/render-adapter.node'),
       '~': path.resolve(__dirname, './src'),
       'electron/main': 'electron',
     },


### PR DESCRIPTION
## Summary
Extended the explicit IoC runtime registry (from PR #10037) to cover crypto and templating operations, removing all remaining Vite aliases and bringing the runtime to 3 total capabilities.

**Changes:**
- Add CryptoRuntime and TemplatingRuntime interfaces to runtime/types.ts
- Update runtime.node.ts and runtime.renderer.ts to include crypto and templating adapters
- Replace direct adapter imports in render.ts and templating/utils.ts with getRuntime() calls
- Remove `'~/templating/render-adapter'` and `'~/utils/crypt-adapter'` aliases from Vite/Vitest configs
- Update test mocks to work through runtime instead of direct imports

**Note:** This PR should be rebased onto PR #10037 for proper sequencing, but created against develop for visibility.

**Validation:**
- TypeScript type-check: ✅ passed
- Unit tests: ✅ 1765 tests passed
- Vite aliases: ✅ removed from all config files
- No remaining direct adapter imports: ✅ verified