### PR TITLE
replace process.type with __IS_RENDERER__

### DIFF
--- a/packages/insomnia-inso/esbuild.ts
+++ b/packages/insomnia-inso/esbuild.ts
@@ -51,7 +51,7 @@ const config: BuildOptions = {
     'process.env.DEFAULT_APP_NAME': JSON.stringify(isProd ? 'Insomnia' : 'insomnia-app'),
     'process.env.VERSION': JSON.stringify(isProd ? version : 'dev'),
     '__DEV__': JSON.stringify(!isProd),
-    'process.type': 'undefined',
+    '__IS_RENDERER__': JSON.stringify(false),
   },
   // node-llama-cpp is not included here because inso does not need it
   external: ['@getinsomnia/node-libcurl', 'fsevents', 'mocha'],

--- a/packages/insomnia-scripting-environment/src/objects/send-request.ts
+++ b/packages/insomnia-scripting-environment/src/objects/send-request.ts
@@ -18,10 +18,9 @@ export async function sendRequest(
   return new Promise(async (resolve, reject) => {
     try {
       const requestOptions = requestToCurlOptions(request, settings);
-      const nodejsCurlRequest =
-        process.type === 'renderer'
-          ? window.bridge.curlRequest
-          : (await import('insomnia/src/main/network/libcurl-promise')).curlRequest;
+      const nodejsCurlRequest = __IS_RENDERER__
+        ? window.bridge.curlRequest
+        : (await import('insomnia/src/main/network/libcurl-promise')).curlRequest;
 
       const output = (await nodejsCurlRequest(requestOptions)) as CurlRequestOutput;
       const transformedOutput = await curlOutputToResponse(output, request);

--- a/packages/insomnia/esbuild.entrypoints.ts
+++ b/packages/insomnia/esbuild.entrypoints.ts
@@ -52,6 +52,9 @@ export default async function build(options: Options) {
     sourcemap: true,
     format: 'cjs',
     external: ['electron'],
+    define: {
+      __IS_RENDERER__: JSON.stringify(true),
+    },
   };
 
   const hiddenBrowserWindowPreloadBuildOptions: BuildOptions = {
@@ -65,6 +68,9 @@ export default async function build(options: Options) {
     external: ['electron'],
     loader: {
       '.node': 'copy',
+    },
+    define: {
+      __IS_RENDERER__: JSON.stringify(true),
     },
   };
 
@@ -81,6 +87,9 @@ export default async function build(options: Options) {
     loader: {
       '.node': 'copy',
     },
+    define: {
+      __IS_RENDERER__: JSON.stringify(true),
+    },
   };
 
   const pluginWindowBuildOptions: BuildOptions = {
@@ -95,6 +104,9 @@ export default async function build(options: Options) {
     loader: {
       '.node': 'copy',
     },
+    define: {
+      __IS_RENDERER__: JSON.stringify(true),
+    },
   };
 
   const pluginWindowPreloadBuildOptions: BuildOptions = {
@@ -106,6 +118,9 @@ export default async function build(options: Options) {
     sourcemap: true,
     format: 'cjs',
     external: ['electron'],
+    define: {
+      __IS_RENDERER__: JSON.stringify(true),
+    },
   };
 
   const mainBuildOptions: BuildOptions = {
@@ -120,6 +135,7 @@ export default async function build(options: Options) {
       ...env,
       // Electron main = "browser"
       'process.type': '"browser"',
+      '__IS_RENDERER__': JSON.stringify(false),
     },
     external: [
       'electron',

--- a/packages/insomnia/src/common/misc.ts
+++ b/packages/insomnia/src/common/misc.ts
@@ -239,7 +239,7 @@ export function unescapeForwardSlash(str: string): string {
 export const SECURITY_SETTINGS_PATH_LABEL = 'Insomnia Preferences → General → Security';
 
 export function cannotAccessPathError(accessingPath: string): string {
-  return process.type === 'renderer' || process.type === 'browser'
+  return __IS_RENDERER__
     ? `Insomnia cannot access the file "${accessingPath}". You must specify which directories Insomnia can access in ${SECURITY_SETTINGS_PATH_LABEL}`
     : `Insomnia cannot access the file ‘${accessingPath}’. You must specify which directories Insomnia can access with one or more "--dataFolders <directory>".`;
 }

--- a/packages/insomnia/src/entry.plugin-window-preload.ts
+++ b/packages/insomnia/src/entry.plugin-window-preload.ts
@@ -1,7 +1,6 @@
 import { ipcRenderer } from 'electron';
 
-// Provide window.app so plugin-loading code (which checks process.type === 'renderer')
-// can resolve the userData path without needing the main renderer's full preload.
+// Provide window.app so plugin-loading code (which checks __IS_RENDERER__) can resolve the userData path without needing the main renderer's full preload.
 window.app = {
   getPath: (name: string) => ipcRenderer.sendSync('getPath', name) as string,
   getAppPath: () => ipcRenderer.sendSync('getAppPath') as string,
@@ -35,6 +34,10 @@ window.dialog = {
 
 window.clipboard = {
   readText: () => ipcRenderer.sendSync('readText') as string,
-  writeText: (text: string) => { ipcRenderer.send('writeText', text); },
-  clear: () => { ipcRenderer.send('clear'); },
+  writeText: (text: string) => {
+    ipcRenderer.send('writeText', text);
+  },
+  clear: () => {
+    ipcRenderer.send('clear');
+  },
 };

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -1,7 +1,5 @@
 // NOTE: this file should not be imported by electron renderer because node-libcurl is not-context-aware
 // Related issue https://github.com/JCMais/node-libcurl/issues/155
-import { invariant } from '../../utils/invariant';
-invariant(process.type !== 'renderer', 'Native abstractions for Nodejs module unavailable in renderer');
 import fs from 'node:fs';
 import path from 'node:path';
 import type { Readable, Writable } from 'node:stream';
@@ -26,6 +24,7 @@ import { version } from '../../../package.json';
 import { type AuthTypes, CONTENT_TYPE_FORM_DATA, CONTENT_TYPE_FORM_URLENCODED } from '../../common/constants';
 import { cannotAccessPathError, describeByteSize, hasAuthHeader } from '../../common/misc';
 import { parseHeaderStrings } from '../../network/parse-header-strings';
+import { invariant } from '../../utils/invariant';
 import { insecureReadFile, isPathAllowed } from '../secure-read-file';
 import { buildMultipart } from './multipart';
 export interface CurlRequestOptions {

--- a/packages/insomnia/src/main/network/multipart.ts
+++ b/packages/insomnia/src/main/network/multipart.ts
@@ -1,7 +1,3 @@
-if (process.type === 'renderer') {
-  throw new Error('multipart.ts unavailable in renderer');
-}
-
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';

--- a/packages/insomnia/src/plugins/context/app.ts
+++ b/packages/insomnia/src/plugins/context/app.ts
@@ -3,18 +3,15 @@ import type { AppContext, RenderPurpose } from 'insomnia/src/templating/types';
 import { invariant } from 'insomnia/src/utils/invariant';
 import { platform } from 'insomnia-data/common';
 
-// TODO: consider how this would work in a webworker context
-const isRenderer = process.type === 'renderer';
-
 export const init = (renderPurpose: RenderPurpose = 'general'): { app: AppContext } => ({
   app: {
     alert: async (title: string, message?: string) => {
-      if (isRenderer) {
+      if (__IS_RENDERER__) {
         return window.showAlert({ title, message });
       }
     },
     dialog: async (title, body, options = {}) => {
-      if (isRenderer) {
+      if (__IS_RENDERER__) {
         window.showWrapper({
           ...options,
           title,
@@ -23,7 +20,7 @@ export const init = (renderPurpose: RenderPurpose = 'general'): { app: AppContex
       }
     },
     prompt: (title, options) => {
-      if (!isRenderer) {
+      if (!__IS_RENDERER__) {
         return Promise.resolve(options?.defaultValue || '');
       }
       // This custom promise converts the prompt modal from being callback-based to reject when the modal is cancelled and resolve when the modal is submitted and hidden

--- a/packages/insomnia/src/plugins/context/network.ts
+++ b/packages/insomnia/src/plugins/context/network.ts
@@ -57,11 +57,10 @@ export function init(): {
         const settings = await services.settings.get();
         const settingFollowRedirects = settings?.followRedirects ? 'on' : 'off';
         const { request: originRequest, caCertficatePath = null } = options;
-        const curlRequest =
-          process.type === 'renderer' || process.type === 'worker'
-            ? window.main.curlRequest
-            : // when exeucted in Inso;
-              (await import('../../main/network/libcurl-promise')).curlRequest;
+        const curlRequest = __IS_RENDERER__
+          ? window.main.curlRequest
+          : // when exeucted in Inso;
+            (await import('../../main/network/libcurl-promise')).curlRequest;
         const response = await curlRequest({
           requestId: `no-sideEffects-request-${requestId}`,
           req: {

--- a/packages/insomnia/src/plugins/index.ts
+++ b/packages/insomnia/src/plugins/index.ts
@@ -145,7 +145,7 @@ export async function getPlugins(force = false): Promise<Plugin[]> {
 
     // Make sure the default directories exist
     const pluginPath = path.resolve(
-      process.env['INSOMNIA_DATA_PATH'] || (process.type === 'renderer' ? window : electron).app.getPath('userData'),
+      process.env['INSOMNIA_DATA_PATH'] || (__IS_RENDERER__ ? window : electron).app.getPath('userData'),
       'plugins',
     );
 
@@ -315,9 +315,7 @@ export function getPluginCommonContext({
     ...pluginNetwork.init(),
     util: {
       openInBrowser: async (url: string) =>
-        process.type === 'renderer' || process.type === 'worker'
-          ? window.main.openInBrowser(url)
-          : electron.shell.openExternal(url),
+        __IS_RENDERER__ ? window.main.openInBrowser(url) : electron.shell.openExternal(url),
       models: {
         request: {
           getById: services.request.getById,


### PR DESCRIPTION
Forces a consistent approach to process forking that allows each entrypoint to define the codeapths followed statically making tracing easier

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
