### PR TITLE
fix: show v13 onboarding immediately after Git migration completes [INS-2552]

### DIFF
--- a/packages/insomnia-smoke-test/playwright/test.ts
+++ b/packages/insomnia-smoke-test/playwright/test.ts
@@ -72,7 +72,9 @@ export const test = baseTest.extend<{
       INSOMNIA_GITLAB_API_URL: echoServer + '/gitlab-api',
       INSOMNIA_UPDATES_URL: echoServer || 'https://updates.insomnia.rest',
       INSOMNIA_MOCK_API_URL: 'https://mock-stage.insomnia.run',
-      INSOMNIA_SKIP_ONBOARDING: String(userConfig.skipOnboarding),
+      // Empty string (not "false") so the renderer's `if (skipOnboarding)` guard is falsy
+      // and onboarding flows can be exercised; "false" would be a truthy string.
+      INSOMNIA_SKIP_ONBOARDING: userConfig.skipOnboarding ? 'true' : '',
       INSOMNIA_PUBLIC_KEY: userConfig.publicKey,
       INSOMNIA_SECRET_KEY: userConfig.secretKey,
       INSOMNIA_VAULT_KEY: userConfig.vaultKey || '',

--- a/packages/insomnia-smoke-test/tests/migration/git-repo-onboarding.test.ts
+++ b/packages/insomnia-smoke-test/tests/migration/git-repo-onboarding.test.ts
@@ -1,0 +1,93 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { expect } from '@playwright/test';
+
+import { test } from '../../playwright/test';
+
+// Seeds a data directory with a single connected Git project whose GitRepository
+// has no `repoMigrationVersion` stamp, so `getInitialEntry` treats it as having a
+// pending Git filesystem migration and routes to `/git-migration` on launch.
+//
+// The repo has no on-disk `git/` or `other/` directories, so the structure
+// migration is a no-op that completes successfully without needing real git files.
+const seedPendingGitMigration = async (dataPath: string) => {
+  const now = Date.now();
+  // Legacy ('git_xxx') format on the project so getInitialEntry's `_id $in` query
+  // matches the GitRepository._id directly (this is the pre-migration layout).
+  const gitRepositoryId = 'git_smoketestpending';
+
+  const project = {
+    _id: 'proj_smoketestgit',
+    type: 'Project',
+    parentId: null,
+    modified: now,
+    created: now,
+    name: 'Git Migration Smoke Project',
+    remoteId: null,
+    gitRepositoryId,
+  };
+
+  const gitRepository = {
+    _id: gitRepositoryId,
+    type: 'GitRepository',
+    parentId: null,
+    modified: now,
+    created: now,
+    needsFullClone: false,
+    uri: 'https://github.com/example/insomnia-git-example.git',
+    credentials: null,
+    author: { name: '', email: '' },
+    uriNeedsMigration: false,
+    // Intentionally no `repoMigrationVersion` → treated as a pending migration.
+  };
+
+  await fs.promises.mkdir(dataPath, { recursive: true });
+  await fs.promises.writeFile(path.join(dataPath, 'insomnia.Project.db'), JSON.stringify(project) + '\n', 'utf8');
+  await fs.promises.writeFile(
+    path.join(dataPath, 'insomnia.GitRepository.db'),
+    JSON.stringify(gitRepository) + '\n',
+    'utf8',
+  );
+};
+
+const testWithPendingGitMigration = test.extend({
+  dataPath: async ({ dataPath }, use) => {
+    await seedPendingGitMigration(dataPath);
+    await use(dataPath);
+  },
+  userConfig: async ({ userConfig }, use) => {
+    await use({
+      ...userConfig,
+      // Do not pre-mark onboarding as seen — we want the v13 onboarding to appear
+      // immediately after the migration completes.
+      skipOnboarding: false,
+    });
+  },
+});
+
+testWithPendingGitMigration(
+  'shows Git migration first, then the v13 onboarding immediately after it completes',
+  async ({ page }) => {
+    // Migration may take a moment; avoid timing out before the min-display window elapses.
+    test.slow();
+
+    // 1. The Git migration route is shown first (before the v13 onboarding).
+    await expect.soft(page.getByRole('heading', { name: "What's new in v12.6.0" })).toBeVisible();
+    // The v13 onboarding welcome must not be visible yet.
+    await expect.soft(page.getByRole('heading', { name: /Welcome to Insomnia 13/ })).toBeHidden();
+
+    await page.getByRole('button', { name: 'Continue' }).click();
+
+    // 2. Run the filesystem migration.
+    await expect.soft(page.getByRole('heading', { name: 'Required file system update' })).toBeVisible();
+    await page.getByRole('button', { name: 'Update Now' }).click();
+
+    // 3. Migration completes successfully.
+    await expect.soft(page.getByRole('heading', { name: 'Update Successful' })).toBeVisible({ timeout: 30_000 });
+
+    // 4. Opening Insomnia from the completed migration lands on the v13 onboarding.
+    await page.getByRole('link', { name: 'Open Insomnia' }).click();
+    await expect.soft(page.getByRole('heading', { name: /Welcome to Insomnia 13/ })).toBeVisible();
+  },
+);

--- a/packages/insomnia/src/routes/git-migration.$.tsx
+++ b/packages/insomnia/src/routes/git-migration.$.tsx
@@ -51,7 +51,12 @@ const MigrationView = () => {
 
   // After the migration completes, send users straight into the v13 onboarding
   // if they haven't seen it yet; otherwise go to the organization view.
-  const postMigrationPath = window.localStorage.getItem('hasSeenOnboardingV13') ? '/organization' : '/onboarding';
+  // Guard `window` so this stays safe during SSR (entry.server.tsx) — the value is
+  // only read once the completion links render, which only happens client-side.
+  const postMigrationPath =
+    typeof window !== 'undefined' && window.localStorage.getItem('hasSeenOnboardingV13')
+      ? '/organization'
+      : '/onboarding';
 
   return (
     <div className="flex h-full min-h-[500px] w-[600px] flex-col items-center justify-center">

--- a/packages/insomnia/src/routes/git-migration.$.tsx
+++ b/packages/insomnia/src/routes/git-migration.$.tsx
@@ -49,6 +49,10 @@ const MigrationView = () => {
   const isUpdateErrored = status === 'error';
   const isUpdateCompletedWithErrors = status === 'partiallyCompleted';
 
+  // After the migration completes, send users straight into the v13 onboarding
+  // if they haven't seen it yet; otherwise go to the organization view.
+  const postMigrationPath = window.localStorage.getItem('hasSeenOnboardingV13') ? '/organization' : '/onboarding';
+
   return (
     <div className="flex h-full min-h-[500px] w-[600px] flex-col items-center justify-center">
       <div className="relative flex w-full flex-col items-center justify-center gap-(--padding-sm) rounded-md border border-solid border-(--hl-sm) bg-(--hl-xs) p-8">
@@ -120,7 +124,7 @@ const MigrationView = () => {
             {isUpdateCompletedSuccessfully ? (
               <Link
                 className="flex h-full items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
-                to="/organization"
+                to={postMigrationPath}
               >
                 Open Insomnia
               </Link>
@@ -136,7 +140,7 @@ const MigrationView = () => {
                 </CopyButton>
                 <Link
                   className="flex h-full items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
-                  to="/organization"
+                  to={postMigrationPath}
                 >
                   Open Insomnia
                 </Link>


### PR DESCRIPTION

After introducing `OnboardingV13`, the intended first-run flow is:
**Git filesystem migration first → v13 onboarding immediately once migration completes.**

The "migration first" half already worked (`getInitialEntry` checks pending Git
migrations before the `hasSeenOnboardingV13` flag). But the "onboarding right after"
half didn't: the migration completion buttons navigated straight to `/organization`,
so the v13 onboarding was skipped and only appeared on the **next app restart**.

Why it was skipped:
1. The "Open Insomnia" buttons are client-side `<Link>` navigations, and
   `getInitialEntry` only runs once at startup — so it isn't re-evaluated.
2. The `/organization` route has no onboarding guard.

## Changes

- **`git-migration.$.tsx`** — added `postMigrationPath`, which resolves to
  `/onboarding` when `hasSeenOnboardingV13` is unset and `/organization` otherwise.
  Both completion buttons (full success + partial success) now use it.
- **`playwright/test.ts`** — `INSOMNIA_SKIP_ONBOARDING` was passed as
  `String(skipOnboarding)`, so `"false"` hit the renderer's `if (skipOnboarding)`
  guard as a *truthy* string and still marked onboarding as seen. Now passes
  `'true'` / `''` so onboarding flows can actually be exercised. No existing test
  relied on `skipOnboarding: false`.
- **`tests/migration/git-repo-onboarding.test.ts`** — new smoke test that seeds a
  connected Git project with a pending migration and asserts:
  migration shown first (v13 welcome hidden) → run migration → "Update Successful"
  → "Open Insomnia" lands on the v13 onboarding.

## Testing

- `npm run lint` and `npm run type-check`: clean.
- New smoke test passes with the fix, and fails when `postMigrationPath` is
  reverted to `/organization` — confirming it guards the behavior.

## Behavior

| Scenario | Before | After |
| --- | --- | --- |
| Pending migration + onboarding unseen | Migration → `/organization` (onboarding only on next restart) | Migration → v13 onboarding immediately |
| Onboarding already seen | Migration → `/organization` | Migration → `/organization` (unchanged) |
