### PR TITLE
fix: cloud sync toast for v13

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/sync-dropdown.tsx
@@ -108,7 +108,11 @@ export const SyncDropdown: FC<Props> = () => {
   useEffect(() => {
     if (pushFetcher.data && 'error' in pushFetcher.data && pushFetcher.data.error) {
       setOperationError(pushFetcher.data.error);
-      showToast({ icon: cloudSyncIcon, title: `Push failed` });
+      showToast({
+        icon: cloudSyncIcon,
+        title: `Push failed`,
+        status: 'error',
+      });
     } else if (pushFetcher.data && 'success' in pushFetcher.data && pushFetcher.data.success) {
       showToast({
         icon: cloudSyncIcon,
@@ -121,7 +125,11 @@ export const SyncDropdown: FC<Props> = () => {
   useEffect(() => {
     if (pullFetcher.data && 'error' in pullFetcher.data && pullFetcher.data.error) {
       setOperationError(pullFetcher.data.error);
-      showToast({ icon: cloudSyncIcon, title: `Pull failed` });
+      showToast({
+        icon: cloudSyncIcon,
+        title: `Pull failed`,
+        status: 'error',
+      });
     } else if (pullFetcher.data && 'success' in pullFetcher.data && pullFetcher.data.success) {
       showToast({
         icon: cloudSyncIcon,
@@ -272,11 +280,7 @@ export const SyncDropdown: FC<Props> = () => {
       isDisabled: compare.behind === 0 || pullFetcher.state !== 'idle',
       action: () => {
         setOperationError(null);
-        showToast({
-          icon: cloudSyncIcon,
-          title: `Pull failed`,
-          status: 'error',
-        });
+        showToast({ icon: cloudSyncIcon, title: `Pull started` });
         pullFetcher.submit({
           organizationId,
           projectId,


### PR DESCRIPTION
Manually pulling from cloud sync was displaying `Pull failed` instead of `Pull started`:
<img width="268" height="145" alt="Screenshot 2026-06-11 at 17 07 45" src="https://github.com/user-attachments/assets/73beb77e-82b4-4f25-9e33-ae8eb9eb4ce5" />


This change fixes it so that pull starts display correctly, and some other failures are classified as errors:
<img width="266" height="163" alt="Screenshot 2026-06-11 at 17 09 08" src="https://github.com/user-attachments/assets/3d120c22-e0fb-4133-9b23-ede1824d2523" />
