### PR TITLE
fix: make property order fields optional for cloud sync [INS-2807]

### DIFF
--- a/packages/insomnia-data/src/models/environment.ts
+++ b/packages/insomnia-data/src/models/environment.ts
@@ -12,12 +12,12 @@ export const vaultEnvironmentMaskValue = '••••••';
 export const canDuplicate = true;
 export const canSync = true;
 // for those keys do not need to add in model init method
-export const optionalKeys = ['kvPairData', 'environmentType'];
+export const optionalKeys: (keyof BaseEnvironment)[] = ['kvPairData', 'environmentType', 'dataPropertyOrder'];
 
 export interface BaseEnvironment {
   name: string;
   data: Record<string, any>;
-  dataPropertyOrder: Record<string, any> | null;
+  dataPropertyOrder?: Record<string, any> | null;
   kvPairData?: EnvironmentKvPairData[];
   color: string | null;
   metaSortKey: number;
@@ -58,7 +58,6 @@ export function init() {
   return {
     name: 'New Environment',
     data: {},
-    dataPropertyOrder: null,
     color: null,
     isPrivate: false,
     metaSortKey: Date.now(),

--- a/packages/insomnia-data/src/models/request-group.ts
+++ b/packages/insomnia-data/src/models/request-group.ts
@@ -13,12 +13,17 @@ export const canDuplicate = true;
 
 export const canSync = true;
 // for those keys do not need to add in model init method
-export const optionalKeys = ['kvPairData', 'environmentType', 'konnectRouteId'];
+export const optionalKeys: (keyof BaseRequestGroup)[] = [
+  'kvPairData',
+  'environmentType',
+  'konnectRouteId',
+  'environmentPropertyOrder',
+];
 interface BaseRequestGroup {
   name: string;
   description: string;
   environment: Record<string, any>;
-  environmentPropertyOrder: Record<string, any> | null;
+  environmentPropertyOrder?: Record<string, any> | null;
   kvPairData?: EnvironmentKvPairData[];
   environmentType?: EnvironmentType;
   metaSortKey: number;
@@ -39,7 +44,6 @@ export function init(): BaseRequestGroup {
     name: 'New Folder',
     description: '',
     environment: {},
-    environmentPropertyOrder: null,
     metaSortKey: -1 * Date.now(),
     preRequestScript: undefined,
     afterResponseScript: undefined,

--- a/packages/insomnia-smoke-test/server/cloud-sync-api.ts
+++ b/packages/insomnia-smoke-test/server/cloud-sync-api.ts
@@ -117,7 +117,7 @@ const projectSnapshots: Record<string, any[]> = {
           name: 'My Collection R1',
         },
         {
-          blob: 'c50bc39ab29bb892df65bdbc97f23af84b9d1067',
+          blob: '1b7fe31ec583c8a42fedc0e86a103b94076e77c4',
           key: 'env_48cf48a4dc8a0984d07cb8dad01a01c5d604439c',
           name: 'Base Environment',
         },
@@ -141,7 +141,7 @@ const projectSnapshots: Record<string, any[]> = {
           name: 'My Collection R1',
         },
         {
-          blob: 'c50bc39ab29bb892df65bdbc97f23af84b9d1067',
+          blob: '1b7fe31ec583c8a42fedc0e86a103b94076e77c4',
           key: 'env_48cf48a4dc8a0984d07cb8dad01a01c5d604439c',
           name: 'Base Environment',
         },
@@ -168,7 +168,7 @@ const projectSnapshots: Record<string, any[]> = {
           name: 'My Environment',
         },
         {
-          blob: 'bf6064229bdaeec3bf597329c640ca2a11fd4d72',
+          blob: '7024cbb27bb92821c17c0b27de612a0b1a8c082c',
           key: 'env_2c63ae5788b4ac6a289cfe3776c7b3fa9f1cd9be',
           name: 'Base Environment',
         },
@@ -190,7 +190,7 @@ const projectSnapshots: Record<string, any[]> = {
           name: 'My MCP Client',
         },
         {
-          blob: 'ee4579d33d3e25e3244ead2dca8c7b6e2e4f8dcf',
+          blob: 'fed20333ca44d6d4aae729f210ce371ed31392a3',
           key: 'env_0c042933878b85facb6c4e673b0166b256f37ad0',
           name: 'Base Environment',
         },
@@ -214,7 +214,7 @@ const projectSnapshots: Record<string, any[]> = {
           name: 'My MCP Client',
         },
         {
-          blob: 'ee4579d33d3e25e3244ead2dca8c7b6e2e4f8dcf',
+          blob: 'fed20333ca44d6d4aae729f210ce371ed31392a3',
           key: 'env_0c042933878b85facb6c4e673b0166b256f37ad0',
           name: 'Base Environment',
         },
@@ -263,7 +263,7 @@ const environmentProjectNewCommitSnapshot = [
         name: 'My Environment',
       },
       {
-        blob: 'bf6064229bdaeec3bf597329c640ca2a11fd4d72',
+        blob: '7024cbb27bb92821c17c0b27de612a0b1a8c082c',
         key: 'env_2c63ae5788b4ac6a289cfe3776c7b3fa9f1cd9be',
         name: 'Base Environment',
       },
@@ -282,7 +282,7 @@ const environmentProjectNewCommitSnapshot = [
         name: 'My Environment',
       },
       {
-        blob: '966ed58bb00e1031ddd69afc171c34cbfde2b307',
+        blob: '8928646f281ac14f6410aa29fa60b7060f6529d0',
         key: 'env_2c63ae5788b4ac6a289cfe3776c7b3fa9f1cd9be',
         name: 'Base Environment',
       },
@@ -295,8 +295,8 @@ const rawBlobs: Record<string, string> = {
   // request collection blobs
   'be076c5943e0d32b05efbbf215b4f9d2bb894a9c':
     '{"_id":"wrk_a7132f924ba7451594ba64ec411c9e13","created":1769407477819,"description":"","name":"My Collection R1","parentId":null,"scope":"collection","type":"Workspace"}',
-  'c50bc39ab29bb892df65bdbc97f23af84b9d1067':
-    '{"_id":"env_48cf48a4dc8a0984d07cb8dad01a01c5d604439c","color":null,"created":1769407477820,"data":{},"dataPropertyOrder":null,"environmentType":"kv","isPrivate":false,"metaSortKey":1769407477820,"name":"Base Environment","parentId":"wrk_a7132f924ba7451594ba64ec411c9e13","type":"Environment"}',
+  '1b7fe31ec583c8a42fedc0e86a103b94076e77c4':
+    '{"_id":"env_48cf48a4dc8a0984d07cb8dad01a01c5d604439c","color":null,"created":1769407477820,"data":{},"environmentType":"kv","isPrivate":false,"metaSortKey":1769407477820,"name":"Base Environment","parentId":"wrk_a7132f924ba7451594ba64ec411c9e13","type":"Environment"}',
   'd78e5942f5508063ea484bb4b497f0ed446309c9':
     '{"_id":"req_d11697e0652742e691374e380cdcd2b2","authentication":{},"body":{},"created":1769407553323,"description":"","headers":[{"name":"Content-Type","value":"application/json"},{"description":"","disabled":false,"name":"User-Agent","value":"insomnia/12.3.0"}],"isPrivate":false,"metaSortKey":-1769407553323,"method":"GET","name":"New Request","parameters":[],"parentId":"wrk_a7132f924ba7451594ba64ec411c9e13","pathParameters":[],"settingDisableRenderRequestBody":false,"settingEncodeUrl":true,"settingFollowRedirects":"global","settingRebuildPath":true,"settingSendCookies":true,"settingStoreCookies":true,"type":"Request","url":""}',
   '1f8a8cd1da88d9abb4bfc1d6e662716d41705ace':
@@ -304,15 +304,15 @@ const rawBlobs: Record<string, string> = {
   // environment blobs
   '2588c9eeaf8c4129c5b33bbb9f77de04e8598c5e':
     '{"_id":"wrk_2068a8dfd6914c369073686bb92737ae","created":1769408109261,"description":"","name":"My Environment","parentId":null,"scope":"environment","type":"Workspace"}',
-  'bf6064229bdaeec3bf597329c640ca2a11fd4d72':
-    '{"_id":"env_2c63ae5788b4ac6a289cfe3776c7b3fa9f1cd9be","color":null,"created":1769408109277,"data":{},"dataPropertyOrder":null,"environmentType":"kv","isPrivate":false,"metaSortKey":1769408109277,"name":"Base Environment","parentId":"wrk_2068a8dfd6914c369073686bb92737ae","type":"Environment"}',
-  '966ed58bb00e1031ddd69afc171c34cbfde2b307':
-    '{"_id":"env_2c63ae5788b4ac6a289cfe3776c7b3fa9f1cd9be","color":null,"created":1769408109277,"data":{"foo":"bar"},"dataPropertyOrder":null,"environmentType":"kv","isPrivate":false,"kvPairData":[{"enabled":true,"id":"envPair_6691b0028e104e499f8c4acf0a1a9e6a","name":"foo","type":"str","value":"bar"}],"metaSortKey":1769408109277,"name":"Base Environment","parentId":"wrk_2068a8dfd6914c369073686bb92737ae","type":"Environment"}',
+  '7024cbb27bb92821c17c0b27de612a0b1a8c082c':
+    '{"_id":"env_2c63ae5788b4ac6a289cfe3776c7b3fa9f1cd9be","color":null,"created":1769408109277,"data":{},"environmentType":"kv","isPrivate":false,"metaSortKey":1769408109277,"name":"Base Environment","parentId":"wrk_2068a8dfd6914c369073686bb92737ae","type":"Environment"}',
+  '8928646f281ac14f6410aa29fa60b7060f6529d0':
+    '{"_id":"env_2c63ae5788b4ac6a289cfe3776c7b3fa9f1cd9be","color":null,"created":1769408109277,"data":{"foo":"bar"},"environmentType":"kv","isPrivate":false,"kvPairData":[{"enabled":true,"id":"envPair_6691b0028e104e499f8c4acf0a1a9e6a","name":"foo","type":"str","value":"bar"}],"metaSortKey":1769408109277,"name":"Base Environment","parentId":"wrk_2068a8dfd6914c369073686bb92737ae","type":"Environment"}',
   // mcp blobs
   'a8252b458e8a1b5f3c214e5e7f944887a142ae72':
     '{"_id":"wrk_efab8e758b97459bab2659d8fdcf8627","created":1769408435321,"description":"","name":"My MCP Client","parentId":null,"scope":"mcp","type":"Workspace"}',
-  'ee4579d33d3e25e3244ead2dca8c7b6e2e4f8dcf':
-    '{"_id":"env_0c042933878b85facb6c4e673b0166b256f37ad0","color":null,"created":1769408435351,"data":{},"dataPropertyOrder":null,"environmentType":"kv","isPrivate":false,"metaSortKey":1769408435351,"name":"Base Environment","parentId":"wrk_efab8e758b97459bab2659d8fdcf8627","type":"Environment"}',
+  'fed20333ca44d6d4aae729f210ce371ed31392a3':
+    '{"_id":"env_0c042933878b85facb6c4e673b0166b256f37ad0","color":null,"created":1769408435351,"data":{},"environmentType":"kv","isPrivate":false,"metaSortKey":1769408435351,"name":"Base Environment","parentId":"wrk_efab8e758b97459bab2659d8fdcf8627","type":"Environment"}',
   '2f6a337993dcbcc164187f74e4278ca22c0ea065':
     '{"_id":"mcp-req_18ee6d8bec7645ada7c4ac48d416bdb0","authentication":{},"connected":false,"created":1769408435331,"description":"","env":[],"headers":[{"name":"User-Agent","value":"insomnia/12.3.0"}],"mcpStdioAccess":false,"parentId":"wrk_efab8e758b97459bab2659d8fdcf8627","roots":[],"sslValidation":true,"subscribeResources":[],"transportType":"streamable-http","type":"McpRequest","url":""}',
   '379b74a13b742b573c16dda3ed38abde8cfdb0c3':

--- a/packages/insomnia/src/common/render.ts
+++ b/packages/insomnia/src/common/render.ts
@@ -58,7 +58,7 @@ export async function buildRenderContext({
   if (rootGlobalEnvironment) {
     const ordered = orderedJSON.order(
       rootGlobalEnvironment.data,
-      rootGlobalEnvironment.dataPropertyOrder,
+      rootGlobalEnvironment.dataPropertyOrder ?? null,
       JSON_ORDER_SEPARATOR,
     );
     envObjects.push(ordered);
@@ -67,7 +67,7 @@ export async function buildRenderContext({
   if (subGlobalEnvironment) {
     const ordered = orderedJSON.order(
       subGlobalEnvironment.data,
-      subGlobalEnvironment.dataPropertyOrder,
+      subGlobalEnvironment.dataPropertyOrder ?? null,
       JSON_ORDER_SEPARATOR,
     );
     envObjects.push(ordered);
@@ -77,12 +77,16 @@ export async function buildRenderContext({
   // Then get sub environment keys in correct order
   // Then get ancestor (folder) environment keys in correct order
   if (rootEnvironment) {
-    const ordered = orderedJSON.order(rootEnvironment.data, rootEnvironment.dataPropertyOrder, JSON_ORDER_SEPARATOR);
+    const ordered = orderedJSON.order(
+      rootEnvironment.data,
+      rootEnvironment.dataPropertyOrder ?? null,
+      JSON_ORDER_SEPARATOR,
+    );
     envObjects.push(ordered);
   }
 
   if (subEnvironment) {
-    const ordered = orderedJSON.order(subEnvironment.data, subEnvironment.dataPropertyOrder, JSON_ORDER_SEPARATOR);
+    const ordered = orderedJSON.order(subEnvironment.data, subEnvironment.dataPropertyOrder ?? null, JSON_ORDER_SEPARATOR);
     envObjects.push(ordered);
   }
 
@@ -91,7 +95,7 @@ export async function buildRenderContext({
     const { environment, environmentPropertyOrder } = ancestor;
 
     if (typeof environment === 'object' && environment !== null) {
-      const ordered = orderedJSON.order(environment, environmentPropertyOrder, JSON_ORDER_SEPARATOR);
+      const ordered = orderedJSON.order(environment, environmentPropertyOrder ?? null, JSON_ORDER_SEPARATOR);
       envObjects.push(ordered);
     }
   }
@@ -100,7 +104,7 @@ export async function buildRenderContext({
   if (userUploadEnvironment) {
     const ordered = orderedJSON.order(
       userUploadEnvironment.data,
-      userUploadEnvironment.dataPropertyOrder,
+      userUploadEnvironment.dataPropertyOrder ?? null,
       JSON_ORDER_SEPARATOR,
     );
     envObjects.push(ordered);
@@ -110,7 +114,7 @@ export async function buildRenderContext({
   if (transientVariables) {
     const ordered = orderedJSON.order(
       transientVariables.data,
-      transientVariables.dataPropertyOrder,
+      transientVariables.dataPropertyOrder ?? null,
       JSON_ORDER_SEPARATOR,
     );
     envObjects.push(ordered);

--- a/packages/insomnia/src/main/cloud-sync/core/__tests__/util.test.ts
+++ b/packages/insomnia/src/main/cloud-sync/core/__tests__/util.test.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import { createBuilder } from '@develohpanda/fluent-builder';
+import { models } from 'insomnia-data';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { baseModelSchema, workspaceModelSchema } from '../../../../sync/__schemas__/model-schemas';
@@ -919,6 +920,36 @@ describe('util', () => {
       const result3 = hashDocument(baseModelBuilder.name('abc').modified(456).build());
       expect(result1.hash).toBe(result2.hash);
       expect(result1.hash).not.toBe(result3.hash);
+    });
+
+    it('does not add missing environment property order', () => {
+      const environment = {
+        ...baseModelBuilder.reset()._id('env_1').parentId('wrk_1').type(models.environment.type).build(),
+        ...models.environment.init(),
+        metaSortKey: 1234,
+        name: 'Base Environment',
+      };
+
+      const result = hashDocument(environment);
+      expect(result.hash).toBe('d0550d0c20563b689c99eadfd254e9220b85325b');
+      expect(result.content).toBe(
+        '{"_id":"env_1","color":null,"created":1234,"data":{},"isPrivate":false,"metaSortKey":1234,"name":"Base Environment","parentId":"wrk_1","type":"Environment"}',
+      );
+    });
+
+    it('does not add missing request group property order', () => {
+      const requestGroup = {
+        ...baseModelBuilder.reset()._id('fld_1').parentId('wrk_1').type(models.requestGroup.type).build(),
+        ...models.requestGroup.init(),
+        metaSortKey: -1234,
+        name: 'Folder',
+      };
+
+      const result = hashDocument(requestGroup);
+      expect(result.hash).toBe('c2cb8d76a07d72620a89dc84588020f21822ded6');
+      expect(result.content).toBe(
+        '{"_id":"fld_1","created":1234,"description":"","environment":{},"isPrivate":false,"metaSortKey":-1234,"name":"Folder","parentId":"wrk_1","type":"RequestGroup"}',
+      );
     });
 
     it('shouldnt change the hash of a workspace after a parent id is added and ignored', () => {

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -424,7 +424,7 @@ export async function savePatchesMadeByScript(patches: {
       dataPropertyOrder,
       // also update kvPairData when environment type is table view(kv pair)
       ...(environmentType === EnvironmentType.KVPAIR && {
-        kvPairData: getKVPairFromData(data, dataPropertyOrder),
+        kvPairData: getKVPairFromData(data, dataPropertyOrder ?? null),
       }),
     });
   };
@@ -453,7 +453,7 @@ export async function savePatchesMadeByScript(patches: {
         environment: mutatedFolder.environment,
         // also update kvPairData when folder environment type is table view(kv pair)
         ...(originalFolder.environmentType === EnvironmentType.KVPAIR && {
-          kvPairData: getKVPairFromData(mutatedFolder.environment, originalFolder.environmentPropertyOrder),
+          kvPairData: getKVPairFromData(mutatedFolder.environment, originalFolder.environmentPropertyOrder ?? null),
         }),
       });
     }

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.tsx
@@ -536,7 +536,7 @@ const Component = ({ loaderData, params }: Route.ComponentProps) => {
                   onChange={debouncedHandleChange}
                   environmentInfo={{
                     object: selectedEnvironment.data,
-                    propertyOrder: selectedEnvironment.dataPropertyOrder,
+                    propertyOrder: selectedEnvironment.dataPropertyOrder ?? null,
                   }}
                 />
               )}

--- a/packages/insomnia/src/sync/__schemas__/model-schemas.ts
+++ b/packages/insomnia/src/sync/__schemas__/model-schemas.ts
@@ -52,12 +52,14 @@ export const requestGroupModelSchema: Schema<RequestGroup> = {
   ...baseModelSchema,
   ...toSchema(requestGroup.init()),
   type: () => requestGroup.type,
+  environmentPropertyOrder: () => null,
 };
 
 export const environmentModelSchema: Schema<Environment> = {
   ...baseModelSchema,
   ...toSchema(environment.init()),
   type: () => environment.type,
+  dataPropertyOrder: () => null,
   environmentType: () => EnvironmentType.JSON,
   kvPairData: () => [
     {

--- a/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
@@ -524,7 +524,7 @@ export const WorkspaceEnvironmentsEditModal = ({ onClose }: { onClose: () => voi
                         onChange={handleEnvironmentChange}
                         environmentInfo={{
                           object: selectedEnvironment.data,
-                          propertyOrder: selectedEnvironment.dataPropertyOrder,
+                          propertyOrder: selectedEnvironment.dataPropertyOrder ?? null,
                         }}
                       />
                     )}

--- a/packages/insomnia/src/ui/components/panes/request-group-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-group-pane.tsx
@@ -245,7 +245,7 @@ export const RequestGroupPane: FC = () => {
                   key={activeRequestGroup ? activeRequestGroup._id : 'n/a'}
                   environmentInfo={{
                     object: activeRequestGroup ? activeRequestGroup.environment : {},
-                    propertyOrder: activeRequestGroup && activeRequestGroup.environmentPropertyOrder,
+                    propertyOrder: (activeRequestGroup && activeRequestGroup.environmentPropertyOrder) ?? null,
                   }}
                   onBlur={saveChanges}
                 />

--- a/packages/insomnia/src/ui/hooks/use-toggle-environment-type.tsx
+++ b/packages/insomnia/src/ui/hooks/use-toggle-environment-type.tsx
@@ -17,7 +17,7 @@ export function useToggleEnvironmentType() {
     ) => {
       const newEnvironmentType = isSelected ? EnvironmentType.JSON : EnvironmentType.KVPAIR;
       // clear kvPairData when switch to json view, otherwise convert json data to kvPairData
-      const kvPairData = isSelected ? [] : getKVPairFromData(environment.data, environment.dataPropertyOrder);
+      const kvPairData = isSelected ? [] : getKVPairFromData(environment.data, environment.dataPropertyOrder ?? null);
       const foundDisabledItem = isSelected && environment.kvPairData?.some(pair => !pair.enabled);
       const foundDuplicateNameItem =
         isSelected &&


### PR DESCRIPTION
Prevents `dataPropertyOrder` and `environmentPropertyOrder` from causing unnecessary "Uncommitted changes" diffs