### PR TITLE
fix(ui): prevent button text truncation

### DIFF
--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -208,7 +208,7 @@ export const RequestPane: FC<Props> = ({ environmentId, settings, onPaste }) => 
                         handleImportQueryFromUrl();
                         window.main.trackAnalyticsEvent({ event: AnalyticsEvent.requestParamsImportFromURLClicked });
                       }}
-                      className="flex h-full w-[14ch] shrink-0 items-center justify-start gap-2 rounded-xs px-2 py-1 text-sm text-(--color-font) ring-1 ring-transparent transition-colors hover:bg-(--hl-xs) focus:bg-(--hl-sm) focus:ring-(--hl-md) focus:ring-inset aria-selected:bg-(--hl-xs) aria-selected:hover:bg-(--hl-sm) aria-selected:focus:bg-(--hl-sm) data-pressed:bg-(--hl-sm)"
+                      className="flex h-full min-w-[14ch] shrink-0 items-center justify-start gap-2 rounded-xs px-2 py-1 text-sm text-(--color-font) ring-1 ring-transparent transition-colors hover:bg-(--hl-xs) focus:bg-(--hl-sm) focus:ring-(--hl-md) focus:ring-inset aria-selected:bg-(--hl-xs) aria-selected:hover:bg-(--hl-sm) aria-selected:focus:bg-(--hl-sm) data-pressed:bg-(--hl-sm)"
                     >
                       Import from URL
                     </Button>
@@ -220,7 +220,7 @@ export const RequestPane: FC<Props> = ({ environmentId, settings, onPaste }) => 
                         window.main.trackAnalyticsEvent({ event: AnalyticsEvent.requestParamsBulkEditToggled });
                       }}
                       isSelected={settings.useBulkParametersEditor}
