### PR TITLE
Spike: Support marking expensive loaders and skip unnecessary revalidation by actions submit 

### DIFF
--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -49,6 +49,7 @@ import { Toaster } from '~/ui/components/toast-notification';
 import { AppHooks } from '~/ui/containers/app-hooks';
 import cssHref from '~/ui/css/styles.css?url';
 import Modals from '~/ui/modals';
+import { createShouldRevalidateByScopes } from '~/utils/router';
 
 import type { Route } from './+types/root';
 
@@ -199,23 +200,26 @@ export const ErrorBoundary: FC<Route.ErrorBoundaryProps> = ({ error }) => {
 
 export interface RootLoaderData {
   settings: Settings;
-  workspaceCount: number;
   userSession: UserSession;
 }
+
+export const shouldRevalidate = createShouldRevalidateByScopes({
+  dataScopes: ['root'],
+  defaultShouldRevalidate: false,
+});
 
 export const useRootLoaderData = () => {
   return useRouteLoaderData<typeof clientLoader>('root');
 };
 
 export async function clientLoader(_args: Route.ClientLoaderArgs) {
+  console.log(`[loader] root`);
   const settings = await services.settings.get();
-  const workspaceCount = await services.workspace.count();
   const userSession = await services.userSession.get();
   const cloudCredentials = await services.cloudCredential.all();
 
   return {
     settings,
-    workspaceCount,
     userSession,
     cloudCredentials,
   };

--- a/packages/insomnia/src/routes/auth.authorize.tsx
+++ b/packages/insomnia/src/routes/auth.authorize.tsx
@@ -9,7 +9,7 @@ import { getLoginUrl, submitAuthCode } from '~/ui/auth-session-provider.client';
 import { Icon } from '~/ui/components/icon';
 import { validateVaultKey } from '~/ui/vault-key.client';
 import { invariant } from '~/utils/invariant';
-import { createFetcherSubmitHook } from '~/utils/router';
+import { addScopeField, createFetcherSubmitHook } from '~/utils/router';
 import { getVaultKeyFromStorage } from '~/utils/vault';
 
 import type { Route } from './+types/auth.authorize';
@@ -65,7 +65,7 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
 
 export const useAuthorizeActionFetcher = createFetcherSubmitHook(
   submit => (data: { code: string }) => {
-    submit(data, {
+    submit(addScopeField({ scopes: ['root'], data }), {
       action: href('/auth/authorize'),
       method: 'POST',
       encType: 'application/json',

--- a/packages/insomnia/src/routes/auth.clear-vault-key.tsx
+++ b/packages/insomnia/src/routes/auth.clear-vault-key.tsx
@@ -3,7 +3,7 @@ import { services } from 'insomnia-data';
 import { href } from 'react-router';
 
 import { showToast } from '~/ui/components/toast-notification';
-import { createFetcherSubmitHook } from '~/utils/router';
+import { addScopeField, createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/auth.clear-vault-key';
 
@@ -34,7 +34,7 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
 
 export const useClearVaultKeyFetcher = createFetcherSubmitHook(
   submit => (data: { organizations: string[]; sessionId: string }) => {
-    submit(data, {
+    submit(addScopeField({ scopes: ['root'], data }), {
       action: href('/auth/clear-vault-key'),
       method: 'POST',
       encType: 'application/json',

--- a/packages/insomnia/src/routes/auth.create-vault-key.tsx
+++ b/packages/insomnia/src/routes/auth.create-vault-key.tsx
@@ -1,7 +1,7 @@
 import { href } from 'react-router';
 
 import { createVaultKey } from '~/ui/vault-key.client';
-import { createFetcherSubmitHook } from '~/utils/router';
+import { addScopeField, createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/auth.create-vault-key';
 
@@ -11,7 +11,10 @@ export async function clientAction(_args: Route.ClientActionArgs) {
 
 export const useCreateVaultKeyFetcher = createFetcherSubmitHook(
   submit => () => {
-    submit({}, { action: href('/auth/create-vault-key'), method: 'POST' });
+    submit(addScopeField({ scopes: ['root'], data: {} }), {
+      action: href('/auth/create-vault-key'),
+      method: 'POST',
+    });
   },
   clientAction,
 );

--- a/packages/insomnia/src/routes/auth.login.tsx
+++ b/packages/insomnia/src/routes/auth.login.tsx
@@ -7,7 +7,7 @@ import { AnalyticsEvent } from '~/ui/analytics';
 import { getLoginUrl } from '~/ui/auth-session-provider.client';
 import { Icon } from '~/ui/components/icon';
 import { Tooltip } from '~/ui/components/tooltip';
-import { createFetcherSubmitHook } from '~/utils/router';
+import { addScopeField, createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/auth.login';
 
@@ -50,7 +50,7 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
 
 export const useLoginActionFetcher = createFetcherSubmitHook(
   submit => (data: { provider: string }) => {
-    submit(data, {
+    submit(addScopeField({ scopes: ['root'], data }), {
       action: href('/auth/login'),
       method: 'POST',
     });

--- a/packages/insomnia/src/routes/auth.logout.tsx
+++ b/packages/insomnia/src/routes/auth.logout.tsx
@@ -1,7 +1,7 @@
 import { href, redirect } from 'react-router';
 
 import { logout } from '~/account/session';
-import { createFetcherSubmitHook } from '~/utils/router';
+import { addScopeField, createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/auth.logout';
 
@@ -18,7 +18,7 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
 export const useLogoutFetcher = createFetcherSubmitHook(
   submit =>
     (data: LogoutData = {}) => {
-      return submit(JSON.stringify(data), {
+      return submit(JSON.stringify(addScopeField({ scopes: ['root'], data })), {
         action: href('/auth/logout'),
         method: 'POST',
         encType: 'application/json',

--- a/packages/insomnia/src/routes/auth.reset-vault-key.tsx
+++ b/packages/insomnia/src/routes/auth.reset-vault-key.tsx
@@ -1,7 +1,7 @@
 import { type ActionFunctionArgs, href } from 'react-router';
 
 import { createVaultKey } from '~/ui/vault-key.client';
-import { createFetcherSubmitHook } from '~/utils/router';
+import { addScopeField, createFetcherSubmitHook } from '~/utils/router';
 
 export async function clientAction(_args: ActionFunctionArgs) {
   return createVaultKey('reset');
@@ -9,7 +9,7 @@ export async function clientAction(_args: ActionFunctionArgs) {
 
 export const useResetVaultKeyFetcher = createFetcherSubmitHook(
   submit => () => {
-    submit({}, { action: href('/auth/reset-vault-key'), method: 'POST' });
+    submit(addScopeField({ scopes: ['root'], data: {} }), { action: href('/auth/reset-vault-key'), method: 'POST' });
   },
   clientAction,
 );

--- a/packages/insomnia/src/routes/auth.update-vault-salt.tsx
+++ b/packages/insomnia/src/routes/auth.update-vault-salt.tsx
@@ -2,7 +2,7 @@ import { getVault } from 'insomnia-api';
 import { services } from 'insomnia-data';
 import { type ActionFunctionArgs, href } from 'react-router';
 
-import { createFetcherSubmitHook } from '~/utils/router';
+import { addScopeField, createFetcherSubmitHook } from '~/utils/router';
 
 export async function clientAction(_args: ActionFunctionArgs) {
   try {
@@ -21,7 +21,10 @@ export async function clientAction(_args: ActionFunctionArgs) {
 
 export const useUpdateVaultSaltFetcher = createFetcherSubmitHook(
   submit => () => {
-    return submit({}, { action: href('/auth/update-vault-salt'), method: 'POST' });
+    return submit(addScopeField({ scopes: ['root'], data: {} }), {
+      action: href('/auth/update-vault-salt'),
+      method: 'POST',
+    });
   },
   clientAction,
 );

--- a/packages/insomnia/src/routes/auth.validate-vault-key.tsx
+++ b/packages/insomnia/src/routes/auth.validate-vault-key.tsx
@@ -2,7 +2,7 @@ import { services } from 'insomnia-data';
 import { type ActionFunctionArgs, href } from 'react-router';
 
 import { saveVaultKey, validateVaultKey } from '~/ui/vault-key.client';
-import { createFetcherSubmitHook } from '~/utils/router';
+import { addScopeField, createFetcherSubmitHook } from '~/utils/router';
 
 export async function clientAction({ request }: ActionFunctionArgs) {
   const { vaultKey, saveVaultKey: saveVaultKeyLocally = false } = await request.json();
@@ -34,7 +34,7 @@ export const useValidateVaultKeyActionFetcher = createFetcherSubmitHook(
     ({ vaultKey, saveVaultKey = false }: { vaultKey: string; saveVaultKey?: boolean }) => {
       const url = href('/auth/validate-vault-key');
 
-      return submit(JSON.stringify({ vaultKey, saveVaultKey }), {
+      return submit(JSON.stringify(addScopeField({ scopes: ['root'], data: { vaultKey, saveVaultKey } })), {
         action: url,
         method: 'POST',
         encType: 'application/json',

--- a/packages/insomnia/src/routes/cloud-credentials.$cloudCredentialId.delete.ts
+++ b/packages/insomnia/src/routes/cloud-credentials.$cloudCredentialId.delete.ts
@@ -2,7 +2,7 @@ import { services } from 'insomnia-data';
 import { href } from 'react-router';
 
 import { invariant } from '~/utils/invariant';
-import { createFetcherSubmitHook } from '~/utils/router';
+import { addScopeField, createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/cloud-credentials.$cloudCredentialId.delete';
 
@@ -18,16 +18,13 @@ export async function clientAction({ params }: Route.ClientActionArgs) {
 export const useDeleteCloudCredentialActionFetcher = createFetcherSubmitHook(
   submit =>
     ({ cloudCredentialId }: { cloudCredentialId: string }) => {
-      return submit(
-        {},
-        {
-          method: 'POST',
-          action: href('/cloud-credentials/:cloudCredentialId/delete', {
-            cloudCredentialId,
-          }),
-          encType: 'application/json',
-        },
-      );
+      return submit(addScopeField({ scopes: ['root'], data: {} }), {
+        method: 'POST',
+        action: href('/cloud-credentials/:cloudCredentialId/delete', {
+          cloudCredentialId,
+        }),
+        encType: 'application/json',
+      });
     },
   clientAction,
 );

--- a/packages/insomnia/src/routes/cloud-credentials.$cloudCredentialId.update.ts
+++ b/packages/insomnia/src/routes/cloud-credentials.$cloudCredentialId.update.ts
@@ -5,7 +5,7 @@ import { href } from 'react-router';
 import { EXTERNAL_VAULT_PLUGIN_NAME } from '~/common/constants';
 import { plugins } from '~/plugins/renderer-bridge';
 import { invariant } from '~/utils/invariant';
-import { createFetcherSubmitHook } from '~/utils/router';
+import { addScopeField, createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/cloud-credentials.$cloudCredentialId.update';
 
@@ -48,7 +48,7 @@ export async function clientAction({ params, request }: Route.ClientActionArgs) 
 export const useUpdateCloudCredentialActionFetcher = createFetcherSubmitHook(
   submit =>
     ({ cloudCredentialId, patch }: { cloudCredentialId: string; patch: Partial<CloudProviderCredential> }) => {
-      return submit(JSON.stringify(patch), {
+      return submit(JSON.stringify(addScopeField({ scopes: ['root'], data: patch })), {
         method: 'POST',
         action: href('/cloud-credentials/:cloudCredentialId/update', {
           cloudCredentialId,

--- a/packages/insomnia/src/routes/cloud-credentials.create.tsx
+++ b/packages/insomnia/src/routes/cloud-credentials.create.tsx
@@ -5,7 +5,7 @@ import { href } from 'react-router';
 import { EXTERNAL_VAULT_PLUGIN_NAME } from '~/common/constants';
 import { plugins } from '~/plugins/renderer-bridge';
 import { invariant } from '~/utils/invariant';
-import { createFetcherSubmitHook } from '~/utils/router';
+import { addScopeField, createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/cloud-credentials.create';
 
@@ -54,7 +54,7 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
 
 export const useCreateCloudCredentialActionFetcher = createFetcherSubmitHook(
   submit => (data: CreateCloudCredentialsData) => {
-    return submit(JSON.stringify(data), {
+    return submit(JSON.stringify(addScopeField({ scopes: ['root'], data })), {
       method: 'POST',
       action: href('/cloud-credentials/create'),
       encType: 'application/json',

--- a/packages/insomnia/src/routes/import.scan.tsx
+++ b/packages/insomnia/src/routes/import.scan.tsx
@@ -11,7 +11,7 @@ import {
 import type { ImportEntry } from '~/main/importers/entities';
 import { AnalyticsEvent, trackImportEvent } from '~/ui/analytics';
 import { invariant } from '~/utils/invariant';
-import { createFetcherSubmitHook } from '~/utils/router';
+import { addScopeField, createFetcherSubmitHook } from '~/utils/router';
 
 export const scanImportResources = async (data: {
   source: ImportSourceType;
@@ -174,10 +174,17 @@ export async function clientAction({ request }: ActionFunctionArgs) {
 
 export const useScanResourcesFetcher = createFetcherSubmitHook(
   submit => (data: FormData | HTMLFormElement) => {
-    return submit(data, {
-      action: href('/import/scan'),
-      method: 'POST',
-    });
+    const formData = data instanceof HTMLFormElement ? new FormData(data) : data;
+    return submit(
+      addScopeField({
+        scopes: [],
+        data: formData,
+      }),
+      {
+        action: href('/import/scan'),
+        method: 'POST',
+      },
+    );
   },
   clientAction,
 );

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.tsx
@@ -30,6 +30,7 @@ import { useLoaderDeferData } from '~/ui/hooks/use-loader-defer-data';
 import { useOrganizationPermissions } from '~/ui/hooks/use-organization-features';
 import { DEFAULT_STORAGE_RULES } from '~/ui/organization-utils';
 import { invariant } from '~/utils/invariant';
+import { createShouldRevalidateByScopes } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId';
 
@@ -61,6 +62,7 @@ const getInsomniaLearningFeature = async (fallbackLearningFeature: LearningFeatu
 };
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
+  console.log(`[loader] organization.$organizationId.project.$projectId`);
   const { organizationId, projectId } = params;
   invariant(projectId, 'Project ID is required');
   invariant(organizationId, 'Organization ID is required');
@@ -130,6 +132,10 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
     learningFeaturePromise,
   };
 }
+
+export const shouldRevalidate = createShouldRevalidateByScopes({
+  dataScopes: ['project'],
+});
 
 export function useProjectLoaderData() {
   return useRouteLoaderData<typeof clientLoader>('routes/organization.$organizationId.project.$projectId');

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.connect.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.connect.tsx
@@ -12,7 +12,7 @@ import { href } from 'react-router';
 import type { RenderedRequest } from '~/templating/types';
 import { AnalyticsEvent } from '~/ui/analytics';
 import { invariant } from '~/utils/invariant';
-import { createFetcherSubmitHook } from '~/utils/router';
+import { addScopeField, createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.connect';
 
@@ -168,12 +168,19 @@ export const useRequestConnectActionFetcher = createFetcherSubmitHook(
           requestId,
         },
       );
-
-      return submit(JSON.stringify(connectParams), {
-        action: url,
-        method: 'POST',
-        encType: 'application/json',
-      });
+      return submit(
+        JSON.stringify(
+          addScopeField({
+            scopes: ['request'],
+            data: connectParams,
+          }),
+        ),
+        {
+          action: url,
+          method: 'POST',
+          encType: 'application/json',
+        },
+      );
     },
   clientAction,
 );

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.response.delete-all.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.response.delete-all.tsx
@@ -2,7 +2,7 @@ import { services } from 'insomnia-data';
 import { href } from 'react-router';
 
 import { invariant } from '~/utils/invariant';
-import { createFetcherSubmitHook } from '~/utils/router';
+import { addScopeField, createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.response.delete';
 
@@ -44,7 +44,12 @@ export const useRequestResponseDeleteAllActionFetcher = createFetcherSubmitHook(
       );
 
       return submit(
-        {},
+        JSON.stringify(
+          addScopeField({
+            scopes: ['request'],
+            data: {},
+          }),
+        ),
         {
           action: url,
           method: 'POST',

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.response.delete.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.response.delete.tsx
@@ -2,7 +2,7 @@ import { models, services } from 'insomnia-data';
 import { href } from 'react-router';
 
 import { invariant } from '~/utils/invariant';
-import { createFetcherSubmitHook } from '~/utils/router';
+import { addScopeField, createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.response.delete';
 
@@ -72,11 +72,19 @@ export const useRequestResponseDeleteActionFetcher = createFetcherSubmitHook(
         },
       );
 
-      return submit(JSON.stringify({ responseId }), {
-        action: url,
-        method: 'POST',
-        encType: 'application/json',
-      });
+      return submit(
+        JSON.stringify(
+          addScopeField({
+            scopes: ['request'],
+            data: { responseId },
+          }),
+        ),
+        {
+          action: url,
+          method: 'POST',
+          encType: 'application/json',
+        },
+      );
     },
   clientAction,
 );

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx
@@ -31,7 +31,7 @@ import {
 import { AnalyticsEvent, type ImportAttribution, importAttributionKey } from '~/ui/analytics';
 import { parseGraphQLReqeustBody } from '~/utils/graph-ql';
 import { invariant } from '~/utils/invariant';
-import { createFetcherSubmitHook } from '~/utils/router';
+import { addScopeField, createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send';
 
@@ -461,19 +461,27 @@ export const useDebugRequestSendActionFetcher = createFetcherSubmitHook(
       requestId: string;
       params: { shouldPromptForPathAfterResponse?: boolean; ignoreUndefinedEnvVariable?: boolean };
     }) => {
-      return submit(JSON.stringify(params), {
-        method: 'POST',
-        action: href(
-          `/organization/:organizationId/project/:projectId/workspace/:workspaceId/debug/request/:requestId/send`,
-          {
-            organizationId,
-            projectId,
-            workspaceId,
-            requestId,
-          },
+      return submit(
+        JSON.stringify(
+          addScopeField({
+            scopes: ['request'],
+            data: params,
+          }),
         ),
-        encType: 'application/json',
-      });
+        {
+          method: 'POST',
+          action: href(
+            `/organization/:organizationId/project/:projectId/workspace/:workspaceId/debug/request/:requestId/send`,
+            {
+              organizationId,
+              projectId,
+              workspaceId,
+              requestId,
+            },
+          ),
+          encType: 'application/json',
+        },
+      );
     },
   clientAction,
 );

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.tsx
@@ -22,6 +22,7 @@ import { href, Outlet, redirect, useRouteLoaderData } from 'react-router';
 
 import { database } from '~/common/database';
 import { showResourceNotFoundToast } from '~/ui/components/toast-notification';
+import { createShouldRevalidateByScopes } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId';
 export default Outlet;
@@ -81,7 +82,14 @@ const getResponseOperations = (request: Request | WebSocketRequest | SocketIOReq
   return services.response;
 };
 
+export const shouldRevalidate = createShouldRevalidateByScopes({
+  dataScopes: ['request'],
+});
+
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
+  console.log(
+    `[loader] organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId`,
+  );
   const { organizationId, projectId, requestId, workspaceId } = params;
 
   const activeWorkspace = await services.workspace.getById(workspaceId);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.set-active-global.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.set-active-global.tsx
@@ -2,7 +2,7 @@ import { services } from 'insomnia-data';
 import { href } from 'react-router';
 
 import { invariant } from '~/utils/invariant';
-import { createFetcherSubmitHook } from '~/utils/router';
+import { addScopeField, createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.set-active-global';
 
@@ -47,10 +47,16 @@ export const useEnvironmentSetActiveGlobalActionFetcher = createFetcherSubmitHoo
       const formData = new FormData();
       formData.set('environmentId', environmentId);
 
-      return submit(formData, {
-        action: url,
-        method: 'POST',
-      });
+      return submit(
+        addScopeField({
+          scopes: ['workspace'],
+          data: formData,
+        }),
+        {
+          action: url,
+          method: 'POST',
+        },
+      );
     },
   clientAction,
 );

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.set-active.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.set-active.tsx
@@ -2,7 +2,7 @@ import { services } from 'insomnia-data';
 import { href } from 'react-router';
 
 import { invariant } from '~/utils/invariant';
-import { createFetcherSubmitHook } from '~/utils/router';
+import { addScopeField, createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.set-active';
 
@@ -36,9 +36,10 @@ export const useSetActiveEnvironmentFetcher = createFetcherSubmitHook(
       environmentId: string;
     }) => {
       return submit(
-        {
-          environmentId,
-        },
+        addScopeField({
+          scopes: ['workspace'],
+          data: { environmentId },
+        }),
         {
           method: 'POST',
           action: href(

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.tsx
@@ -1,5 +1,4 @@
 import type {
-  ApiSpec,
   CaCertificate,
   ClientCertificate,
   CookieJar,
@@ -7,7 +6,6 @@ import type {
   GitRepository,
   GrpcRequest,
   GrpcRequestMeta,
-  MockServer,
   Project,
   Request,
   RequestGroup,
@@ -33,7 +31,7 @@ import { pushSnapshotOnInitialize } from '~/sync/vcs/initialize-backend-project'
 import { Icon } from '~/ui/components/icon';
 import { showResourceNotFoundToast } from '~/ui/components/toast-notification';
 import { useGitFileIssues } from '~/ui/hooks/use-git-file-issues';
-import { createFetcherLoadHook } from '~/utils/router';
+import { createFetcherLoadHook, createShouldRevalidateByScopes } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId';
 
@@ -42,7 +40,6 @@ const { isRequestGroup } = models.requestGroup;
 export type Collection = Child[];
 
 export interface WorkspaceLoaderData {
-  workspaces: Workspace[];
   activeWorkspace: Workspace;
   activeWorkspaceMeta: WorkspaceMeta;
   activeProject: Project;
@@ -54,11 +51,10 @@ export interface WorkspaceLoaderData {
   subEnvironments: Environment[];
   globalBaseEnvironments: (Environment & { workspaceName: string })[];
   globalSubEnvironments: Environment[];
-  activeApiSpec: ApiSpec | null;
-  activeMockServer?: MockServer | null;
+  // activeApiSpec: ApiSpec | null;
+  // activeMockServer?: MockServer | null;
   clientCertificates: ClientCertificate[];
   caCertificate: CaCertificate | null;
-  projects: Project[];
   requestTree: Child[];
   grpcRequests: GrpcRequest[];
   collection: Collection;
@@ -86,6 +82,7 @@ const workspaceFileIssueModalText = {
 } as const;
 
 export async function clientLoader({ params, request }: Route.ClientLoaderArgs) {
+  console.log(`[loader] organization.$organizationId.project.$projectId.workspace.$workspaceId`);
   const { organizationId, projectId, workspaceId } = params;
 
   const activeProject = await services.project.get(projectId);
@@ -149,16 +146,7 @@ export async function clientLoader({ params, request }: Route.ClientLoaderArgs) 
 
   const activeCookieJar = await services.cookieJar.getOrCreateForParentId(workspaceId);
 
-  const activeApiSpec = await services.apiSpec.getByParentId(workspaceId);
   const clientCertificates = await services.clientCertificate.findByParentId(workspaceId);
-  const activeMockServer = await services.mockServer.getByParentId(workspaceId);
-
-  const organizationProjects =
-    (await database.find<Project>(models.project.type, {
-      parentId: organizationId,
-    })) || [];
-
-  const projects = models.project.sortProjects(organizationProjects);
 
   const searchParams = new URL(request.url).searchParams;
   const sortOrder = searchParams.get('sortOrder') as SortOrder;
@@ -296,8 +284,6 @@ export async function clientLoader({ params, request }: Route.ClientLoaderArgs) 
     }
   }
 
-  const workspaces = await services.workspace.findByParentId(projectId);
-
   const collection = flattenTree();
 
   // If there is a filter then we need to show all the parents of the requests that are not hidden.
@@ -316,7 +302,6 @@ export async function clientLoader({ params, request }: Route.ClientLoaderArgs) 
   });
 
   return {
-    workspaces,
     activeWorkspace,
     activeProject,
     gitRepository,
@@ -328,11 +313,8 @@ export async function clientLoader({ params, request }: Route.ClientLoaderArgs) 
     baseEnvironment,
     globalSubEnvironments,
     globalBaseEnvironments: globalBaseEnvironmentsWithWorkspaceName,
-    activeApiSpec,
-    activeMockServer,
     clientCertificates,
     caCertificate: await services.caCertificate.getByParentId(workspaceId),
-    projects,
     requestTree,
     // TODO: remove this state hack when the grpc responses go somewhere else
     grpcRequests: grpcReqs,
@@ -346,6 +328,10 @@ export function useWorkspaceLoaderData() {
     'routes/organization.$organizationId.project.$projectId.workspace.$workspaceId',
   );
 }
+
+export const shouldRevalidate = createShouldRevalidateByScopes({
+  dataScopes: ['workspace'],
+});
 
 export const useWorkspaceLoaderFetcher = createFetcherLoadHook(
   load =>

--- a/packages/insomnia/src/routes/organization.tsx
+++ b/packages/insomnia/src/routes/organization.tsx
@@ -29,7 +29,7 @@ import { SidebarContext } from '~/ui/context/app/insomnia-sidebar-context';
 import { InsomniaTabProvider } from '~/ui/context/app/insomnia-tab-context';
 import { RunnerProvider } from '~/ui/context/app/runner-context';
 import { useCloseConnection } from '~/ui/hooks/use-close-connection';
-import type { AsyncTask } from '~/utils/router';
+import { type AsyncTask, createShouldRevalidateByScopes } from '~/utils/router';
 
 import type { Route } from './+types/organization';
 
@@ -40,6 +40,7 @@ export interface OrganizationLoaderData {
 }
 
 export async function clientLoader(_args: Route.ClientLoaderArgs) {
+  console.log(`[loader] organization`);
   const { id, accountId } = await services.userSession.get();
   if (id) {
     const organizations = JSON.parse(localStorage.getItem(`${accountId}:organizations`) || '[]') as Organization[];
@@ -57,6 +58,10 @@ export async function clientLoader(_args: Route.ClientLoaderArgs) {
     currentPlan: undefined,
   };
 }
+
+export const shouldRevalidate = createShouldRevalidateByScopes({
+  dataScopes: ['organization'],
+});
 
 export interface OrganizationFeatureLoaderData {
   featuresPromise: Promise<FeatureList>;

--- a/packages/insomnia/src/routes/settings.update.tsx
+++ b/packages/insomnia/src/routes/settings.update.tsx
@@ -2,7 +2,7 @@ import type { Settings } from 'insomnia-data';
 import { services } from 'insomnia-data';
 
 import { AnalyticsEvent } from '~/ui/analytics';
-import { createFetcherSubmitHook } from '~/utils/router';
+import { addScopeField, createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/settings.update';
 
@@ -18,7 +18,7 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
 export const useSettingsUpdateActionFetcher = createFetcherSubmitHook(
   submit =>
     ({ patch }: { patch: Partial<Settings> }) => {
-      return submit(JSON.stringify(patch), {
+      return submit(JSON.stringify(addScopeField({ scopes: ['root'], data: patch })), {
         method: 'POST',
         action: '/settings/update',
         encType: 'application/json',

--- a/packages/insomnia/src/ui/components/dropdowns/workspace-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-dropdown.tsx
@@ -56,7 +56,7 @@ export const WorkspaceDropdown: FC<{}> = () => {
     workspaceId: string;
   };
   invariant(organizationId, 'Expected organizationId');
-  const { activeWorkspace, activeWorkspaceMeta, activeProject, activeMockServer } = useWorkspaceLoaderData()!;
+  const { activeWorkspace, activeWorkspaceMeta, activeProject } = useWorkspaceLoaderData()!;
 
   const [isDuplicateModalOpen, setIsDuplicateModalOpen] = useState(false);
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
@@ -401,7 +401,6 @@ export const WorkspaceDropdown: FC<{}> = () => {
       {isSettingsModalOpen && (
         <WorkspaceSettingsModal
           workspace={activeWorkspace}
-          mockServer={activeMockServer}
           project={activeProject}
           gitFilePath={activeWorkspaceMeta?.gitFilePath}
           onClose={() => setIsSettingsModalOpen(false)}

--- a/packages/insomnia/src/ui/components/modals/workspace-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-settings-modal.tsx
@@ -28,18 +28,18 @@ import { MarkdownEditor } from '../markdown-editor';
 interface Props {
   onClose: () => void;
   workspace: Workspace;
-  mockServer?: MockServer | null;
   gitFilePath?: string | null;
   project?: Project;
 }
 
-export const WorkspaceSettingsModal = ({ workspace, gitFilePath, project, mockServer, onClose }: Props) => {
+export const WorkspaceSettingsModal = ({ workspace, gitFilePath, project, onClose }: Props) => {
   const { organizationId, projectId } = useParams() as {
     organizationId: string;
     projectId: string;
     workspaceId: string;
   };
   const [description, setDescription] = useState<string>(workspace.description);
+  const [mockServer, setMockServer] = useState<MockServer | null>(null);
 
   const gitRepoTreeFetcher = useGitProjectRepositoryTreeLoaderFetcher();
 
@@ -53,6 +53,17 @@ export const WorkspaceSettingsModal = ({ workspace, gitFilePath, project, mockSe
       gitRepoTreeFetcher.load({ projectId: project._id });
     }
   }, [project, gitRepoTreeFetcher]);
+
+  useEffect(() => {
+    async function loadMockServer() {
+      if (models.workspace.isMockServer(workspace)) {
+        const mockServer = await services.mockServer.getByParentId(workspace._id);
+        mockServer && setMockServer(mockServer);
+      }
+    }
+
+    loadMockServer();
+  }, [workspace]);
 
   const isScratchpadWorkspace = models.workspace.isScratchpad(workspace);
 

--- a/packages/insomnia/src/ui/components/settings/import-export.tsx
+++ b/packages/insomnia/src/ui/components/settings/import-export.tsx
@@ -659,7 +659,11 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal, onModalChange }) =>
 
   const workspaceData = useWorkspaceLoaderData();
   const activeWorkspaceName = workspaceData?.activeWorkspace.name;
-  const { workspaceCount, userSession } = useRootLoaderData()!;
+  const { userSession } = useRootLoaderData()!;
+  const [workspaceCount, setWorkspaceCount] = useState(0);
+  useEffect(() => {
+    services.workspace.count().then(setWorkspaceCount);
+  }, []);
   const workspacesFetcher = useProjectListWorkspacesLoaderFetcher();
   useEffect(() => {
     const isIdleAndUninitialized = workspacesFetcher.state === 'idle' && !workspacesFetcher.data;

--- a/packages/insomnia/src/utils/router.ts
+++ b/packages/insomnia/src/utils/router.ts
@@ -2,7 +2,9 @@ import type { Organization } from 'insomnia-api';
 import type { GitProject, GitRepository, Project } from 'insomnia-data';
 import { database, models, services } from 'insomnia-data';
 import { useCallback } from 'react';
-import { href, matchPath, type PathMatch, useFetcher } from 'react-router';
+import { href, matchPath, type PathMatch, type ShouldRevalidateFunctionArgs, useFetcher } from 'react-router';
+
+import { isValidJSONString } from '~/utils/string-check';
 
 import { CURRENT_MIGRATION_VERSION } from '../sync/git/git-migration-version';
 
@@ -11,6 +13,8 @@ export const enum AsyncTask {
   MigrateProjects,
   SyncProjects,
 }
+
+export type RouteScopes = 'organization' | 'project' | 'workspace';
 
 const getMatchParams = (location: string) => {
   const workspaceMatch = matchPath(
@@ -199,3 +203,107 @@ export const createFetcherLoadHook =
       load,
     } as Override<typeof fetcher, { load: ReturnType<T> }>;
   };
+
+// The scope here is used to determine which loaders to revalidate after a successful action submission.
+// root matches to root.tsx for global data like user session, settings, and workspace count, which are used across the app and most likely to be updated by an action.
+// organization matches to organization.tsx for new global organization, user and current plan data (by default cached in local storage).
+// project matches to organization.$organizationId.project.$projectId.tsx for all projects and its child workspace data
+// workspace matches to organization.$organizationId.project.$projectId.workspace.$workspaceId.tsx for current workspace data(including meta) and its child data (environment, certificates, api spec, mock server, requests).
+// request matches to organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.tsx for request data (request, request meat, responses, request versions, mock server and routers).
+export type submitRevalidateDataScope = 'root' | 'organization' | 'project' | 'workspace' | 'request';
+
+const SCOPE_TO_REVALIDATE_FIELD = '__INSOMNIA_REVALIDATE_SCOPES__';
+
+export const createShouldRevalidateByScopes = ({
+  dataScopes,
+  params,
+  defaultShouldRevalidate,
+}: {
+  // The scopes that should trigger revalidation when included in the form data of a submission
+  dataScopes: submitRevalidateDataScope[];
+  // The route params that should trigger revalidation when changed.
+  params?: string[];
+  defaultShouldRevalidate?: boolean;
+}) => {
+  const getScopesFromSubmission = (args: ShouldRevalidateFunctionArgs): submitRevalidateDataScope[] | null => {
+    const { formData, json, text } = args;
+    if (formData && formData.has(SCOPE_TO_REVALIDATE_FIELD)) {
+      const scopesJsonStr = formData.get(SCOPE_TO_REVALIDATE_FIELD);
+      if (typeof scopesJsonStr === 'string' && isValidJSONString(scopesJsonStr)) {
+        const scopes = JSON.parse(scopesJsonStr);
+        if (Array.isArray(scopes)) {
+          return scopes as submitRevalidateDataScope[];
+        }
+      }
+    }
+
+    if (json && typeof json === 'object' && SCOPE_TO_REVALIDATE_FIELD in json) {
+      return json[SCOPE_TO_REVALIDATE_FIELD] as submitRevalidateDataScope[];
+    }
+
+    // JSON-encoded object
+    if (typeof text === 'string') {
+      try {
+        const parsed = JSON.parse(text);
+        if (typeof parsed === 'object' && SCOPE_TO_REVALIDATE_FIELD in parsed) {
+          return parsed[SCOPE_TO_REVALIDATE_FIELD] as submitRevalidateDataScope[];
+        }
+      } catch {
+        // Ignore JSON parse errors
+      }
+    }
+
+    return null;
+  };
+
+  const shouldRevalidate = (args: ShouldRevalidateFunctionArgs) => {
+    const { currentParams, nextParams, formMethod, defaultShouldRevalidate: defaultShouldRevalidateArg } = args;
+
+    if (!formMethod || formMethod.toUpperCase() === 'GET') {
+      return defaultShouldRevalidateArg;
+    }
+
+    if (params) {
+      // If any of the specified params are different between current and next, we should revalidate
+      for (const param of params) {
+        if (currentParams[param] !== nextParams[param]) {
+          return true;
+        }
+      }
+      // If params are specified but none of them are different, we should not revalidate regardless of form data
+      return false;
+    }
+    const scopes = getScopesFromSubmission(args);
+    if (Array.isArray(scopes)) {
+      if (scopes.length === 0) {
+        // If the form data explicitly includes an empty scopes array, it will bypass revalidation when they know the changes won't affect the current page.
+        return false;
+      }
+      // If the form data includes scopes and any of them match the scopes for this shouldRevalidate function, then we should revalidate
+      return scopes.some(scope => dataScopes.includes(scope));
+    }
+    return defaultShouldRevalidate ?? defaultShouldRevalidateArg;
+  };
+  return shouldRevalidate;
+};
+
+export const addScopeField = ({
+  scopes,
+  data,
+}: {
+  scopes: submitRevalidateDataScope[];
+  data: Record<string, any> | FormData;
+}) => {
+  if (data instanceof FormData) {
+    const newFormData = new FormData();
+    for (const [key, value] of data.entries()) {
+      newFormData.append(key, value);
+    }
+    newFormData.append(SCOPE_TO_REVALIDATE_FIELD, JSON.stringify(scopes));
+    return newFormData;
+  }
+  return {
+    ...data,
+    [SCOPE_TO_REVALIDATE_FIELD]: scopes,
+  };
+};


### PR DESCRIPTION
# Changes:
**Add shouldRevalidate with an enforced scope registry:**
- Loaders export `shouldRevalidate` which revalidates only when the submission's declared scopes intersect the loader's scope.
- A reserved scope field is injected into the submission body 

Design doc: https://konghq.atlassian.net/wiki/spaces/~7120200ecfc756d7d24b19aacb30d7ea8bf917/pages/5620924446/Decoupling+Loaders+from+Action+Revalidation

[INS-2735](https://konghq.atlassian.net/browse/INS-2735)

[INS-2735]: https://konghq.atlassian.net/browse/INS-2735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