### PR TITLE
fix: let user toggle parameters for newer URL-based LLMs

### DIFF
--- a/packages/insomnia/src/main/__tests__/llm-config-service.test.ts
+++ b/packages/insomnia/src/main/__tests__/llm-config-service.test.ts
@@ -98,6 +98,9 @@ describe('llm-config-service', () => {
         mockPluginData('url.maxTokens', '4096'),
         mockPluginData('url.temperature', '0.7'),
         mockPluginData('url.topP', '0.95'),
+        mockPluginData('url.sendTemperature', 'false'),
+        mockPluginData('url.sendTopP', 'true'),
+        mockPluginData('url.sendMaxTokens', 'false'),
       ]);
 
       const config = await getBackendConfig('url');
@@ -108,6 +111,9 @@ describe('llm-config-service', () => {
         maxTokens: 4096,
         temperature: 0.7,
         topP: 0.95,
+        sendTemperature: false,
+        sendTopP: true,
+        sendMaxTokens: false,
       });
     });
 
@@ -155,11 +161,17 @@ describe('llm-config-service', () => {
         maxTokens: 4096,
         temperature: 0.7,
         topP: 0.95,
+        sendTemperature: false,
+        sendTopP: true,
+        sendMaxTokens: false,
       });
 
       expect(services.pluginData.upsertByKey).toHaveBeenCalledWith('insomnia-llm', 'url.maxTokens', '4096');
       expect(services.pluginData.upsertByKey).toHaveBeenCalledWith('insomnia-llm', 'url.temperature', '0.7');
       expect(services.pluginData.upsertByKey).toHaveBeenCalledWith('insomnia-llm', 'url.topP', '0.95');
+      expect(services.pluginData.upsertByKey).toHaveBeenCalledWith('insomnia-llm', 'url.sendTemperature', 'false');
+      expect(services.pluginData.upsertByKey).toHaveBeenCalledWith('insomnia-llm', 'url.sendTopP', 'true');
+      expect(services.pluginData.upsertByKey).toHaveBeenCalledWith('insomnia-llm', 'url.sendMaxTokens', 'false');
     });
 
     it('should handle partial config updates', async () => {

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -101,6 +101,32 @@ export const openInBrowser = (href: string) => {
   }
 };
 
+const sanitizeModelConfigForRequest = (modelConfig: ModelConfig | null | undefined): ModelConfig | null => {
+  if (!modelConfig) {
+    return null;
+  }
+
+  const sanitizedConfig: ModelConfig = { ...modelConfig };
+
+  if (sanitizedConfig.backend === 'url') {
+    if (sanitizedConfig.sendTemperature === false) {
+      delete sanitizedConfig.temperature;
+    }
+    if (sanitizedConfig.sendTopP === false) {
+      delete sanitizedConfig.topP;
+    }
+    if (sanitizedConfig.sendMaxTokens === false) {
+      delete sanitizedConfig.maxTokens;
+    }
+  }
+
+  delete sanitizedConfig.sendTemperature;
+  delete sanitizedConfig.sendTopP;
+  delete sanitizedConfig.sendMaxTokens;
+
+  return sanitizedConfig;
+};
+
 const readDir = async (_: unknown, options: { path: string }) => {
   try {
     const files = await fs.promises.readdir(options.path);
@@ -750,7 +776,7 @@ export function registerMainHandlers() {
           openApiSpec,
           specUrl,
           specText,
-          modelConfig,
+          modelConfig: sanitizeModelConfigForRequest(modelConfig as ModelConfig),
           useDynamicMockResponses,
           mockServerAdditionalFiles,
           aiPluginName: AI_PLUGIN_NAME,
@@ -802,7 +828,7 @@ export function registerMainHandlers() {
 
       process.postMessage({
         input,
-        modelConfig,
+        modelConfig: sanitizeModelConfigForRequest(modelConfig),
         aiPluginName: AI_PLUGIN_NAME,
       });
     });
@@ -864,7 +890,7 @@ export function registerMainHandlers() {
       process.postMessage({
         messages,
         systemPrompt,
-        modelConfig: mergedModelConfig,
+        modelConfig: sanitizeModelConfigForRequest(mergedModelConfig as ModelConfig),
         aiPluginName: AI_PLUGIN_NAME,
       });
     });

--- a/packages/insomnia/src/main/llm-config-service.ts
+++ b/packages/insomnia/src/main/llm-config-service.ts
@@ -21,6 +21,9 @@ export interface LLMConfig {
   maxTokens?: number;
   temperature?: number;
   topP?: number;
+  sendTemperature?: boolean;
+  sendTopP?: boolean;
+  sendMaxTokens?: boolean;
   topK?: number;
   seed?: boolean;
   repeatPenalty?: number;
@@ -68,6 +71,12 @@ export const getBackendConfig = async (backend: LLMBackend): Promise<Partial<LLM
         break;
       }
       case 'seed': {
+        config[field] = value === 'true';
+        break;
+      }
+      case 'sendTemperature':
+      case 'sendTopP':
+      case 'sendMaxTokens': {
         config[field] = value === 'true';
         break;
       }

--- a/packages/insomnia/src/plugins/types.ts
+++ b/packages/insomnia/src/plugins/types.ts
@@ -23,6 +23,9 @@ export interface ModelConfig {
   // openai, gemini, url, gguf
   topP?: number;
   temperature?: number;
+  sendTemperature?: boolean;
+  sendTopP?: boolean;
+  sendMaxTokens?: boolean;
 
   // gguf, gemini, url
   topK?: number;

--- a/packages/insomnia/src/ui/components/settings/llms/url-utils.test.ts
+++ b/packages/insomnia/src/ui/components/settings/llms/url-utils.test.ts
@@ -31,6 +31,9 @@ describe('url-utils', () => {
         temperature: 0.75,
         topP: 0.8,
         maxTokens: DEFAULT_URL_MODEL_PARAMETERS.maxTokens,
+        sendTemperature: DEFAULT_URL_MODEL_PARAMETERS.sendTemperature,
+        sendTopP: DEFAULT_URL_MODEL_PARAMETERS.sendTopP,
+        sendMaxTokens: DEFAULT_URL_MODEL_PARAMETERS.sendMaxTokens,
       });
     });
   });
