### PR TITLE
Fix:  Avoid request actions to trigger the project loader

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
@@ -29,7 +29,7 @@ import {
 } from '~/common/constants';
 import { scopeToBgColorMap, scopeToIconMap, scopeToTextColorMap } from '~/common/get-workspace-label';
 import { fuzzyMatchAll } from '~/common/misc';
-import type { InsomniaFile } from '~/common/project';
+import { type InsomniaFile } from '~/common/project';
 import { sortMethodMap } from '~/common/sorting';
 import { useRootLoaderData } from '~/root';
 import { useOrganizationLoaderData } from '~/routes/organization';
@@ -62,13 +62,6 @@ import { isPrimaryClickModifier } from '~/ui/utils';
 
 export interface ProjectLoaderData {
   localFiles: InsomniaFile[];
-  allFilesCount: number;
-  documentsCount: number;
-  environmentsCount: number;
-  collectionsCount: number;
-  mockServersCount: number;
-  mcpClientsCount: number;
-  projectsCount: number;
   activeProject?: Project;
   activeProjectGitRepository?: GitRepository;
   projects: (Project & { gitRepository?: GitRepository })[];

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.tsx
@@ -3,7 +3,16 @@ import { models, services } from 'insomnia-data';
 import { type Dispatch, type SetStateAction, useEffect, useRef, useState } from 'react';
 import { Button, Heading } from 'react-aria-components';
 import { type ImperativePanelHandle, Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
-import { href, Outlet, redirect, useOutletContext, useParams, useRouteLoaderData, useSearchParams } from 'react-router';
+import {
+  href,
+  Outlet,
+  redirect,
+  type ShouldRevalidateFunctionArgs,
+  useOutletContext,
+  useParams,
+  useRouteLoaderData,
+  useSearchParams,
+} from 'react-router';
 import * as reactUse from 'react-use';
 
 import { logout } from '~/account/session';
@@ -55,6 +64,12 @@ const getInsomniaLearningFeature = async (fallbackLearningFeature: LearningFeatu
   }
   return learningFeature;
 };
+
+export function shouldRevalidate({ currentParams, nextParams }: ShouldRevalidateFunctionArgs) {
+  const isProjectOrOrganizationChanging =
+    currentParams.projectId !== nextParams.projectId || currentParams.organizationId !== nextParams.organizationId;
+  return isProjectOrOrganizationChanging;
+}
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   const { organizationId, projectId } = params;

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.tsx
@@ -73,12 +73,13 @@ export function shouldRevalidate({ currentParams, nextParams, formMethod, formAc
   const isActionMutation = formMethod !== undefined && formMethod.toUpperCase() !== 'GET';
   const isOrgScopedMutation =
     isActionMutation && !!formAction?.startsWith(`/organization/${nextParams.organizationId}`);
-  const isWorkspaceSpecificAction =
-    isActionMutation && nextParams.workspaceId && formAction?.includes(`/workspace/${nextParams.workspaceId}`);
+  const isWorkspaceSpecificAction = Boolean(
+    isActionMutation && nextParams.workspaceId && formAction?.includes(`/workspace/${nextParams.workspaceId}`),
+  );
   // Only revalidate if the project, organization, or workspace is changing, or if it's an org-scoped mutation that is not workspace specific
-  const shouldRevalidate =
+  const shouldRevalidateProjectLoaderData =
     isProjectOrOrganizationOrWorkspaceChanging || (isOrgScopedMutation && !isWorkspaceSpecificAction);
-  return shouldRevalidate;
+  return shouldRevalidateProjectLoaderData;
 }
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.tsx
@@ -65,10 +65,20 @@ const getInsomniaLearningFeature = async (fallbackLearningFeature: LearningFeatu
   return learningFeature;
 };
 
-export function shouldRevalidate({ currentParams, nextParams }: ShouldRevalidateFunctionArgs) {
-  const isProjectOrOrganizationChanging =
-    currentParams.projectId !== nextParams.projectId || currentParams.organizationId !== nextParams.organizationId;
-  return isProjectOrOrganizationChanging;
+export function shouldRevalidate({ currentParams, nextParams, formMethod, formAction }: ShouldRevalidateFunctionArgs) {
+  const isProjectOrOrganizationOrWorkspaceChanging =
+    currentParams.projectId !== nextParams.projectId ||
+    currentParams.organizationId !== nextParams.organizationId ||
+    currentParams.workspaceId !== nextParams.workspaceId;
+  const isActionMutation = formMethod !== undefined && formMethod.toUpperCase() !== 'GET';
+  const isOrgScopedMutation =
+    isActionMutation && !!formAction?.startsWith(`/organization/${nextParams.organizationId}`);
+  const isWorkspaceSpecificAction =
+    isActionMutation && nextParams.workspaceId && formAction?.includes(`/workspace/${nextParams.workspaceId}`);
+  // Only revalidate if the project, organization, or workspace is changing, or if it's an org-scoped mutation that is not workspace specific
+  const shouldRevalidate =
+    isProjectOrOrganizationOrWorkspaceChanging || (isOrgScopedMutation && !isWorkspaceSpecificAction);
+  return shouldRevalidate;
 }
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
@@ -154,15 +164,8 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
     localFiles,
     remoteFilesPromise,
     projects,
-    projectsCount: organizationProjects.length,
     activeProject: project,
     activeProjectGitRepository,
-    allFilesCount: localFiles.length,
-    environmentsCount: localFiles.filter(file => file.scope === 'environment').length,
-    documentsCount: localFiles.filter(file => file.scope === 'design').length,
-    collectionsCount: localFiles.filter(file => file.scope === 'collection').length,
-    mockServersCount: localFiles.filter(file => file.scope === 'mock-server').length,
-    mcpClientsCount: localFiles.filter(file => file.scope === 'mcp').length,
     projectsSyncStatusPromise,
     learningFeaturePromise,
   };

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar-utils.ts
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar-utils.ts
@@ -94,8 +94,8 @@ export function invalidateSidebarCaches(
     }
 
     if (doc.type === models.workspace.type) {
-      const movedBetweenProjects = patches.some(p => 'parentId' in p);
-      if (movedBetweenProjects) {
+      const isChangingParent = patches.some(p => 'parentId' in p);
+      if (isChangingParent) {
         // parentId changed,clear the whole map
         if (workspacesByProjectId.size > 0) {
           workspacesByProjectId.clear();
@@ -107,9 +107,11 @@ export function invalidateSidebarCaches(
       invalidateWorkspaceData(doc._id);
       continue;
     }
-    // Request or request group or meta change, clear the collectionDataByWorkspaceId cache
-    collectionDataByWorkspaceId.clear();
-    shouldInvalidate = true;
+    if (collectionDataByWorkspaceId.size > 0) {
+      // Request or request group or meta change, clear the collectionDataByWorkspaceId cache
+      collectionDataByWorkspaceId.clear();
+      shouldInvalidate = true;
+    }
   }
 
   return shouldInvalidate;

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar-utils.ts
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar-utils.ts
@@ -1,4 +1,5 @@
 import type {
+  ChangeBufferEvent,
   GrpcRequest,
   GrpcRequestMeta,
   Request,
@@ -49,6 +50,64 @@ export interface AllRequestsAndMetaInWorkspace {
 //   modified: r.modified,
 //   created: r.created,
 // });
+
+// Document types whose changes can affect the sidebar tree.
+export const SIDEBAR_RELEVANT_DOC_TYPES = [
+  models.project.type,
+  models.workspace.type,
+  models.request.type,
+  models.grpcRequest.type,
+  models.webSocketRequest.type,
+  models.socketIORequest.type,
+  models.requestGroup.type,
+  models.requestMeta.type,
+  models.grpcRequestMeta.type,
+  models.webSocketRequestMeta.type,
+  models.socketIORequestMeta.type,
+  models.requestGroupMeta.type,
+];
+
+export function invalidateSidebarCaches(
+  changes: ChangeBufferEvent[],
+  workspacesByProjectId: Map<string, Workspace[]>,
+  collectionDataByWorkspaceId: Map<string, AllRequestsAndMetaInWorkspace>,
+): boolean {
+  let shouldInvalidate = false;
+  const invalidateWorkspaceData = (workspaceId: string | undefined) => {
+    if (workspaceId && collectionDataByWorkspaceId.delete(workspaceId)) {
+      shouldInvalidate = true;
+    }
+  };
+
+  for (const [_, doc] of changes) {
+    if (!SIDEBAR_RELEVANT_DOC_TYPES.includes(doc.type)) {
+      continue;
+    }
+
+    if (doc.type === models.project.type) {
+      // A project change, clear the workspace list cache
+      if (workspacesByProjectId.size > 0) {
+        workspacesByProjectId.clear();
+        shouldInvalidate = true;
+      }
+      continue;
+    }
+
+    if (doc.type === models.workspace.type) {
+      // Workspace change, clear the workspace from workspacesByProjectId
+      if (workspacesByProjectId.delete(doc.parentId)) {
+        shouldInvalidate = true;
+      }
+      invalidateWorkspaceData(doc._id);
+      continue;
+    }
+    // Request or request group or meta change, clear the collectionDataByWorkspaceId cache
+    collectionDataByWorkspaceId.clear();
+    shouldInvalidate = true;
+  }
+
+  return shouldInvalidate;
+}
 
 export async function getWorkspacesByProjectIds(projectIds: string[]) {
   const workspaces = await database.find<Workspace>(models.workspace.type, {

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar-utils.ts
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar-utils.ts
@@ -79,7 +79,7 @@ export function invalidateSidebarCaches(
     }
   };
 
-  for (const [_, doc] of changes) {
+  for (const [, doc, patches] of changes) {
     if (!SIDEBAR_RELEVANT_DOC_TYPES.includes(doc.type)) {
       continue;
     }
@@ -94,8 +94,14 @@ export function invalidateSidebarCaches(
     }
 
     if (doc.type === models.workspace.type) {
-      // Workspace change, clear the workspace from workspacesByProjectId
-      if (workspacesByProjectId.delete(doc.parentId)) {
+      const movedBetweenProjects = patches.some(p => 'parentId' in p);
+      if (movedBetweenProjects) {
+        // parentId changed,clear the whole map
+        if (workspacesByProjectId.size > 0) {
+          workspacesByProjectId.clear();
+          shouldInvalidate = true;
+        }
+      } else if (workspacesByProjectId.delete(doc.parentId)) {
         shouldInvalidate = true;
       }
       invalidateWorkspaceData(doc._id);

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
@@ -1,6 +1,6 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
 import type { StorageRules } from 'insomnia-api';
-import type { RequestGroup, Workspace } from 'insomnia-data';
+import type { ChangeBufferEvent, RequestGroup, Workspace } from 'insomnia-data';
 import { models, services } from 'insomnia-data';
 import {
   type Dispatch,
@@ -64,6 +64,7 @@ import {
   flattenCollectionChildren,
   getAllRequestsAndMetaByWorkspace,
   getWorkspacesByProjectIds,
+  invalidateSidebarCaches,
 } from './project-navigation-sidebar-utils';
 import { ProjectNode } from './project-node';
 import { PinnedHeaderNode, RequestNode } from './request-node';
@@ -217,6 +218,10 @@ const ProjectNavigationSidebarInner = (
   const [flatItems, setFlatItems] = useState<FlatItem[]>([]);
   const [projectWorkspaceSortOrder, setProjectWorkspaceSortOrder] = useState<Record<string, WorkspaceSortOrder>>({});
   const [unsyncedFilesByProjectId, setUnsyncedFilesByProjectId] = useState<Map<string, InsomniaFile[]>>(new Map());
+  // Bumped when a sidebar-relevant db change invalidates the caches, to re-run the tree build below.
+  const [dataVersion, setDataVersion] = useState(0);
+  // Debounce tree rebuilds so a burst of db changes (e.g. a bulk import) collapses into one rebuild.
+  const rebuildTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Customized workspace sort orders by projectId
   const [localWorkspaceOrders, setLocalWorkspaceOrders] = reactUse.useLocalStorage<Record<string, string[]>>(
     `${organizationId}:local-workspace-orders`,
@@ -461,10 +466,30 @@ const ProjectNavigationSidebarInner = (
   }, [getAllRemoteFilesByProjectId, organizationId]);
 
   useEffect(() => {
-    // clear caches on any router data change to avoid showing stale data
-    cachedWorkspacesRef.current.clear();
-    cachedCollectionChildrenAndMetaRef.current.clear();
-  }, [projectLoaderData]);
+    const scheduleRebuild = () => {
+      if (rebuildTimeoutRef.current) {
+        // debounce multiple db changes into one rebuild
+        clearTimeout(rebuildTimeoutRef.current);
+      }
+      rebuildTimeoutRef.current = setTimeout(() => setDataVersion(v => v + 1), 100);
+    };
+    const unsubscribe = window.main.on('db.changes', (_, changes: ChangeBufferEvent[]) => {
+      const shouldInvalidate = invalidateSidebarCaches(
+        changes,
+        cachedWorkspacesRef.current,
+        cachedCollectionChildrenAndMetaRef.current,
+      );
+      if (shouldInvalidate) {
+        scheduleRebuild();
+      }
+    });
+    return () => {
+      unsubscribe?.();
+      if (rebuildTimeoutRef.current) {
+        clearTimeout(rebuildTimeoutRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     const tryToGetWorkspacesFromCache = async (projectIds: string[]) => {
@@ -728,6 +753,7 @@ const ProjectNavigationSidebarInner = (
     projectNavigationSidebarFilter,
     projectsWithPresence,
     unsyncedFilesByProjectId,
+    dataVersion,
   ]);
 
   const handleLocalWorkspaceReorder = useCallback(

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
@@ -580,6 +580,16 @@ const ProjectNavigationSidebarInner = (
 
         for (const workspace of allWorkspaces) {
           if (workspace.scope === 'unsynced') {
+            // When a filter is active, show the unsynced workspace only if its name matches the filter.
+            const unsyncedWorkspaceMatchesFilter =
+              !projectNavigationSidebarFilter ||
+              Boolean(
+                fuzzyMatchAll(
+                  projectNavigationSidebarFilter.toLowerCase(),
+                  [workspace.name?.toLowerCase() || ''],
+                  { splitSpace: true, loose: true },
+                )?.indexes,
+              );
             items.push({
               kind: 'unsyncedWorkspace',
               organizationId,
@@ -590,7 +600,7 @@ const ProjectNavigationSidebarInner = (
                 ...workspace,
               },
               collapsed: false,
-              hidden: isProjectCollapsed,
+              hidden: projectNavigationSidebarFilter ? !unsyncedWorkspaceMatchesFilter : isProjectCollapsed,
             });
           } else {
             const { scope, _id: workspaceId } = workspace as Workspace;
@@ -724,7 +734,10 @@ const ProjectNavigationSidebarInner = (
             ?.toLowerCase()
             .includes(projectNavigationSidebarFilter.toLowerCase());
           const hasVisibleWorkspace = items.some(
-            i => i.kind === 'workspace' && i.project._id === projectId && !i.hidden,
+            i =>
+              (i.kind === 'workspace' || i.kind === 'unsyncedWorkspace') &&
+              i.project._id === projectId &&
+              !i.hidden,
           );
           const shouldHideProject = !projectMatchesFilter && !hasVisibleWorkspace;
           items.find(i => i.kind === 'project' && i.doc._id === projectId)!.hidden = shouldHideProject;


### PR DESCRIPTION
# Changes:
- Add a `shouldRevalidate` to avoid any request actions to trigger the heavy project loaders
- Using `db.change` to detect any data in current organization change in sidebar