### PR TITLE
Fix: Avoid unrelevant actions to trigger the project loader

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
@@ -1,6 +1,6 @@
 import type { IconName, IconProp } from '@fortawesome/fontawesome-svg-core';
 import type { WorkspaceScope } from 'insomnia-data';
-import { models, services } from 'insomnia-data';
+import { models } from 'insomnia-data';
 import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Button,

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
@@ -1,6 +1,6 @@
 import type { IconName, IconProp } from '@fortawesome/fontawesome-svg-core';
-import type { GitRepository, Project, WorkspaceScope } from 'insomnia-data';
-import { models } from 'insomnia-data';
+import type { WorkspaceScope } from 'insomnia-data';
+import { models, services } from 'insomnia-data';
 import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Button,
@@ -29,8 +29,9 @@ import {
 } from '~/common/constants';
 import { scopeToBgColorMap, scopeToIconMap, scopeToTextColorMap } from '~/common/get-workspace-label';
 import { fuzzyMatchAll } from '~/common/misc';
-import type { InsomniaFile } from '~/common/project';
+import { getAllLocalFiles, type InsomniaFile } from '~/common/project';
 import { sortMethodMap } from '~/common/sorting';
+import { invariant } from '~/common/utils/invariant';
 import { useRootLoaderData } from '~/root';
 import { useOrganizationLoaderData } from '~/routes/organization';
 import { useInsomniaSyncPullRemoteFileActionFetcher } from '~/routes/organization.$organizationId.insomnia-sync.pull-remote-file';
@@ -59,26 +60,27 @@ import { useLoaderDeferData } from '~/ui/hooks/use-loader-defer-data';
 import { useOrganizationPermissions } from '~/ui/hooks/use-organization-features';
 import { DEFAULT_STORAGE_RULES } from '~/ui/organization-utils';
 import { isPrimaryClickModifier } from '~/ui/utils';
+import { getAllRemoteFiles } from '~/ui/utils/remote-projects';
 
-export interface ProjectLoaderData {
-  localFiles: InsomniaFile[];
-  allFilesCount: number;
-  documentsCount: number;
-  environmentsCount: number;
-  collectionsCount: number;
-  mockServersCount: number;
-  mcpClientsCount: number;
-  projectsCount: number;
-  activeProject?: Project;
-  activeProjectGitRepository?: GitRepository;
-  projects: (Project & { gitRepository?: GitRepository })[];
-  remoteFilesPromise?: Promise<InsomniaFile[]>;
-  projectsSyncStatusPromise?: Promise<Record<string, boolean>>;
+import type { Route } from './+types/organization.$organizationId.project.$projectId._index';
+
+export async function clientLoader({ params }: Route.ClientLoaderArgs) {
+  const { organizationId, projectId } = params;
+  invariant(projectId, 'Project ID is required');
+  invariant(organizationId, 'Organization ID is required');
+
+  const remoteFilesPromise = getAllRemoteFiles({ projectId, organizationId });
+  const localFiles = await getAllLocalFiles({ projectId });
+
+  return {
+    localFiles,
+    remoteFilesPromise,
+  };
 }
 
-const Component = () => {
-  const { localFiles, activeProject, activeProjectGitRepository, projects, remoteFilesPromise } =
-    useProjectLoaderData()!;
+const Component = ({ loaderData }: Route.ComponentProps) => {
+  const { localFiles, remoteFilesPromise } = loaderData;
+  const { activeProject, activeProjectGitRepository, projects } = useProjectLoaderData()!;
   const { activeSidebarTab } = useProjectRouteContext();
   const { organizationId, projectId } = useParams() as {
     organizationId: string;

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.tsx
@@ -8,7 +8,7 @@ import * as reactUse from 'react-use';
 
 import { Icon } from '~/basic-components/icon';
 import { DEFAULT_SIDEBAR_SIZE } from '~/common/constants';
-import { checkAllProjectSyncStatus, getAllLocalFiles, getProjectsWithGitRepositories } from '~/common/project';
+import { checkAllProjectSyncStatus, getProjectsWithGitRepositories } from '~/common/project';
 import { invariant } from '~/common/utils/invariant';
 import { useStorageRulesLoaderFetcher } from '~/routes/organization.$organizationId.storage-rules';
 import { logout } from '~/ui/account/session';
@@ -25,7 +25,6 @@ import { GitFileIssuesProvider, useProjectGitFileIssues } from '~/ui/hooks/use-g
 import { useLoaderDeferData } from '~/ui/hooks/use-loader-defer-data';
 import { useOrganizationPermissions } from '~/ui/hooks/use-organization-features';
 import { DEFAULT_STORAGE_RULES } from '~/ui/organization-utils';
-import { getAllRemoteFiles } from '~/ui/utils/remote-projects';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId';
 
@@ -119,13 +118,10 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
     url: '',
   };
 
-  const [localFiles, organizationProjects = []] = await Promise.all([
-    getAllLocalFiles({ projectId }),
-    getProjectsWithGitRepositories({ organizationId }),
-  ]);
+  const organizationProjects = await getProjectsWithGitRepositories({ organizationId });
+
   const projects = models.project.sortProjects(organizationProjects);
 
-  const remoteFilesPromise = getAllRemoteFiles({ projectId, organizationId });
   const learningFeaturePromise = getInsomniaLearningFeature(fallbackLearningFeature);
 
   const projectsSyncStatusPromise = checkAllProjectSyncStatus(projects);
@@ -136,18 +132,9 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
       : undefined;
 
   return {
-    localFiles,
-    remoteFilesPromise,
     projects,
-    projectsCount: organizationProjects.length,
     activeProject: project,
     activeProjectGitRepository,
-    allFilesCount: localFiles.length,
-    environmentsCount: localFiles.filter(file => file.scope === 'environment').length,
-    documentsCount: localFiles.filter(file => file.scope === 'design').length,
-    collectionsCount: localFiles.filter(file => file.scope === 'collection').length,
-    mockServersCount: localFiles.filter(file => file.scope === 'mock-server').length,
-    mcpClientsCount: localFiles.filter(file => file.scope === 'mcp').length,
     projectsSyncStatusPromise,
     learningFeaturePromise,
   };


### PR DESCRIPTION
# Changes:
- Move the logic to load data with heavy computation to the project index page `xxx.project.$projectId._index.tsx`. Only this page will consume the data.

[INS-2811](https://konghq.atlassian.net/browse/INS-2811)

[INS-2811]: https://konghq.atlassian.net/browse/INS-2811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