-                      className="flex h-full w-[14ch] shrink-0 items-center justify-start gap-2 rounded-xs px-2 py-1 text-sm text-(--color-font) ring-1 ring-transparent transition-colors hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset"
+                      className="flex h-full min-w-[14ch] shrink-0 items-center justify-start gap-2 rounded-xs px-2 py-1 text-sm text-(--color-font) ring-1 ring-transparent transition-colors hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset"
                     >
                       {({ isSelected }) => (
                         <Fragment>

--- a/packages/insomnia/src/ui/components/project/project-create-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-create-form.tsx
@@ -176,7 +176,7 @@ export const ProjectCreateForm: FC<Props> = ({
                 type="submit"
                 form={FORMID}
                 isDisabled={!isGitSyncEnabled || isGitCredentialInvalid}
-                className="flex h-full items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 font-sans text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
+                className="flex h-full items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
               >
                 <span>Scan for files</span>
               </Button>

--- a/packages/insomnia/src/ui/components/project/project-create-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-create-form.tsx
@@ -176,9 +176,9 @@ export const ProjectCreateForm: FC<Props> = ({
                 type="submit"
                 form={FORMID}
                 isDisabled={!isGitSyncEnabled || isGitCredentialInvalid}
-                className="flex h-full items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
+                className="flex h-full items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 font-sans text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
               >
-                Scan for files
+                <span>Scan for files</span>
               </Button>
             )}
           </div>

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -530,9 +530,9 @@ export const ProjectSettingsForm: FC<Props> = ({
                 }
                 form={FORMID}
                 type="submit"
-                className="flex h-full w-[14ch] items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
+                className="flex h-full w-[14ch] items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 font-sans text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
               >
-                Scan for files
+                <span>Scan for files</span>
               </Button>
             ) : (
               <Button

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -530,7 +530,7 @@ export const ProjectSettingsForm: FC<Props> = ({
                 }
                 form={FORMID}
                 type="submit"
-                className="flex h-full w-[14ch] items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 font-sans text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
+                className="flex h-full w-[14ch] items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
               >
                 <span>Scan for files</span>
               </Button>

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -530,7 +530,7 @@ export const ProjectSettingsForm: FC<Props> = ({
                 }
                 form={FORMID}
                 type="submit"
-                className="flex h-full w-[14ch] items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
+                className="flex h-full items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
               >
                 <span>Scan for files</span>
               </Button>

--- a/packages/insomnia/src/ui/components/settings/cloud-service-credentials.tsx
+++ b/packages/insomnia/src/ui/components/settings/cloud-service-credentials.tsx
@@ -244,7 +244,7 @@ export const CloudServiceCredentialList = () => {
             max={720}
           />
           <button
-            className="pointer mb-(--padding-sm) ml-(--padding-sm) flex h-(--line-height-xs) w-32 items-center gap-2 rounded-md border border-solid border-(--hl-lg) px-(--padding-md) hover:bg-(--hl-xs)"
+            className="pointer mb-(--padding-sm) ml-(--padding-sm) flex h-(--line-height-xs) shrink-0 min-w-32 items-center justify-center rounded-md border border-solid border-(--hl-lg) px-(--padding-md) text-center whitespace-nowrap hover:bg-(--hl-xs)"
             onClick={async () =>
               await pluginsBridge.executePluginMainAction({
                 pluginName: EXTERNAL_VAULT_PLUGIN_NAME,

--- a/packages/insomnia/src/ui/components/settings/plugins.tsx
+++ b/packages/insomnia/src/ui/components/settings/plugins.tsx
@@ -179,7 +179,7 @@ export const Plugins: FC = () => {
                   />
                 </TextField>
                 <Button
-                  className="flex h-full w-[13ch] items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--color-surprise)/80"
+                  className="flex h-full shrink-0 min-w-[13ch] items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-center text-sm font-semibold whitespace-nowrap text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--color-surprise)/80"
                   isDisabled={isInstallingFromNpm}
                   type="submit"
                   onPress={async () => {

--- a/packages/insomnia/src/ui/components/socket-io/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/socket-io/request-pane.tsx
@@ -210,7 +210,7 @@ export const SocketIORequestPane: FC<Props> = ({ environment }) => {
                     <Button
                       isDisabled={disabled || !urlHasQueryParameters}
                       onPress={handleImportQueryFromUrl}
-                      className="flex h-full w-[14ch] shrink-0 items-center justify-start gap-2 rounded-xs px-2 py-1 text-sm text-(--color-font) ring-1 ring-transparent transition-colors hover:bg-(--hl-xs) focus:bg-(--hl-sm) focus:ring-(--hl-md) focus:ring-inset aria-selected:bg-(--hl-xs) aria-selected:hover:bg-(--hl-sm) aria-selected:focus:bg-(--hl-sm) data-pressed:bg-(--hl-sm)"
+                      className="flex h-full min-w-[14ch] shrink-0 items-center justify-start gap-2 rounded-xs px-2 py-1 text-sm text-(--color-font) ring-1 ring-transparent transition-colors hover:bg-(--hl-xs) focus:bg-(--hl-sm) focus:ring-(--hl-md) focus:ring-inset aria-selected:bg-(--hl-xs) aria-selected:hover:bg-(--hl-sm) aria-selected:focus:bg-(--hl-sm) data-pressed:bg-(--hl-sm)"
                     >
                       Import from URL
                     </Button>
@@ -222,7 +222,7 @@ export const SocketIORequestPane: FC<Props> = ({ environment }) => {
                         });
                       }}
                       isSelected={settings.useBulkParametersEditor}
-                      className="flex h-full w-[14ch] shrink-0 items-center justify-start gap-2 rounded-xs px-2 py-1 text-sm text-(--color-font) ring-1 ring-transparent transition-colors hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset"
+                      className="flex h-full min-w-[14ch] shrink-0 items-center justify-start gap-2 rounded-xs px-2 py-1 text-sm text-(--color-font) ring-1 ring-transparent transition-colors hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset"
                     >
                       {({ isSelected }) => (
                         <Fragment>

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -353,7 +353,7 @@ export const WebSocketRequestPane: FC<Props> = ({ environment }) => {
                     <Button
                       isDisabled={disabled || !urlHasQueryParameters}
                       onPress={handleImportQueryFromUrl}
-                      className="flex h-full w-[14ch] shrink-0 items-center justify-start gap-2 rounded-xs px-2 py-1 text-sm text-(--color-font) ring-1 ring-transparent transition-colors hover:bg-(--hl-xs) focus:bg-(--hl-sm) focus:ring-(--hl-md) focus:ring-inset aria-selected:bg-(--hl-xs) aria-selected:hover:bg-(--hl-sm) aria-selected:focus:bg-(--hl-sm) data-pressed:bg-(--hl-sm)"
+                      className="flex h-full min-w-[14ch] shrink-0 items-center justify-start gap-2 rounded-xs px-2 py-1 text-sm text-(--color-font) ring-1 ring-transparent transition-colors hover:bg-(--hl-xs) focus:bg-(--hl-sm) focus:ring-(--hl-md) focus:ring-inset aria-selected:bg-(--hl-xs) aria-selected:hover:bg-(--hl-sm) aria-selected:focus:bg-(--hl-sm) data-pressed:bg-(--hl-sm)"
                     >
                       Import from URL
                     </Button>
@@ -365,7 +365,7 @@ export const WebSocketRequestPane: FC<Props> = ({ environment }) => {
                         });
                       }}
                       isSelected={settings.useBulkParametersEditor}
-                      className="flex h-full w-[14ch] shrink-0 items-center justify-start gap-2 rounded-xs px-2 py-1 text-sm text-(--color-font) ring-1 ring-transparent transition-colors hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset"
+                      className="flex h-full min-w-[14ch] shrink-0 items-center justify-start gap-2 rounded-xs px-2 py-1 text-sm text-(--color-font) ring-1 ring-transparent transition-colors hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset"
                     >
                       {({ isSelected }) => (
                         <Fragment>


### PR DESCRIPTION
- Use min-w instead of fixed width to allow buttons to expand
- Add whitespace-nowrap to prevent text wrapping

|before|after|
|-----------|----------|
|<img width="730" height="230" alt="image" src="https://github.com/user-attachments/assets/1ee0780a-a589-473a-9c71-db80ce52e5cb" />|<img width="740" height="230" alt="image" src="https://github.com/user-attachments/assets/b83fb498-0826-4c1c-bcd7-073283e3da92" />|
|<img width="628" height="185" alt="image" src="https://github.com/user-attachments/assets/a6ce8afe-0a78-4c70-b6e0-c9dd08ef32e4" />|<img width="625" height="184" alt="image" src="https://github.com/user-attachments/assets/cb04a02f-4559-48a2-b05a-21abce77d043" />|
|<img width="651" height="600" alt="image" src="https://github.com/user-attachments/assets/f3dd7057-5420-411e-b4b4-3d373c31e82f" />|<img width="650" height="600" alt="image" src="https://github.com/user-attachments/assets/82ee9436-f412-487b-a00a-ffa67a08af90" />|
