### PR TITLE
fix: Unexpected disableUserAgentHeader field occur in cloud sync

### DIFF
--- a/packages/insomnia-data/__tests__/grpc-request.test.ts
+++ b/packages/insomnia-data/__tests__/grpc-request.test.ts
@@ -22,7 +22,6 @@ describe('init()', () => {
       },
       metaSortKey: -1_478_795_580_200,
       isPrivate: false,
-      disableUserAgentHeader: false,
     });
   });
 });
@@ -56,7 +55,6 @@ describe('create()', () => {
       },
       metaSortKey: -1_478_795_580_200,
       isPrivate: false,
-      disableUserAgentHeader: false,
       type: 'GrpcRequest',
     };
     expect(request).toEqual(expected);

--- a/packages/insomnia-data/node-src/database/database.test.ts
+++ b/packages/insomnia-data/node-src/database/database.test.ts
@@ -178,7 +178,7 @@ describe('requestCreate()', () => {
       parentId: 'wrk_123',
     };
     const r = await services.request.create(patch);
-    expect(Object.keys(r).length).toBe(25);
+    expect(Object.keys(r).length).toBe(24);
     expect(r._id).toMatch(/^req_[a-zA-Z0-9]{32}$/);
     expect(r.created).toBeGreaterThanOrEqual(now);
     expect(r.modified).toBeGreaterThanOrEqual(now);

--- a/packages/insomnia-data/src/models/grpc-request.ts
+++ b/packages/insomnia-data/src/models/grpc-request.ts
@@ -34,7 +34,7 @@ interface BaseGrpcRequest {
     apiKey: string;
     module: string;
   };
-  disableUserAgentHeader: boolean;
+  disableUserAgentHeader?: boolean;
   konnectRouteKey?: string | null;
   konnectManagedHeaderNames?: string[] | null;
 }
@@ -45,7 +45,11 @@ export const isGrpcRequest = (model: Pick<BaseModel, 'type'>): model is GrpcRequ
 
 export const isGrpcRequestId = (id?: string | null) => id?.startsWith(`${prefix}_`);
 
-export const optionalKeys = ['konnectRouteKey', 'konnectManagedHeaderNames'];
+export const optionalKeys: (keyof BaseGrpcRequest)[] = [
+  'konnectRouteKey',
+  'konnectManagedHeaderNames',
+  'disableUserAgentHeader',
+];
 
 export function rewriteReferences(request: GrpcRequest, idMapping: Map<string, string>): GrpcRequest {
   return {
@@ -75,6 +79,5 @@ export function init(): BaseGrpcRequest {
       apiKey: '',
       module: 'buf.build/connectrpc/eliza',
     },
-    disableUserAgentHeader: false,
   };
 }

--- a/packages/insomnia-data/src/models/mcp-request.ts
+++ b/packages/insomnia-data/src/models/mcp-request.ts
@@ -29,7 +29,7 @@ export interface BaseMcpRequest {
   connected: boolean;
   // See: https://nodejs.org/api/tls.html#tlsconnectoptions-callback
   sslValidation: boolean;
-  disableUserAgentHeader: boolean;
+  disableUserAgentHeader?: boolean;
 }
 export type McpServerPrimitiveTypes = 'tools' | 'resources' | 'prompts' | 'resourceTemplates';
 
@@ -54,6 +54,7 @@ export function init(): BaseMcpRequest {
     subscribeResources: [],
     connected: false,
     sslValidation: true,
-    disableUserAgentHeader: false,
   };
 }
+
+export const optionalKeys: (keyof BaseMcpRequest)[] = ['disableUserAgentHeader'];

--- a/packages/insomnia-data/src/models/request.ts
+++ b/packages/insomnia-data/src/models/request.ts
@@ -289,7 +289,7 @@ export interface BaseRequest {
   settingEncodeUrl: boolean;
   settingRebuildPath: boolean;
   settingFollowRedirects: 'global' | 'on' | 'off';
-  disableUserAgentHeader: boolean;
+  disableUserAgentHeader?: boolean;
   konnectRouteKey?: string | null;
   konnectManagedHeaderNames?: string[] | null;
 }