@@ -41,6 +44,9 @@ describe('url-utils', () => {
         temperature: 0.7,
         topP: 0.9,
         maxTokens: 4096,
+        sendTemperature: true,
+        sendTopP: true,
+        sendMaxTokens: true,
       });
       expect(result.success).toBe(true);
     });
@@ -50,6 +56,9 @@ describe('url-utils', () => {
         temperature: 2.5,
         topP: 1.2,
         maxTokens: 0,
+        sendTemperature: true,
+        sendTopP: true,
+        sendMaxTokens: true,
       });
       expect(result.success).toBe(false);
     });
@@ -61,6 +70,9 @@ describe('url-utils', () => {
         temperature: 0.7,
         topP: 0.9,
         maxTokens: 4096,
+        sendTemperature: true,
+        sendTopP: true,
+        sendMaxTokens: true,
       };
       expect(hasUrlModelParameterChanges(currentConfig, getUrlModelParametersFromConfig(currentConfig))).toBe(false);
     });
@@ -70,12 +82,39 @@ describe('url-utils', () => {
         temperature: 0.7,
         topP: 0.9,
         maxTokens: 4096,
+        sendTemperature: true,
+        sendTopP: true,
+        sendMaxTokens: true,
       };
       expect(
         hasUrlModelParameterChanges(currentConfig, {
           temperature: 0.8,
           topP: 0.85,
           maxTokens: 2048,
+          sendTemperature: true,
+          sendTopP: true,
+          sendMaxTokens: true,
+        }),
+      ).toBe(true);
+    });
+
+    it('returns true when send flags differ from current config', () => {
+      const currentConfig = {
+        temperature: 0.7,
+        topP: 0.9,
+        maxTokens: 4096,
+        sendTemperature: true,
+        sendTopP: true,
+        sendMaxTokens: true,
+      };
+      expect(
+        hasUrlModelParameterChanges(currentConfig, {
+          temperature: 0.7,
+          topP: 0.9,
+          maxTokens: 4096,
+          sendTemperature: false,
+          sendTopP: true,
+          sendMaxTokens: true,
         }),
       ).toBe(true);
     });
