### PR TITLE
Fix: Catch organization list fetch error in loader

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.tsx
@@ -79,14 +79,18 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
     return redirect(href('/organization/:organizationId', { organizationId }));
   }
 
-  const organization = await services.organization.get(organizationId);
+  try {
+    const organization = await services.organization.get(organizationId);
 
-  if (accountId && organization && models.organization.isPersonalOrganization(organization)) {
-    const firstPersonalOrgLandingKey = `firstPersonalOrgLandingHandled:${accountId}`;
+    if (accountId && organization && models.organization.isPersonalOrganization(organization)) {
+      const firstPersonalOrgLandingKey = `firstPersonalOrgLandingHandled:${accountId}`;
 
-    if (!window.localStorage.getItem(firstPersonalOrgLandingKey)) {
-      window.localStorage.setItem(firstPersonalOrgLandingKey, 'true');
+      if (!window.localStorage.getItem(firstPersonalOrgLandingKey)) {
+        window.localStorage.setItem(firstPersonalOrgLandingKey, 'true');
+      }
     }
+  } catch (error) {
+    console.log('[organizations] Failed to load Organizations', error);
   }
 
   const fallbackLearningFeature = {

--- a/packages/insomnia/src/routes/organization.$organizationId.project._index.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project._index.tsx
@@ -40,6 +40,7 @@ const shouldAutoCreateInitialProject = async ({
     }
   } catch (error) {
     console.log('[organizations] Failed to load Organizations', error);
+    return false;
   }
 
   const firstPersonalOrgLandingKey = `firstPersonalOrgLandingHandled:${accountId}`;

--- a/packages/insomnia/src/routes/organization.$organizationId.project._index.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project._index.tsx
@@ -33,10 +33,13 @@ const shouldAutoCreateInitialProject = async ({
     return false;
   }
 
-  const organization = await services.organization.get(organizationId);
-
-  if (!organization || !models.organization.isPersonalOrganization(organization)) {
-    return false;
+  try {
+    const organization = await services.organization.get(organizationId);
+    if (!organization || !models.organization.isPersonalOrganization(organization)) {
+      return false;
+    }
+  } catch (error) {
+    console.log('[organizations] Failed to load Organizations', error);
   }
 
   const firstPersonalOrgLandingKey = `firstPersonalOrgLandingHandled:${accountId}`;


### PR DESCRIPTION
Catch the organization list fetch error in loader to avoid unexpected app crash when network fails