### PR TITLE
feat: support more curl features in import [INS-1531]

### DIFF
--- a/packages/insomnia/src/main/importers/importers/__snapshots__/index.test.ts.snap
+++ b/packages/insomnia/src/main/importers/importers/__snapshots__/index.test.ts.snap
@@ -439,7 +439,12 @@ exports[`Fixtures > Import curl > simple-url-input.sh 1`] = `
       "_type": "request",
       "authentication": {},
       "body": {},
-      "headers": [],
+      "headers": [
+        {
+          "name": "Accept-Encoding",
+          "value": "deflate, gzip",
+        },
+      ],
       "method": "GET",
       "name": "https://www.google.com",
       "parameters": [],

--- a/packages/insomnia/src/main/importers/importers/curl.test.ts
+++ b/packages/insomnia/src/main/importers/importers/curl.test.ts
@@ -187,6 +187,23 @@ describe('curl', () => {
       curl: "curl -X POST https://example.com -d 'key=value'",
       expected: { body: { text: 'key=value' } },
     },
+    {
+      // https://github.com/Kong/insomnia/issues/9412
+      name: 'should preserve a token with multiple equals signs as raw text body',
+      curl: "curl -X POST https://example.com -d 'token=abc==123==xyz'",
+      expected: { body: { text: 'token=abc==123==xyz' } },
+    },
+    {
+      // https://github.com/Kong/insomnia/issues/6731
+      name: 'should drop the ;type= modifier from a --form file value',
+      curl: "curl -X POST https://example.com -F 'data=@/tmp/dex.json;type=application/json'",
+      expected: {
+        body: {
+          mimeType: 'multipart/form-data',
+          params: [{ name: 'data', fileName: '/tmp/dex.json', type: 'file' }],
+        },
+      },
+    },
 
     // -H flags
     {
@@ -264,10 +281,51 @@ describe('curl', () => {
         headers: [{ name: 'user-agent', value: 'my-agent/1.0' }],
       },
     },
+    {
+      // https://github.com/Kong/insomnia/issues/4530
+      name: 'should preserve a trailing slash on a non-root path',
+      curl: "curl 'https://example.com/foo/bar/'",
+      expected: { url: 'https://example.com/foo/bar/' },
+    },
+    {
+      // https://github.com/Kong/insomnia/issues/8838
+      name: 'should decode shell-escaped query brackets',
+      curl: "curl 'https://example.com/?test\\[\\]=1234'",
+      expected: {
+        url: 'https://example.com',
+        parameters: [{ name: 'test[]', value: '1234', disabled: false }],
+      },
+    },
+    {
+      name: 'adds an Accept-Encoding header for --compressed',
+      curl: "curl --compressed 'https://rest.rodeo/pokemon/vaporeon'",
+      expected: {
+        url: 'https://rest.rodeo/pokemon/vaporeon',
+        method: 'GET',
+        headers: [{ name: 'Accept-Encoding', value: 'deflate, gzip' }],
+      },
+    },
   ];
 
   it.each(testCases)('$name', async ({ curl, expected }) => {
     const result = await convert(curl);
     expect(result).toMatchObject([expected]);
+  });
+
+  // https://github.com/Kong/insomnia/issues/9151
+  it('returns null for non-curl input (e.g. Postman JSON) instead of throwing', async () => {
+    const postmanJson =
+      '{"info":{"name":"My Collection","schema":"https://schema.getpostman.com/json/collection/v2.1.0"},"item":[]}';
+    const result = await convert(postmanJson);
+    expect(result).toBeNull();
+  });
+
+  it('prefers an explicit Authorization header over -u basic auth', async () => {
+    const result = await convert("curl https://example.com -u user:pass -H 'Authorization: Basic custom'");
+    expect(result).toMatchObject([{ headers: [{ name: 'Authorization', value: 'Basic custom' }] }]);
+    if (!Array.isArray(result)) {
+      throw new TypeError('Expected curl import to return requests');
+    }
+    expect(result[0]?.authentication).toEqual({});
   });
 });

--- a/packages/insomnia/src/main/importers/importers/curl.test.ts
+++ b/packages/insomnia/src/main/importers/importers/curl.test.ts
@@ -305,6 +305,15 @@ describe('curl', () => {
         headers: [{ name: 'Accept-Encoding', value: 'deflate, gzip' }],
       },
     },
+    {
+      name: 'does not swallow the URL when -G immediately precedes it',
+      curl: "curl -G https://example.com -d 'a=b'",
+      expected: {
+        url: 'https://example.com',
+        method: 'GET',
+        parameters: [{ name: 'a', value: 'b' }],
+      },
+    },
   ];
 
   it.each(testCases)('$name', async ({ curl, expected }) => {

--- a/packages/insomnia/src/main/importers/importers/curl.ts
+++ b/packages/insomnia/src/main/importers/importers/curl.ts
@@ -66,7 +66,7 @@ const importCommand = (parseEntries: ParseEntry[]) => {
         // Handle squished arguments like -XPOST
         value = name.slice(1);
         name = name.slice(0, 1);
-      } else if (name === 'compressed') {
+      } else if (name === 'compressed' || name === 'G' || name === 'get') {
         value = true;
       } else if (typeof nextEntry === 'string' && !nextEntry.startsWith('-')) {
         // Next arg is not a flag, so assign it as the value

--- a/packages/insomnia/src/main/importers/importers/curl.ts
+++ b/packages/insomnia/src/main/importers/importers/curl.ts
@@ -31,6 +31,7 @@ const SUPPORTED_ARGS = [
   'F',
   'request',
   'X',
+  'compressed',
 ];
 
 type PairsByName = Record<string, (string | boolean)[]>;
@@ -65,6 +66,8 @@ const importCommand = (parseEntries: ParseEntry[]) => {
         // Handle squished arguments like -XPOST
         value = name.slice(1);
         name = name.slice(0, 1);
+      } else if (name === 'compressed') {
+        value = true;
       } else if (typeof nextEntry === 'string' && !nextEntry.startsWith('-')) {
         // Next arg is not a flag, so assign it as the value
         value = nextEntry;
@@ -86,13 +89,13 @@ const importCommand = (parseEntries: ParseEntry[]) => {
 };
 const extractUrlAndParameters = (urlValue: string): { url: string; parameters: Parameter[] } => {
   try {
-    const { searchParams, href, search } = new URL(urlValue);
+    const { searchParams, href, search, pathname } = new URL(urlValue.replace(/\\([[\]{}])/g, '$1'));
     const parameters = Array.from(searchParams.entries()).map(([name, value]) => ({
       name,
       value,
       disabled: false,
     }));
-    const url = href.replace(search, '').replace(/\/$/, '');
+    const url = pathname === '/' ? href.replace(search, '').replace(/\/$/, '') : href.replace(search, '');
     return { url, parameters };
   } catch {
     return { url: '', parameters: [] };
@@ -113,6 +116,9 @@ const extractAuth = (pairsByName: PairsByName): RequestAuthentication | {} => {
   if (bearerAuthHeader) {
     const [_, value] = bearerAuthHeader.split(/:(.*)$/);
     return { type: 'bearer', token: value.trim().slice(7) };
+  }
+  if (allHeaders.some(h => h.split(/:(.*)$/)[0].trim().toLowerCase() === 'authorization')) {
+    return {};
   }
   return username
     ? {
@@ -166,7 +172,8 @@ const extractBody = (
     ...((pairsByName.form as string[] | undefined) || []),
     ...((pairsByName.F as string[] | undefined) || []),
   ].map(str => {
-    const [name, value] = str.split('=');
+    const [name, ...rest] = str.split('=');
+    const value = rest.join('=').split(';')[0];
     const item: Parameter = {
       name,
     };
@@ -239,6 +246,9 @@ const buildRequestObject = ({
       name: 'Cookie',
       value: cookieHeaderValue,
     });
+  }
+  if (getPairValue(pairsByName, false, ['compressed']) && !headers.some(header => header.name.toLowerCase() === 'accept-encoding')) {
+    headers.push({ name: 'Accept-Encoding', value: 'deflate, gzip' });
   }
   const dataParameters = pairsToDataParameters(pairsByName);
   let body = {};


### PR DESCRIPTION
In the absence of an actively maintained public package for more comprehensive curl parsing, these import parser changes cover some gaps and adds some regression tests for previously identified import issues.

- form file uploads keep the correct filename when type is specified
- urls keep their trailing slash
- explicit auth headers are preferred over basic auth options (`-u`)

closes #6731, #4530, and #8838