### PR TITLE
feat: Adds dialog to confirm closing a modal with unsaved changes (p1)

### DIFF
--- a/packages/insomnia/src/ui/components/unsaved-changes-confirm-dialog.tsx
+++ b/packages/insomnia/src/ui/components/unsaved-changes-confirm-dialog.tsx
@@ -13,7 +13,7 @@ export const UnsavedChangesConfirmDialog = ({
   <ModalOverlay
     isOpen={isOpen}
     onOpenChange={open => !open && onDismiss()}
-    className="fixed top-0 left-0 z-[200] flex h-(--visual-viewport-height) w-full items-center justify-center bg-black/30"
+    className="fixed top-0 left-0 z-[200] flex h-(--visual-viewport-height) w-full items-center justify-center bg-transparent"
   >
     <Modal className="flex w-full max-w-sm flex-col rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) p-6 text-(--color-font) shadow-xl">
       <Dialog className="flex flex-col gap-4 outline-hidden">
@@ -23,13 +23,13 @@ export const UnsavedChangesConfirmDialog = ({
           <Button
             autoFocus
             onPress={onDismiss}
-            className="rounded-xs border border-solid border-(--hl-md) px-3 py-2 text-sm text-(--color-font) transition-colors hover:bg-(--hl-xs)"
+            className="rounded-md border border-solid border-(--hl-md) px-3 py-2 text-sm text-(--color-font) transition-colors hover:bg-(--hl-xs)"
           >
             No
           </Button>
           <Button
             onPress={onConfirm}
-            className="rounded-xs border border-solid border-(--hl-md) bg-(--color-danger) px-3 py-2 text-sm text-(--color-font-danger) transition-colors hover:bg-(--color-danger)/90"
+            className="rounded-md border border-solid border-(--hl-md) bg-(--color-danger) px-3 py-2 text-sm text-(--color-font-danger) transition-colors hover:bg-(--color-danger)/90"
           >
             Yes
           </Button>

--- a/packages/insomnia/src/ui/components/unsaved-changes-confirm-dialog.tsx
+++ b/packages/insomnia/src/ui/components/unsaved-changes-confirm-dialog.tsx
@@ -20,7 +20,7 @@ export const UnsavedChangesConfirmDialog = ({
         <Heading slot="title" className="text-lg font-semibold">
           Unsaved changes
         </Heading>
-        <p slot="description" className="text-sm">
+        <p className="text-sm">
           You will lose any unsaved changes. Are you sure you want to cancel?
         </p>
         <div className="flex items-center justify-end gap-2">

--- a/packages/insomnia/src/ui/components/unsaved-changes-confirm-dialog.tsx
+++ b/packages/insomnia/src/ui/components/unsaved-changes-confirm-dialog.tsx
@@ -1,15 +1,24 @@
 import React from 'react';
 import { Button, Dialog, Heading, Modal, ModalOverlay } from 'react-aria-components';
 
-export const UnsavedChangesConfirmDialog = ({
-  isOpen,
-  onConfirm,
-  onDismiss,
-}: {
+interface Props {
+  /** Whether the confirm dialog is visible. */
   isOpen: boolean;
+  /** Called when the user confirms discarding their unsaved changes. */
   onConfirm: () => void;
+  /** Called when the user backs out (Escape, the "No" button) to keep editing. */
   onDismiss: () => void;
-}) => (
+}
+
+/**
+ * Presentational confirm dialog for "you have unsaved changes" flows. Stateless
+ * and fully controlled — it only renders based on `isOpen` and reports the
+ * user's choice via `onConfirm` (discard) / `onDismiss` (keep editing).
+ *
+ * Normally you don't render this directly: `UnsavedChangesGuard` owns the open
+ * state and renders it for you. Reach for it only when you need custom placement.
+ */
+export const UnsavedChangesConfirmDialog = ({ isOpen, onConfirm, onDismiss }: Props) => (
   <ModalOverlay
     isOpen={isOpen}
     onOpenChange={open => !open && onDismiss()}

--- a/packages/insomnia/src/ui/components/unsaved-changes-confirm-dialog.tsx
+++ b/packages/insomnia/src/ui/components/unsaved-changes-confirm-dialog.tsx
@@ -16,11 +16,11 @@ export const UnsavedChangesConfirmDialog = ({
     className="fixed top-0 left-0 z-[200] flex h-(--visual-viewport-height) w-full items-center justify-center bg-transparent"
   >
     <Modal className="flex w-full max-w-sm flex-col rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) p-6 text-(--color-font) shadow-xl">
-      <Dialog className="flex flex-col gap-4 outline-hidden">
+      <Dialog className="flex flex-col gap-4 outline-hidden" aria-describedby="unsaved-description">
         <Heading slot="title" className="text-lg font-semibold">
           Unsaved changes
         </Heading>
-        <p className="text-sm">
+        <p id="unsaved-description" className="text-sm">
           You will lose any unsaved changes. Are you sure you want to cancel?
         </p>
         <div className="flex items-center justify-end gap-2">

--- a/packages/insomnia/src/ui/components/unsaved-changes-confirm-dialog.tsx
+++ b/packages/insomnia/src/ui/components/unsaved-changes-confirm-dialog.tsx
@@ -17,8 +17,12 @@ export const UnsavedChangesConfirmDialog = ({
   >
     <Modal className="flex w-full max-w-sm flex-col rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) p-6 text-(--color-font) shadow-xl">
       <Dialog className="flex flex-col gap-4 outline-hidden">
-        <Heading className="text-lg font-semibold">Unsaved changes</Heading>
-        <p className="text-sm">You will lose any unsaved changes. Are you sure you want to cancel?</p>
+        <Heading slot="title" className="text-lg font-semibold">
+          Unsaved changes
+        </Heading>
+        <p slot="description" className="text-sm">
+          You will lose any unsaved changes. Are you sure you want to cancel?
+        </p>
         <div className="flex items-center justify-end gap-2">
           <Button
             autoFocus

--- a/packages/insomnia/src/ui/components/unsaved-changes-confirm-dialog.tsx
+++ b/packages/insomnia/src/ui/components/unsaved-changes-confirm-dialog.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Button, Dialog, Heading, Modal, ModalOverlay } from 'react-aria-components';
+
+export const UnsavedChangesConfirmDialog = ({
+  isOpen,
+  onConfirm,
+  onDismiss,
+}: {
+  isOpen: boolean;
+  onConfirm: () => void;
+  onDismiss: () => void;
+}) => (
+  <ModalOverlay
+    isOpen={isOpen}
+    onOpenChange={open => !open && onDismiss()}
+    className="fixed top-0 left-0 z-[200] flex h-(--visual-viewport-height) w-full items-center justify-center bg-black/30"
+  >
+    <Modal className="flex w-full max-w-sm flex-col rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) p-6 text-(--color-font) shadow-xl">
+      <Dialog className="flex flex-col gap-4 outline-hidden">
+        <Heading className="text-lg font-semibold">Unsaved changes</Heading>
+        <p className="text-sm">You will lose any unsaved changes. Are you sure you want to cancel?</p>
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            autoFocus
+            onPress={onDismiss}
+            className="rounded-xs border border-solid border-(--hl-md) px-3 py-2 text-sm text-(--color-font) transition-colors hover:bg-(--hl-xs)"
+          >
+            No
+          </Button>
+          <Button
+            onPress={onConfirm}
+            className="rounded-xs border border-solid border-(--hl-md) bg-(--color-danger) px-3 py-2 text-sm text-(--color-font-danger) transition-colors hover:bg-(--color-danger)/90"
+          >
+            Yes
+          </Button>
+        </div>
+      </Dialog>
+    </Modal>
+  </ModalOverlay>
+);

--- a/packages/insomnia/src/ui/components/unsaved-changes-guard.tsx
+++ b/packages/insomnia/src/ui/components/unsaved-changes-guard.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react';
+
+import { useUnsavedChangesGuard } from '~/ui/hooks/use-unsaved-changes-guard';
+
+import { UnsavedChangesConfirmDialog } from './unsaved-changes-confirm-dialog';
+
+interface Props {
+  /** Whether there are unsaved changes that should be confirmed before closing. */
+  isDirty: boolean;
+  /** Called once the close is allowed (no changes, or the user confirmed discarding them). */
+  onClose: () => void;
+  /**
+   * Render content here. Wire every close affordance (X button, Cancel,
+   * overlay dismiss) to the provided `requestClose` instead of closing directly —
+   * it gates on `isDirty` and prompts the confirm dialog when needed.
+   */
+  children: (api: { requestClose: () => void }) => ReactNode;
+}
+
+/**
+ * Drop-in guard for "you have unsaved changes" flows. Owns the confirm-dialog
+ * state and renders the dialog itself, so consumers only need to render this
+ * component and route their close actions through `requestClose`.
+ */
+export const UnsavedChangesGuard = ({ isDirty, onClose, children }: Props) => {
+  const { requestClose, confirmDialogProps } = useUnsavedChangesGuard(isDirty, onClose);
+
+  return (
+    <>
+      {children({ requestClose })}
+      <UnsavedChangesConfirmDialog {...confirmDialogProps} />
+    </>
+  );
+};

--- a/packages/insomnia/src/ui/components/unsaved-changes-guard.tsx
+++ b/packages/insomnia/src/ui/components/unsaved-changes-guard.tsx
@@ -6,13 +6,13 @@ import { UnsavedChangesConfirmDialog } from './unsaved-changes-confirm-dialog';
 
 interface Props {
   /** Whether there are unsaved changes that should be confirmed before closing. */
-  isDirty: boolean;
+  hasUnsavedChanges: boolean;
   /** Called once the close is allowed (no changes, or the user confirmed discarding them). */
   onClose: () => void;
   /**
    * Render content here. Wire every close affordance (X button, Cancel,
    * overlay dismiss) to the provided `requestClose` instead of closing directly —
-   * it gates on `isDirty` and prompts the confirm dialog when needed.
+   * it gates on `hasUnsavedChanges` and prompts the confirm dialog when needed.
    */
   children: (api: { requestClose: () => void }) => ReactNode;
 }
@@ -22,8 +22,8 @@ interface Props {
  * state and renders the dialog itself, so consumers only need to render this
  * component and route their close actions through `requestClose`.
  */
-export const UnsavedChangesGuard = ({ isDirty, onClose, children }: Props) => {
-  const { requestClose, confirmDialogProps } = useUnsavedChangesGuard(isDirty, onClose);
+export const UnsavedChangesGuard = ({ hasUnsavedChanges, onClose, children }: Props) => {
+  const { requestClose, confirmDialogProps } = useUnsavedChangesGuard(hasUnsavedChanges, onClose);
 
   return (
     <>

--- a/packages/insomnia/src/ui/hooks/use-unsaved-changes-guard.ts
+++ b/packages/insomnia/src/ui/hooks/use-unsaved-changes-guard.ts
@@ -1,5 +1,19 @@
 import { useCallback, useState } from 'react';
 
+/**
+ * Gate logic for "you have unsaved changes" confirm-on-close flows.
+ *
+ * Route every close affordance through the returned `requestClose`: it closes
+ * immediately when there are no changes, otherwise it opens a confirm dialog and
+ * defers `onClose` until the user confirms.
+ *
+ * Most consumers should use `UnsavedChangesGuard`, which pairs this hook with
+ * the dialog. Use this hook directly only when you need custom dialog placement;
+ * spread `confirmDialogProps` onto `UnsavedChangesConfirmDialog`.
+ *
+ * @param hasUnsavedChanges Whether closing would discard unsaved changes.
+ * @param onClose Invoked once the close is allowed (no changes, or confirmed).
+ */
 export function useUnsavedChangesGuard(hasUnsavedChanges: boolean, onClose: () => void) {
   const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
 

--- a/packages/insomnia/src/ui/hooks/use-unsaved-changes-guard.ts
+++ b/packages/insomnia/src/ui/hooks/use-unsaved-changes-guard.ts
@@ -1,0 +1,25 @@
+import { useCallback, useState } from 'react';
+
+export function useUnsavedChangesGuard(isDirty: boolean, onClose: () => void) {
+  const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
+
+  const requestClose = useCallback(() => {
+    if (isDirty) {
+      setIsConfirmDialogOpen(true);
+      return;
+    }
+    onClose();
+  }, [isDirty, onClose]);
+
+  const confirmClose = useCallback(() => {
+    setIsConfirmDialogOpen(false);
+    onClose();
+  }, [onClose]);
+
+  return {
+    isConfirmDialogOpen,
+    setIsConfirmDialogOpen,
+    requestClose,
+    confirmClose,
+  };
+}

--- a/packages/insomnia/src/ui/hooks/use-unsaved-changes-guard.ts
+++ b/packages/insomnia/src/ui/hooks/use-unsaved-changes-guard.ts
@@ -16,10 +16,14 @@ export function useUnsavedChangesGuard(isDirty: boolean, onClose: () => void) {
     onClose();
   }, [onClose]);
 
+  const dismissClose = useCallback(() => setIsConfirmDialogOpen(false), []);
+
   return {
-    isConfirmDialogOpen,
-    setIsConfirmDialogOpen,
     requestClose,
-    confirmClose,
+    confirmDialogProps: {
+      isOpen: isConfirmDialogOpen,
+      onConfirm: confirmClose,
+      onDismiss: dismissClose,
+    },
   };
 }

--- a/packages/insomnia/src/ui/hooks/use-unsaved-changes-guard.ts
+++ b/packages/insomnia/src/ui/hooks/use-unsaved-changes-guard.ts
@@ -1,15 +1,15 @@
 import { useCallback, useState } from 'react';
 
-export function useUnsavedChangesGuard(isDirty: boolean, onClose: () => void) {
+export function useUnsavedChangesGuard(hasUnsavedChanges: boolean, onClose: () => void) {
   const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
 
   const requestClose = useCallback(() => {
-    if (isDirty) {
+    if (hasUnsavedChanges) {
       setIsConfirmDialogOpen(true);
       return;
     }
     onClose();
-  }, [isDirty, onClose]);
+  }, [hasUnsavedChanges, onClose]);
 
   const confirmClose = useCallback(() => {
     setIsConfirmDialogOpen(false);


### PR DESCRIPTION
Addresses part 1 of displaying a confirmation dialog when a user attempts to close a modal which has input fields that have been modified. [Ticket here](https://konghq.atlassian.net/browse/INS-2551).

Part 1 - The approach is to create a reusable wrapper component that intercepts close attempts on modals. Consumers simply use the `requestClose` passed from the wrapper component to control whether the modal actually closes. Determining whether input field state is dirty is the responsibility of the consumer that owns the inputs.