### PR TITLE
fix: load plugins with available require() and align cloud sync mocks with real API

### DIFF
--- a/packages/insomnia-smoke-test/server/cloud-sync-api.ts
+++ b/packages/insomnia-smoke-test/server/cloud-sync-api.ts
@@ -14,9 +14,7 @@ export interface AESMessage {
 }
 
 function jwkToKeyBuf(jwkOrKey: string | JsonWebKey): Buffer {
-  return typeof jwkOrKey === 'string'
-    ? Buffer.from(jwkOrKey, 'hex')
-    : Buffer.from(jwkOrKey.k || '', 'base64url');
+  return typeof jwkOrKey === 'string' ? Buffer.from(jwkOrKey, 'hex') : Buffer.from(jwkOrKey.k || '', 'base64url');
 }
 
 export function decryptAESBuffer(jwkOrKey: string | JsonWebKey, msg: AESMessage): Buffer {
@@ -352,6 +350,41 @@ const getSnapshotsForProject = (projectId: string) => {
   return [...originalSnapshots, ...addedSnapshots];
 };
 
+// Empty payloads matching the live API responses
+const emptyQueryData: Record<string, unknown> = {
+  projects: [],
+  project: null,
+  branches: [],
+  branch: null,
+  snapshots: [],
+  blobs: [],
+  blobsMissing: { missing: [] },
+  projectKey: null,
+  teamMemberKeys: { memberKeys: [] },
+};
+const emptyMutationData: Record<string, unknown> = {
+  projectArchive: true,
+  branchRemove: true,
+  snapshotsCreate: [],
+  blobsCreate: { count: 0 },
+  projectCreate: null,
+};
+
+const disabledCloudSyncResponse = (query?: string) => {
+  if (!query) {
+    return { data: {} };
+  }
+  try {
+    const operation = parse(query).definitions[0] as OperationDefinitionNode;
+    const operationName = (operation.selectionSet.selections[0] as FieldNode).name.value;
+    const table = operation.operation === 'mutation' ? emptyMutationData : emptyQueryData;
+    const value = operationName in table ? table[operationName] : null;
+    return { data: { [operationName]: value } };
+  } catch {
+    return { data: {} };
+  }
+};
+
 export default function setup(app: Application) {
   app.post('/__test-config/cloud-sync', json(), (req, res) => {
     const { enabled = false } = req.body ?? {};
@@ -384,10 +417,11 @@ export default function setup(app: Application) {
 
   // handling response for all graphql requests
   app.post('/graphql', json(), (req, res) => {
+    const { query, variables } = req.body ?? {};
+
     if (!cloudSyncApiEnabled) {
-      return res.status(200).send();
+      return res.status(200).json(disabledCloudSyncResponse(query));
     }
-    const { query, variables } = req.body;
 
     try {
       // Parse the GraphQL query using the graphql package

--- a/packages/insomnia/src/plugins/index.ts
+++ b/packages/insomnia/src/plugins/index.ts
@@ -36,11 +36,11 @@ export function _testOnlySetPlugins(p: Plugin[] | null) {
 // window and main process; the inso CLI exposes it via `global.require`, so we use it when present
 // to ensure plugin modules load in all three runtimes.
 function getNodeRequire(): NodeRequire {
-  const globalRequire = (global as typeof global & { require?: NodeRequire }).require;
-  if (globalRequire) {
-    return globalRequire;
+  const globalRequire = (global as typeof global & { require?: unknown }).require;
+  if (typeof globalRequire === 'function') {
+    return globalRequire as NodeRequire;
   }
-  if (typeof require !== 'undefined') {
+  if (typeof require === 'function') {
     return require;
   }
   throw new Error('No require function available to load plugin modules');

--- a/packages/insomnia/src/plugins/index.ts
+++ b/packages/insomnia/src/plugins/index.ts
@@ -32,6 +32,20 @@ export function _testOnlySetPlugins(p: Plugin[] | null) {
   plugins = p;
 }
 
+// The native `require` is in scope inside the bundled CommonJS that runs in the Electron plugin
+// window and main process; the inso CLI exposes it via `global.require`, so we use it when present
+// to ensure plugin modules load in all three runtimes.
+function getNodeRequire(): NodeRequire {
+  const globalRequire = (global as typeof global & { require?: NodeRequire }).require;
+  if (globalRequire) {
+    return globalRequire;
+  }
+  if (typeof require !== 'undefined') {
+    return require;
+  }
+  throw new Error('No require function available to load plugin modules');
+}
+
 export async function init() {
   await reloadPlugins();
 }
@@ -75,15 +89,17 @@ async function traversePluginPath(pluginMap: Record<string, Plugin>, allPaths: s
           continue;
         }
 
+        const nodeRequire = getNodeRequire();
+
         // Now delete the require cache for this module, ensuring we're deleting only the relevant entries
-        for (const cachePath of Object.keys(global.require.cache)) {
+        for (const cachePath of Object.keys(nodeRequire.cache)) {
           // Check if the cache path starts with the safe module path
           if (cachePath.startsWith(safeModulePath)) {
-            delete global.require.cache[cachePath];
+            delete nodeRequire.cache[cachePath];
           }
         }
 
-        const pluginJson = global.require(packageJSONPath);
+        const pluginJson = nodeRequire(packageJSONPath);
 
         // Not an Insomnia plugin because it doesn't have the package.json['insomnia']
         if (!('insomnia' in pluginJson)) {
@@ -91,7 +107,7 @@ async function traversePluginPath(pluginMap: Record<string, Plugin>, allPaths: s
         }
 
         // Delete require cache entry and re-require
-        const module = global.require(modulePath);
+        const module = nodeRequire(modulePath);
 
         pluginMap[pluginJson.name] = {
           name: pluginJson.name,
@@ -165,7 +181,7 @@ function getBundlePluginMap() {
         bundlePluginPath = require.resolve(pluginName, { paths: [rootNodeModuleDir] });
       }
       console.log('[plugin] Loading bundled plugin %s from %s', pluginName, bundlePluginPath);
-      const module = global.require(bundlePluginPath);
+      const module = getNodeRequire()(bundlePluginPath);
       bundlePluginMap[pluginName] = {
         name: pluginName,
         description: `Insomnia bundled plugin for ${pluginName}`,


### PR DESCRIPTION
- Fix internal plugin loading failures seen in e2e tests
- Matches cloud-sync mock with real API output instead of an empty body

Mitigates these two oft-seen logs in test output:
```
[renderer console.error] 20:09:03.441 › Error occurred in handler for 'sync.invoke': Error: Failed to query branches: no data returned
    at _VCS._runGraphQL (/home/runner/work/insomnia/insomnia/packages/insomnia/build/entry.main.min.js:412993:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async _VCS.getRemoteBranchNames (/home/runner/work/insomnia/insomnia/packages/insomnia/build/entry.main.min.js:412722:26)
    at async Session.<anonymous> (node:electron/js2c/browser_init:2:116791)

[renderer console.error] 20:09:05.071 › Failed to load bundled plugin @kong/insomnia-plugin-external-vault TypeError: global.require is not a function
    at /home/runner/work/insomnia/insomnia/packages/insomnia/build/entry.main.min.js:130170:30
    at Array.forEach (<anonymous>)
    at getBundlePluginMap (/home/runner/work/insomnia/insomnia/packages/insomnia/build/entry.main.min.js:130161:20)
    at getPlugins (/home/runner/work/insomnia/insomnia/packages/insomnia/build/entry.main.min.js:130152:29)
    at async getActivePlugins (/home/runner/work/insomnia/insomnia/packages/insomnia/build/entry.main.min.js:130196:11)
    at async Object.getRequestHooks (/home/runner/work/insomnia/insomnia/packages/insomnia/build/entry.main.min.js:130335:25)
    at async Object.applyRequestHooks (/home/runner/work/insomnia/insomnia/packages/insomnia/build/entry.main.min.js:397994:43)
    at async exportHarWithRequest (/home/runner/work/insomnia/insomnia/packages/insomnia/build/entry.main.min.js:376078:29)
    at async Session.<anonymous> (node:electron/js2c/browser_init:2:116791)
```