@@ -100,6 +139,9 @@ describe('url-utils', () => {
         temperature: 1.1,
         topP: 0.8,
         maxTokens: 1024,
+        sendTemperature: false,
+        sendTopP: true,
+        sendMaxTokens: false,
       });
 
       expect(payload).toEqual({
@@ -108,6 +150,9 @@ describe('url-utils', () => {
         temperature: 1.1,
         topP: 0.8,
         maxTokens: 1024,
+        sendTemperature: false,
+        sendTopP: true,
+        sendMaxTokens: false,
       });
     });
 
@@ -116,6 +161,9 @@ describe('url-utils', () => {
         temperature: 0.7,
         topP: 0.95,
         maxTokens: 2048,
+        sendTemperature: true,
+        sendTopP: false,
+        sendMaxTokens: true,
       });
 
       expect(payload).toEqual({
@@ -125,6 +173,9 @@ describe('url-utils', () => {
         temperature: 0.7,
         topP: 0.95,
         maxTokens: 2048,
+        sendTemperature: true,
+        sendTopP: false,
+        sendMaxTokens: true,
       });
     });
   });

--- a/packages/insomnia/src/ui/components/settings/llms/url-utils.ts
+++ b/packages/insomnia/src/ui/components/settings/llms/url-utils.ts
@@ -6,6 +6,9 @@ export const urlModelParametersSchema = z.object({
   temperature: z.number().min(0).max(2),
   topP: z.number().min(0).max(1),
   maxTokens: z.number().int().min(1).max(128_000),
+  sendTemperature: z.boolean(),
+  sendTopP: z.boolean(),
+  sendMaxTokens: z.boolean(),
 });
 
 export type UrlModelParameters = z.infer<typeof urlModelParametersSchema>;
