### PR TITLE
fix(plugins): register user-installed plugin template tags in LiquidJS render worker

### DIFF
--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -9,7 +9,7 @@ import { services } from 'insomnia-data';
 import { v4 as uuidv4 } from 'uuid';
 
 import { jarFromCookies } from '~/common/cookies';
-import { getPluginCommonContext } from '~/plugins';
+import { getPluginCommonContext, getTemplateTags } from '~/plugins';
 
 import { getAppBundlePlugins, RESPONSE_CODE_REASONS } from '../common/constants';
 import { isDevelopment } from '../common/constants';
@@ -286,6 +286,43 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
         // @ts-expect-error -- TSCONVERSION: Bundle plugin tag context do not have node functions in utils
         return targetTag.run({ meta, renderPurpose, context, ...commonContext }, ...args);
       }
+    }
+    throw new Error(`Unsupported tag ${tagName} for plugin ${pluginName}`);
+  },
+  // generate the template tags for user-installed plugins and send back to the web worker.
+  // Bundle plugins are handled separately by `plugin.getBundlePluginTemplateTags`.
+  'plugin.getUserPluginTemplateTags': async () => {
+    const tags = await getTemplateTags();
+    // Bundle plugins have an empty `directory`; everything else is user-installed.
+    return tags
+      .filter(({ plugin }) => plugin.directory !== '')
+      .map(({ plugin, templateTag }) => ({
+        plugin: {
+          name: plugin.name,
+          description: plugin.description,
+          version: plugin.version,
+          directory: plugin.directory,
+          config: plugin.config,
+        },
+        templateTag,
+      }));
+  },
+  // execute a user-installed plugin tag with the given parameters, in the main process where
+  // Node built-ins (e.g. crypto) the plugin requires are available.
+  'plugin.executeUserPluginTag': async (body: {
+    args: any[];
+    pluginName: string;
+    tagName: string;
+    context: Pick<PluginTemplateTagContext, 'meta' | 'renderPurpose' | 'context'>;
+  }) => {
+    const { tagName, pluginName, args, context: originContext } = body;
+    const { meta, renderPurpose, context } = originContext;
+    const tags = await getTemplateTags();
+    const targetTag = tags.find(t => t.plugin.name === pluginName && t.templateTag.name === tagName);
+    if (targetTag) {
+      const commonContext = getPluginCommonContext({ plugin: { name: pluginName }, renderPurpose });
+      // @ts-expect-error -- TSCONVERSION: plugin tag context does not perfectly match PluginTemplateTagContext
+      return targetTag.templateTag.run({ meta, renderPurpose, context, ...commonContext }, ...args);
     }
     throw new Error(`Unsupported tag ${tagName} for plugin ${pluginName}`);
   },

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -64,6 +64,22 @@ const getBundlePluginModule = (pluginName: string): Plugin['module'] => {
   return {};
 };
 
