### PR TITLE
Fix: Change default behavior when delete cloud sync workspaces in sidebar

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/sidebar-workspace-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/sidebar-workspace-dropdown.tsx
@@ -477,7 +477,7 @@ export const SidebarWorkspaceDropdown = ({
                         )}
                       </p>
                       {models.project.isRemoteProject(project) && (
-                        <RadioGroup name="localOnly" defaultValue="false" className="mb-2 flex flex-col gap-2">
+                        <RadioGroup name="localOnly" defaultValue="true" className="mb-2 flex flex-col gap-2">
                           <Label className="text-sm text-(--hl)">How do you want to delete it?</Label>
                           <div className="flex gap-2">
                             <Radio


### PR DESCRIPTION
Change the default behavior to `delete local copy` when deleting cloud sync workspaces in sidebar