@@ -14,12 +17,18 @@ export const DEFAULT_URL_MODEL_PARAMETERS: UrlModelParameters = {
   temperature: 0.6,
   topP: 0.9,
   maxTokens: 8192,
+  sendTemperature: true,
+  sendTopP: true,
+  sendMaxTokens: true,
 };
 
 export const getUrlModelParametersFromConfig = (config?: Partial<LLMConfig> | null): UrlModelParameters => ({
   temperature: config?.temperature ?? DEFAULT_URL_MODEL_PARAMETERS.temperature,
   topP: config?.topP ?? DEFAULT_URL_MODEL_PARAMETERS.topP,
   maxTokens: config?.maxTokens ?? DEFAULT_URL_MODEL_PARAMETERS.maxTokens,
+  sendTemperature: config?.sendTemperature ?? DEFAULT_URL_MODEL_PARAMETERS.sendTemperature,
+  sendTopP: config?.sendTopP ?? DEFAULT_URL_MODEL_PARAMETERS.sendTopP,
+  sendMaxTokens: config?.sendMaxTokens ?? DEFAULT_URL_MODEL_PARAMETERS.sendMaxTokens,
 });
 
 export const hasUrlModelParameterChanges = (
@@ -30,7 +39,10 @@ export const hasUrlModelParameterChanges = (
   return (
     modelParameters.temperature !== current.temperature ||
     modelParameters.topP !== current.topP ||
-    modelParameters.maxTokens !== current.maxTokens
+    modelParameters.maxTokens !== current.maxTokens ||
+    modelParameters.sendTemperature !== current.sendTemperature ||
+    modelParameters.sendTopP !== current.sendTopP ||
+    modelParameters.sendMaxTokens !== current.sendMaxTokens
   );
 };
 
@@ -55,6 +67,9 @@ export const getUrlLoadModelsSettingsPayload = (
   maxTokens: modelParameters.maxTokens,
   temperature: modelParameters.temperature,
   topP: modelParameters.topP,
+  sendMaxTokens: modelParameters.sendMaxTokens,
+  sendTemperature: modelParameters.sendTemperature,
+  sendTopP: modelParameters.sendTopP,
 });
 
 export const getUrlActivateSettingsPayload = (
@@ -69,6 +84,9 @@ export const getUrlActivateSettingsPayload = (
   maxTokens: modelParameters.maxTokens,
   temperature: modelParameters.temperature,
   topP: modelParameters.topP,
+  sendMaxTokens: modelParameters.sendMaxTokens,
+  sendTemperature: modelParameters.sendTemperature,
+  sendTopP: modelParameters.sendTopP,
 });
 
 export const isUrlActivateDisabled = ({

--- a/packages/insomnia/src/ui/components/settings/llms/url.tsx
+++ b/packages/insomnia/src/ui/components/settings/llms/url.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useId, useMemo, useState } from 'react';
 import { Button, Input, Text } from 'react-aria-components';
 
 import type { LLMBackend, LLMConfig } from '~/main/llm-config-service';
+import { Checkbox } from '~/ui/components/base/checkbox';
 import { Icon } from '~/ui/components/icon';
 import {
   DEFAULT_URL_MODEL_PARAMETERS,
@@ -293,6 +294,7 @@ export const Url = ({
                       id={temperatureId}
                       type="number"
                       value={modelParameters.temperature.toString()}
+                      disabled={!modelParameters.sendTemperature}
                       onChange={e => {
                         const value = Number.parseFloat(e.target.value);
                         if (!Number.isNaN(value) && value >= 0 && value <= 2) {
@@ -303,6 +305,18 @@ export const Url = ({
                       min={0}
                       max={2}
                     />
+                    <Checkbox
+                      className="mt-1 cursor-pointer rounded-sm px-2 py-1 text-xs text-(--hl) transition-colors hover:bg-(--hl-sm) hover:text-(--color-font)"
+                      isSelected={modelParameters.sendTemperature}
+                      onChange={isSelected =>
+                        setModelParameters(prev => ({
+                          ...prev,
+                          sendTemperature: isSelected,
+                        }))
+                      }
+                    >
+                      Send Temperature parameter
+                    </Checkbox>
                   </div>
 
                   <div className="form-control form-control--outlined">
@@ -311,6 +325,7 @@ export const Url = ({
                       id={topPId}
                       type="number"
                       value={modelParameters.topP.toString()}
+                      disabled={!modelParameters.sendTopP}
                       onChange={e => {
                         const value = Number.parseFloat(e.target.value);
                         if (!Number.isNaN(value) && value >= 0 && value <= 1) {
@@ -321,6 +336,18 @@ export const Url = ({
                       min={0}
                       max={1}
                     />
+                    <Checkbox
+                      className="mt-1 cursor-pointer rounded-sm px-2 py-1 text-xs text-(--hl) transition-colors hover:bg-(--hl-sm) hover:text-(--color-font)"
+                      isSelected={modelParameters.sendTopP}
+                      onChange={isSelected =>
+                        setModelParameters(prev => ({
+                          ...prev,
+                          sendTopP: isSelected,
+                        }))
+                      }
+                    >
+                      Send Top P parameter
+                    </Checkbox>
                   </div>
 
                   <div className="form-control form-control--outlined">
@@ -329,6 +356,7 @@ export const Url = ({
                       id={maxTokensId}
                       type="number"
                       value={modelParameters.maxTokens.toString()}
+                      disabled={!modelParameters.sendMaxTokens}
                       onChange={e => {
                         const value = Number.parseInt(e.target.value, 10);
                         if (!Number.isNaN(value) && value >= 1 && value <= 128_000) {
@@ -339,6 +367,18 @@ export const Url = ({
                       min="1"
                       max="128000"
                     />
+                    <Checkbox
+                      className="mt-1 cursor-pointer rounded-sm px-2 py-1 text-xs text-(--hl) transition-colors hover:bg-(--hl-sm) hover:text-(--color-font)"
+                      isSelected={modelParameters.sendMaxTokens}
+                      onChange={isSelected =>
+                        setModelParameters(prev => ({
+                          ...prev,
+                          sendMaxTokens: isSelected,
+                        }))
+                      }
+                    >
+                      Send Max Tokens parameter
+                    </Checkbox>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Need to let user toggle parameters in case some LLMs error because they do not support them. For example, Claude Opus 4.7 and 4.8 do not support temperature, so if a user uses a gateway or proxy (Kong API Gateway, LiteLLM, etc.) to call Claude Opus 4.8 and has temperature enabled in the parameters, then the calls will fail. This gives users a proper workaround.

<img width="521" height="513" alt="Screenshot 2026-06-12 at 10 53 48 AM" src="https://github.com/user-attachments/assets/7de955d0-3d3b-4f95-a9ba-76dedc760d39" />
