### PR TITLE
fix(e2e): prevent feature-flag mock leak from breaking export tests

### DIFF
--- a/packages/insomnia-smoke-test/playwright/utils/file-operations.ts
+++ b/packages/insomnia-smoke-test/playwright/utils/file-operations.ts
@@ -17,6 +17,11 @@ export function createTempExportDir(): string {
 /**
  * Waits for export files to be created in the directory.
  * Used for project-level exports that don't show an alert.
+ *
+ * Waits not only for the expected number of files to appear, but also for each
+ * file to be non-empty and for its size to stabilise across two polls. Export
+ * writes the file in chunks, so reading the moment the file is created can yield
+ * a truncated file (e.g. `JSON.parse` failing with "Unexpected end of JSON input").
  * @param dirPath - The directory to check for files
  * @param expectedCount - The expected number of files
  * @param timeout - Maximum time to wait in milliseconds (default: 10000)
@@ -24,11 +29,18 @@ export function createTempExportDir(): string {
 export async function waitForExportFiles(dirPath: string, expectedCount: number, timeout = 10_000): Promise<void> {
   const startTime = Date.now();
   const pollInterval = 100;
+  let previousSizes = new Map<string, number>();
 
   while (Date.now() - startTime < timeout) {
     const files = getExportedFiles(dirPath);
     if (files.length >= expectedCount) {
-      return;
+      const currentSizes = new Map(files.map(file => [file, fs.statSync(file).size]));
+      const allNonEmpty = files.every(file => (currentSizes.get(file) ?? 0) > 0);
+      const allStable = files.every(file => previousSizes.get(file) === currentSizes.get(file));
+      if (allNonEmpty && allStable) {
+        return;
+      }
+      previousSizes = currentSizes;
     }
     await new Promise(resolve => setTimeout(resolve, pollInterval));
   }

--- a/packages/insomnia-smoke-test/server/insomnia-api.ts
+++ b/packages/insomnia-smoke-test/server/insomnia-api.ts
@@ -91,18 +91,20 @@ const organizations = [
   },
 ];
 
-let organizationFeatures = {
-  features: {
-    gitSync: {
-      enabled: true,
-    },
-    bulkImport: {
-      enabled: true,
-    },
-    konnectSync: {
-      enabled: true,
-    },
+const defaultOrganizationFeatures = {
+  gitSync: {
+    enabled: true,
   },
+  bulkImport: {
+    enabled: true,
+  },
+  konnectSync: {
+    enabled: true,
+  },
+};
+
+let organizationFeatures = {
+  features: { ...defaultOrganizationFeatures },
 };
 
 const v3User = {
@@ -477,9 +479,14 @@ export default function setup(app: Application) {
     res.status(200).send(organizationFeatures);
   });
 
-  // Test Utility Endpoint - Allows altering features at runtime
+  // Test Utility Endpoint - Allows altering features at runtime.
+  // Merge partial overrides over the complete default set so a test that only
+  // toggles a subset of features cannot drop the others (e.g. bulkImport) and
+  // alter later tests sharing this server process.
   app.post('/v1/test-utils/organizations/features', json(), (req, res) => {
-    organizationFeatures = req.body;
+    organizationFeatures = {
+      features: { ...defaultOrganizationFeatures, ...req.body?.features },
+    };
     res.status(200).send();
   });
 

--- a/packages/insomnia/src/ui/components/settings/import-export.tsx
+++ b/packages/insomnia/src/ui/components/settings/import-export.tsx
@@ -700,7 +700,7 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal, onModalChange }) =>
   const hasUntrackedWorkspaces = untrackedWorkspaces.length > 0;
   const hasUntrackedProjects = untrackedProjects.length > 0;
   const showImportButtons =
-    !isScratchPadWorkspace && (activeProject || features.bulkImport.enabled || isEnterprisePlan);
+    !isScratchPadWorkspace && (activeProject || features.bulkImport?.enabled || isEnterprisePlan);
   if (!isScratchPadWorkspace && !isLoggedIn) {
     return (
       <Button
@@ -842,7 +842,7 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal, onModalChange }) =>
                   {`Import to the "${projectName}" ${strings.project.singular}`}
                 </Button>
               )}
-              {features.bulkImport.enabled ? (
+              {features.bulkImport?.enabled ? (
                 <Button
                   className="flex items-center justify-center gap-2 rounded-xs border border-solid border-(--hl-md) px-4 py-1 text-sm font-semibold text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
                   isDisabled={


### PR DESCRIPTION
Mock `/features` replaces the whole object, so tests that toggle one flag drop `bulkImport` for later tests, crashing the Preferences render and flaking the export tests.

- merge partial overrides over the defaults in the mock
- guard `features.bulkImport?.enabled`
- harden `waitForExportFiles` against a read-before-write race