### PR TITLE
fix(ci): optimize E2E workflow triggers

### DIFF
--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - develop
   pull_request:
-    branches:
-      - develop
     types:
       - opened
       - synchronize

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -6,8 +6,9 @@ on:
   push:
     branches:
       - develop
-      - 'release/**'
   pull_request:
+    branches:
+      - develop
     types:
       - opened
       - synchronize

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - develop
   pull_request:
-    branches:
-      - develop
     types:
       - opened
       - synchronize

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -6,8 +6,9 @@ on:
   push:
     branches:
       - develop
-      - 'release/**'
   pull_request:
+    branches:
+      - develop
     types:
       - opened
       - synchronize


### PR DESCRIPTION
[INS-2632](https://konghq.atlassian.net/browse/INS-2632)

Cancels in-progress builds or adds concurrency limits to avoid running duplicate E2E tests on the same branch.

[INS-2632]: https://konghq.atlassian.net/browse/INS-2632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