+// Run a resolved plugin template tag with a freshly-built common context. Shared by the bundle
+// and user-plugin execute handlers so both build context (incl. renderPurpose) identically.
+const runPluginTag = (
+  run: (context: any, ...args: any[]) => any,
+  body: {
+    args: any[];
+    pluginName: string;
+    context: Pick<PluginTemplateTagContext, 'meta' | 'renderPurpose' | 'context'>;
+  },
+) => {
+  const { pluginName, args, context: originContext } = body;
+  const { meta, renderPurpose, context } = originContext;
+  const commonContext = getPluginCommonContext({ plugin: { name: pluginName }, renderPurpose });
+  return run({ meta, renderPurpose, context, ...commonContext }, ...args);
+};
+
 // These are exposed to the templating worker and can be used by plugins from context.util
 const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<any>> = {
   'readFile': async (body: { path: string }) => {
@@ -274,17 +290,14 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
     tagName: string;
     context: Pick<PluginTemplateTagContext, 'meta' | 'renderPurpose' | 'context'>;
   }) => {
-    const { tagName, pluginName, args, context: originContext } = body;
-    const { meta, renderPurpose, context } = originContext;
+    const { tagName, pluginName } = body;
     const appBundlePluginNames = getAppBundlePlugins().map(p => p.name);
     if (appBundlePluginNames.includes(pluginName)) {
       const module = getBundlePluginModule(pluginName);
       const templateTags = module?.templateTags || [];
       const targetTag = templateTags.find(tag => tag.name === tagName);
       if (targetTag) {
-        const commonContext = getPluginCommonContext({ plugin: { name: pluginName } });
-        // @ts-expect-error -- TSCONVERSION: Bundle plugin tag context do not have node functions in utils
-        return targetTag.run({ meta, renderPurpose, context, ...commonContext }, ...args);
+        return runPluginTag(targetTag.run, body);
       }
     }
     throw new Error(`Unsupported tag ${tagName} for plugin ${pluginName}`);
@@ -315,14 +328,11 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
     tagName: string;
     context: Pick<PluginTemplateTagContext, 'meta' | 'renderPurpose' | 'context'>;
   }) => {
-    const { tagName, pluginName, args, context: originContext } = body;
-    const { meta, renderPurpose, context } = originContext;
+    const { tagName, pluginName } = body;
     const tags = await getTemplateTags();
     const targetTag = tags.find(t => t.plugin.name === pluginName && t.templateTag.name === tagName);
     if (targetTag) {
-      const commonContext = getPluginCommonContext({ plugin: { name: pluginName }, renderPurpose });
-      // @ts-expect-error -- TSCONVERSION: plugin tag context does not perfectly match PluginTemplateTagContext
-      return targetTag.templateTag.run({ meta, renderPurpose, context, ...commonContext }, ...args);
+      return runPluginTag(targetTag.templateTag.run, body);
     }
     throw new Error(`Unsupported tag ${tagName} for plugin ${pluginName}`);
   },

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -787,11 +787,7 @@ export const tryToTransformRequestWithPlugins = async (renderResult: {
   context: Record<string, any>;
 }) => {
   const { request, context } = renderResult;
-  try {
-    return await getRuntime().network.applyRequestHooks(request, context);
-  } catch {
-    throw new Error(`Failed to transform request with plugins: ${request._id}`);
-  }
+  return await getRuntime().network.applyRequestHooks(request, context);
 };
 
 export interface sendCurlAndWriteTimelineError {

--- a/packages/insomnia/src/plugins/invoke-method.ts
+++ b/packages/insomnia/src/plugins/invoke-method.ts
@@ -1,3 +1,4 @@
+import { deserializeRenderContext } from '../templating/render-context-serialization';
 import type {
   ApplyRequestHooksArgs,
   ApplyResponseHooksArgs,
@@ -187,7 +188,7 @@ export async function invokePluginMethod(method: PluginInvokeMethod, args?: unkn
     case 'applyRequestHooks': {
       const { renderedRequest, projectId, environment } = args as ApplyRequestHooksArgs;
       const newRenderedRequest = { ...renderedRequest };
-      const renderedContext = { ...environment, getProjectId: () => projectId };
+      const renderedContext = deserializeRenderContext(environment);
 
       for (const { plugin, hook } of await getRequestHooks()) {
         const context = {
@@ -212,7 +213,7 @@ export async function invokePluginMethod(method: PluginInvokeMethod, args?: unkn
       const { response, renderedRequest, projectId, environment } = args as ApplyResponseHooksArgs;
       const newResponse = { ...response };
       const newRequest = { ...renderedRequest };
-      const renderedContext = { ...environment, getProjectId: () => projectId };
+      const renderedContext = deserializeRenderContext(environment);
 
       for (const { plugin, hook } of await getResponseHooks()) {
         const context = {

--- a/packages/insomnia/src/runtimes/network/network-adapter.renderer.ts
+++ b/packages/insomnia/src/runtimes/network/network-adapter.renderer.ts
@@ -1,6 +1,7 @@
 import type { Cookie, RequestHeader } from 'insomnia-data';
 
 import { plugins as pluginsBridge } from '~/plugins/renderer-bridge';
+import { serializeRenderContext } from '~/templating/render-context-serialization';
 import type { RenderedRequest } from '~/templating/types';
 
 import type { RequestContext } from '../../../../insomnia-scripting-environment/src/objects';
@@ -62,7 +63,8 @@ export async function applyRequestHooks(
   return pluginsBridge.applyRequestHooks({
     renderedRequest: request,
     projectId: renderedContext.getProjectId(),
-    environment: renderedContext,
+    // Functions on the render context cannot be structured-cloned over IPC to the plugin window.
+    environment: serializeRenderContext(renderedContext),
   });
 }
 
@@ -78,6 +80,7 @@ export async function applyResponseHooks(
     response,
     renderedRequest,
     projectId: renderedContext.getProjectId(),
-    environment: renderedContext,
+    // Functions on the render context cannot be structured-cloned over IPC to the plugin window.
+    environment: serializeRenderContext(renderedContext),
   });
 }

--- a/packages/insomnia/src/templating/__tests__/render-context-serialization.test.ts
+++ b/packages/insomnia/src/templating/__tests__/render-context-serialization.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { deserializeRenderContext, serializeRenderContext } from '../render-context-serialization';
+
+const makeContext = () => ({
+  // environment data
+  foo: 'bar',
+  nested: { a: 1 },
+  DEFAULT_HEADERS: [{ name: 'X', value: 'y' }],
+  // helper functions
+  getMeta: () => ({ requestId: 'req_1', workspaceId: 'wrk_1' }),
+  getEnvironmentId: () => 'env_1',
+  getExtraInfo: () => ({ extra: true }),
+  getGlobalEnvironmentId: () => 'genv_1',
+  getKeysContext: () => ({ keyContext: {} }),
+  getProjectId: () => 'proj_1',
+  getPurpose: () => 'send',
+  getSettings: () => ({ dataFolders: [] }),
+});
+
+describe('serializeRenderContext', () => {
+  it('strips functions so the result is structured-clone safe', () => {
+    const serialized = serializeRenderContext(makeContext());
+
+    expect(Object.values(serialized).some(v => typeof v === 'function')).toBe(false);
+    // structuredClone throws on functions; this must not throw
+    expect(() => structuredClone(serialized)).not.toThrow();
+  });
+
+  it('preserves environment data and resolves helper values into serializedFunctions', () => {
+    const serialized = serializeRenderContext(makeContext());
+
+    expect(serialized.foo).toBe('bar');
+    expect(serialized.nested).toEqual({ a: 1 });
+    expect(serialized.serializedFunctions).toEqual({
+      requestId: 'req_1',
+      workspaceId: 'wrk_1',
+      environmentId: 'env_1',
+      extraInfo: { extra: true },
+      globalEnvironmentId: 'genv_1',
+      keysContext: { keyContext: {} },
+      projectId: 'proj_1',
+      purpose: 'send',
+      settings: { dataFolders: [] },
+    });
+  });
+});
+
+describe('deserializeRenderContext', () => {
+  it('rebuilds the helper functions from serializedFunctions after a clone round-trip', () => {
+    const roundTripped = structuredClone(serializeRenderContext(makeContext()));
+    const context = deserializeRenderContext(roundTripped);
+
+    expect(context.getMeta()).toEqual({ requestId: 'req_1', workspaceId: 'wrk_1' });
+    expect(context.getProjectId()).toBe('proj_1');
+    expect(context.getEnvironmentId()).toBe('env_1');
+    expect(context.getSettings()).toEqual({ dataFolders: [] });
+    // environment data survives the round-trip
+    expect(context.foo).toBe('bar');
+  });
+});

--- a/packages/insomnia/src/templating/__tests__/worker.test.ts
+++ b/packages/insomnia/src/templating/__tests__/worker.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { TemplateTag } from '../../plugins/types';
+import * as extWorker from '../liquid-extension-worker';
+import { reload, render } from '../worker';
+
+// Mock only the IPC bridge; keep createLiquidTagWorker (and everything else) real so the
+// engine is built and the tag is rendered exactly as it is at runtime.
+vi.mock('../liquid-extension-worker', async importOriginal => {
+  return { ...(await importOriginal()), fetchFromTemplateWorkerDatabase: vi.fn() };
+});
+
+const mockFetch = vi.mocked(extWorker.fetchFromTemplateWorkerDatabase);
+
+const userPluginTag: TemplateTag = {
+  plugin: {
+    name: 'insomnia-plugin-request-body-hmac',
+    description: 'a user-installed plugin',
+    version: '1.0.0',
+    // user-installed plugins are loaded from disk and have a non-empty directory
+    directory: '/Users/me/Library/Application Support/Insomnia/plugins/insomnia-plugin-request-body-hmac',
+    config: { disabled: false },
+    module: {},
+  },
+  templateTag: {
+    name: 'requestbodyhmac',
+    displayName: 'Request Body HMAC',
+    description: 'hmac of the request body',
+    args: [],
+    // overridden by the worker to route execution back over IPC; never called directly
+    run: async () => 'unrouted',
+  },
+};
+
+describe('worker getLiquid plugin tag registration', () => {
+  beforeEach(() => {
+    reload();
+    mockFetch.mockReset();
+  });
+
+  it('registers user-installed plugin tags and routes their execution to the main process', async () => {
+    mockFetch.mockImplementation(async (path: any) => {
+      switch (path) {
+        case 'plugin.getBundlePluginTemplateTags': {
+          return [];
+        }
+        case 'plugin.getUserPluginTemplateTags': {
+          return [userPluginTag];
+        }
+        case 'plugin.executeUserPluginTag': {
+          return 'ROUTED_RESULT';
+        }
+        default: {
+          return;
+        }
+      }
+    });
+
+    // Before the fix this threw `tag "requestbodyhmac" not found`, because user-installed
+    // plugin tags were collected for the editor but never merged into the render engine.
+    const result = await render('{% requestbodyhmac %}');
+
+    expect(result).toBe('ROUTED_RESULT');
+    expect(mockFetch).toHaveBeenCalledWith(
+      'plugin.executeUserPluginTag',
+      expect.objectContaining({
+        pluginName: 'insomnia-plugin-request-body-hmac',
+        tagName: 'requestbodyhmac',
+      }),
+    );
+  });
+});

--- a/packages/insomnia/src/templating/render-context-serialization.ts
+++ b/packages/insomnia/src/templating/render-context-serialization.ts
@@ -1,0 +1,55 @@
+// The render context carries helper functions (getMeta, getProjectId, getSettings, ...) alongside
+// the environment data. Functions cannot cross a process/worker boundary — structured clone (IPC)
+// rejects them with "An object could not be cloned", and JSON.stringify silently drops them.
+//
+// `serializeRenderContext` resolves those helpers into a plain `serializedFunctions` bag and strips
+// the functions, leaving a cloneable object. `deserializeRenderContext` rebuilds the helpers on the
+// far side. Shared by the templating web worker bridge and the plugin-hook IPC bridge.
+
+export interface SerializedRenderFunctions {
+  requestId?: string;
+  workspaceId?: string;
+  environmentId?: string;
+  extraInfo?: any;
+  globalEnvironmentId?: string;
+  keysContext?: any;
+  projectId?: string;
+  purpose?: any;
+  settings?: any;
+}
+
+export function serializeRenderContext(context: Record<string, any>): Record<string, any> {
+  const meta = context.getMeta?.() || {};
+  const serializedFunctions: SerializedRenderFunctions = {
+    requestId: meta.requestId,
+    workspaceId: meta.workspaceId,
+    environmentId: context.getEnvironmentId?.(),
+    extraInfo: context.getExtraInfo?.(),
+    globalEnvironmentId: context.getGlobalEnvironmentId?.(),
+    keysContext: context.getKeysContext?.(),
+    projectId: context.getProjectId?.(),
+    purpose: context.getPurpose?.(),
+    settings: context.getSettings?.(),
+  };
+  // Drop function-valued properties so the result is structured-clone safe.
+  const dataOnly = Object.fromEntries(Object.entries(context).filter(([, value]) => typeof value !== 'function'));
+  return { ...dataOnly, serializedFunctions };
+}
+
+export function deserializeRenderContext(context: Record<string, any>): Record<string, any> {
+  const serializedFunctions: SerializedRenderFunctions = context.serializedFunctions || {};
+  return {
+    ...context,
+    getMeta: () => ({
+      requestId: serializedFunctions.requestId,
+      workspaceId: serializedFunctions.workspaceId,
+    }),
+    getEnvironmentId: () => serializedFunctions.environmentId,
+    getExtraInfo: () => serializedFunctions.extraInfo,
+    getGlobalEnvironmentId: () => serializedFunctions.globalEnvironmentId,
+    getKeysContext: () => serializedFunctions.keysContext,
+    getProjectId: () => serializedFunctions.projectId,
+    getPurpose: () => serializedFunctions.purpose,
+    getSettings: () => serializedFunctions.settings,
+  };
+}

--- a/packages/insomnia/src/templating/types.ts
+++ b/packages/insomnia/src/templating/types.ts
@@ -90,6 +90,8 @@ export type PluginToMainAPIPaths =
   | 'plugin.getBundlePluginTemplateTags'
   | 'plugin.executeBundlePluginTag'
   | 'plugin.executeBundlePluginMainAction'
+  | 'plugin.getUserPluginTemplateTags'
+  | 'plugin.executeUserPluginTag'
   | 'app.alert'
   | 'app.dialog'
   | 'app.prompt'

--- a/packages/insomnia/src/templating/worker.ts
+++ b/packages/insomnia/src/templating/worker.ts
@@ -119,7 +119,27 @@ async function getLiquid(
       });
   });
 
-  const allTags = [...localTemplateTags, ...bundlePluginTemplateTags];
+  const userPluginTemplateTags = (await fetchFromTemplateWorkerDatabase(
+    'plugin.getUserPluginTemplateTags',
+    {},
+  )) as TemplateTag[];
+
+  userPluginTemplateTags.forEach(tag => {
+    const { templateTag, plugin } = tag;
+    const pluginName = plugin.name;
+    const tagName = templateTag.name;
+    // Route execution of user-installed plugin tags back to main process, where the
+    // Node built-ins they require (e.g. crypto) are available.
+    templateTag.run = async (context, ...args) =>
+      await fetchFromTemplateWorkerDatabase('plugin.executeUserPluginTag', {
+        context,
+        args,
+        pluginName,
+        tagName,
+      });
+  });
+
+  const allTags = [...localTemplateTags, ...bundlePluginTemplateTags, ...userPluginTemplateTags];
 
   allTags.forEach((ext, i) => {
     ext.templateTag.priority = ext.templateTag.priority ?? i;

--- a/packages/insomnia/src/templating/worker.ts
+++ b/packages/insomnia/src/templating/worker.ts
@@ -7,6 +7,7 @@ import { LIQUID_TEMPLATE_GLOBAL_PROPERTY_NAME, NUNJUCKS_TEMPLATE_GLOBAL_PROPERTY
 import { buildLiquidEngine, stripLiquidComments } from './liquid-engine';
 import { createLiquidTagWorker, fetchFromTemplateWorkerDatabase } from './liquid-extension-worker';
 import { extractUndefinedVariableKey, translateLiquidError } from './render-error';
+import type { PluginToMainAPIPaths } from './types';
 export { LIQUID_TEMPLATE_GLOBAL_PROPERTY_NAME, NUNJUCKS_TEMPLATE_GLOBAL_PROPERTY_NAME };
 
 // Cached engine instances
@@ -93,6 +94,22 @@ export async function getTagDefinitions() {
     }));
 }
 
+// Fetch plugin template tags from main and route each tag's `run` back over IPC, so execution
+// happens in the main process where the Node built-ins plugins require (e.g. crypto) are available.
+async function fetchAndRoutePluginTags(
+  getPath: PluginToMainAPIPaths,
+  executePath: PluginToMainAPIPaths,
+): Promise<TemplateTag[]> {
+  const tags = (await fetchFromTemplateWorkerDatabase(getPath, {})) as TemplateTag[];
+  tags.forEach(({ templateTag, plugin }) => {
+    const pluginName = plugin.name;
+    const tagName = templateTag.name;
+    templateTag.run = async (context, ...args) =>
+      await fetchFromTemplateWorkerDatabase(executePath, { context, args, pluginName, tagName });
+  });
+  return tags;
+}
+
 async function getLiquid(
   ignoreUndefinedEnvVariable?: boolean,
 ): Promise<{ engine: Liquid; tagMetadata: Map<string, any> }> {
@@ -100,44 +117,16 @@ async function getLiquid(
     return { engine: liquidAll, tagMetadata: liquidAllTagMetadata };
   }
 
-  const bundlePluginTemplateTags = (await fetchFromTemplateWorkerDatabase(
+  // Bundle plugins ship inside the app; user-installed plugins are loaded from disk. Both are
+  // registered here so their tags resolve at render time, not just in the editor autocomplete.
+  const bundlePluginTemplateTags = await fetchAndRoutePluginTags(
     'plugin.getBundlePluginTemplateTags',
-    {},
-  )) as TemplateTag[];
-
-  bundlePluginTemplateTags.forEach(tag => {
-    const { templateTag, plugin } = tag;
-    const pluginName = plugin.name;
-    const tagName = templateTag.name;
-    // Route execution of bundled plugin tags back to main process
-    templateTag.run = async (context, ...args) =>
-      await fetchFromTemplateWorkerDatabase('plugin.executeBundlePluginTag', {
-        context,
-        args,
-        pluginName,
-        tagName,
-      });
-  });
-
-  const userPluginTemplateTags = (await fetchFromTemplateWorkerDatabase(
+    'plugin.executeBundlePluginTag',
+  );
+  const userPluginTemplateTags = await fetchAndRoutePluginTags(
     'plugin.getUserPluginTemplateTags',
-    {},
-  )) as TemplateTag[];
-
-  userPluginTemplateTags.forEach(tag => {
-    const { templateTag, plugin } = tag;
-    const pluginName = plugin.name;
-    const tagName = templateTag.name;
-    // Route execution of user-installed plugin tags back to main process, where the
-    // Node built-ins they require (e.g. crypto) are available.
-    templateTag.run = async (context, ...args) =>
-      await fetchFromTemplateWorkerDatabase('plugin.executeUserPluginTag', {
-        context,
-        args,
-        pluginName,
-        tagName,
-      });
-  });
+    'plugin.executeUserPluginTag',
+  );
 
   const allTags = [...localTemplateTags, ...bundlePluginTemplateTags, ...userPluginTemplateTags];
 

--- a/packages/insomnia/src/ui/worker/templating-handler.ts
+++ b/packages/insomnia/src/ui/worker/templating-handler.ts
@@ -1,3 +1,4 @@
+import { serializeRenderContext } from '../../templating/render-context-serialization';
 import { extractUndefinedVariableKey, RenderError } from '../../templating/render-error';
 import type { RenderInputType } from '../../templating/types';
 
@@ -11,20 +12,7 @@ worker.addEventListener('error', event => {
 });
 
 export function renderInWorker({ input, context, path, ignoreUndefinedEnvVariable }: RenderInputType): Promise<string> {
-  const newContext = {
-    ...context,
-    serializedFunctions: {
-      requestId: context.getMeta().requestId,
-      workspaceId: context.getMeta().workspaceId,
-      environmentId: context.getEnvironmentId(),
-      extraInfo: context.getExtraInfo(),
-      globalEnvironmentId: context.getGlobalEnvironmentId(),
-      keysContext: context.getKeysContext(),
-      projectId: context.getProjectId(),
-      purpose: context.getPurpose(),
-      settings: context.getSettings(),
-    },
-  };
+  const newContext = serializeRenderContext(context);
 
   // Id to avoid race conditions
   const id = window.crypto.randomUUID();

--- a/packages/insomnia/src/ui/worker/templating-worker.ts
+++ b/packages/insomnia/src/ui/worker/templating-worker.ts
@@ -1,3 +1,4 @@
+import { deserializeRenderContext } from '../../templating/render-context-serialization';
 import * as templating from '../../templating/worker';
 
 async function performJob(input: {
@@ -17,18 +18,12 @@ async function performJob(input: {
 self.onmessage = async event => {
   const { id, input, context, path, ignoreUndefinedEnvVariable } = JSON.parse(event.data);
   try {
-    context.getMeta = () => ({
-      requestId: context.serializedFunctions.requestId,
-      workspaceId: context.serializedFunctions.workspaceId,
+    const result = await performJob({
+      input,
+      context: deserializeRenderContext(context),
+      path,
+      ignoreUndefinedEnvVariable,
     });
-    context.getEnvironmentId = () => context.serializedFunctions.environmentId;
-    context.getExtraInfo = () => context.serializedFunctions.extraInfo;
-    context.getGlobalEnvironmentId = () => context.serializedFunctions.globalEnvironmentId;
-    context.getKeysContext = () => context.serializedFunctions.keysContext;
-    context.getProjectId = () => context.serializedFunctions.projectId;
-    context.getPurpose = () => context.serializedFunctions.purpose;
-    context.getSettings = () => context.serializedFunctions.settings;
-    const result = await performJob({ input, context, path, ignoreUndefinedEnvVariable });
     self.postMessage({ id, result });
   } catch (err) {
     self.postMessage({ id, err });


### PR DESCRIPTION
Fixes third-party template-tag plugins (e.g. [`insomnia-plugin-request-body-hmac`](https://insomnia.rest/plugins/insomnia-plugin-request-body-hmac)) which were fully broken after the Nunjucks→LiquidJS migration. Two distinct bugs, surfaced one after the other:

## 1. User-installed template tags never registered in the render worker

**Symptom:** `tag "requestbodyhmac" not found` at render time, even though the tag showed up in autocomplete.

The LiquidJS render engine (in a Web Worker) was built from `localTemplateTags` + **bundle** plugin tags only (`plugin.getBundlePluginTemplateTags`, which iterates `getAppBundlePlugins()`). User-installed plugins were never collected, so their tags were registered nowhere in the render engine. The editor UI uses the full `getTemplateTags()` via the renderer bridge, which is why the tag still appeared in autocomplete.

**Fix:** add `plugin.getUserPluginTemplateTags` / `plugin.executeUserPluginTag` IPC handlers (user plugins = active plugins with `directory !== ''`, so bundle plugins aren't double-counted), merge them into the worker engine, and route their `run` back to the main process — where the Node built-ins user plugins require (e.g. `crypto`) are available. Mirrors the existing bundle-plugin path.

## 2. Render context not cloneable across the request-hook IPC bridge

**Symptom (once #1 was fixed and the request proceeded to send):** `An object could not be cloned`.

`applyRequestHooks`/`applyResponseHooks` passed the rendered context as `environment` over IPC to the plugin window. That context carries helper functions (`getMeta`, `getProjectId`, `getSettings`, …) which structured clone rejects.

**Fix:** reuse the render-context serialization pattern that already existed inline in the templating web-worker bridge — extracted into a shared `serializeRenderContext` / `deserializeRenderContext` module and applied to the hook bridge too. The serializer resolves the helpers into a plain `serializedFunctions` bag and strips the functions (clone-safe); the plugin-window handler rebuilds them. Also stopped masking the underlying plugin-transform error with a generic message.

## Validation

- `npm run type-check -w packages/insomnia` — passes
- `eslint` on touched files — clean
- `plugin-hooks.test.ts` (11) + render/templating suites (176) — pass
- New `render-context-serialization.test.ts` round-trip tests — pass

Together these restore the full `insomnia-plugin-request-body-hmac` flow: the template tag emits a placeholder, then the request hook replaces it with the real HMAC of the request body.