### PR TITLE
fix: persist sidebar width when switching between document tabs [INS-2773]

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
@@ -41,7 +41,7 @@ import { type ImperativePanelGroupHandle, Panel, PanelGroup, PanelResizeHandle }
 import { href, redirect, useFetchers, useMatch, useParams, useSearchParams } from 'react-router';
 import * as reactUse from 'react-use';
 
-import { getProductName, SORT_ORDERS, type SortOrder, sortOrderName } from '~/common/constants';
+import { DEFAULT_SIDEBAR_SIZE, getProductName, SORT_ORDERS, type SortOrder, sortOrderName } from '~/common/constants';
 import { generateId } from '~/common/misc';
 import type { GrpcMethodInfo } from '~/main/ipc/grpc';
 import { useRootLoaderData } from '~/root';
@@ -796,7 +796,7 @@ const Debug = () => {
         {/* Design page has a collection view with legacy collection list */}
         {isDesignWorkspace && (
           <>
-            <Panel id="sidebar" order={1} className="sidebar theme--sidebar" maxSize={40} minSize={10} collapsible>
+            <Panel id="sidebar" order={1} className="sidebar theme--sidebar" defaultSize={DEFAULT_SIDEBAR_SIZE} maxSize={40} minSize={10} collapsible>
               <div className="flex flex-1 flex-col divide-y divide-solid divide-(--hl-md) overflow-hidden">
                 <div className="flex flex-col items-start divide-y divide-solid divide-(--hl-md)">
                   {models.workspace.isDesign(activeWorkspace) && (
@@ -1144,7 +1144,7 @@ const Debug = () => {
             <PanelResizeHandle className="h-full w-px bg-(--hl-md)" />
           </>
         )}
-        <Panel order={2} className="flex flex-col">
+        <Panel id="workspace-content" order={2} className="flex flex-col">
           <PanelGroup autoSaveId="insomnia-panels" id="insomnia-panels" direction={direction}>
             {isRunner ? (
               <Runner />

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx
@@ -1343,7 +1343,7 @@ const Component = ({ params }: Route.ComponentProps) => {
           </div>
         </Panel>
         <PanelResizeHandle className="h-full w-px bg-(--hl-md)" />
-        <Panel className="flex flex-col">
+        <Panel id="workspace-content" className="flex flex-col">
           <PanelGroup autoSaveId="insomnia-panels" direction={direction}>
             <Panel id="pane-one" minSize={10} className="pane-one theme--pane">
               <div className="flex h-full w-full flex-col">

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.tsx
@@ -393,7 +393,7 @@ const Component = () => {
           </ErrorBoundary>
         </Panel>
         <PanelResizeHandle className="h-full w-px bg-(--hl-md)" />
-        <Panel className="flex flex-col">
+        <Panel id="workspace-content" className="flex flex-col">
           <PanelGroup autoSaveId="insomnia-panels" direction={direction}>
             <Panel id="pane-one" minSize={10} className="pane-one theme--pane relative overflow-hidden">
               <Routes>


### PR DESCRIPTION
When switching between the **Spec**, **Collection**, and **Tests** tabs of a
design document, the sidebar width reset instead of keeping the width the user
last set.

All three tabs share the same `react-resizable-panels` `autoSaveId="insomnia-sidebar"`,
which persists the layout to `localStorage`. However, the library keys each saved
layout by a *panelKey* derived from the panels in the group: a panel with an
explicit `id` contributes its `id`, while a panel without one contributes its
`order` + constraints.

The sidebar panel had `id="sidebar"` in all three routes, but the content panel
had **no** `id`:

- Spec / Tests → key fragment `"{}"`
- Collection (debug) → key fragment `"2:{}"` (it carries `order={2}`)

As a result the Collection tab saved the sidebar width under a different key than
Spec/Tests within the same storage entry, so switching tabs read a different key
and the width appeared to reset.

## Changes

- Add a stable `id="workspace-content"` to the content panel in `spec.tsx`,
  `test.tsx`, and `debug.tsx` so all three produce an identical panelKey and
  share one persisted sidebar width.
- Add `defaultSize={DEFAULT_SIDEBAR_SIZE}` to the Collection sidebar panel (it was
  missing) so a fresh layout defaults to the same width as the other tabs.

## Notes

Previously-saved widths were stored under the old keys and won't carry over on the
first load after this change — the sidebar starts at the default once, then
persists consistently across tabs from then on.

## Testing

- `npm run type-check -w packages/insomnia` passes.
- Manually verified resizing the sidebar in one tab keeps the width when switching
  to the other tabs.