@@ -325,7 +325,11 @@ export function getOperationType(request: Request) {
 export const isGraphqlSubscriptionRequest = (model: Pick<BaseModel, 'type'>) =>
   isRequest(model) && getOperationType(model) === OperationTypeNode.SUBSCRIPTION;
 
-export const optionalKeys = ['konnectRouteKey', 'konnectManagedHeaderNames'];
+export const optionalKeys: (keyof BaseRequest)[] = [
+  'konnectRouteKey',
+  'konnectManagedHeaderNames',
+  'disableUserAgentHeader',
+];
 
 export function init(): BaseRequest {
   return {
@@ -349,7 +353,6 @@ export function init(): BaseRequest {
     settingEncodeUrl: true,
     settingRebuildPath: true,
     settingFollowRedirects: 'global',
-    disableUserAgentHeader: false,
   };
 }
 

--- a/packages/insomnia-data/src/models/socket-io-request.ts
+++ b/packages/insomnia-data/src/models/socket-io-request.ts
@@ -32,7 +32,7 @@ export interface BaseSocketIORequest {
   settingStoreCookies: boolean;
   settingSendCookies: boolean;
   settingPath?: string;
-  disableUserAgentHeader: boolean;
+  disableUserAgentHeader?: boolean;
   eventListeners: SocketIOEventListener[];
 }
 
@@ -55,9 +55,10 @@ export const init = (): BaseSocketIORequest => ({
   settingSendCookies: true,
   settingPath: undefined,
   description: '',
-  disableUserAgentHeader: false,
   eventListeners: [],
 });
+
+export const optionalKeys: (keyof BaseSocketIORequest)[] = ['disableUserAgentHeader'];
 
 export function rewriteReferences(request: SocketIORequest, idMapping: Map<string, string>): SocketIORequest {
   return {

--- a/packages/insomnia-data/src/models/websocket-request.ts
+++ b/packages/insomnia-data/src/models/websocket-request.ts
@@ -26,7 +26,7 @@ export interface BaseWebSocketRequest {
   settingSendCookies: boolean;
   settingFollowRedirects: 'global' | 'on' | 'off';
   settingUseProxy?: boolean;
-  disableUserAgentHeader: boolean;
+  disableUserAgentHeader?: boolean;
   konnectRouteKey?: string | null;
   konnectManagedHeaderNames?: string[] | null;
 }
@@ -36,9 +36,6 @@ export type WebSocketRequest = BaseModel & BaseWebSocketRequest & { type: typeof
 export const isWebSocketRequest = (model: Pick<BaseModel, 'type'>): model is WebSocketRequest => model.type === type;
 
 export const isWebSocketRequestId = (id?: string | null) => id?.startsWith(`${prefix}_`);
-
-// for those keys do not need to add in model init method but can update
-export const optionalKeys = ['settingUseProxy', 'konnectRouteKey', 'konnectManagedHeaderNames'];
 
 export const init = (): BaseWebSocketRequest => ({
   name: 'New WebSocket Request',
@@ -53,8 +50,15 @@ export const init = (): BaseWebSocketRequest => ({
   settingSendCookies: true,
   settingFollowRedirects: 'global',
   description: '',
-  disableUserAgentHeader: false,
 });
+
+// for those keys do not need to add in model init method but can update
+export const optionalKeys: (keyof BaseWebSocketRequest)[] = [
+  'settingUseProxy',
+  'konnectRouteKey',
+  'konnectManagedHeaderNames',
+  'disableUserAgentHeader',
+];
 
 export function rewriteReferences(request: WebSocketRequest, idMapping: Map<string, string>): WebSocketRequest {
   return {

--- a/packages/insomnia/src/main/ipc/grpc.ts
+++ b/packages/insomnia/src/main/ipc/grpc.ts
@@ -336,7 +336,7 @@ export const getSelectedMethod = async (
     request.metadata,
     settings.validateSSL,
     request.reflectionApi,
-    request.disableUserAgentHeader,
+    request.disableUserAgentHeader || false,
     ipcParams.clientCert,
     ipcParams.clientKey,
     ipcParams.caCertificate,

--- a/packages/insomnia/src/main/ipc/grpc.ts
+++ b/packages/insomnia/src/main/ipc/grpc.ts
@@ -336,7 +336,7 @@ export const getSelectedMethod = async (
     request.metadata,
     settings.validateSSL,
     request.reflectionApi,
-    request.disableUserAgentHeader || false,
+    request.disableUserAgentHeader ?? false,
     ipcParams.clientCert,
     ipcParams.clientKey,
     ipcParams.caCertificate,


### PR DESCRIPTION
# Changes:
For all requests using `disableUserAgentHeader`, add it to `optionalKeys` so that it will not impact cloud sync to as a change in diff
