### PR TITLE
fix: preserve OpenAPI spec when importing a design document [INS-2628]

### DIFF
--- a/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/baggage.yaml
+++ b/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/baggage.yaml
@@ -1,0 +1,1602 @@
+type: spec.insomnia.rest/5.0
+schema_version: "5.1"
+name: Baggage
+meta:
+  id: wrk_e96df57152234c179314a5ef258ca590
+  created: 1778268014674
+  modified: 1778268014674
+  description: ""
+collection:
+  - name: bags
+    meta:
+      id: fld_4d05cf4384934426870c9ac6ef04cefa
+      created: 1778268657028
+      modified: 1779737487511
+      sortKey: -1778268657028
+      description: >-
+        # Weird Auth Examples
+
+
+        This folder demonstrates **three ways to attach a bearer token** in
+        Insomnia. All three pull from the same source.
+
+
+        ## Auth token endpoint
+
+
+        `GET /auth/token` lives in the **auth** sub-folder at the bottom of this
+        folder. No credentials required — it returns a token valid for 24 hours:
+
+
+        ```json
+
+        { "token": "...", "issuedAt": "...", "expiresIn": 86400 }
+
+        ```
+
+
+        Send it once to prime the response cache, then all three examples below
+        use it automatically via request chaining.
+
+
+        ---
+
+
+        ## 1. Auth tab — `GET /bags`
+
+
+        The token is configured in the **Auth tab** (type: Bearer). The value is
+        a **Response template tag** — a built-in Insomnia feature that chains
+        the result of one request into a field of another:
+
+
+        ```
+
+        {% response 'body', '<req-id>', 'b64::JC50b2tlbg==::46b', 'always', 60
+        %}
+
+        ```
+
+
+        `b64::JC50b2tlbg==::46b` is a base64-encoded JSONPath that decodes to
+        `$.token`. `'always'` tells Insomnia to re-send the chained request if
+        the cached result is older than `60` seconds. Insomnia injects
+        `Authorization: Bearer <token>` automatically — no script involved.
+
+
+        **When to use:** Simplest option. Auth is visible in the UI, not buried
+        in a script. Best for shared collections where transparency matters.
+
+
+        ---
+
+
+        ## 2. Pre-request script — `GET /bookings/:pnr/bags`
+
+
+        A pre-request script fetches the token at send time and injects it as a
+        header programmatically:
+
+
+        ```js
+
+        const response = await insomnia.sendRequest({
+          url: insomnia.globals.get('base_url') + '/auth/token',
+          method: 'GET'
+        });
+
+        const body = response.json();
+
+        insomnia.request.addHeader({ key: 'Authorization', value: 'Bearer ' +
+        body.token });
+
+        ```
+
+
+        There is no static `Authorization` header on the request — the script
+        adds it at runtime via `insomnia.request.addHeader()`. You could extend
+        this to cache the token in globals to avoid a round-trip on every send.
+
+
+        **When to use:** When you need runtime logic — conditional fetch, token
+        caching, environment-aware auth schemes, or multiple custom headers.
+
+
+        ---
+
+
+        ## 3. Response template tag in header + pre-request path param seeding —
+        `GET /flights/.../bags`
+
+
+        This request stacks two techniques.
+
+
+        ### Auth: Response template tag directly in the Headers tab
+
+
+        Same `{% response %}` chain as example 1, but placed as a raw **header
+        value** rather than in the Auth tab:
+
+
+        ```
+
+        Authorization: Bearer {% response 'body', '<req-id>',
+        'b64::JC50b2tlbg==::46b', 'always', 60 %}
+
+        ```
+
+
+        **When to use:** When you need explicit control over the header
+        name/format — non-standard schemes, or when you want the Authorization
+        header visible alongside other headers rather than in a separate tab.
+
+
+        ### Path param seeding via pre-request script
+
+
+        `flightNumber` and `departureDate` are both required by this endpoint
+        but aren't always known upfront. Rather than forcing a manual lookup,
+        the pre-request script seeds them automatically from `GET /bookings` the
+        first time you send:
+
+
+        ```js
+
+        if (!insomnia.globals.get('flight_number')) {
+          const response = await insomnia.sendRequest({
+            url: insomnia.globals.get('base_url') + '/bookings',
+            method: 'GET'
+          });
+          const bookings = response.json();
+          const booking = bookings.find(b => b.segments && b.segments.length > 0);
+          if (booking) {
+            const segment = booking.segments[0];
+            insomnia.globals.set('flight_number', segment.flightNumber);
+            insomnia.globals.set('departure_date', segment.departureDate);
+          }
+        }
+
+        ```
+
+
+        - On first send, the script calls `GET /bookings`, grabs the first
+        segment of the first booking, and writes both values to globals.
+
+        - The URL template `{{ _.flight_number }}` and `departureDate` query
+        param `{{ _.departure_date }}` then resolve automatically.
+
+        - On subsequent sends the check short-circuits — no extra round-trip.
+
+
+        To force a re-seed with a different flight, clear `flight_number` from
+        globals.
+    children:
+      - url: "{{ _.base_url }}/bags/:bagTag"
+        name: Get bag by tag.
+        meta:
+          id: req_6c5d541159744ffdb794ecb1199d4181
+          created: 1778268657029
+          modified: 1778268657029
+          isPrivate: false
+          description: Returns the current state of a bag.
+          sortKey: -1778268657029
+        method: GET
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+            insomnia.test('Response body has bagTag field', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.have.property('bagTag');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/bags"
+        name: Check in a bag.
+        meta:
+          id: req_8611e0007d2541e7a19131afa04c86f4
+          created: 1778268657029
+          modified: 1778268657029
+          isPrivate: false
+          description: |-
+            Registers a new bag against an existing booking. The bag tag is
+            generated server-side and an initial `CHECK_IN` tracking event is
+            recorded automatically.
+          sortKey: -1778268657029
+        method: POST
+        body:
+          mimeType: application/json
+          text: |-
+            {
+              "pnr": "AB12CD",
+              "passengerId": "string",
+              "weightKg": 18.4,
+              "assignedFlightNumber": "IA204",
+              "assignedDepartureDate": "2026-05-12"
+            }
+        headers:
+          - name: Content-Type
+            value: application/json
+            disabled: false
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 201', () => {
+              insomnia.expect(insomnia.response.status).to.eql(201);
+            });
+            insomnia.test('Response body has bagTag field', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.have.property('bagTag');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/bags"
+        name: List bags (auth tab)
+        meta:
+          id: req_ffc01c058f6846c1933d675e45b28f7b
+          created: 1778268657029
+          modified: 1779737564542
+          isPrivate: false
+          description: Returns bags, optionally filtered by status, booking, flight, or
+            passenger.
+          sortKey: -1778268657029
+        method: GET
+        parameters:
+          - name: pnr
+            value: string
+            disabled: true
+          - name: flightNumber
+            value: string
+            disabled: true
+          - name: status
+            value: string
+            disabled: true
+          - name: limit
+            value: "50"
+            disabled: true
+        authentication:
+          type: bearer
+          token: "{% response 'body', 'req_5ba25ad947d6419fb339cbdea342f5ad',
+            'b64::JC50b2tlbg==::46b', 'always', 60 %}"
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+            insomnia.test('Response body is an array', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.be.a('array');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/flights/{{ _.flight_number }}/bags"
+        name: List bags on a flight (template tag)
+        meta:
+          id: req_1f87e9944aba48e992399baa002e346e
+          created: 1778268657030
+          modified: 1779737551878
+          isPrivate: false
+          description: |-
+            Returns bags currently assigned to a given flight instance. Used by
+            ground crew to reconcile what should be loaded.
+          sortKey: -1778268657030
+        method: GET
+        parameters:
+          - name: departureDate
+            value: "{{ _.departure_date }}"
+            description: ""
+            disabled: false
+        headers:
+          - name: Authorization
+            value: Bearer {% response 'body', 'req_5ba25ad947d6419fb339cbdea342f5ad',
+              'b64::JC50b2tlbg==::46b', 'always', 60 %}
+            description: ""
+            disabled: false
+        scripts:
+          preRequest: >-
+            if (!insomnia.globals.get('flight_number')) {
+              const response = await insomnia.sendRequest({
+                url: insomnia.globals.get('base_url') + '/bookings',
+                method: 'GET'
+              });
+              const bookings = response.json();
+              const booking = bookings.find(b => b.segments && b.segments.length > 0);
+              if (booking) {
+                const segment = booking.segments[0];
+                insomnia.globals.set('flight_number', segment.flightNumber);
+                insomnia.globals.set('departure_date', segment.departureDate);
+              }
+            }
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+            insomnia.test('Response body is an array', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.be.a('array');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/bags/:bagTag"
+        name: Remove a bag.
+        meta:
+          id: req_4c5431d0929c4c4bb3dea60767ecaf97
+          created: 1778268657030
+          modified: 1778268657030
+          isPrivate: false
+          description: |-
+            Removes a bag record. Intended only for correcting check-in mistakes
+            before the bag has moved through the system; rejected once any
+            non-`CHECK_IN` tracking events exist.
+          sortKey: -1778268657030
+        method: DELETE
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/bookings/:pnr/bags"
+        name: List bags on a booking (script auth)
+        meta:
+          id: req_ae5d71a2dc814140b9c982dc4f75a9ba
+          created: 1778268657030
+          modified: 1779737530044
+          isPrivate: false
+          description: Returns all bags currently associated with a booking.
+          sortKey: -1778268657030
+        method: GET
+        scripts:
+          preRequest: >+
+            const response = await insomnia.sendRequest({
+              url: insomnia.globals.get('base_url') + '/auth/token',
+              method: 'GET'
+            });
+
+            const body = response.json();
+
+            insomnia.request.addHeader({key: 'Authorization', value: 'Bearer ' +
+            body.token });
+
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+            insomnia.test('Response body is an array', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.be.a('array');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/bags/:bagTag"
+        name: Update bag fields.
+        meta:
+          id: req_afb22c788fe54068b8dd0d7a38693646
+          created: 1778268657030
+          modified: 1778268657030
+          isPrivate: false
+          description: |-
+            Partially updates a bag — typically used by ground staff to correct
+            weight or to change the assigned flight after a misroute.
+          sortKey: -1778268657030
+        method: PATCH
+        body:
+          mimeType: application/json
+          text: |-
+            {
+              "weightKg": 0,
+              "assignedFlightNumber": "string",
+              "assignedDepartureDate": "string",
+              "status": "string"
+            }
+        headers:
+          - name: Content-Type
+            value: application/json
+            disabled: false
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - name: auth
+        meta:
+          id: fld_ee2823800d2745bd8d33dcf7cd156628
+          created: 1779736685573
+          modified: 1779736748415
+          sortKey: -1779736685573
+          description: ""
+        children:
+          - url: "{{ _.base_url }}/auth/token"
+            name: Get Auth Token
+            meta:
+              id: req_5ba25ad947d6419fb339cbdea342f5ad
+              created: 1779736700597
+              modified: 1779736775168
+              isPrivate: false
+              description: ""
+              sortKey: -1779736700597
+            method: GET
+            headers:
+              - name: User-Agent
+                value: insomnia/12.5.1-alpha.0
+                description: ""
+                disabled: false
+            settings:
+              renderRequestBody: true
+              encodeUrl: true
+              followRedirects: global
+              cookies:
+                send: true
+                store: true
+              rebuildPath: true
+  - name: tracking
+    meta:
+      id: fld_0471ae96e0b74b128793f9cd5e71b517
+      created: 1778268657029
+      modified: 1779736469977
+      sortKey: -1778268657029
+      description: Bag tracking events (scans through check-in, load, transfer, claim).
+    children:
+      - url: "{{ _.base_url }}/bags/:bagTag/events"
+        name: List a bag's tracking events.
+        meta:
+          id: req_2bc5f6eb97cb48c7adf5438383085ae5
+          created: 1778268657030
+          modified: 1779737457029
+          isPrivate: false
+          description: Returns the chronological history of scans recorded against a bag.
+          sortKey: -1778268657030
+        method: GET
+        headers:
+          - name: Authorization
+            value: Bearer {{ _.auth_token }}
+            disabled: false
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+            insomnia.test('Response body is an array', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.be.a('array');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/bags/:bagTag/events"
+        name: Record a tracking event.
+        meta:
+          id: req_525b0ea6d4a8477a985a12cf2ce11e8b
+          created: 1778268657030
+          modified: 1779737457029
+          isPrivate: false
+          description: |-
+            Records a new tracking event for a bag. The bag's current status and
+            location are updated as a side-effect based on the event type.
+          sortKey: -1778268657030
+        method: POST
+        body:
+          mimeType: application/json
+          text: |-
+            {
+              "type": "string",
+              "location": "SFO",
+              "flightNumber": "IA204",
+              "occurredAt": "2026-05-12T18:42:30Z",
+              "notes": "Transferred to inbound flight IA918."
+            }
+        headers:
+          - name: Authorization
+            value: Bearer {{ _.auth_token }}
+            disabled: false
+          - name: Content-Type
+            value: application/json
+            disabled: false
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 201', () => {
+              insomnia.expect(insomnia.response.status).to.eql(201);
+            });
+            insomnia.test('Response body has type field', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.have.property('type');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+    scripts:
+      preRequest: |-
+        const response = await insomnia.sendRequest({
+          url: insomnia.globals.get('base_url') + '/auth/token',
+          method: 'GET'
+        });
+        const body = response.json();
+        insomnia.globals.set('auth_token', body.token);
+  - name: lost-baggage
+    meta:
+      id: fld_ae21d5ea6aee4c20ae02d1e1aa23b27f
+      created: 1778268657029
+      modified: 1779736473478
+      sortKey: -1778268657029
+      description: Lost or mishandled baggage cases.
+    children:
+      - url: "{{ _.base_url }}/lost-baggage-cases/:caseId"
+        name: Update a lost-baggage case.
+        meta:
+          id: req_0ccb9e72633047b289f67aef5e5807f1
+          created: 1778268657031
+          modified: 1779737457029
+          isPrivate: false
+          description: |-
+            Partially updates a case — typically used to attach the bag tag once
+            located, advance the status, or append staff notes.
+          sortKey: -1778268657031
+        method: PATCH
+        body:
+          mimeType: application/json
+          text: |-
+            {
+              "bagTag": "string",
+              "status": "string",
+              "notes": "string"
+            }
+        headers:
+          - name: Authorization
+            value: Bearer {{ _.auth_token }}
+            disabled: false
+          - name: Content-Type
+            value: application/json
+            disabled: false
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/lost-baggage-cases/:caseId"
+        name: Get a lost-baggage case.
+        meta:
+          id: req_20147dda0c8142cbb7a1b4d83e6fc5b3
+          created: 1778268657031
+          modified: 1779737457029
+          isPrivate: false
+          description: Returns the current state of a lost-baggage case.
+          sortKey: -1778268657031
+        method: GET
+        headers:
+          - name: Authorization
+            value: Bearer {{ _.auth_token }}
+            disabled: false
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+            insomnia.test('Response body has caseId field', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.have.property('caseId');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/lost-baggage-cases"
+        name: Open a lost-baggage case.
+        meta:
+          id: req_a61ce6b6d9e544e68238c56df31fcf5f
+          created: 1778268657031
+          modified: 1779737457029
+          isPrivate: false
+          description: >-
+            Opens a new lost-baggage case for a passenger. The bag tag is
+            optional
+
+            — passengers can report a missing bag they didn't keep the receipt
+
+            for, in which case staff fill in the tag later.
+          sortKey: -1778268657031
+        method: POST
+        body:
+          mimeType: application/json
+          text: |-
+            {
+              "pnr": "AB12CD",
+              "bagTag": "0074123456",
+              "reportedAtAirport": "SFO",
+              "description": "Black hardshell roller, red ribbon on handle."
+            }
+        headers:
+          - name: Authorization
+            value: Bearer {{ _.auth_token }}
+            disabled: false
+          - name: Content-Type
+            value: application/json
+            disabled: false
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 201', () => {
+              insomnia.expect(insomnia.response.status).to.eql(201);
+            });
+            insomnia.test('Response body has caseId field', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.have.property('caseId');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/lost-baggage-cases/:caseId"
+        name: Close a lost-baggage case.
+        meta:
+          id: req_ad968c219795417690d59ca2f19d6a56
+          created: 1778268657031
+          modified: 1779737457029
+          isPrivate: false
+          description: Closes a case. Soft-deletes by setting status to `CLOSED`.
+          sortKey: -1778268657031
+        method: DELETE
+        headers:
+          - name: Authorization
+            value: Bearer {{ _.auth_token }}
+            disabled: false
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/lost-baggage-cases"
+        name: List lost-baggage cases.
+        meta:
+          id: req_af25932e51f84cfc9b0ac7ceb041bc44
+          created: 1778268657031
+          modified: 1779736428650
+          isPrivate: false
+          description: Returns lost-baggage cases, optionally filtered by status or booking.
+          sortKey: -1778268657031
+        method: GET
+        parameters:
+          - name: status
+            value: string
+            disabled: true
+          - name: pnr
+            value: string
+            disabled: true
+        headers:
+          - name: Authorization
+            value: Bearer {{ _.auth_token }}
+            disabled: false
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+            insomnia.test('Response body is an array', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.be.a('array');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+    scripts:
+      preRequest: |-
+        
+        const response = await insomnia.sendRequest({
+          url: insomnia.globals.get('base_url') + '/auth/token',
+          method: 'GET'
+        });
+
+        const body = response.json();
+        insomnia.globals.set('auth_token', body.token);
+cookieJar:
+  name: Default Jar
+  meta:
+    id: jar_f22f18ed9d7f5d2eecf16b38e781a39a07faeb00
+    created: 1778268014676
+    modified: 1779737852960
+environments:
+  name: Base Environment
+  meta:
+    id: env_f22f18ed9d7f5d2eecf16b38e781a39a07faeb00
+    created: 1778268014676
+    modified: 1779737852961
+    isPrivate: false
+spec:
+  contents:
+    openapi: 3.0.4
+    info:
+      title: Insomnia Airlines — Baggage API
+      description: >-
+        REST API for **Insomnia Airlines** checked baggage.
+
+
+        Each bag is identified by a 10-digit IATA bag tag and is associated with
+        a
+
+        booking (PNR) from the Bookings API and, indirectly, with the flights it
+
+        moves on (from the Flights API). Bags accumulate tracking events as they
+
+        are scanned through check-in, loading, transfers, and claim.
+
+
+        Lost or mishandled bags are tracked as separate cases under
+
+        `/lost-baggage-cases`.
+      version: 1.0.0
+      contact:
+        name: Insomnia Airlines API Team
+        email: api@insomnia-airlines.example
+      license:
+        name: Apache 2.0
+        url: https://www.apache.org/licenses/LICENSE-2.0.html
+    servers:
+      - url: https://2110842ae3.us.serverless.gateways.konggateway.com
+        description: Kong Gateway
+      - url: https://insomnia-airlines-api.onrender.com
+        description: Production
+      - url: http://localhost:8000
+        description: Local dev
+    tags:
+      - name: bags
+        description: Individual checked bags and their current status.
+      - name: tracking
+        description: Bag tracking events (scans through check-in, load, transfer, claim).
+      - name: lost-baggage
+        description: Lost or mishandled baggage cases.
+    paths:
+      /bags:
+        get:
+          tags:
+            - bags
+          summary: List bags.
+          description: Returns bags, optionally filtered by status, booking, flight, or
+            passenger.
+          operationId: listBags
+          parameters:
+            - name: pnr
+              in: query
+              description: Filter to bags on this booking.
+              required: false
+              schema:
+                type: string
+                minLength: 6
+                maxLength: 6
+                pattern: ^[A-Z0-9]{6}$
+            - name: flightNumber
+              in: query
+              description: Filter to bags currently associated with this flight.
+              required: false
+              schema:
+                type: string
+                pattern: ^IA[0-9]{1,4}$
+            - name: status
+              in: query
+              description: Filter by current bag status.
+              required: false
+              schema:
+                $ref: "#/components/schemas/BagStatus"
+            - name: limit
+              in: query
+              description: Maximum number of bags to return.
+              required: false
+              schema:
+                type: integer
+                format: int32
+                minimum: 1
+                maximum: 200
+                default: 50
+          responses:
+            "200":
+              description: Successful operation.
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Bag"
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        post:
+          tags:
+            - bags
+          summary: Check in a bag.
+          description: |-
+            Registers a new bag against an existing booking. The bag tag is
+            generated server-side and an initial `CHECK_IN` tracking event is
+            recorded automatically.
+          operationId: checkInBag
+          requestBody:
+            description: Bag to check in.
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/BagInput"
+          responses:
+            "201":
+              description: Bag checked in.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Bag"
+            "400":
+              description: Invalid bag payload (e.g. unknown PNR or passenger, weight out of
+                range).
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+      /bags/{bagTag}:
+        parameters:
+          - name: bagTag
+            in: path
+            description: 10-digit IATA bag tag.
+            required: true
+            schema:
+              type: string
+              minLength: 10
+              maxLength: 10
+              pattern: ^[0-9]{10}$
+        get:
+          tags:
+            - bags
+          summary: Get bag by tag.
+          description: Returns the current state of a bag.
+          operationId: getBag
+          responses:
+            "200":
+              description: Successful operation.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Bag"
+            "404":
+              description: Bag not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        patch:
+          tags:
+            - bags
+          summary: Update bag fields.
+          description: |-
+            Partially updates a bag — typically used by ground staff to correct
+            weight or to change the assigned flight after a misroute.
+          operationId: patchBag
+          requestBody:
+            description: Fields to update.
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/BagPatch"
+          responses:
+            "200":
+              description: Bag updated.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Bag"
+            "400":
+              description: Invalid patch payload.
+            "404":
+              description: Bag not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        delete:
+          tags:
+            - bags
+          summary: Remove a bag.
+          description: |-
+            Removes a bag record. Intended only for correcting check-in mistakes
+            before the bag has moved through the system; rejected once any
+            non-`CHECK_IN` tracking events exist.
+          operationId: deleteBag
+          responses:
+            "204":
+              description: Bag removed.
+            "404":
+              description: Bag not found.
+            "409":
+              description: Bag already has tracking history and cannot be hard-deleted.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+      /bags/{bagTag}/events:
+        parameters:
+          - name: bagTag
+            in: path
+            required: true
+            schema:
+              type: string
+              minLength: 10
+              maxLength: 10
+              pattern: ^[0-9]{10}$
+        get:
+          tags:
+            - tracking
+          summary: List a bag's tracking events.
+          description: Returns the chronological history of scans recorded against a bag.
+          operationId: listBagEvents
+          responses:
+            "200":
+              description: Successful operation.
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/BagEvent"
+            "404":
+              description: Bag not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        post:
+          tags:
+            - tracking
+          summary: Record a tracking event.
+          description: |-
+            Records a new tracking event for a bag. The bag's current status and
+            location are updated as a side-effect based on the event type.
+          operationId: recordBagEvent
+          requestBody:
+            description: Event to record.
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/BagEventInput"
+          responses:
+            "201":
+              description: Event recorded.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/BagEvent"
+            "400":
+              description: Invalid event payload (e.g. unknown event type, bad airport code).
+            "404":
+              description: Bag not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+      /bookings/{pnr}/bags:
+        parameters:
+          - name: pnr
+            in: path
+            description: Booking PNR.
+            required: true
+            schema:
+              type: string
+              minLength: 6
+              maxLength: 6
+              pattern: ^[A-Z0-9]{6}$
+        get:
+          tags:
+            - bags
+          summary: List bags on a booking.
+          description: Returns all bags currently associated with a booking.
+          operationId: listBookingBags
+          responses:
+            "200":
+              description: Successful operation.
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Bag"
+            "404":
+              description: Booking not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+      /flights/{flightNumber}/bags:
+        parameters:
+          - name: flightNumber
+            in: path
+            description: Insomnia Airlines flight number.
+            required: true
+            schema:
+              type: string
+              pattern: ^IA[0-9]{1,4}$
+          - name: departureDate
+            in: query
+            description: Local departure date at the origin (ISO 8601 `YYYY-MM-DD`).
+              Required to disambiguate recurring flight numbers.
+            required: true
+            schema:
+              type: string
+              format: date
+        get:
+          tags:
+            - bags
+          summary: List bags on a flight.
+          description: |-
+            Returns bags currently assigned to a given flight instance. Used by
+            ground crew to reconcile what should be loaded.
+          operationId: listFlightBags
+          responses:
+            "200":
+              description: Successful operation.
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Bag"
+            "404":
+              description: Flight not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+      /lost-baggage-cases:
+        get:
+          tags:
+            - lost-baggage
+          summary: List lost-baggage cases.
+          description: Returns lost-baggage cases, optionally filtered by status or booking.
+          operationId: listLostBaggageCases
+          parameters:
+            - name: status
+              in: query
+              description: Filter by case status.
+              required: false
+              schema:
+                $ref: "#/components/schemas/LostBaggageCaseStatus"
+            - name: pnr
+              in: query
+              description: Filter to cases on this booking.
+              required: false
+              schema:
+                type: string
+                minLength: 6
+                maxLength: 6
+                pattern: ^[A-Z0-9]{6}$
+          responses:
+            "200":
+              description: Successful operation.
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/LostBaggageCase"
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        post:
+          tags:
+            - lost-baggage
+          summary: Open a lost-baggage case.
+          description: >-
+            Opens a new lost-baggage case for a passenger. The bag tag is
+            optional
+
+            — passengers can report a missing bag they didn't keep the receipt
+
+            for, in which case staff fill in the tag later.
+          operationId: createLostBaggageCase
+          requestBody:
+            description: Case to open.
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/LostBaggageCaseInput"
+          responses:
+            "201":
+              description: Case opened.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/LostBaggageCase"
+            "400":
+              description: Invalid case payload.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+      /lost-baggage-cases/{caseId}:
+        parameters:
+          - name: caseId
+            in: path
+            description: Lost-baggage case identifier.
+            required: true
+            schema:
+              type: string
+              format: uuid
+        get:
+          tags:
+            - lost-baggage
+          summary: Get a lost-baggage case.
+          description: Returns the current state of a lost-baggage case.
+          operationId: getLostBaggageCase
+          responses:
+            "200":
+              description: Successful operation.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/LostBaggageCase"
+            "404":
+              description: Case not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        patch:
+          tags:
+            - lost-baggage
+          summary: Update a lost-baggage case.
+          description: |-
+            Partially updates a case — typically used to attach the bag tag once
+            located, advance the status, or append staff notes.
+          operationId: patchLostBaggageCase
+          requestBody:
+            description: Fields to update.
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/LostBaggageCasePatch"
+          responses:
+            "200":
+              description: Case updated.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/LostBaggageCase"
+            "400":
+              description: Invalid patch payload.
+            "404":
+              description: Case not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        delete:
+          tags:
+            - lost-baggage
+          summary: Close a lost-baggage case.
+          description: Closes a case. Soft-deletes by setting status to `CLOSED`.
+          operationId: closeLostBaggageCase
+          responses:
+            "204":
+              description: Case closed.
+            "404":
+              description: Case not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+    components:
+      schemas:
+        BagStatus:
+          type: string
+          description: Current handling state of a bag.
+          enum:
+            - CHECKED_IN
+            - IN_TRANSIT
+            - LOADED
+            - ARRIVED
+            - CLAIMED
+            - DELAYED
+            - LOST
+            - DAMAGED
+        BagEventType:
+          type: string
+          description: Type of bag tracking event.
+          enum:
+            - CHECK_IN
+            - SECURITY_CLEAR
+            - LOAD
+            - UNLOAD
+            - TRANSFER
+            - CLAIM
+            - FLAG_DELAYED
+            - FLAG_LOST
+            - FLAG_DAMAGED
+        Bag:
+          type: object
+          required:
+            - bagTag
+            - pnr
+            - passengerId
+            - weightKg
+            - status
+            - checkedInAt
+          properties:
+            bagTag:
+              type: string
+              description: 10-digit IATA bag tag.
+              minLength: 10
+              maxLength: 10
+              pattern: ^[0-9]{10}$
+              example: "0074123456"
+            pnr:
+              type: string
+              description: PNR of the booking this bag belongs to.
+              minLength: 6
+              maxLength: 6
+              pattern: ^[A-Z0-9]{6}$
+              example: AB12CD
+            passengerId:
+              type: string
+              format: uuid
+              description: Passenger on the booking who owns this bag.
+            weightKg:
+              type: number
+              format: double
+              description: Weight in kilograms.
+              minimum: 0
+              maximum: 50
+              example: 18.4
+            status:
+              $ref: "#/components/schemas/BagStatus"
+            currentLocation:
+              type: string
+              description: IATA code of the airport where the bag was last scanned.
+              minLength: 3
+              maxLength: 3
+              pattern: ^[A-Z]{3}$
+              example: YYZ
+            assignedFlightNumber:
+              type: string
+              description: Flight the bag is currently assigned to, if any.
+              pattern: ^IA[0-9]{1,4}$
+              example: IA204
+            assignedDepartureDate:
+              type: string
+              format: date
+              description: Departure date of the assigned flight.
+              example: 2026-05-12
+            checkedInAt:
+              type: string
+              format: date-time
+              example: 2026-05-12T11:42:18Z
+        BagInput:
+          type: object
+          required:
+            - pnr
+            - passengerId
+            - weightKg
+          properties:
+            pnr:
+              type: string
+              minLength: 6
+              maxLength: 6
+              pattern: ^[A-Z0-9]{6}$
+              example: AB12CD
+            passengerId:
+              type: string
+              format: uuid
+            weightKg:
+              type: number
+              format: double
+              minimum: 0
+              maximum: 50
+              example: 18.4
+            assignedFlightNumber:
+              type: string
+              pattern: ^IA[0-9]{1,4}$
+              example: IA204
+            assignedDepartureDate:
+              type: string
+              format: date
+              example: 2026-05-12
+        BagPatch:
+          type: object
+          description: Partial update payload for a bag. Any field omitted is left
+            unchanged.
+          properties:
+            weightKg:
+              type: number
+              format: double
+              minimum: 0
+              maximum: 50
+            assignedFlightNumber:
+              type: string
+              pattern: ^IA[0-9]{1,4}$
+            assignedDepartureDate:
+              type: string
+              format: date
+            status:
+              $ref: "#/components/schemas/BagStatus"
+        BagEvent:
+          type: object
+          required:
+            - id
+            - bagTag
+            - type
+            - location
+            - occurredAt
+          properties:
+            id:
+              type: string
+              format: uuid
+            bagTag:
+              type: string
+              minLength: 10
+              maxLength: 10
+              pattern: ^[0-9]{10}$
+            type:
+              $ref: "#/components/schemas/BagEventType"
+            location:
+              type: string
+              description: IATA code of the airport where the scan occurred.
+              minLength: 3
+              maxLength: 3
+              pattern: ^[A-Z]{3}$
+              example: SFO
+            flightNumber:
+              type: string
+              description: Flight associated with the event, if any (e.g. for
+                `LOAD`/`UNLOAD`).
+              pattern: ^IA[0-9]{1,4}$
+              example: IA204
+            occurredAt:
+              type: string
+              format: date-time
+              example: 2026-05-12T18:42:30Z
+            notes:
+              type: string
+              description: Free-form note captured by ground staff.
+              example: Loaded into forward cargo hold.
+        BagEventInput:
+          type: object
+          required:
+            - type
+            - location
+          properties:
+            type:
+              $ref: "#/components/schemas/BagEventType"
+            location:
+              type: string
+              minLength: 3
+              maxLength: 3
+              pattern: ^[A-Z]{3}$
+              example: SFO
+            flightNumber:
+              type: string
+              pattern: ^IA[0-9]{1,4}$
+              example: IA204
+            occurredAt:
+              type: string
+              format: date-time
+              description: Event timestamp. Defaults to the server's now if omitted.
+              example: 2026-05-12T18:42:30Z
+            notes:
+              type: string
+              example: Transferred to inbound flight IA918.
+        LostBaggageCaseStatus:
+          type: string
+          description: Lifecycle state of a lost-baggage case.
+          enum:
+            - OPEN
+            - SEARCHING
+            - LOCATED
+            - DELIVERED
+            - CLOSED
+        LostBaggageCase:
+          type: object
+          required:
+            - caseId
+            - pnr
+            - status
+            - openedAt
+          properties:
+            caseId:
+              type: string
+              format: uuid
+            pnr:
+              type: string
+              minLength: 6
+              maxLength: 6
+              pattern: ^[A-Z0-9]{6}$
+              example: AB12CD
+            bagTag:
+              type: string
+              description: Bag tag, if known. May be filled in later.
+              minLength: 10
+              maxLength: 10
+              pattern: ^[0-9]{10}$
+              example: "0074123456"
+            reportedAtAirport:
+              type: string
+              description: IATA code where the passenger reported the loss.
+              minLength: 3
+              maxLength: 3
+              pattern: ^[A-Z]{3}$
+              example: SFO
+            description:
+              type: string
+              description: Description of the bag (color, brand, distinguishing marks).
+              example: Black hardshell roller, red ribbon on handle.
+            status:
+              $ref: "#/components/schemas/LostBaggageCaseStatus"
+            openedAt:
+              type: string
+              format: date-time
+              example: 2026-05-12T20:01:00Z
+            notes:
+              type: string
+              description: Free-form notes from staff handling the case.
+        LostBaggageCaseInput:
+          type: object
+          required:
+            - pnr
+            - reportedAtAirport
+            - description
+          properties:
+            pnr:
+              type: string
+              minLength: 6
+              maxLength: 6
+              pattern: ^[A-Z0-9]{6}$
+              example: AB12CD
+            bagTag:
+              type: string
+              minLength: 10
+              maxLength: 10
+              pattern: ^[0-9]{10}$
+              example: "0074123456"
+            reportedAtAirport:
+              type: string
+              minLength: 3
+              maxLength: 3
+              pattern: ^[A-Z]{3}$
+              example: SFO
+            description:
+              type: string
+              example: Black hardshell roller, red ribbon on handle.
+        LostBaggageCasePatch:
+          type: object
+          description: Partial update payload for a lost-baggage case. Any field omitted
+            is left unchanged.
+          properties:
+            bagTag:
+              type: string
+              minLength: 10
+              maxLength: 10
+              pattern: ^[0-9]{10}$
+            status:
+              $ref: "#/components/schemas/LostBaggageCaseStatus"
+            notes:
+              type: string
+        Error:
+          type: object
+          required:
+            - code
+            - message
+          properties:
+            code:
+              type: string
+              example: BAG_NOT_FOUND
+            message:
+              type: string
+              example: No bag with tag '0074123456' exists.
+      securitySchemes:
+        bearerAuth:
+          type: http
+          scheme: bearer
+          description: Token obtained from `GET /auth/token` (Security & Testing API).
+            Tokens are valid for 24 hours.
+  meta:
+    id: spc_a843f4922ef248898e4eea7acd4c11fa
+    created: 1778268014675
+    modified: 1779737457029

--- a/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/bookings.yaml
+++ b/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/bookings.yaml
@@ -1,0 +1,1413 @@
+type: spec.insomnia.rest/5.0
+schema_version: "5.1"
+name: Bookings
+meta:
+  id: wrk_060c906db6a44bc7ade8896d6ffe2726
+  created: 1778268038797
+  modified: 1778268038797
+  description: ""
+collection:
+  - name: bookings
+    meta:
+      id: fld_757edf5f994e4050bf8ce3c752d197e0
+      created: 1778268647500
+      modified: 1779737347265
+      sortKey: -1778268647500
+      description: Passenger reservations (PNRs).
+    children:
+      - url: "{{ _.base_url }}/bookings"
+        name: Create a booking.
+        meta:
+          id: req_241da844d9f24a5db0c05401f736264f
+          created: 1778268647501
+          modified: 1778268647501
+          isPrivate: false
+          description: >-
+            Creates a new booking with one or more passengers and one or more
+            flight
+
+            segments. The PNR is generated server-side. Seat assignments are not
+
+            created here — use the seat endpoints after the booking exists.
+          sortKey: -1778268647501
+        method: POST
+        body:
+          mimeType: application/json
+          text: |-
+            {
+              "contactEmail": "alex.morgan@example.com",
+              "passengers": [
+                {
+                  "firstName": "Alex",
+                  "lastName": "Morgan",
+                  "email": "alex.morgan@example.com",
+                  "phone": "+14165550199",
+                  "frequentFlyerId": "FF1029384",
+                  "dateOfBirth": "1988-04-12"
+                }
+              ],
+              "segments": [
+                {
+                  "flightNumber": "IA204",
+                  "departureDate": "2026-05-12",
+                  "travelClass": "string"
+                }
+              ]
+            }
+        headers:
+          - name: Content-Type
+            value: application/json
+            disabled: false
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 201', () => {
+              insomnia.expect(insomnia.response.status).to.eql(201);
+            });
+            insomnia.test('Response body has pnr field', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.have.property('pnr');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/bookings/:pnr"
+        name: Get booking by PNR.
+        meta:
+          id: req_25db42141735441fb9c91019db080b61
+          created: 1778268647501
+          modified: 1778268647501
+          isPrivate: false
+          description: Returns a single booking, including its passengers and segments.
+          sortKey: -1778268647501
+        method: GET
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+            insomnia.test('Response body has pnr field', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.have.property('pnr');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/bookings"
+        name: List bookings.
+        meta:
+          id: req_2b90951d0c4b4e66bfd93318fe8a2ec8
+          created: 1778268647501
+          modified: 1778268647501
+          isPrivate: false
+          description: Returns bookings, optionally filtered by status, frequent-flyer ID,
+            or flight.
+          sortKey: -1778268647501
+        method: GET
+        parameters:
+          - name: status
+            value: string
+            disabled: true
+          - name: frequentFlyerId
+            value: string
+            disabled: true
+          - name: flightNumber
+            value: string
+            disabled: true
+          - name: limit
+            value: "50"
+            disabled: true
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+            insomnia.test('Response body is an array', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.be.a('array');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/bookings/:pnr"
+        name: Update booking fields.
+        meta:
+          id: req_4ff85657362842b3bba30555a49b4162
+          created: 1778268647501
+          modified: 1778268647501
+          isPrivate: false
+          description: >-
+            Partially updates a booking — typically used to change status (e.g.
+            to
+
+            `CONFIRMED` after payment) or to update contact details.
+          sortKey: -1778268647501
+        method: PATCH
+        body:
+          mimeType: application/json
+          text: |-
+            {
+              "status": "string",
+              "contactEmail": "user@example.com"
+            }
+        headers:
+          - name: Content-Type
+            value: application/json
+            disabled: false
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/bookings/:pnr"
+        name: Cancel a booking.
+        meta:
+          id: req_af8a480978e04a9088c43160b4e21723
+          created: 1778268647502
+          modified: 1778268647502
+          isPrivate: false
+          description: Cancels a booking. Soft-deletes by setting status to `CANCELLED`.
+          sortKey: -1778268647502
+        method: DELETE
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+  - name: seats
+    meta:
+      id: fld_d375380612ad4bf1acdd12663e375a6f
+      created: 1778268647500
+      modified: 1778268647500
+      sortKey: -1778268647500
+      description: Seat assignments on a booking's flight segments.
+    children:
+      - url: "{{ _.base_url }}/bookings/:pnr/seats/:seatAssignmentId"
+        name: Release a seat assignment.
+        meta:
+          id: req_446993164a4442bf9fe8f8804abb869d
+          created: 1778268647503
+          modified: 1778268647503
+          isPrivate: false
+          description: Removes a seat assignment, leaving the passenger unseated on that
+            segment.
+          sortKey: -1778268647503
+        method: DELETE
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/bookings/:pnr/seats"
+        name: List seat assignments.
+        meta:
+          id: req_9c8e1e72d37f4ec58d736c66d3342014
+          created: 1778268647503
+          modified: 1778268647503
+          isPrivate: false
+          description: Returns all seat assignments on this booking, across all segments.
+          sortKey: -1778268647503
+        method: GET
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+            insomnia.test('Response body is an array', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.be.a('array');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/bookings/:pnr/seats"
+        name: Assign a seat.
+        meta:
+          id: req_c06ee702804b488ba20dfbb148662282
+          created: 1778268647503
+          modified: 1778268647503
+          isPrivate: false
+          description: |-
+            Assigns a seat on one segment to one passenger on this booking. The
+            passenger must already be attached to the booking, and the segment
+            index must be valid for the booking.
+          sortKey: -1778268647503
+        method: POST
+        body:
+          mimeType: application/json
+          text: |-
+            {
+              "passengerId": "string",
+              "segmentIndex": 0,
+              "seatNumber": "14C"
+            }
+        headers:
+          - name: Content-Type
+            value: application/json
+            disabled: false
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 201', () => {
+              insomnia.expect(insomnia.response.status).to.eql(201);
+            });
+            insomnia.test('Response body has seatNumber field', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.have.property('seatNumber');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/bookings/:pnr/seats/:seatAssignmentId"
+        name: Change a seat assignment.
+        meta:
+          id: req_fb1a99c01aa84c08985ec06d789afbd8
+          created: 1778268647503
+          modified: 1778268647503
+          isPrivate: false
+          description: Updates the seat number on an existing seat assignment (e.g. moving
+            14C → 15A).
+          sortKey: -1778268647503
+        method: PATCH
+        body:
+          mimeType: application/json
+          text: |-
+            {
+              "seatNumber": "15A"
+            }
+        headers:
+          - name: Content-Type
+            value: application/json
+            disabled: false
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+  - name: passengers
+    meta:
+      id: fld_f8dea1bb61a348239fa3c82732a2244d
+      created: 1778268647500
+      modified: 1778268647500
+      sortKey: -1778268647500
+      description: Passengers attached to a booking, plus frequent-flyer profiles.
+    children:
+      - url: "{{ _.base_url }}/bookings/:pnr/passengers"
+        name: List passengers on a booking.
+        meta:
+          id: req_55fbde79d81f492ab85383c1c2252eea
+          created: 1778268647502
+          modified: 1778268647502
+          isPrivate: false
+          description: Returns the passengers currently attached to a booking.
+          sortKey: -1778268647502
+        method: GET
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+            insomnia.test('Response body is an array', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.be.a('array');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/bookings/:pnr/passengers"
+        name: Add a passenger to a booking.
+        meta:
+          id: req_6d448beb6db64bbe9e0db9c064ea0f19
+          created: 1778268647502
+          modified: 1778268647502
+          isPrivate: false
+          description: Attaches a passenger to an existing booking.
+          sortKey: -1778268647502
+        method: POST
+        body:
+          mimeType: application/json
+          text: |-
+            {
+              "firstName": "Alex",
+              "lastName": "Morgan",
+              "email": "alex.morgan@example.com",
+              "phone": "+14165550199",
+              "frequentFlyerId": "FF1029384",
+              "dateOfBirth": "1988-04-12"
+            }
+        headers:
+          - name: Content-Type
+            value: application/json
+            disabled: false
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 201', () => {
+              insomnia.expect(insomnia.response.status).to.eql(201);
+            });
+            insomnia.test('Response body has id field', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.have.property('id');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/bookings/:pnr/passengers/:passengerId"
+        name: Get a booking's passenger.
+        meta:
+          id: req_9db7040021284636a03bddf1c06307a2
+          created: 1778268647502
+          modified: 1778268647502
+          isPrivate: false
+          description: Returns details for a single passenger on a booking.
+          sortKey: -1778268647502
+        method: GET
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+            insomnia.test('Response body has id field', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.have.property('id');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/bookings/:pnr/passengers/:passengerId"
+        name: Remove a passenger from a booking.
+        meta:
+          id: req_f060f89c7e07438593d49e59eee8307d
+          created: 1778268647502
+          modified: 1778269075934
+          isPrivate: false
+          description: Removes a passenger and any seat assignments held by that passenger.
+          sortKey: -1778268647502
+        method: DELETE
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/passengers/:frequentFlyerId"
+        name: Get frequent-flyer profile.
+        meta:
+          id: req_5e530c0c5fa84c87959a521db103e4e9
+          created: 1778268647503
+          modified: 1778268647503
+          isPrivate: false
+          description: Returns the standalone frequent-flyer profile (independent of any
+            one booking).
+          sortKey: -1778268647503
+        method: GET
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+            insomnia.test('Response body has frequentFlyerId field', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.have.property('frequentFlyerId');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/passengers/:frequentFlyerId/bookings"
+        name: List a frequent flyer's bookings.
+        meta:
+          id: req_fbc2dfb534f44b2889e4e8f63d09e354
+          created: 1778268647503
+          modified: 1778268647503
+          isPrivate: false
+          description: Returns bookings on which this frequent flyer is a passenger.
+          sortKey: -1778268647503
+        method: GET
+        parameters:
+          - name: status
+            value: string
+            disabled: true
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+            insomnia.test('Response body is an array', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.be.a('array');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+cookieJar:
+  name: Default Jar
+  meta:
+    id: jar_834ec44a17c6e993775ec531d73b3df208b2cebd
+    created: 1778268038800
+    modified: 1779737347264
+environments:
+  name: Base Environment
+  meta:
+    id: env_834ec44a17c6e993775ec531d73b3df208b2cebd
+    created: 1778268038799
+    modified: 1779737347265
+    isPrivate: false
+spec:
+  contents:
+    openapi: 3.0.4
+    info:
+      title: Insomnia Airlines — Bookings API
+      description: >-
+        REST API for **Insomnia Airlines** passenger reservations.
+
+
+        A booking is identified by a 6-character alphanumeric **PNR** (Passenger
+        Name
+
+        Record). Each booking has one or more passengers and one or more flight
+
+        segments — a segment references a flight (by flight number and departure
+
+        date) from the Flights API. Seat assignments are per (passenger,
+        segment).
+
+
+        Baggage is handled separately by the Baggage API and is keyed off the
+        PNR
+
+        defined here.
+      version: 1.0.0
+      contact:
+        name: Insomnia Airlines API Team
+        email: api@insomnia-airlines.example
+      license:
+        name: Apache 2.0
+        url: https://www.apache.org/licenses/LICENSE-2.0.html
+    servers:
+      - url: https://2110842ae3.us.serverless.gateways.konggateway.com
+        description: Kong Gateway
+      - url: https://insomnia-airlines-api.onrender.com
+        description: Production
+      - url: http://localhost:8000
+        description: Local dev
+    tags:
+      - name: bookings
+        description: Passenger reservations (PNRs).
+      - name: passengers
+        description: Passengers attached to a booking, plus frequent-flyer profiles.
+      - name: seats
+        description: Seat assignments on a booking's flight segments.
+    paths:
+      /bookings:
+        get:
+          tags:
+            - bookings
+          summary: List bookings.
+          description: Returns bookings, optionally filtered by status, frequent-flyer ID,
+            or flight.
+          operationId: listBookings
+          parameters:
+            - name: status
+              in: query
+              description: Filter by booking status.
+              required: false
+              schema:
+                $ref: "#/components/schemas/BookingStatus"
+            - name: frequentFlyerId
+              in: query
+              description: Filter to bookings that include this frequent flyer as a passenger.
+              required: false
+              schema:
+                type: string
+                pattern: ^FF[0-9]{6,10}$
+            - name: flightNumber
+              in: query
+              description: Filter to bookings with a segment on this flight number.
+              required: false
+              schema:
+                type: string
+                pattern: ^IA[0-9]{1,4}$
+            - name: limit
+              in: query
+              description: Maximum number of bookings to return.
+              required: false
+              schema:
+                type: integer
+                format: int32
+                minimum: 1
+                maximum: 200
+                default: 50
+          responses:
+            "200":
+              description: Successful operation.
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Booking"
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        post:
+          tags:
+            - bookings
+          summary: Create a booking.
+          description: >-
+            Creates a new booking with one or more passengers and one or more
+            flight
+
+            segments. The PNR is generated server-side. Seat assignments are not
+
+            created here — use the seat endpoints after the booking exists.
+          operationId: createBooking
+          requestBody:
+            description: Booking to create.
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/BookingInput"
+          responses:
+            "201":
+              description: Booking created.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Booking"
+            "400":
+              description: Invalid booking payload (e.g. unknown flight, no passengers).
+            "409":
+              description: Conflict (e.g. duplicate frequent flyer on the same booking).
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+      /bookings/{pnr}:
+        parameters:
+          - name: pnr
+            in: path
+            description: 6-character alphanumeric Passenger Name Record.
+            required: true
+            schema:
+              type: string
+              minLength: 6
+              maxLength: 6
+              pattern: ^[A-Z0-9]{6}$
+        get:
+          tags:
+            - bookings
+          summary: Get booking by PNR.
+          description: Returns a single booking, including its passengers and segments.
+          operationId: getBooking
+          responses:
+            "200":
+              description: Successful operation.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Booking"
+            "404":
+              description: Booking not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        patch:
+          tags:
+            - bookings
+          summary: Update booking fields.
+          description: >-
+            Partially updates a booking — typically used to change status (e.g.
+            to
+
+            `CONFIRMED` after payment) or to update contact details.
+          operationId: patchBooking
+          requestBody:
+            description: Fields to update.
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/BookingPatch"
+          responses:
+            "200":
+              description: Booking updated.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Booking"
+            "400":
+              description: Invalid patch payload.
+            "404":
+              description: Booking not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        delete:
+          tags:
+            - bookings
+          summary: Cancel a booking.
+          description: Cancels a booking. Soft-deletes by setting status to `CANCELLED`.
+          operationId: cancelBooking
+          responses:
+            "204":
+              description: Booking cancelled.
+            "404":
+              description: Booking not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+      /bookings/{pnr}/passengers:
+        parameters:
+          - name: pnr
+            in: path
+            required: true
+            schema:
+              type: string
+              minLength: 6
+              maxLength: 6
+              pattern: ^[A-Z0-9]{6}$
+        get:
+          tags:
+            - passengers
+          summary: List passengers on a booking.
+          description: Returns the passengers currently attached to a booking.
+          operationId: listBookingPassengers
+          responses:
+            "200":
+              description: Successful operation.
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Passenger"
+            "404":
+              description: Booking not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        post:
+          tags:
+            - passengers
+          summary: Add a passenger to a booking.
+          description: Attaches a passenger to an existing booking.
+          operationId: addBookingPassenger
+          requestBody:
+            description: Passenger to attach.
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/PassengerInput"
+          responses:
+            "201":
+              description: Passenger added.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Passenger"
+            "400":
+              description: Invalid passenger payload.
+            "404":
+              description: Booking not found.
+            "409":
+              description: Passenger is already on this booking.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+      /bookings/{pnr}/passengers/{passengerId}:
+        parameters:
+          - name: pnr
+            in: path
+            required: true
+            schema:
+              type: string
+              minLength: 6
+              maxLength: 6
+              pattern: ^[A-Z0-9]{6}$
+          - name: passengerId
+            in: path
+            description: Server-assigned passenger identifier within the booking.
+            required: true
+            schema:
+              type: string
+              format: uuid
+        get:
+          tags:
+            - passengers
+          summary: Get a booking's passenger.
+          description: Returns details for a single passenger on a booking.
+          operationId: getBookingPassenger
+          responses:
+            "200":
+              description: Successful operation.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Passenger"
+            "404":
+              description: Booking or passenger not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        delete:
+          tags:
+            - passengers
+          summary: Remove a passenger from a booking.
+          description: Removes a passenger and any seat assignments held by that passenger.
+          operationId: removeBookingPassenger
+          responses:
+            "204":
+              description: Passenger removed.
+            "404":
+              description: Booking or passenger not found.
+            "409":
+              description: Cannot remove the last remaining passenger on a booking — cancel
+                the booking instead.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+      /bookings/{pnr}/seats:
+        parameters:
+          - name: pnr
+            in: path
+            required: true
+            schema:
+              type: string
+              minLength: 6
+              maxLength: 6
+              pattern: ^[A-Z0-9]{6}$
+        get:
+          tags:
+            - seats
+          summary: List seat assignments.
+          description: Returns all seat assignments on this booking, across all segments.
+          operationId: listSeatAssignments
+          responses:
+            "200":
+              description: Successful operation.
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/SeatAssignment"
+            "404":
+              description: Booking not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        post:
+          tags:
+            - seats
+          summary: Assign a seat.
+          description: |-
+            Assigns a seat on one segment to one passenger on this booking. The
+            passenger must already be attached to the booking, and the segment
+            index must be valid for the booking.
+          operationId: createSeatAssignment
+          requestBody:
+            description: Seat assignment to create.
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/SeatAssignmentInput"
+          responses:
+            "201":
+              description: Seat assigned.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/SeatAssignment"
+            "400":
+              description: Invalid payload (e.g. unknown passenger, invalid segment index, bad
+                seat number).
+            "404":
+              description: Booking not found.
+            "409":
+              description: Seat is already assigned on this segment.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+      /bookings/{pnr}/seats/{seatAssignmentId}:
+        parameters:
+          - name: pnr
+            in: path
+            required: true
+            schema:
+              type: string
+              minLength: 6
+              maxLength: 6
+              pattern: ^[A-Z0-9]{6}$
+          - name: seatAssignmentId
+            in: path
+            description: Server-assigned seat-assignment identifier.
+            required: true
+            schema:
+              type: string
+              format: uuid
+        patch:
+          tags:
+            - seats
+          summary: Change a seat assignment.
+          description: Updates the seat number on an existing seat assignment (e.g. moving
+            14C → 15A).
+          operationId: patchSeatAssignment
+          requestBody:
+            description: Fields to update.
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/SeatAssignmentPatch"
+          responses:
+            "200":
+              description: Seat assignment updated.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/SeatAssignment"
+            "400":
+              description: Invalid patch payload.
+            "404":
+              description: Booking or seat assignment not found.
+            "409":
+              description: New seat is already assigned on this segment.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        delete:
+          tags:
+            - seats
+          summary: Release a seat assignment.
+          description: Removes a seat assignment, leaving the passenger unseated on that
+            segment.
+          operationId: deleteSeatAssignment
+          responses:
+            "204":
+              description: Seat assignment removed.
+            "404":
+              description: Booking or seat assignment not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+      /passengers/{frequentFlyerId}:
+        parameters:
+          - name: frequentFlyerId
+            in: path
+            description: Frequent-flyer membership identifier.
+            required: true
+            schema:
+              type: string
+              pattern: ^FF[0-9]{6,10}$
+        get:
+          tags:
+            - passengers
+          summary: Get frequent-flyer profile.
+          description: Returns the standalone frequent-flyer profile (independent of any
+            one booking).
+          operationId: getFrequentFlyer
+          responses:
+            "200":
+              description: Successful operation.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/FrequentFlyer"
+            "404":
+              description: Frequent flyer not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+      /passengers/{frequentFlyerId}/bookings:
+        parameters:
+          - name: frequentFlyerId
+            in: path
+            required: true
+            schema:
+              type: string
+              pattern: ^FF[0-9]{6,10}$
+        get:
+          tags:
+            - passengers
+          summary: List a frequent flyer's bookings.
+          description: Returns bookings on which this frequent flyer is a passenger.
+          operationId: listFrequentFlyerBookings
+          parameters:
+            - name: status
+              in: query
+              description: Filter by booking status.
+              required: false
+              schema:
+                $ref: "#/components/schemas/BookingStatus"
+          responses:
+            "200":
+              description: Successful operation.
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Booking"
+            "404":
+              description: Frequent flyer not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+    components:
+      schemas:
+        BookingStatus:
+          type: string
+          description: Lifecycle state of a booking.
+          enum:
+            - HELD
+            - CONFIRMED
+            - CHECKED_IN
+            - FLOWN
+            - CANCELLED
+        TravelClass:
+          type: string
+          description: Cabin class for a flight segment.
+          enum:
+            - ECONOMY
+            - PREMIUM_ECONOMY
+            - BUSINESS
+            - FIRST
+        Money:
+          type: object
+          required:
+            - amount
+            - currency
+          properties:
+            amount:
+              type: number
+              format: double
+              description: Monetary amount.
+              example: 842.5
+            currency:
+              type: string
+              description: ISO 4217 currency code.
+              minLength: 3
+              maxLength: 3
+              example: USD
+        FlightSegment:
+          type: object
+          description: One leg of a journey on a booking. References a flight from the
+            Flights API.
+          required:
+            - segmentIndex
+            - flightNumber
+            - departureDate
+            - origin
+            - destination
+            - travelClass
+          properties:
+            segmentIndex:
+              type: integer
+              format: int32
+              description: Zero-based index of this segment within the booking.
+              minimum: 0
+              example: 0
+            flightNumber:
+              type: string
+              pattern: ^IA[0-9]{1,4}$
+              example: IA204
+            departureDate:
+              type: string
+              format: date
+              description: Local departure date at the origin.
+              example: 2026-05-12
+            origin:
+              type: string
+              minLength: 3
+              maxLength: 3
+              pattern: ^[A-Z]{3}$
+              example: YYZ
+            destination:
+              type: string
+              minLength: 3
+              maxLength: 3
+              pattern: ^[A-Z]{3}$
+              example: SFO
+            scheduledDeparture:
+              type: string
+              format: date-time
+              description: Scheduled departure time, in UTC.
+              example: 2026-05-12T13:30:00Z
+            travelClass:
+              $ref: "#/components/schemas/TravelClass"
+        FlightSegmentInput:
+          type: object
+          required:
+            - flightNumber
+            - departureDate
+            - travelClass
+          properties:
+            flightNumber:
+              type: string
+              pattern: ^IA[0-9]{1,4}$
+              example: IA204
+            departureDate:
+              type: string
+              format: date
+              example: 2026-05-12
+            travelClass:
+              $ref: "#/components/schemas/TravelClass"
+        Passenger:
+          type: object
+          required:
+            - id
+            - firstName
+            - lastName
+          properties:
+            id:
+              type: string
+              format: uuid
+              description: Server-assigned identifier within the booking.
+            firstName:
+              type: string
+              example: Alex
+            lastName:
+              type: string
+              example: Morgan
+            email:
+              type: string
+              format: email
+              example: alex.morgan@example.com
+            phone:
+              type: string
+              example: "+14165550199"
+            frequentFlyerId:
+              type: string
+              description: Frequent-flyer membership ID, if the passenger has one.
+              pattern: ^FF[0-9]{6,10}$
+              example: FF1029384
+            dateOfBirth:
+              type: string
+              format: date
+              example: 1988-04-12
+        PassengerInput:
+          type: object
+          required:
+            - firstName
+            - lastName
+          properties:
+            firstName:
+              type: string
+              example: Alex
+            lastName:
+              type: string
+              example: Morgan
+            email:
+              type: string
+              format: email
+              example: alex.morgan@example.com
+            phone:
+              type: string
+              example: "+14165550199"
+            frequentFlyerId:
+              type: string
+              pattern: ^FF[0-9]{6,10}$
+              example: FF1029384
+            dateOfBirth:
+              type: string
+              format: date
+              example: 1988-04-12
+        SeatAssignment:
+          type: object
+          required:
+            - id
+            - passengerId
+            - segmentIndex
+            - seatNumber
+          properties:
+            id:
+              type: string
+              format: uuid
+              description: Server-assigned identifier for this seat assignment.
+            passengerId:
+              type: string
+              format: uuid
+              description: Passenger this seat belongs to.
+            segmentIndex:
+              type: integer
+              format: int32
+              minimum: 0
+              description: Which segment of the booking this seat applies to.
+              example: 0
+            seatNumber:
+              type: string
+              description: Seat number, row and letter (e.g. `14C`).
+              pattern: ^[0-9]{1,3}[A-K]$
+              example: 14C
+        SeatAssignmentInput:
+          type: object
+          required:
+            - passengerId
+            - segmentIndex
+            - seatNumber
+          properties:
+            passengerId:
+              type: string
+              format: uuid
+            segmentIndex:
+              type: integer
+              format: int32
+              minimum: 0
+              example: 0
+            seatNumber:
+              type: string
+              pattern: ^[0-9]{1,3}[A-K]$
+              example: 14C
+        SeatAssignmentPatch:
+          type: object
+          description: Partial update payload for a seat assignment. Any field omitted is
+            left unchanged.
+          properties:
+            seatNumber:
+              type: string
+              pattern: ^[0-9]{1,3}[A-K]$
+              example: 15A
+        Booking:
+          type: object
+          required:
+            - pnr
+            - status
+            - passengers
+            - segments
+            - totalFare
+            - createdAt
+          properties:
+            pnr:
+              type: string
+              description: 6-character alphanumeric Passenger Name Record.
+              minLength: 6
+              maxLength: 6
+              pattern: ^[A-Z0-9]{6}$
+              example: AB12CD
+            status:
+              $ref: "#/components/schemas/BookingStatus"
+            contactEmail:
+              type: string
+              format: email
+              description: Primary contact email for the booking.
+              example: alex.morgan@example.com
+            passengers:
+              type: array
+              items:
+                $ref: "#/components/schemas/Passenger"
+            segments:
+              type: array
+              items:
+                $ref: "#/components/schemas/FlightSegment"
+            totalFare:
+              $ref: "#/components/schemas/Money"
+            createdAt:
+              type: string
+              format: date-time
+              example: 2026-04-30T19:14:02Z
+        BookingInput:
+          type: object
+          required:
+            - passengers
+            - segments
+          properties:
+            contactEmail:
+              type: string
+              format: email
+              example: alex.morgan@example.com
+            passengers:
+              type: array
+              minItems: 1
+              items:
+                $ref: "#/components/schemas/PassengerInput"
+            segments:
+              type: array
+              minItems: 1
+              items:
+                $ref: "#/components/schemas/FlightSegmentInput"
+        BookingPatch:
+          type: object
+          description: Partial update payload for a booking. Any field omitted is left
+            unchanged.
+          properties:
+            status:
+              $ref: "#/components/schemas/BookingStatus"
+            contactEmail:
+              type: string
+              format: email
+        FrequentFlyerTier:
+          type: string
+          description: Frequent-flyer tier within the Insomnia Airlines loyalty program.
+          enum:
+            - STANDARD
+            - SILVER
+            - GOLD
+            - PLATINUM
+        FrequentFlyer:
+          type: object
+          required:
+            - frequentFlyerId
+            - firstName
+            - lastName
+            - tier
+            - milesBalance
+          properties:
+            frequentFlyerId:
+              type: string
+              pattern: ^FF[0-9]{6,10}$
+              example: FF1029384
+            firstName:
+              type: string
+              example: Alex
+            lastName:
+              type: string
+              example: Morgan
+            email:
+              type: string
+              format: email
+              example: alex.morgan@example.com
+            tier:
+              $ref: "#/components/schemas/FrequentFlyerTier"
+            milesBalance:
+              type: integer
+              format: int64
+              minimum: 0
+              example: 48230
+            memberSince:
+              type: string
+              format: date
+              example: 2019-08-04
+        Error:
+          type: object
+          required:
+            - code
+            - message
+          properties:
+            code:
+              type: string
+              example: BOOKING_NOT_FOUND
+            message:
+              type: string
+              example: No booking with PNR 'XYZAB1' exists.
+  meta:
+    id: spc_46a53c6013b54e1a81ead9283b3ae566
+    created: 1778268038799
+    modified: 1778268038799

--- a/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/collection_runner.yaml
+++ b/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/collection_runner.yaml
@@ -1,0 +1,292 @@
+type: collection.insomnia.rest/5.0
+schema_version: "5.1"
+name: Collection Runner Example
+meta:
+  id: wrk_d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6
+  created: 1779753600000
+  modified: 1779743446079
+  description: ""
+collection:
+  - url: "{{ _.base_url }}/test/delay"
+    name: 02 Request
+    meta:
+      id: req_a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7
+      created: 1779753600000
+      modified: 1779753600000
+      isPrivate: false
+      description: ""
+      sortKey: -1779753600001
+    method: GET
+    parameters:
+      - name: ms
+        value: "200"
+        disabled: false
+    scripts:
+      afterResponse: |-
+        insomnia.test('Second best is still pretty good', () => {
+          insomnia.expect(true).to.be.true;
+        });
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+  - url: "{{ _.base_url }}/test/delay"
+    name: 08 Request
+    meta:
+      id: req_a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3
+      created: 1779753600000
+      modified: 1779753600000
+      isPrivate: false
+      description: ""
+      sortKey: -1779753600007
+    method: GET
+    parameters:
+      - name: ms
+        value: "800"
+        disabled: false
+    scripts:
+      afterResponse: |-
+        insomnia.test('Eighth wonder of the test suite', () => {
+          insomnia.expect(true).to.be.true;
+        });
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+  - url: "{{ _.base_url }}/test/delay"
+    name: 03 Request
+    meta:
+      id: req_b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8
+      created: 1779753600000
+      modified: 1779753600000
+      isPrivate: false
+      description: ""
+      sortKey: -1779753600002
+    method: GET
+    parameters:
+      - name: ms
+        value: "300"
+        disabled: false
+    scripts:
+      afterResponse: |-
+        insomnia.test('Third time is the charm', () => {
+          insomnia.expect(true).to.be.true;
+        });
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+  - url: "{{ _.base_url }}/test/delay"
+    name: 09 Request
+    meta:
+      id: req_b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4
+      created: 1779753600000
+      modified: 1779753600000
+      isPrivate: false
+      description: ""
+      sortKey: -1779753600008
+    method: GET
+    parameters:
+      - name: ms
+        value: "900"
+        disabled: false
+    scripts:
+      afterResponse: |-
+        insomnia.test('Cloud nine vibes', () => {
+          insomnia.expect(true).to.be.true;
+        });
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+  - url: "{{ _.base_url }}/test/delay"
+    name: 10 Request
+    meta:
+      id: req_c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5
+      created: 1779753600000
+      modified: 1779753600000
+      isPrivate: false
+      description: ""
+      sortKey: -1779753600009
+    method: GET
+    parameters:
+      - name: ms
+        value: "1000"
+        disabled: false
+    scripts:
+      afterResponse: |-
+        insomnia.test('Perfect ten, stuck the landing', () => {
+          insomnia.expect(true).to.be.true;
+        });
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+  - url: "{{ _.base_url }}/test/delay"
+    name: 04 Request
+    meta:
+      id: req_c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9
+      created: 1779753600000
+      modified: 1779753600000
+      isPrivate: false
+      description: ""
+      sortKey: -1779753600003
+    method: GET
+    parameters:
+      - name: ms
+        value: "400"
+        disabled: false
+    scripts:
+      afterResponse: |-
+        insomnia.test('Four score and seven delays ago', () => {
+          insomnia.expect(true).to.be.true;
+        });
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+  - url: "{{ _.base_url }}/test/delay"
+    name: 05 Request
+    meta:
+      id: req_d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0
+      created: 1779753600000
+      modified: 1779753600000
+      isPrivate: false
+      description: ""
+      sortKey: -1779753600004
+    method: GET
+    parameters:
+      - name: ms
+        value: "500"
+        disabled: false
+    scripts:
+      afterResponse: |-
+        insomnia.test('High five! (wrong kind of five)', () => {
+          insomnia.expect(true).to.be.true;
+        });
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+  - url: "{{ _.base_url }}/test/delay"
+    name: 06 Request
+    meta:
+      id: req_e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1
+      created: 1779753600000
+      modified: 1779753600000
+      isPrivate: false
+      description: ""
+      sortKey: -1779753600005
+    method: GET
+    parameters:
+      - name: ms
+        value: "600"
+        disabled: false
+    scripts:
+      afterResponse: |-
+        insomnia.test('Six appeal', () => {
+          insomnia.expect(true).to.be.true;
+        });
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+  - url: "{{ _.base_url }}/test/delay"
+    name: 01 Request
+    meta:
+      id: req_f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6
+      created: 1779753600000
+      modified: 1779753600000
+      isPrivate: false
+      description: ""
+      sortKey: -1779753600000
+    method: GET
+    parameters:
+      - name: ms
+        value: "100"
+        disabled: false
+    scripts:
+      afterResponse: |-
+        insomnia.test('First! (insert victory screech)', () => {
+          insomnia.expect(true).to.be.true;
+        });
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+  - url: "{{ _.base_url }}/test/delay"
+    name: 07 Request
+    meta:
+      id: req_f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2
+      created: 1779753600000
+      modified: 1779753600000
+      isPrivate: false
+      description: ""
+      sortKey: -1779753600006
+    method: GET
+    parameters:
+      - name: ms
+        value: "700"
+        disabled: false
+    scripts:
+      afterResponse: |-
+        insomnia.test('Lucky number seven', () => {
+          insomnia.expect(true).to.be.true;
+        });
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+cookieJar:
+  name: Default Jar
+  meta:
+    id: jar_b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0
+    created: 1779753600000
+    modified: 1779744547323
+environments:
+  name: Base Environment
+  meta:
+    id: env_b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0
+    created: 1779753600000
+    modified: 1779744547324
+    isPrivate: false

--- a/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/dev_environment.yaml
+++ b/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/dev_environment.yaml
@@ -1,0 +1,19 @@
+type: environment.insomnia.rest/5.0
+schema_version: "5.1"
+name: Dev Environment
+meta:
+  id: wrk_dafaad8e1d184b94918ec2438823437a
+  created: 1778268301603
+  modified: 1778268301603
+  description: ""
+environments:
+  name: Dev
+  meta:
+    id: env_82094b5b696655da532214cd1b6ca31215ea29b7
+    created: 1778268301614
+    modified: 1779815579930
+    isPrivate: false
+  data:
+    base_url: http://localhost:8000
+    auth_token: e1015e6d-039b-42dd-b038-31068702935d
+    inherited_value: from_global_env

--- a/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/flights.yaml
+++ b/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/flights.yaml
@@ -1,0 +1,1298 @@
+type: spec.insomnia.rest/5.0
+schema_version: "5.1"
+name: Flights
+meta:
+  id: wrk_aab4a6a7a3d1409cac2a6e5a8a1ddc7d
+  created: 1778266774011
+  modified: 1778266774011
+  description: ""
+collection:
+  - name: airports
+    meta:
+      id: fld_0e5467398ea849d1af43767632f55ddc
+      created: 1778267676045
+      modified: 1778273505588
+      sortKey: -1778267676045
+      description: Airports served by Insomnia Airlines.
+    children:
+      - url: "{{ _.base_url }}/airports"
+        name: List airports.
+        meta:
+          id: req_ec678ccaa5b34b47a2ef5128ee88e845
+          created: 1778267676045
+          modified: 1778273484219
+          isPrivate: false
+          description: Returns the airports served by Insomnia Airlines, optionally
+            filtered by country.
+          sortKey: -1778267676045
+        method: GET
+        parameters:
+          - name: country
+            value: string
+            disabled: true
+          - name: limit
+            value: "2"
+            disabled: false
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+            insomnia.test('Response body is an array', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.be.a('array');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/airports/:iataCode"
+        name: Remove an airport.
+        meta:
+          id: req_0449c024a8354107b738c66cbc676e23
+          created: 1778267676046
+          modified: 1778267676046
+          isPrivate: false
+          description: Removes an airport from the network. Fails if active routes still
+            reference it.
+          sortKey: -1778267676046
+        method: DELETE
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/airports/:iataCode"
+        name: Get airport by IATA code.
+        meta:
+          id: req_1f1091e67b38436e8223a8e35a6bacf1
+          created: 1778267676046
+          modified: 1778267676046
+          isPrivate: false
+          description: Returns details for a single airport.
+          sortKey: -1778267676046
+        method: GET
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+            insomnia.test('Response body has iataCode field', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.have.property('iataCode');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/airports/:iataCode"
+        name: Update an airport.
+        meta:
+          id: req_aad8cc9c3e5f41e2bc2b635b21e86929
+          created: 1778267676046
+          modified: 1778267676046
+          isPrivate: false
+          description: Replaces the stored details for an airport.
+          sortKey: -1778267676046
+        method: PUT
+        body:
+          mimeType: application/json
+          text: |-
+            {
+              "iataCode": "YUL",
+              "name": "Montréal–Trudeau International Airport",
+              "city": "Montréal",
+              "country": "CA",
+              "timezone": "America/Montreal"
+            }
+        headers:
+          - name: Content-Type
+            value: application/json
+            disabled: false
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/airports"
+        name: Add an airport.
+        meta:
+          id: req_ba5048ee5a0248d18f1b27cd82ecc6c9
+          created: 1778267676046
+          modified: 1778267676046
+          isPrivate: false
+          description: Registers a new airport in the Insomnia Airlines network.
+          sortKey: -1778267676046
+        method: POST
+        body:
+          mimeType: application/json
+          text: |-
+            {
+              "iataCode": "YUL",
+              "name": "Montréal–Trudeau International Airport",
+              "city": "Montréal",
+              "country": "CA",
+              "timezone": "America/Montreal"
+            }
+        headers:
+          - name: Content-Type
+            value: application/json
+            disabled: false
+        scripts:
+          afterResponse: >-
+            insomnia.test('Status is 201', () => {
+              insomnia.expect(insomnia.response.status).to.eql(201);
+            });
+
+            insomnia.test('Created airport has all required fields', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.have.all.keys('iataCode', 'name', 'city', 'country', 'timezone');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+  - name: flights
+    meta:
+      id: fld_0f6df53267ad419ba33cb266808c9852
+      created: 1778267676045
+      modified: 1778267676045
+      sortKey: -1778267676045
+      description: Specific scheduled flight instances on a given date.
+    children:
+      - url: "{{ _.base_url }}/flights"
+        name: List flights.
+        meta:
+          id: req_4afdb49a01db4bba814efb7a8b08074c
+          created: 1778267676048
+          modified: 1778267676048
+          isPrivate: false
+          description: >-
+            Returns scheduled flight instances. Filters allow narrowing by date,
+
+            origin, destination, or current status (e.g. to find today's
+            departures
+
+            from `YYZ`).
+          sortKey: -1778267676048
+        method: GET
+        parameters:
+          - name: origin
+            value: string
+            disabled: true
+          - name: destination
+            value: string
+            disabled: true
+          - name: departureDate
+            value: string
+            disabled: true
+          - name: status
+            value: string
+            disabled: true
+          - name: limit
+            value: "50"
+            disabled: true
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+            insomnia.test('Response body is an array', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.be.a('array');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/flights"
+        name: Schedule a flight.
+        meta:
+          id: req_5fc48468b40b423eb342c88ab2b873c3
+          created: 1778267676048
+          modified: 1778267676048
+          isPrivate: false
+          description: Schedules a new flight instance against an existing route and
+            aircraft.
+          sortKey: -1778267676048
+        method: POST
+        body:
+          mimeType: application/json
+          text: |-
+            {
+              "flightNumber": "IA918",
+              "departureDate": "2026-05-12",
+              "routeId": "string",
+              "aircraftTailNumber": "C-GZZZ",
+              "scheduledDeparture": "2026-05-12T22:00:00Z",
+              "scheduledArrival": "2026-05-13T05:45:00Z",
+              "gate": "B14"
+            }
+        headers:
+          - name: Content-Type
+            value: application/json
+            disabled: false
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 201', () => {
+              insomnia.expect(insomnia.response.status).to.eql(201);
+            });
+            insomnia.test('Response body has flightNumber field', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.have.property('flightNumber');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/flights/:flightNumber"
+        name: Get flight by number and date.
+        meta:
+          id: req_b1b750dcb985458e8b34104e3e73f545
+          created: 1778267676048
+          modified: 1778267676048
+          isPrivate: false
+          description: Returns the scheduled flight instance for the given flight number
+            on the given departure date.
+          sortKey: -1778267676048
+        method: GET
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+            insomnia.test('Response body has flightNumber field', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.have.property('flightNumber');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/flights/:flightNumber"
+        name: Update flight fields.
+        meta:
+          id: req_2247ed9e534c45ddac219030423b52f9
+          created: 1778267676049
+          modified: 1778267676049
+          isPrivate: false
+          description: >-
+            Partially updates a flight — typically used to change status (e.g.
+            to
+
+            `BOARDING`, `DEPARTED`, `CANCELLED`), reassign a gate, or adjust the
+
+            scheduled departure time.
+          sortKey: -1778267676049
+        method: PATCH
+        body:
+          mimeType: application/json
+          text: |-
+            {
+              "scheduledDeparture": "2026-05-08T19:14:36.042Z",
+              "scheduledArrival": "2026-05-08T19:14:36.042Z",
+              "aircraftTailNumber": "string",
+              "gate": "string",
+              "status": "string"
+            }
+        headers:
+          - name: Content-Type
+            value: application/json
+            disabled: false
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/flights/:flightNumber"
+        name: Cancel a flight.
+        meta:
+          id: req_b9a0a1ab1cec47e5b3b3d4b7af233f7a
+          created: 1778267676049
+          modified: 1778267676049
+          isPrivate: false
+          description: Cancels a scheduled flight instance. Soft-deletes by setting status
+            to `CANCELLED`.
+          sortKey: -1778267676049
+        method: DELETE
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+  - name: routes
+    meta:
+      id: fld_78432cf4c48f413383f228efc660c5cc
+      created: 1778267676045
+      modified: 1778513252317
+      sortKey: -1778267676045
+      description: Published city-pairs the airline operates between.
+    children:
+      - url: "{{ _.base_url }}/routes"
+        name: List published routes.
+        meta:
+          id: req_2bc5fbd433f34d229c483193c3f38a24
+          created: 1778267676047
+          modified: 1778267676047
+          isPrivate: false
+          description: >-
+            Returns the city-pairs that Insomnia Airlines publishes. Network
+            connectivity
+
+            is intentionally not total — only a subset of all possible
+            origin–destination
+
+            pairs across the 10 served airports are operated.
+          sortKey: -1778267676047
+        method: GET
+        parameters:
+          - name: origin
+            value: string
+            disabled: true
+          - name: destination
+            value: string
+            disabled: true
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+            insomnia.test('Response body is an array', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.be.a('array');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/routes"
+        name: Publish a route.
+        meta:
+          id: req_7e5dfef36f7d465eb003bf927ff0cfaf
+          created: 1778267676047
+          modified: 1778267676047
+          isPrivate: false
+          description: Adds a new origin–destination city-pair to the published network.
+          sortKey: -1778267676047
+        method: POST
+        body:
+          mimeType: application/json
+          text: |-
+            {
+              "origin": "YVR",
+              "destination": "ORD",
+              "distanceNauticalMiles": 1605,
+              "blockTimeMinutes": 245
+            }
+        headers:
+          - name: Content-Type
+            value: application/json
+            disabled: false
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 201', () => {
+              insomnia.expect(insomnia.response.status).to.eql(201);
+            });
+            insomnia.test('Response body has origin and destination', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.have.property('origin');
+              insomnia.expect(body).to.have.property('destination');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/routes/:routeId"
+        name: Withdraw a route.
+        meta:
+          id: req_2e356bc0d5aa48a0ad5a51b75b19eb87
+          created: 1778267676048
+          modified: 1778267676048
+          isPrivate: false
+          description: Removes a route from the published network. Fails if future flights
+            still reference it.
+          sortKey: -1778267676048
+        method: DELETE
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/routes/:routeId"
+        name: Get route by ID.
+        meta:
+          id: req_764395347d804acf8ea4ab4ee60c067e
+          created: 1778267676048
+          modified: 1778268733363
+          isPrivate: false
+          description: Returns details for a single published route.
+          sortKey: -1778267676048
+        method: GET
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+            insomnia.test('Response body has id field', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.have.property('id');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+cookieJar:
+  name: Default Jar
+  meta:
+    id: jar_89cd5087041dfdbd9c564a8d9fb03a789ef5abd5
+    created: 1778266774014
+    modified: 1778513252316
+environments:
+  name: Base Environment
+  meta:
+    id: env_89cd5087041dfdbd9c564a8d9fb03a789ef5abd5
+    created: 1778266774013
+    modified: 1778513252317
+    isPrivate: false
+spec:
+  contents:
+    openapi: 3.0.4
+    info:
+      title: Insomnia Airlines — Flights & Airports API
+      description: |-
+        REST API for **Insomnia Airlines**, covering the airline's airport
+        network, published routes, and scheduled flight instances.
+
+        Insomnia Airlines operates two aircraft types — the **Airbus A320**
+        (narrow-body) and **Boeing 787** (wide-body) — and serves 10 major
+        North American airports: YYZ, YUL, YVR, SEA, SFO, ORD, IAH, IAD, BOS,
+        and FLL. The network has reasonable but not total connectivity, so not
+        every origin–destination pair is served; the served city-pairs are
+        exposed via the `/routes` resource.
+
+        The fleet (individual airframes, maintenance state, etc.) is managed by
+        the Operations team and is **not** in scope for this API — see the
+        Operations collection. Bookings and baggage also live in their own
+        specs.
+      version: 1.0.0
+      contact:
+        name: Insomnia Airlines API Team
+        email: api@insomnia-airlines.example
+      license:
+        name: Apache 2.0
+        url: https://www.apache.org/licenses/LICENSE-2.0.html
+    servers:
+      - url: https://2110842ae3.us.serverless.gateways.konggateway.com
+        description: Kong Gateway
+      - url: https://insomnia-airlines-api.onrender.com
+        description: Production
+      - url: http://localhost:8000
+        description: Local dev
+    tags:
+      - name: airports
+        description: Airports served by Insomnia Airlines.
+      - name: routes
+        description: Published city-pairs the airline operates between.
+      - name: flights
+        description: Specific scheduled flight instances on a given date.
+    paths:
+      /airports:
+        get:
+          tags:
+            - airports
+          summary: List airports.
+          description: Returns the airports served by Insomnia Airlines, optionally
+            filtered by country.
+          operationId: listAirports
+          parameters:
+            - name: country
+              in: query
+              description: ISO 3166-1 alpha-2 country code (e.g. `US`, `CA`).
+              required: false
+              schema:
+                type: string
+                minLength: 2
+                maxLength: 2
+            - name: limit
+              in: query
+              description: Maximum number of airports to return.
+              required: false
+              schema:
+                type: integer
+                format: int32
+                minimum: 1
+                maximum: 100
+                default: 50
+          responses:
+            "200":
+              description: Successful operation.
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Airport"
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        post:
+          tags:
+            - airports
+          summary: Add an airport.
+          description: Registers a new airport in the Insomnia Airlines network.
+          operationId: createAirport
+          requestBody:
+            description: Airport to add.
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/AirportInput"
+          responses:
+            "201":
+              description: Airport created.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Airport"
+            "400":
+              description: Invalid airport payload.
+            "409":
+              description: An airport with that IATA code already exists.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+      /airports/{iataCode}:
+        parameters:
+          - name: iataCode
+            in: path
+            description: 3-letter IATA airport code (e.g. `YYZ`).
+            required: true
+            schema:
+              type: string
+              minLength: 3
+              maxLength: 3
+              pattern: ^[A-Z]{3}$
+        get:
+          tags:
+            - airports
+          summary: Get airport by IATA code.
+          description: Returns details for a single airport.
+          operationId: getAirportByIata
+          responses:
+            "200":
+              description: Successful operation.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Airport"
+            "404":
+              description: Airport not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        put:
+          tags:
+            - airports
+          summary: Update an airport.
+          description: Replaces the stored details for an airport.
+          operationId: updateAirport
+          requestBody:
+            description: Updated airport details.
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/AirportInput"
+          responses:
+            "200":
+              description: Airport updated.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Airport"
+            "400":
+              description: Invalid payload.
+            "404":
+              description: Airport not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        delete:
+          tags:
+            - airports
+          summary: Remove an airport.
+          description: Removes an airport from the network. Fails if active routes still
+            reference it.
+          operationId: deleteAirport
+          responses:
+            "204":
+              description: Airport deleted.
+            "404":
+              description: Airport not found.
+            "409":
+              description: Airport is referenced by one or more active routes.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+      /routes:
+        get:
+          tags:
+            - routes
+          summary: List published routes.
+          description: >-
+            Returns the city-pairs that Insomnia Airlines publishes. Network
+            connectivity
+
+            is intentionally not total — only a subset of all possible
+            origin–destination
+
+            pairs across the 10 served airports are operated.
+          operationId: listRoutes
+          parameters:
+            - name: origin
+              in: query
+              description: Filter by origin airport IATA code.
+              required: false
+              schema:
+                type: string
+                minLength: 3
+                maxLength: 3
+                pattern: ^[A-Z]{3}$
+            - name: destination
+              in: query
+              description: Filter by destination airport IATA code.
+              required: false
+              schema:
+                type: string
+                minLength: 3
+                maxLength: 3
+                pattern: ^[A-Z]{3}$
+          responses:
+            "200":
+              description: Successful operation.
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Route"
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        post:
+          tags:
+            - routes
+          summary: Publish a route.
+          description: Adds a new origin–destination city-pair to the published network.
+          operationId: createRoute
+          requestBody:
+            description: Route to publish.
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/RouteInput"
+          responses:
+            "201":
+              description: Route published.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Route"
+            "400":
+              description: Invalid route payload (e.g. unknown airport, identical origin and
+                destination).
+            "409":
+              description: Route already exists for that origin–destination pair.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+      /routes/{routeId}:
+        parameters:
+          - name: routeId
+            in: path
+            description: Route identifier.
+            required: true
+            schema:
+              type: string
+              format: uuid
+        get:
+          tags:
+            - routes
+          summary: Get route by ID.
+          description: Returns details for a single published route.
+          operationId: getRouteById
+          responses:
+            "200":
+              description: Successful operation.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Route"
+            "404":
+              description: Route not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        delete:
+          tags:
+            - routes
+          summary: Withdraw a route.
+          description: Removes a route from the published network. Fails if future flights
+            still reference it.
+          operationId: deleteRoute
+          responses:
+            "204":
+              description: Route withdrawn.
+            "404":
+              description: Route not found.
+            "409":
+              description: Route is referenced by future flights.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+      /flights:
+        get:
+          tags:
+            - flights
+          summary: List flights.
+          description: >-
+            Returns scheduled flight instances. Filters allow narrowing by date,
+
+            origin, destination, or current status (e.g. to find today's
+            departures
+
+            from `YYZ`).
+          operationId: listFlights
+          parameters:
+            - name: origin
+              in: query
+              description: Origin airport IATA code.
+              required: false
+              schema:
+                type: string
+                minLength: 3
+                maxLength: 3
+                pattern: ^[A-Z]{3}$
+            - name: destination
+              in: query
+              description: Destination airport IATA code.
+              required: false
+              schema:
+                type: string
+                minLength: 3
+                maxLength: 3
+                pattern: ^[A-Z]{3}$
+            - name: departureDate
+              in: query
+              description: Local departure date at the origin (ISO 8601 `YYYY-MM-DD`).
+              required: false
+              schema:
+                type: string
+                format: date
+            - name: status
+              in: query
+              description: Filter by flight status.
+              required: false
+              schema:
+                $ref: "#/components/schemas/FlightStatus"
+            - name: limit
+              in: query
+              description: Maximum number of flights to return.
+              required: false
+              schema:
+                type: integer
+                format: int32
+                minimum: 1
+                maximum: 200
+                default: 50
+          responses:
+            "200":
+              description: Successful operation.
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Flight"
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        post:
+          tags:
+            - flights
+          summary: Schedule a flight.
+          description: Schedules a new flight instance against an existing route and
+            aircraft.
+          operationId: scheduleFlight
+          requestBody:
+            description: Flight to schedule.
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/FlightInput"
+          responses:
+            "201":
+              description: Flight scheduled.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Flight"
+            "400":
+              description: Invalid flight payload (e.g. unknown route or aircraft, scheduling
+                conflict).
+            "409":
+              description: Flight number already in use for that departure date.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+      /flights/{flightNumber}:
+        parameters:
+          - name: flightNumber
+            in: path
+            description: Insomnia Airlines flight number (e.g. `IA123`).
+            required: true
+            schema:
+              type: string
+              pattern: ^IA[0-9]{1,4}$
+          - name: departureDate
+            in: query
+            description: >-
+              Local departure date at the origin (ISO 8601 `YYYY-MM-DD`).
+              Required to
+
+              disambiguate when the same flight number recurs on multiple days.
+            required: true
+            schema:
+              type: string
+              format: date
+        get:
+          tags:
+            - flights
+          summary: Get flight by number and date.
+          description: Returns the scheduled flight instance for the given flight number
+            on the given departure date.
+          operationId: getFlight
+          responses:
+            "200":
+              description: Successful operation.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Flight"
+            "404":
+              description: Flight not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        patch:
+          tags:
+            - flights
+          summary: Update flight fields.
+          description: >-
+            Partially updates a flight — typically used to change status (e.g.
+            to
+
+            `BOARDING`, `DEPARTED`, `CANCELLED`), reassign a gate, or adjust the
+
+            scheduled departure time.
+          operationId: patchFlight
+          requestBody:
+            description: Fields to update.
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/FlightPatch"
+          responses:
+            "200":
+              description: Flight updated.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Flight"
+            "400":
+              description: Invalid patch payload.
+            "404":
+              description: Flight not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        delete:
+          tags:
+            - flights
+          summary: Cancel a flight.
+          description: Cancels a scheduled flight instance. Soft-deletes by setting status
+            to `CANCELLED`.
+          operationId: cancelFlight
+          responses:
+            "204":
+              description: Flight cancelled.
+            "404":
+              description: Flight not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+    components:
+      schemas:
+        Airport:
+          type: object
+          required:
+            - iataCode
+            - name
+            - city
+            - country
+            - timezone
+          properties:
+            iataCode:
+              type: string
+              description: 3-letter IATA airport code.
+              minLength: 3
+              maxLength: 3
+              pattern: ^[A-Z]{3}$
+              example: YYZ
+            name:
+              type: string
+              description: Full airport name.
+              example: Toronto Pearson International Airport
+            city:
+              type: string
+              example: Toronto
+            country:
+              type: string
+              description: ISO 3166-1 alpha-2 country code.
+              minLength: 2
+              maxLength: 2
+              example: CA
+            timezone:
+              type: string
+              description: IANA timezone name.
+              example: America/Toronto
+        AirportInput:
+          type: object
+          required:
+            - iataCode
+            - name
+            - city
+            - country
+            - timezone
+          properties:
+            iataCode:
+              type: string
+              minLength: 3
+              maxLength: 3
+              pattern: ^[A-Z]{3}$
+              example: YUL
+            name:
+              type: string
+              example: Montréal–Trudeau International Airport
+            city:
+              type: string
+              example: Montréal
+            country:
+              type: string
+              minLength: 2
+              maxLength: 2
+              example: CA
+            timezone:
+              type: string
+              example: America/Montreal
+        Route:
+          type: object
+          required:
+            - id
+            - origin
+            - destination
+            - blockTimeMinutes
+          properties:
+            id:
+              type: string
+              format: uuid
+              example: 3f2504e0-4f89-11d3-9a0c-0305e82c3301
+            origin:
+              type: string
+              description: Origin airport IATA code.
+              minLength: 3
+              maxLength: 3
+              pattern: ^[A-Z]{3}$
+              example: YYZ
+            destination:
+              type: string
+              description: Destination airport IATA code.
+              minLength: 3
+              maxLength: 3
+              pattern: ^[A-Z]{3}$
+              example: SFO
+            distanceNauticalMiles:
+              type: integer
+              format: int32
+              description: Great-circle distance between origin and destination, in nautical
+                miles.
+              minimum: 1
+              example: 1850
+            blockTimeMinutes:
+              type: integer
+              format: int32
+              description: Scheduled gate-to-gate block time, in minutes.
+              minimum: 1
+              example: 305
+        RouteInput:
+          type: object
+          required:
+            - origin
+            - destination
+            - blockTimeMinutes
+          properties:
+            origin:
+              type: string
+              minLength: 3
+              maxLength: 3
+              pattern: ^[A-Z]{3}$
+              example: YVR
+            destination:
+              type: string
+              minLength: 3
+              maxLength: 3
+              pattern: ^[A-Z]{3}$
+              example: ORD
+            distanceNauticalMiles:
+              type: integer
+              format: int32
+              minimum: 1
+              example: 1605
+            blockTimeMinutes:
+              type: integer
+              format: int32
+              minimum: 1
+              example: 245
+        FlightStatus:
+          type: string
+          description: Current status of a scheduled flight instance.
+          enum:
+            - SCHEDULED
+            - BOARDING
+            - DEPARTED
+            - ARRIVED
+            - DELAYED
+            - CANCELLED
+        Flight:
+          type: object
+          required:
+            - flightNumber
+            - departureDate
+            - routeId
+            - aircraftTailNumber
+            - scheduledDeparture
+            - scheduledArrival
+            - status
+          properties:
+            flightNumber:
+              type: string
+              description: Insomnia Airlines flight number.
+              pattern: ^IA[0-9]{1,4}$
+              example: IA204
+            departureDate:
+              type: string
+              format: date
+              description: Local departure date at the origin.
+              example: 2026-05-12
+            routeId:
+              type: string
+              format: uuid
+              description: Route this flight operates.
+            aircraftTailNumber:
+              type: string
+              description: Tail number of the aircraft assigned to this flight. The airframe
+                itself is managed by the Operations API.
+              example: C-FINS
+            scheduledDeparture:
+              type: string
+              format: date-time
+              description: Scheduled departure time, in UTC.
+              example: 2026-05-12T13:30:00Z
+            scheduledArrival:
+              type: string
+              format: date-time
+              description: Scheduled arrival time, in UTC.
+              example: 2026-05-12T18:35:00Z
+            gate:
+              type: string
+              description: Departure gate at the origin airport.
+              example: D32
+            status:
+              $ref: "#/components/schemas/FlightStatus"
+        FlightInput:
+          type: object
+          required:
+            - flightNumber
+            - departureDate
+            - routeId
+            - aircraftTailNumber
+            - scheduledDeparture
+            - scheduledArrival
+          properties:
+            flightNumber:
+              type: string
+              pattern: ^IA[0-9]{1,4}$
+              example: IA918
+            departureDate:
+              type: string
+              format: date
+              example: 2026-05-12
+            routeId:
+              type: string
+              format: uuid
+            aircraftTailNumber:
+              type: string
+              example: C-GZZZ
+            scheduledDeparture:
+              type: string
+              format: date-time
+              example: 2026-05-12T22:00:00Z
+            scheduledArrival:
+              type: string
+              format: date-time
+              example: 2026-05-13T05:45:00Z
+            gate:
+              type: string
+              example: B14
+        FlightPatch:
+          type: object
+          description: Partial update payload for a flight. Any field omitted is left
+            unchanged.
+          properties:
+            scheduledDeparture:
+              type: string
+              format: date-time
+            scheduledArrival:
+              type: string
+              format: date-time
+            aircraftTailNumber:
+              type: string
+            gate:
+              type: string
+            status:
+              $ref: "#/components/schemas/FlightStatus"
+        Error:
+          type: object
+          required:
+            - code
+            - message
+          properties:
+            code:
+              type: string
+              description: Machine-readable error code.
+              example: AIRPORT_NOT_FOUND
+            message:
+              type: string
+              description: Human-readable explanation.
+              example: No airport with IATA code 'XYZ' exists.
+  meta:
+    id: spc_55c0f7a247dc42909d58a498e1e136ae
+    created: 1778266774013
+    modified: 1778267217292

--- a/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/imported_collection.yaml
+++ b/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/imported_collection.yaml
@@ -1,0 +1,72 @@
+type: collection.insomnia.rest/5.0
+schema_version: "5.1"
+name: Imported from Try in Insomnia
+meta:
+  id: wrk_23c61ab98f3646f09135c07aed8a8245
+  created: 1778511433620
+  modified: 1778786300089
+  description: ""
+collection:
+  - url: http://localhost:8000/flights
+    name: http://localhost:8000/flights
+    meta:
+      id: req_a4cdf8671bee4d69bb2d7fb516fcd51e
+      created: 1778511433621
+      modified: 1778511433621
+      isPrivate: false
+      description: ""
+      sortKey: -1778511433621
+    method: GET
+    parameters:
+      - name: origin
+        value: YYZ
+        disabled: false
+    headers:
+      - name: User-Agent
+        value: insomnia/12.5.1-alpha.0
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+  - url: https://insomnia-airlines-api.onrender.com/flights
+    name: https://insomnia-airlines-api.onrender.com/flights
+    meta:
+      id: req_20bde7c7b5ed4b8d839ea86d53a35792
+      created: 1778512055254
+      modified: 1778512055254
+      isPrivate: false
+      description: ""
+      sortKey: -1778512055254
+    method: GET
+    parameters:
+      - name: status
+        value: BOARDING
+        disabled: false
+    headers:
+      - name: User-Agent
+        value: insomnia/12.5.1-alpha.0
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+cookieJar:
+  name: Default Jar
+  meta:
+    id: jar_96cac014d79f891d0866aef82234f8d59090262c
+    created: 1778511433708
+    modified: 1778511433708
+environments:
+  name: Base Environment
+  meta:
+    id: env_96cac014d79f891d0866aef82234f8d59090262c
+    created: 1778511433622
+    modified: 1778511433622
+    isPrivate: false

--- a/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/linting_bookings.yaml
+++ b/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/linting_bookings.yaml
@@ -1,0 +1,728 @@
+type: spec.insomnia.rest/5.0
+schema_version: "5.1"
+name: Bookings for Linting Demo
+meta:
+  id: wrk_4ecb9af5e9114adea995237bbc84b9b4
+  created: 1780004611728
+  modified: 1780004611728
+  description: ""
+cookieJar:
+  name: Default Jar
+  meta:
+    id: jar_59d04557176d043021affc3c43923893ae48765e
+    created: 1780004611733
+    modified: 1780004611733
+environments:
+  name: Base Environment
+  meta:
+    id: env_59d04557176d043021affc3c43923893ae48765e
+    created: 1780004611732
+    modified: 1780004611732
+    isPrivate: false
+spec:
+  contents:
+    openapi: 3.0.4
+    info:
+      title: Insomnia Airlines — Bookings API
+      description: REST API for **Insomnia Airlines** passenger reservations. A
+        booking is identified by a 6-character alphanumeric **PNR** (Passenger
+        Name Record). Each booking has one or more passengers and one or more
+        flight segments.
+      version: 1.0.0
+      contact:
+        name: Insomnia Airlines API Team
+        email: api@insomnia-airlines.example
+    servers:
+      - url: https://2110842ae3.us.serverless.gateways.konggateway.com
+        description: Kong Gateway
+      - url: https://insomnia-airlines-api.onrender.com
+        description: Production
+      - url: http://localhost:8000
+        description: Local dev
+    tags:
+      - name: bookings
+        description: Passenger reservations (PNRs).
+      - name: passengers
+      - name: seats
+        description: Seat assignments on a booking's flight segments.
+    paths:
+      /bookings:
+        get:
+          tags:
+            - bookings
+          description: Returns bookings, optionally filtered by status, frequent-flyer ID,
+            or flight.
+          operationId: listBookings
+          parameters:
+            - name: status
+              in: query
+              description: Filter by booking status.
+              required: false
+              schema:
+                $ref: "#/components/schemas/BookingStatus"
+            - name: limit
+              in: query
+              description: Maximum number of bookings to return.
+              required: false
+              schema:
+                type: integer
+                format: int32
+                minimum: 1
+                maximum: 200
+                default: 50
+          responses:
+            "200":
+              description: Successful operation.
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Booking"
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        post:
+          tags:
+            - bookings
+          summary: Create a booking.
+          description: Creates a new booking with one or more passengers and one or more
+            flight segments. The PNR is generated server-side.
+          operationId: create_booking
+          requestBody:
+            description: Booking to create.
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/BookingInput"
+          responses:
+            "201":
+              description: Booking created.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Booking"
+            "400":
+              description: Invalid booking payload.
+            "409":
+              description: Conflict — duplicate frequent flyer on the same booking.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+      /bookings/{pnr}:
+        parameters:
+          - name: pnr
+            in: path
+            required: true
+            schema:
+              type: string
+              minLength: 6
+              maxLength: 6
+              pattern: ^[A-Z0-9]{6}$
+        get:
+          tags:
+            - bookings
+          summary: Get booking by PNR.
+          description: Returns a single booking, including its passengers and segments.
+          operationId: getBooking
+          responses:
+            "200":
+              description: Successful operation.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Booking"
+            "404":
+              description: Booking not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        patch:
+          tags:
+            - bookings
+          summary: Update booking fields.
+          description: Partially updates a booking — typically used to change status or
+            contact details.
+          operationId: PatchBooking
+          requestBody:
+            description: Fields to update.
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/BookingPatch"
+          responses:
+            "200":
+              description: Booking updated.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Booking"
+            "400":
+              description: Invalid patch payload.
+            "404":
+              description: Booking not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        delete:
+          tags:
+            - bookings
+          summary: Cancel a booking.
+          description: Cancels a booking by setting status to CANCELLED.
+          operationId: cancelBooking
+          responses:
+            "204":
+              description: Booking cancelled.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+      /bookings/{pnr}/passengers:
+        parameters:
+          - name: pnr
+            in: path
+            required: true
+            schema:
+              type: string
+              minLength: 6
+              maxLength: 6
+              pattern: ^[A-Z0-9]{6}$
+        get:
+          tags:
+            - passengers
+          summary: List passengers on a booking.
+          description: Returns the passengers currently attached to a booking.
+          operationId: listBookingPassengers
+          responses:
+            "200":
+              description: Successful operation.
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Passenger"
+            "404":
+              description: Booking not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        post:
+          tags:
+            - passengers
+          summary: Add a passenger to a booking.
+          description: Attaches a passenger to an existing booking.
+          operationId: addBookingPassenger
+          requestBody:
+            description: Passenger to attach.
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/PassengerInput"
+          responses:
+            "201":
+              description: Passenger added.
+            "400":
+              description: Invalid passenger payload.
+            "404":
+              description: Booking not found.
+            "409":
+              description: Passenger already on this booking.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+      /bookings/{pnr}/seats:
+        parameters:
+          - name: pnr
+            in: path
+            required: true
+            description: 6-character alphanumeric Passenger Name Record.
+            schema:
+              type: string
+              minLength: 6
+              maxLength: 6
+              pattern: ^[A-Z0-9]{6}$
+        get:
+          tags:
+            - seats
+          description: Returns all seat assignments on this booking, across all segments.
+          operationId: listSeatAssignments
+          responses:
+            "200":
+              description: Successful operation.
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/SeatAssignment"
+            "404":
+              description: Booking not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        post:
+          tags:
+            - seats
+          summary: Assign a seat.
+          description: Assigns a seat on one segment to one passenger on this booking.
+          operationId: createSeatAssignment
+          requestBody:
+            description: Seat assignment to create.
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/SeatAssignmentInput"
+          responses:
+            "201":
+              description: Seat assigned.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/SeatAssignment"
+            "400":
+              description: Invalid payload.
+            "404":
+              description: Booking not found.
+            "409":
+              description: Seat already assigned on this segment.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+      /bookings/{pnr}/seats/{seatAssignmentId}:
+        parameters:
+          - name: pnr
+            in: path
+            required: true
+            description: 6-character alphanumeric Passenger Name Record.
+            schema:
+              type: string
+              minLength: 6
+              maxLength: 6
+              pattern: ^[A-Z0-9]{6}$
+          - name: seatAssignmentId
+            in: path
+            description: Server-assigned seat-assignment identifier.
+            required: true
+            schema:
+              type: string
+              format: uuid
+        patch:
+          tags:
+            - seats
+          summary: Change a seat assignment.
+          description: Updates the seat number on an existing seat assignment.
+          operationId: patchSeatAssignment
+          requestBody:
+            description: Fields to update.
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/SeatAssignmentPatch"
+          responses:
+            "200":
+              description: Seat assignment updated.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/SeatAssignment"
+            "400":
+              description: Invalid patch payload.
+            "404":
+              description: Booking or seat assignment not found.
+            "409":
+              description: New seat already assigned on this segment.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+        delete:
+          tags:
+            - seats
+          summary: Release a seat assignment.
+          description: Removes a seat assignment, leaving the passenger unseated on that
+            segment.
+          operationId: deleteSeatAssignment
+          responses:
+            "204":
+              description: Seat assignment removed.
+            "404":
+              description: Booking or seat assignment not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+      /passengers/{frequentFlyerId}:
+        parameters:
+          - name: frequentFlyerId
+            in: path
+            description: Frequent-flyer membership identifier.
+            required: true
+            schema:
+              type: string
+              pattern: ^FF[0-9]{6,10}$
+        get:
+          tags:
+            - passengers
+          summary: Get frequent-flyer profile.
+          description: Returns the standalone frequent-flyer profile.
+          operationId: getFrequentFlyer
+          responses:
+            "200":
+              description: Successful operation.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/FrequentFlyer"
+            "404":
+              description: Frequent flyer not found.
+            default:
+              description: Unexpected error.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/Error"
+    components:
+      schemas:
+        BookingStatus:
+          type: string
+          enum:
+            - HELD
+            - CONFIRMED
+            - CHECKED_IN
+            - FLOWN
+            - CANCELLED
+        TravelClass:
+          type: string
+          enum:
+            - ECONOMY
+            - PREMIUM_ECONOMY
+            - BUSINESS
+            - FIRST
+        Money:
+          type: object
+          description: A monetary value with currency.
+          required:
+            - amount
+            - currency
+          properties:
+            amount:
+              type: number
+              format: double
+              description: Monetary amount.
+              example: 842.5
+            currency:
+              type: string
+              description: ISO 4217 currency code.
+              minLength: 3
+              maxLength: 3
+              example: USD
+        FlightSegment:
+          type: object
+          description: One leg of a journey on a booking.
+          required:
+            - segmentIndex
+            - flightNumber
+            - departureDate
+            - origin
+            - destination
+            - travelClass
+          properties:
+            segmentIndex:
+              type: integer
+              format: int32
+              description: Zero-based index of this segment within the booking.
+              minimum: 0
+              example: 0
+            flightNumber:
+              type: string
+              pattern: ^IA[0-9]{1,4}$
+              example: IA204
+            departureDate:
+              type: string
+              format: date
+              description: Local departure date at the origin.
+              example: 2026-05-12
+            origin:
+              type: string
+              minLength: 3
+              maxLength: 3
+              pattern: ^[A-Z]{3}$
+              example: YYZ
+            destination:
+              type: string
+              minLength: 3
+              maxLength: 3
+              pattern: ^[A-Z]{3}$
+              example: SFO
+            travelClass:
+              $ref: "#/components/schemas/TravelClass"
+        Passenger:
+          type: object
+          description: A person attached to a booking.
+          required:
+            - id
+            - firstName
+            - lastName
+          properties:
+            id:
+              type: string
+              format: uuid
+              description: Server-assigned identifier within the booking.
+            firstName:
+              type: string
+              example: Alex
+            lastName:
+              type: string
+              example: Morgan
+            email:
+              type: string
+              format: email
+              example: alex.morgan@example.com
+            frequentFlyerId:
+              type: string
+              pattern: ^FF[0-9]{6,10}$
+              example: FF1029384
+        PassengerInput:
+          type: object
+          required:
+            - firstName
+            - lastName
+          properties:
+            firstName:
+              type: string
+              example: Alex
+            lastName:
+              type: string
+              example: Morgan
+            email:
+              type: string
+              format: email
+              example: alex.morgan@example.com
+            frequentFlyerId:
+              type: string
+              pattern: ^FF[0-9]{6,10}$
+              example: FF1029384
+        SeatAssignment:
+          type: object
+          description: A seat assignment linking one passenger to one seat on one segment.
+          required:
+            - id
+            - passengerId
+            - segmentIndex
+            - seatNumber
+          properties:
+            id:
+              type: string
+              format: uuid
+              description: Server-assigned identifier for this seat assignment.
+            passengerId:
+              type: string
+              format: uuid
+              description: Passenger this seat belongs to.
+            segmentIndex:
+              type: integer
+              format: int32
+              minimum: 0
+              example: 0
+            seatNumber:
+              type: string
+              pattern: ^[0-9]{1,3}[A-K]$
+              example: 14C
+        SeatAssignmentInput:
+          type: object
+          required:
+            - passengerId
+            - segmentIndex
+            - seatNumber
+          properties:
+            passengerId:
+              type: string
+              format: uuid
+            segmentIndex:
+              type: integer
+              format: int32
+              minimum: 0
+              example: 0
+            seatNumber:
+              type: string
+              pattern: ^[0-9]{1,3}[A-K]$
+              example: 14C
+        SeatAssignmentPatch:
+          type: object
+          description: Partial update payload for a seat assignment.
+          properties:
+            seatNumber:
+              type: string
+              pattern: ^[0-9]{1,3}[A-K]$
+              example: 15A
+        Booking:
+          type: object
+          description: A passenger reservation record (PNR).
+          required:
+            - pnr
+            - status
+            - passengers
+            - segments
+            - totalFare
+            - createdAt
+          properties:
+            pnr:
+              type: string
+              minLength: 6
+              maxLength: 6
+              pattern: ^[A-Z0-9]{6}$
+              example: AB12CD
+            status:
+              $ref: "#/components/schemas/BookingStatus"
+            contactEmail:
+              type: string
+              format: email
+              example: alex.morgan@example.com
+            passengers:
+              type: array
+              items:
+                $ref: "#/components/schemas/Passenger"
+            segments:
+              type: array
+              items:
+                $ref: "#/components/schemas/FlightSegment"
+            totalFare:
+              $ref: "#/components/schemas/Money"
+            createdAt:
+              type: string
+              format: date-time
+              example: 2026-04-30T19:14:02Z
+        BookingInput:
+          type: object
+          description: Payload for creating a new booking.
+          required:
+            - passengers
+            - segments
+          properties:
+            contactEmail:
+              type: string
+              format: email
+              example: alex.morgan@example.com
+            passengers:
+              type: array
+              minItems: 1
+              items:
+                $ref: "#/components/schemas/PassengerInput"
+            segments:
+              type: array
+              minItems: 1
+              items:
+                $ref: "#/components/schemas/FlightSegmentInput"
+        BookingPatch:
+          type: object
+          properties:
+            status:
+              $ref: "#/components/schemas/BookingStatus"
+            contactEmail:
+              type: string
+              format: email
+        FrequentFlyerTier:
+          type: string
+          description: Loyalty tier within the Insomnia Airlines frequent-flyer program.
+          enum:
+            - STANDARD
+            - SILVER
+            - GOLD
+            - PLATINUM
+        FrequentFlyer:
+          type: object
+          description: A frequent-flyer profile, independent of any one booking.
+          required:
+            - frequentFlyerId
+            - firstName
+            - lastName
+            - tier
+            - milesBalance
+          properties:
+            frequentFlyerId:
+              type: string
+              pattern: ^FF[0-9]{6,10}$
+              example: FF1029384
+            firstName:
+              type: string
+              example: Alex
+            lastName:
+              type: string
+              example: Morgan
+            tier:
+              $ref: "#/components/schemas/FrequentFlyerTier"
+            milesBalance:
+              type: integer
+              format: int64
+              minimum: 0
+              example: 48230
+        FlightSegmentInput:
+          type: object
+          required:
+            - flightNumber
+            - departureDate
+            - travelClass
+          properties:
+            flightNumber:
+              type: string
+              pattern: ^IA[0-9]{1,4}$
+              example: IA204
+            departureDate:
+              type: string
+              format: date
+              example: 2026-05-12
+            travelClass:
+              $ref: "#/components/schemas/TravelClass"
+        Error:
+          type: object
+          description: Standard error response envelope.
+          required:
+            - code
+            - message
+          properties:
+            code:
+              type: string
+              example: BOOKING_NOT_FOUND
+            message:
+              type: string
+              example: No booking with PNR 'XYZAB1' exists.
+  meta:
+    id: spc_34cc24c495f447f0ac024d5067fe58ee
+    created: 1780004611732
+    modified: 1780004674930

--- a/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/mcp_flights.yaml
+++ b/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/mcp_flights.yaml
@@ -1,0 +1,26 @@
+type: mcpClient.insomnia/5.0
+schema_version: "5.1"
+name: Insomnia Airlines MCP
+meta:
+  id: wrk_0d459dfea8494d02b93b16df8ed958de
+  created: 1778529679886
+  modified: 1778530232951
+  description: ""
+mcpRequest:
+  name: ""
+  url: "  https://2110842ae3.us.serverless.gateways.konggateway.com/mcp"
+  transportType: streamable-http
+  headers:
+    - name: User-Agent
+      value: insomnia/12.5.1-alpha.0
+  meta:
+    id: mcp-req_0c5cb3a7acdf4074b436e329adf5a7ca
+    created: 1778529679890
+    modified: 1779743467969
+environments:
+  name: Base Environment
+  meta:
+    id: env_a613d1b98cffbf911687e7ceac2131a9e5ffeed8
+    created: 1778529679891
+    modified: 1778529679891
+    isPrivate: false

--- a/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/operations.yaml
+++ b/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/operations.yaml
@@ -1,0 +1,567 @@
+type: collection.insomnia.rest/5.0
+schema_version: "5.1"
+name: Operations
+meta:
+  id: wrk_e126af2206e94bf6aebf53183c9e4bda
+  created: 1778268242109
+  modified: 1778270504000
+  description: |-
+    **Operations** — ad-hoc requests against the airline's Operations API.
+
+    This API is **owned by another team** (Ops Engineering) and lives at
+    `airline-ops.example`. We consume it; we don't define it. Treat the
+    request shapes here as snapshots of the upstream contract — confirm
+    with their team's docs before relying on edge-case behaviour.
+
+    Folders are grouped by domain:
+
+    - **Aircraft** — fleet status and utilization
+    - **Mechanics** — maintenance work orders and required checks
+    - **Catering** — meal manifests and station inventory
+    - **Rewards** — loyalty program member operations
+
+    The base URL comes from the `base_url` environment variable — point it at
+    `api.airline-ops.example/v1` (or the staging equivalent) before sending.
+collection:
+  - name: Rewards
+    meta:
+      id: fld_d4f7a0c6b1e3639c2a8d1e4f0a6c3d05
+      created: 1778270501000
+      modified: 1778270501000
+      sortKey: -1778270501000
+      description: Loyalty program member profile, redemptions, and miles credits.
+    children:
+      - url: "{{ _.base_url }}/loyalty/members/:ffId/credits"
+        name: Credit miles
+        meta:
+          id: req_d3f7d3e8b2406c9d5a8f1e7b3c0d9043
+          created: 1778270501098
+          modified: 1781124796917
+          isPrivate: false
+          description: >-
+            Credits miles to a member's account, typically after a flight is
+            flown.
+
+
+            **Eventually consistent:** credits take **~5 seconds** to reflect in
+
+            the balance returned by `Get loyalty member`. Don't immediately
+
+            re-fetch and assume the new balance is right — either trust the
+
+            response of this call, or wait briefly before re-querying. Tests
+            that
+
+            credit then immediately read will be flaky.
+          sortKey: -1778270501098
+        method: POST
+        body:
+          mimeType: application/json
+          text: |-
+            {
+              "miles": 4830,
+              "reason": "FLIGHT_FLOWN",
+              "flightNumber": "IA204",
+              "departureDate": "2026-05-12"
+            }
+        headers:
+          - name: Content-Type
+            value: application/json
+            disabled: false
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/loyalty/members/:ffId/redemptions"
+        name: Redeem miles
+        meta:
+          id: req_d2f7d3e8b2406c9d5a8f1e7b3c0d9042
+          created: 1778270501099
+          modified: 1778270501099
+          isPrivate: false
+          description: >-
+            Redeems miles against an award (upgrade, free flight, etc.).
+
+
+            **Error codes don't follow the obvious pattern — read carefully:**
+
+
+            - **400** — malformed request (missing `awardCode`, etc.)
+
+            - **422** — _insufficient miles balance_. Surface this distinctly in
+              UI; users hate seeing a generic "bad request" when they're really
+              just short on miles.
+            - **409** — duplicate redemption attempt within 60s
+            (anti-double-click
+              guard). Safe to ignore on retry, but don't show two confirmations.
+
+            A `200` is **conditional** — confirm with `Get loyalty member`
+            before
+
+            telling the user the upgrade is real. We've seen the redemption show
+
+            up there a few seconds later than expected (see eventual-consistency
+
+            note on `Credit miles`).
+          sortKey: -1778270501099
+        method: POST
+        body:
+          mimeType: application/json
+          text: |-
+            {
+              "awardCode": "UPGRADE_J_DOM",
+              "flightNumber": "IA204",
+              "departureDate": "2026-05-12",
+              "milesCost": 25000
+            }
+        headers:
+          - name: Content-Type
+            value: application/json
+            disabled: false
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/loyalty/members/:ffId"
+        name: Get loyalty member
+        meta:
+          id: req_d1f7d3e8b2406c9d5a8f1e7b3c0d9041
+          created: 1778270501100
+          modified: 1778270501100
+          isPrivate: false
+          description: Returns the loyalty member's profile, tier, and current miles
+            balance.
+          sortKey: -1778270501100
+        method: GET
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+  - name: Catering
+    meta:
+      id: fld_c3e6f9b5a0d2528b1f7c0d3e9f5b2c94
+      created: 1778270502000
+      modified: 1778270502000
+      sortKey: -1778270502000
+      description: Per-flight meal manifests and per-station catering inventory.
+    children:
+      - url: "{{ _.base_url }}/catering/inventory/:stationIata"
+        name: Station catering inventory
+        meta:
+          id: req_c3f7d3e8b2406c9d5a8f1e7b3c0d9033
+          created: 1778270502098
+          modified: 1778270502098
+          isPrivate: false
+          description: Returns current meal-tray inventory at a catering station, by
+            category.
+          sortKey: -1778270502098
+        method: GET
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/catering/manifests/:flightNumber"
+        name: Update meal manifest
+        meta:
+          id: req_c2f7d3e8b2406c9d5a8f1e7b3c0d9032
+          created: 1778270502099
+          modified: 1778270502099
+          isPrivate: false
+          description: |-
+            Replaces the meal counts and special-meal selections for a flight.
+
+            **Cutoff:** edits are rejected with **422 Unprocessable Entity**
+            within **90 minutes of scheduled departure**. After the cutoff, the
+            manifest is locked and any changes have to go through the ground-ops
+            radio process — there's no API path through it. If you're building
+            UI that modifies the manifest, surface the cutoff to the user
+            _before_ they bother filling out the form.
+          sortKey: -1778270502099
+        method: PUT
+        body:
+          mimeType: application/json
+          text: |-
+            {
+              "departureDate": "2026-05-12",
+              "meals": {
+                "ECONOMY": 156,
+                "PREMIUM_ECONOMY": 18,
+                "BUSINESS": 12
+              },
+              "specialMeals": [
+                { "category": "VGML", "count": 4 },
+                { "category": "GFML", "count": 2 }
+              ]
+            }
+        headers:
+          - name: Content-Type
+            value: application/json
+            disabled: false
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/catering/manifests/:flightNumber"
+        name: Get meal manifest
+        meta:
+          id: req_c1f7d3e8b2406c9d5a8f1e7b3c0d9031
+          created: 1778270502100
+          modified: 1778270502100
+          isPrivate: false
+          description: >-
+            Returns the meal manifest for a specific flight instance.
+
+
+            **Timezone gotcha:** `departureDate` is the **station-local** date
+            at
+
+            the origin, _not_ UTC. A flight that pushes back at 23:55 ORD will
+
+            have `departureDate == ORD-local date`, which can be a different
+
+            calendar day from UTC. This matches how the Flights API stores it —
+
+            don't convert to UTC on the way in or you'll fetch the wrong
+
+            manifest (or a 404).
+          sortKey: -1778270502100
+        method: GET
+        parameters:
+          - name: departureDate
+            value: 2026-05-12
+            description: Station-local departure date at the origin (YYYY-MM-DD). Required.
+            disabled: false
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+  - name: Mechanics
+    meta:
+      id: fld_b2d5e8a4f9c1417a0e6b9c2d8e4f1a83
+      created: 1778270503000
+      modified: 1778270503000
+      sortKey: -1778270503000
+      description: Maintenance work orders and required-check tracking.
+    children:
+      - url: "{{ _.base_url }}/maintenance/checks/:tail"
+        name: Required checks for airframe
+        meta:
+          id: req_b4f7d3e8b2406c9d5a8f1e7b3c0d9024
+          created: 1778270503097
+          modified: 1778270503097
+          isPrivate: false
+          description: Returns the next mandatory checks (A/B/C/D) due for an airframe,
+            with hours/cycles remaining.
+          sortKey: -1778270503097
+        method: GET
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/maintenance/work-orders/:id"
+        name: Update work order
+        meta:
+          id: req_b3f7d3e8b2406c9d5a8f1e7b3c0d9023
+          created: 1778270503098
+          modified: 1778270503098
+          isPrivate: false
+          description: Partially updates a work order — typically used by mechanics to
+            advance status, log actual hours, or attach notes.
+          sortKey: -1778270503098
+        method: PATCH
+        body:
+          mimeType: application/json
+          text: |-
+            {
+              "status": "IN_PROGRESS",
+              "actualHours": 6.5,
+              "notes": "Borescope clean; moving to landing gear inspection."
+            }
+        headers:
+          - name: Content-Type
+            value: application/json
+            disabled: false
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/maintenance/work-orders"
+        name: Create work order
+        meta:
+          id: req_b2f7d3e8b2406c9d5a8f1e7b3c0d9022
+          created: 1778270503099
+          modified: 1778270503099
+          isPrivate: false
+          description: |-
+            Opens a new maintenance work order against an airframe.
+
+            **Idempotency-Key is required.** Without it, retries (network blip,
+            client retry, etc.) can create duplicate work orders, which the
+            mechanics team _will_ notice and complain about. Use a UUID v4 per
+            logical create — same key on retry, new key on a genuinely new
+            request.
+
+            Returns **400** if the header is missing.
+          sortKey: -1778270503099
+        method: POST
+        body:
+          mimeType: application/json
+          text: >-
+            {
+              "tailNumber": "C-FINS",
+              "type": "B_CHECK",
+              "priority": "ROUTINE",
+              "scheduledStart": "2026-05-15T08:00:00Z",
+              "estimatedHours": 24,
+              "notes": "Engine #2 borescope, scheduled with the heavy maintenance window."
+            }
+        headers:
+          - name: Content-Type
+            value: application/json
+            disabled: false
+          - name: Idempotency-Key
+            value: 9f3c2b8e-4d1a-4f7b-9c0e-2a8d6f4b1c93
+            description: UUID v4. Reuse on retries; rotate on new logical creates.
+            disabled: false
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/maintenance/work-orders"
+        name: List work orders
+        meta:
+          id: req_b1f7d3e8b2406c9d5a8f1e7b3c0d9021
+          created: 1778270503100
+          modified: 1781124471670
+          isPrivate: false
+          description: >-
+            Lists open and recent maintenance work orders, optionally filtered.
+
+
+            **Pagination quirk:** this endpoint paginates with **`?cursor=`**,
+            not
+
+            `?page=`. Without a cursor you get the first 50 results. The next
+
+            cursor is in the `Link` header — don't try to construct it yourself,
+
+            the format is opaque (looks like a base64 blob today, but their team
+
+            reserves the right to change it).
+          sortKey: -1778270503100
+        method: GET
+        parameters:
+          - name: status
+            value: OPEN
+            description: One of OPEN, IN_PROGRESS, CLOSED, CANCELLED.
+            disabled: false
+          - name: tail
+            value: C-FINS
+            description: Filter to work orders for a specific airframe.
+            disabled: true
+          - name: cursor
+            value: ""
+            description: Opaque pagination cursor from the previous response's Link header.
+            disabled: true
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+  - name: Aircraft
+    meta:
+      id: fld_a1c4f7d3e8b2406c9d5a8f1e7b3c0d92
+      created: 1778270504000
+      modified: 1778270504000
+      sortKey: -1778270504000
+      description: Fleet status, individual airframes, and utilization reporting.
+    children:
+      - url: "{{ _.base_url }}/fleet/utilization"
+        name: Fleet utilization report
+        meta:
+          id: req_a4f7d3e8b2406c9d5a8f1e7b3c0d9014
+          created: 1778270504097
+          modified: 1778270504097
+          isPrivate: false
+          description: Block hours and cycles per airframe across a date range. Used by
+            the planning team for fleet rotation.
+          sortKey: -1778270504097
+        method: GET
+        parameters:
+          - name: from
+            value: 2026-05-01
+            description: Inclusive start date (YYYY-MM-DD).
+            disabled: false
+          - name: to
+            value: 2026-05-08
+            description: Inclusive end date (YYYY-MM-DD).
+            disabled: false
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/fleet/:tail/status"
+        name: Set airframe status
+        meta:
+          id: req_a3f7d3e8b2406c9d5a8f1e7b3c0d9013
+          created: 1778270504098
+          modified: 1778270675613
+          isPrivate: false
+          description: >-
+            Changes the operational status of an airframe. Validated
+            server-side.
+
+
+            **Allowed transitions:**
+
+
+            - `ACTIVE` ↔ `MAINTENANCE` (round-trip — a plane can come out of MX)
+
+            - `ACTIVE` → `RETIRED` (one-way — see note below)
+
+
+            Anything else returns **409 Conflict**, _not_ 400. In particular,
+
+            `RETIRED` → `ACTIVE` is rejected: un-retiring an airframe is a
+            manual
+
+            process owned by Ops Engineering, talk to them before assuming this
+
+            endpoint can do it.
+          sortKey: -1778270504098
+        method: POST
+        body:
+          mimeType: application/json
+          text: |-
+            {
+              "status": "MAINTENANCE",
+              "reason": "Routine 500-cycle inspection",
+              "effectiveAt": "2026-05-09T03:00:00Z"
+            }
+        headers:
+          - name: Content-Type
+            value: application/json
+            disabled: false
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/fleet/:tail"
+        name: Get airframe by tail number
+        meta:
+          id: req_a2f7d3e8b2406c9d5a8f1e7b3c0d9012
+          created: 1778270504099
+          modified: 1778270504099
+          isPrivate: false
+          description: >-
+            Returns details for a single airframe.
+
+
+            **Heads up — tail numbers are case-sensitive _and_
+            punctuation-sensitive.**
+
+            Send them exactly as `C-FINS` (uppercase, with the dash). Variants
+            like
+
+            `cfins`, `C FINS`, or `C_FINS` all 404 with a generic `"not found"`
+            body
+
+            and no hint about the formatting. Don't lowercase before sending.
+          sortKey: -1778270504099
+        method: GET
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/fleet"
+        name: List fleet
+        meta:
+          id: req_a1f7d3e8b2406c9d5a8f1e7b3c0d9011
+          created: 1778270504100
+          modified: 1778270504100
+          isPrivate: false
+          description: Returns all airframes, with optional filters by aircraft type and
+            operational status.
+          sortKey: -1778270504100
+        method: GET
+        parameters:
+          - name: status
+            value: ACTIVE
+            description: One of ACTIVE, MAINTENANCE, RETIRED.
+            disabled: true
+          - name: type
+            value: A320
+            description: Aircraft type code (A320, B787).
+            disabled: true
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+cookieJar:
+  name: Default Jar
+  meta:
+    id: jar_ea26a0af122c2de0cf5c11966d492252bfa20809
+    created: 1778268242119
+    modified: 1778268242119
+environments:
+  name: Base Environment
+  meta:
+    id: env_ea26a0af122c2de0cf5c11966d492252bfa20809
+    created: 1778268242119
+    modified: 1778268242119
+    isPrivate: false

--- a/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/production_environment.yaml
+++ b/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/production_environment.yaml
@@ -1,0 +1,17 @@
+type: environment.insomnia.rest/5.0
+schema_version: "5.1"
+name: Production Environment
+meta:
+  id: wrk_359184e6c5fa4e86a4f92a586a6f7dd4
+  created: 1778528107896
+  modified: 1778528107896
+  description: ""
+environments:
+  name: Production
+  meta:
+    id: env_f77d857e60ce4a3eb0a626ff95f145e9
+    created: 1778268347067
+    modified: 1778531998213
+    isPrivate: false
+  data:
+    base_url: https://2110842ae3.us.serverless.gateways.konggateway.com

--- a/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/security.yaml
+++ b/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/security.yaml
@@ -1,0 +1,171 @@
+openapi: 3.0.4
+info:
+  title: Insomnia Airlines — Security & Testing API
+  description: >-
+    Authentication and testing utilities for **Insomnia Airlines**.
+
+
+    Use `GET /auth/token` to obtain a bearer token, then pass it as
+    `Authorization: Bearer <token>` on any Baggage API request. Tokens are
+    valid for 24 hours from the moment they are issued.
+
+
+    `GET /test/extra-data` generates large synthetic payloads for load and
+    performance testing. `GET /test/delay` introduces a controlled response
+    delay for latency and timeout testing. Both endpoints require a bearer
+    token and do not interact with any airline data.
+  version: 1.0.0
+  contact:
+    name: Insomnia Airlines API Team
+    email: api@insomnia-airlines.example
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: https://2110842ae3.us.serverless.gateways.konggateway.com
+    description: Kong Gateway
+  - url: https://insomnia-airlines-api.onrender.com
+    description: Production
+  - url: http://localhost:8000
+    description: Local dev
+tags:
+  - name: auth
+    description: Token issuance. Call this first to get a bearer token for the Baggage API.
+  - name: test
+    description: Synthetic data generation for load and performance testing.
+paths:
+  /auth/token:
+    get:
+      tags:
+        - auth
+      summary: Get auth token.
+      description: >-
+        Issues a new UUID bearer token. The token is valid for 24 hours. Pass
+        it to all Baggage API requests as `Authorization: Bearer <token>`.
+      operationId: getAuthToken
+      responses:
+        '200':
+          description: A freshly-issued auth token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthToken'
+              example:
+                token: 3f2a1b4c-dead-beef-cafe-000000000001
+                issuedAt: '2026-05-25T10:00:00Z'
+                expiresIn: 24h
+  /test/delay:
+    get:
+      tags:
+        - test
+      summary: Delayed response.
+      description: >-
+        Waits for the specified number of milliseconds before returning `200 OK`.
+        Defaults to 500 ms. Use this endpoint to test client timeout handling,
+        gateway timeout policies, and latency-dependent logic.
+      operationId: getDelay
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: ms
+          in: query
+          description: How long to wait before responding, in milliseconds.
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 30000
+            default: 500
+          example: 2000
+      responses:
+        '200':
+          description: Response returned after the requested delay.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DelayResponse'
+              example:
+                delayed_ms: 2000
+        '401':
+          description: Missing or invalid bearer token.
+  /test/extra-data:
+    get:
+      tags:
+        - test
+      summary: Get extra data.
+      description: >-
+        Returns a JSON object of synthetic name/value pairs. Use `itemCount` to
+        specify the number of fields directly, or `sizeInKB` to target an
+        approximate payload size. Defaults to 100 fields; maximum is 10 000
+        fields or 500 KB.
+      operationId: getExtraData
+      parameters:
+        - name: itemCount
+          in: query
+          description: Number of name/value pairs to include in the response.
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 10000
+          example: 500
+        - name: sizeInKB
+          in: query
+          description: Target response payload size in kilobytes (approximate).
+          required: false
+          schema:
+            type: number
+            exclusiveMinimum: 0
+            maximum: 500
+          example: 64
+      responses:
+        '200':
+          description: A flat object of synthetic name/value pairs.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+              example:
+                name1: value1
+                name2: value2
+                name3: value3
+        '400':
+          description: Both `itemCount` and `sizeInKB` were provided.
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+  schemas:
+    DelayResponse:
+      type: object
+      required:
+        - delayed_ms
+      properties:
+        delayed_ms:
+          type: integer
+          description: The number of milliseconds the server waited before responding.
+          example: 2000
+    AuthToken:
+      type: object
+      required:
+        - token
+        - issuedAt
+        - expiresIn
+      properties:
+        token:
+          type: string
+          format: uuid
+          description: Bearer token to pass in the Authorization header.
+          example: 3f2a1b4c-dead-beef-cafe-000000000001
+        issuedAt:
+          type: string
+          format: date-time
+          description: UTC timestamp when the token was issued.
+          example: '2026-05-25T10:00:00Z'
+        expiresIn:
+          type: string
+          description: Token lifetime expressed as a human-readable duration.
+          example: 24h

--- a/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/security_collection.yaml
+++ b/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/security_collection.yaml
@@ -1,0 +1,500 @@
+type: spec.insomnia.rest/5.0
+schema_version: "5.1"
+name: Security & Testing
+meta:
+  id: wrk_b2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7
+  created: 1779753600000
+  modified: 1779753600000
+  description: ""
+collection:
+  - url: "{{ _.base_url }}/test/extra-data"
+    name: Inheritance Test
+    meta:
+      id: req_6d4d4da71cdc41ad9fd942ac9e960c5e
+      created: 1779815482769
+      modified: 1779816054491
+      isPrivate: false
+      description: Returns a JSON object of synthetic name/value pairs. Use
+        `itemCount` to specify the number of fields directly, or `sizeInKB` to
+        target an approximate payload size. Defaults to 100 fields; maximum is
+        10 000 fields or 500 KB.
+      sortKey: -1779815199724
+    method: GET
+    parameters:
+      - name: itemCount
+        value: "100"
+        disabled: true
+      - name: sizeInKB
+        value: "64"
+        disabled: true
+    headers:
+      - name: x-inherited-value
+        value: "{{ _.inherited_value }}"
+        description: ""
+        disabled: false
+    authentication:
+      type: basic
+      useISO88591: false
+      username: "{{ _.inherited_value }}"
+      password: ""
+      disabled: false
+    scripts:
+      afterResponse: |-
+        insomnia.test('Status is 200', () => {
+          insomnia.expect(insomnia.response.status).to.eql(200);
+        });
+        insomnia.test('Response body is an object', () => {
+          const body = insomnia.response.json();
+          insomnia.expect(body).to.be.an('object');
+        });
+        insomnia.test('Response contains name1 field', () => {
+          const body = insomnia.response.json();
+          insomnia.expect(body).to.have.property('name1');
+        });
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+  - name: auth
+    meta:
+      id: fld_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6
+      created: 1779753600000
+      modified: 1779743141387
+      sortKey: -1779753600000
+      description: Token issuance. Call this first to get a bearer token for the
+        Baggage API.
+    children:
+      - url: "{{ _.base_url }}/auth/token"
+        name: Get auth token.
+        meta:
+          id: req_c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0
+          created: 1779753600000
+          modified: 1779753600000
+          isPrivate: false
+          description: "Issues a new UUID bearer token. The token is valid for 24 hours.
+            Pass it to all Baggage API requests as `Authorization: Bearer
+            <token>`."
+          sortKey: -1779753600000
+        method: GET
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+            insomnia.test('Response has token field', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.have.property('token');
+            });
+            insomnia.test('Response has issuedAt and expiresIn', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.have.property('issuedAt');
+              insomnia.expect(body).to.have.property('expiresIn');
+            });
+            const body = insomnia.response.json();
+            insomnia.globals.set('auth_token', body.token);
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+  - name: test
+    meta:
+      id: fld_f0e1d2c3b4a5f6e7d8c9b0a1f2e3d4c5
+      created: 1779753600000
+      modified: 1781112672831
+      sortKey: -1779753600001
+      description: Synthetic data generation for load and performance testing.
+    children:
+      - url: "{{ _.base_url }}/test/extra-data"
+        name: Get extra data.
+        meta:
+          id: req_d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9
+          created: 1779753600000
+          modified: 1781109096543
+          isPrivate: false
+          description: Returns a JSON object of synthetic name/value pairs. Use
+            `itemCount` to specify the number of fields directly, or `sizeInKB`
+            to target an approximate payload size. Defaults to 100 fields;
+            maximum is 10 000 fields or 500 KB.
+          sortKey: -1779753600001
+        method: GET
+        parameters:
+          - name: itemCount
+            value: "100"
+            disabled: true
+          - name: sizeInKB
+            value: "64"
+            disabled: true
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+            insomnia.test('Response body is an object', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.be.an('object');
+            });
+            insomnia.test('Response contains name1 field', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.have.property('name1');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/test/delay"
+        name: Delayed response.
+        meta:
+          id: req_e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8
+          created: 1779753600000
+          modified: 1779753600000
+          isPrivate: false
+          description: Waits for the specified number of milliseconds before returning
+            `200 OK`. Defaults to 500 ms. Use this to test client timeout
+            handling, gateway timeout policies, and latency-dependent logic.
+          sortKey: -1779753600000
+        method: GET
+        parameters:
+          - name: ms
+            value: "500"
+            disabled: true
+        headers:
+          - name: Authorization
+            value: Bearer {{ _.auth_token }}
+            disabled: false
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+            insomnia.test('Response has delayed_ms field', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.have.property('delayed_ms');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/test/delay"
+        name: Delayed response with prompt
+        meta:
+          id: req_2499a1df6cdc40e4a251818c6635ac58
+          created: 1779802919175
+          modified: 1779802954706
+          isPrivate: false
+          description: Waits for the specified number of milliseconds before returning
+            `200 OK`. Defaults to 500 ms. Use this to test client timeout
+            handling, gateway timeout policies, and latency-dependent logic.
+          sortKey: -1779746488882.5
+        method: GET
+        parameters:
+          - name: ms
+            value: "{% prompt 'How many milliseconds?', '', '500', '', false, true %}"
+            disabled: false
+        headers:
+          - name: Authorization
+            value: Bearer {{ _.auth_token }}
+            disabled: false
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+            insomnia.test('Response has delayed_ms field', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.have.property('delayed_ms');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+      - url: "{{ _.base_url }}/test/extra-data"
+        name: Massive Response
+        meta:
+          id: req_831b287b06574cfb93015241974b2b2a
+          created: 1781109105220
+          modified: 1781112797160
+          isPrivate: false
+          description: Returns a JSON object of synthetic name/value pairs. Use
+            `itemCount` to specify the number of fields directly, or `sizeInKB`
+            to target an approximate payload size. Defaults to 100 fields;
+            maximum is 10 000 fields or 500 KB.
+          sortKey: -1779753600000.5
+        method: GET
+        parameters:
+          - name: itemCount
+            value: "100"
+            disabled: true
+          - name: sizeInKB
+            value: "40000"
+            disabled: false
+        scripts:
+          afterResponse: |-
+            insomnia.test('Status is 200', () => {
+              insomnia.expect(insomnia.response.status).to.eql(200);
+            });
+            insomnia.test('Response body is an object', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.be.an('object');
+            });
+            insomnia.test('Response contains name1 field', () => {
+              const body = insomnia.response.json();
+              insomnia.expect(body).to.have.property('name1');
+            });
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+    scripts:
+      preRequest: |-
+        /*if (!insomnia.globals.get('auth_token')) {
+          const response = await insomnia.sendRequest({
+            url: insomnia.globals.get('base_url') + '/auth/token',
+            method: 'GET'
+          });
+          const body = response.json();
+          insomnia.globals.set('auth_token', body.token);
+        }*/
+  - name: inheritance
+    meta:
+      id: fld_e24f092224c24712bc0e624bae1ee0bc
+      created: 1779815199624
+      modified: 1779815930130
+      sortKey: -1779815199624
+      description: ""
+    environment:
+      inherited_value: from-folder
+    environmentPropertyOrder:
+      "&":
+        - inherited_value
+cookieJar:
+  name: Default Jar
+  meta:
+    id: jar_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0
+    created: 1779753600000
+    modified: 1781112672829
+environments:
+  name: Security Collection-level Env
+  meta:
+    id: env_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0
+    created: 1779753600000
+    modified: 1781112672830
+    isPrivate: false
+  data:
+    inherited_value: from-collection-env
+  subEnvironments:
+    - name: Shared Child Collection Env
+      meta:
+        id: env_ce01ec4776894c65bdac6257f386682e
+        created: 1779815070437
+        modified: 1779815572862
+        isPrivate: false
+        sortKey: 1779815070437
+      data:
+        inherited_value: from-shared-child-collection-env
+      color: "#ca2121"
+    - name: Empty Env
+      meta:
+        id: env_78889bc1bfad49a19d1d56fe11578272
+        created: 1779815546981
+        modified: 1781112672830
+        isPrivate: false
+        sortKey: 1779815546981
+spec:
+  contents:
+    openapi: 3.0.4
+    info:
+      title: Insomnia Airlines — Security & Testing API
+      description: >-
+        Authentication and testing utilities for **Insomnia Airlines**.
+
+
+        Use `GET /auth/token` to obtain a bearer token, then pass it as
+        `Authorization: Bearer <token>` on any Baggage API request. Tokens are
+        valid for 24 hours from the moment they are issued.
+
+
+        `GET /test/extra-data` generates large synthetic payloads for load and
+        performance testing. `GET /test/delay` introduces a controlled response
+        delay for latency and timeout testing. Both endpoints require a bearer
+        token and do not interact with any airline data.
+      version: 1.0.0
+      contact:
+        name: Insomnia Airlines API Team
+        email: api@insomnia-airlines.example
+      license:
+        name: Apache 2.0
+        url: https://www.apache.org/licenses/LICENSE-2.0.html
+    servers:
+      - url: https://2110842ae3.us.serverless.gateways.konggateway.com
+        description: Kong Gateway
+      - url: https://insomnia-airlines-api.onrender.com
+        description: Production
+      - url: http://localhost:8000
+        description: Local dev
+    tags:
+      - name: auth
+        description: Token issuance. Call this first to get a bearer token for the
+          Baggage API.
+      - name: test
+        description: Synthetic data generation for load and performance testing.
+    paths:
+      /auth/token:
+        get:
+          tags:
+            - auth
+          summary: Get auth token.
+          description: "Issues a new UUID bearer token. The token is valid for 24 hours.
+            Pass it to all Baggage API requests as `Authorization: Bearer
+            <token>`."
+          operationId: getAuthToken
+          responses:
+            "200":
+              description: A freshly-issued auth token.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/AuthToken"
+                  example:
+                    token: 3f2a1b4c-dead-beef-cafe-000000000001
+                    issuedAt: 2026-05-25T10:00:00Z
+                    expiresIn: 24h
+      /test/delay:
+        get:
+          tags:
+            - test
+          summary: Delayed response.
+          description: Waits for the specified number of milliseconds before returning
+            `200 OK`. Defaults to 500 ms. Use this endpoint to test client
+            timeout handling, gateway timeout policies, and latency-dependent
+            logic.
+          operationId: getDelay
+          parameters:
+            - name: ms
+              in: query
+              description: How long to wait before responding, in milliseconds.
+              required: false
+              schema:
+                type: integer
+                minimum: 0
+                maximum: 30000
+                default: 500
+              example: 2000
+          responses:
+            "200":
+              description: Response returned after the requested delay.
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/DelayResponse"
+                  example:
+                    delayed_ms: 2000
+            "401":
+              description: Missing or invalid bearer token.
+      /test/extra-data:
+        get:
+          tags:
+            - test
+          summary: Get extra data.
+          description: Returns a JSON object of synthetic name/value pairs. Use
+            `itemCount` to specify the number of fields directly, or `sizeInKB`
+            to target an approximate payload size. Defaults to 100 fields;
+            maximum is 10 000 fields or 500 KB.
+          operationId: getExtraData
+          parameters:
+            - name: itemCount
+              in: query
+              description: Number of name/value pairs to include in the response.
+              required: false
+              schema:
+                type: integer
+                minimum: 1
+                maximum: 10000
+              example: 500
+            - name: sizeInKB
+              in: query
+              description: Target response payload size in kilobytes (approximate).
+              required: false
+              schema:
+                type: number
+                exclusiveMinimum: 0
+                maximum: 500
+              example: 64
+          responses:
+            "200":
+              description: A flat object of synthetic name/value pairs.
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    additionalProperties:
+                      type: string
+                  example:
+                    name1: value1
+                    name2: value2
+                    name3: value3
+            "400":
+              description: Both `itemCount` and `sizeInKB` were provided.
+    components:
+      securitySchemes:
+        bearerAuth:
+          type: http
+          scheme: bearer
+      schemas:
+        DelayResponse:
+          type: object
+          required:
+            - delayed_ms
+          properties:
+            delayed_ms:
+              type: integer
+              description: The number of milliseconds the server waited before responding.
+              example: 2000
+        AuthToken:
+          type: object
+          required:
+            - token
+            - issuedAt
+            - expiresIn
+          properties:
+            token:
+              type: string
+              format: uuid
+              description: Bearer token to pass in the Authorization header.
+              example: 3f2a1b4c-dead-beef-cafe-000000000001
+            issuedAt:
+              type: string
+              format: date-time
+              description: UTC timestamp when the token was issued.
+              example: 2026-05-25T10:00:00Z
+            expiresIn:
+              type: string
+              description: Token lifetime expressed as a human-readable duration.
+              example: 24h
+  meta:
+    id: spc_e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6
+    created: 1779753600000
+    modified: 1779814874523

--- a/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/staging_environment.yaml
+++ b/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/staging_environment.yaml
@@ -1,0 +1,17 @@
+type: environment.insomnia.rest/5.0
+schema_version: "5.1"
+name: Staging Environment
+meta:
+  id: wrk_ecddfb22aa874848b5c074758e70bbd3
+  created: 1778268347052
+  modified: 1778268347052
+  description: ""
+environments:
+  name: Staging
+  meta:
+    id: env_fd4df06d094a0ae36506ef56850c97d10a978188
+    created: 1778268347067
+    modified: 1778513255096
+    isPrivate: false
+  data:
+    base_url: https://insomnia-airlines-api.onrender.com

--- a/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/variable_inheritance.yaml
+++ b/packages/insomnia/src/common/__fixtures__/insomnia-v5-roundtrip/variable_inheritance.yaml
@@ -1,0 +1,75 @@
+type: collection.insomnia.rest/5.0
+schema_version: "5.1"
+name: Variable Inheritance
+meta:
+  id: wrk_efcf2df7312846d184cb82fba2fe8755
+  created: 1779816112607
+  modified: 1779816112607
+  description: ""
+collection:
+  - name: grandparent
+    meta:
+      id: fld_87b0432032bf4237977594affb1976fb
+      created: 1779816124318
+      modified: 1779816364828
+      sortKey: -1779816124318
+      description: ""
+    children:
+      - name: parent
+        meta:
+          id: fld_416a8cde60014e13808286c925cda903
+          created: 1779816141613
+          modified: 1779816391323
+          sortKey: -1779816141613
+          description: ""
+        children:
+          - url: https://insomnia-airlines-api.onrender.com/test/extra-data
+            name: Child Request
+            meta:
+              id: req_70759093fbcf498996c1da257b8e6f8b
+              created: 1779816145656
+              modified: 1779816330205
+              isPrivate: false
+              description: ""
+              sortKey: -1779816145656
+            method: GET
+            headers:
+              - name: User-Agent
+                value: insomnia/12.5.1-alpha.0
+                description: ""
+                disabled: false
+              - name: x-test-value
+                value: "{{ _['test-value'] }}"
+                description: ""
+                disabled: false
+            authentication:
+              type: basic
+              useISO88591: false
+              username: "{{ _['test-value'] }}"
+              password: ""
+              disabled: false
+            settings:
+              renderRequestBody: true
+              encodeUrl: true
+              followRedirects: global
+              cookies:
+                send: true
+                store: true
+              rebuildPath: true
+    environment:
+      test-value: grandparent
+cookieJar:
+  name: Default Jar
+  meta:
+    id: jar_4886ac6900e625c33f800075dc17c4aec7c508d6
+    created: 1779816112609
+    modified: 1779816112609
+environments:
+  name: Base Environment
+  meta:
+    id: env_4886ac6900e625c33f800075dc17c4aec7c508d6
+    created: 1779816112609
+    modified: 1779816233120
+    isPrivate: false
+  data:
+    test-value: collection

--- a/packages/insomnia/src/common/__tests__/import-export-roundtrip.test.ts
+++ b/packages/insomnia/src/common/__tests__/import-export-roundtrip.test.ts
@@ -1,0 +1,114 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { database as db, models, services } from 'insomnia-data';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+// eslint-disable-next-line no-restricted-imports
+import { resetV4Counter } from '../../../../insomnia-data/__mocks__/uuid';
+import * as importUtil from '../import';
+import { getInsomniaV5DataExport } from '../insomnia-v5';
+
+// The shared test setup mocks `uuid` with a finite pool and shares one NeDB
+// instance across tests. Wipe every collection and reset the id pool per test so
+// each fixture starts from a clean slate with the full pool for its two
+// round-trips (the mocked ids are deterministic, so a clean DB avoids collisions).
+beforeEach(async () => {
+  await Promise.all(models.types().map(type => db.removeWhere(type, {})));
+  resetV4Counter();
+});
+
+const FIXTURE_DIR = path.join(__dirname, '..', '__fixtures__', 'insomnia-v5-roundtrip');
+
+// Real-world Insomnia exports (airline demo) covering every workspace type:
+// design specs, collections, environments and an MCP client, plus a raw
+// OpenAPI document that imports as a design doc.
+const fixtures = fs.readdirSync(FIXTURE_DIR).filter(f => f.endsWith('.yaml'));
+
+// Strip the fields that are legitimately regenerated on every import (ids and
+// timestamps) so two exports can be compared for structural/semantic equality.
+const VOLATILE_KEYS = new Set(['id', 'created', 'modified']);
+// Model ids have the form `<prefix>_<32 hex>`. They are regenerated on every
+// import and can appear embedded inside string values too - e.g. a `{% response
+// 'body', 'req_...' %}` template tag that references another request. The
+// importer correctly rewrites those references, so the reference is stable, only
+// its opaque value changes. Mask them so the comparison is about structure.
+const EMBEDDED_ID = /\b[a-z]{2,}_[0-9a-f]{32}\b/g;
+const normalize = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    // Sort arrays by their canonical content so the comparison is insensitive to
+    // sibling ordering. The export currently emits collection items and
+    // sub-environments in database insertion order, which is not stable across
+    // round-trips; making the export order deterministic (by metaSortKey) is
+    // tracked as a separate change, so this test asserts data preservation only.
+    return value
+      .map(normalize)
+      .sort((a, b) => (JSON.stringify(a) < JSON.stringify(b) ? -1 : 1));
+  }
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = VOLATILE_KEYS.has(key) ? '<normalized>' : normalize(val);
+    }
+    return out;
+  }
+  if (typeof value === 'string') {
+    return value.replace(EMBEDDED_ID, '<id>');
+  }
+  return value;
+};
+
+// Imports a YAML string into a fresh project and exports every workspace it
+// created back to v5 YAML.
+const importThenExport = async (contentStr: string): Promise<string[]> => {
+  const scanResult = await importUtil.scanResources([{ contentStr }]);
+  expect(scanResult.flatMap(r => r.errors)).toEqual([]);
+
+  const project = await services.project.create();
+  const workspaces = await importUtil.importResourcesToProject({ projectId: project._id });
+  expect(workspaces.length).toBeGreaterThan(0);
+
+  return Promise.all(
+    workspaces.map(workspace =>
+      getInsomniaV5DataExport({ workspaceId: workspace._id, includePrivateEnvironments: true }),
+    ),
+  );
+};
+
+describe('import/export round-trip is deterministic on real exports', () => {
+  it.each(fixtures)('%s reaches a stable fixed point after a second round-trip', async fixture => {
+    const original = fs.readFileSync(path.join(FIXTURE_DIR, fixture), 'utf8');
+
+    // First round-trip: import the (possibly non-canonical) source and export
+    // it to its canonical v5 form.
+    const [firstExport] = await importThenExport(original);
+    expect(firstExport).not.toBe('');
+
+    // Second round-trip: re-importing and re-exporting the canonical form must
+    // produce the exact same document (a fixed point). The design-doc wrapper
+    // bug breaks this - the spec contents grow an extra Insomnia envelope each
+    // round.
+    const [secondExport] = await importThenExport(firstExport);
+
+    expect(normalize(parse(secondExport))).toEqual(normalize(parse(firstExport)));
+  });
+
+  it('never wraps a design-doc spec in the Insomnia v5 envelope', async () => {
+    const designFixtures = fixtures.filter(f => fs.readFileSync(path.join(FIXTURE_DIR, f), 'utf8').startsWith('type: spec.insomnia.rest/5.0'));
+    expect(designFixtures.length).toBeGreaterThan(0);
+
+    for (const fixture of designFixtures) {
+      const original = fs.readFileSync(path.join(FIXTURE_DIR, fixture), 'utf8');
+      const [firstExport] = await importThenExport(original);
+      const parsed = parse(firstExport);
+
+      // spec.contents must be the OpenAPI document, not the Insomnia envelope.
+      const contents = parsed?.spec?.contents;
+      expect(contents, `${fixture} should export spec.contents`).toBeTruthy();
+      expect(contents.type, `${fixture} leaked the v5 envelope into spec.contents`).toBeUndefined();
+      expect(contents.schema_version, `${fixture} leaked schema_version into spec.contents`).toBeUndefined();
+      expect(contents.openapi || contents.swagger, `${fixture} should be an OpenAPI/Swagger doc`).toBeTruthy();
+    }
+  });
+});

--- a/packages/insomnia/src/common/__tests__/import.test.ts
+++ b/packages/insomnia/src/common/__tests__/import.test.ts
@@ -7,7 +7,7 @@ import { parse } from 'yaml';
 
 import * as importUtil from '../import';
 import { INSOMNIA_SCHEMA_VERSION } from '../insomnia-schema-migrations/schema-version';
-import { tryImportV5Data } from '../insomnia-v5';
+import { getInsomniaV5DataExport, tryImportV5Data } from '../insomnia-v5';
 import { generateId } from '../misc';
 
 describe('pathPatternMatches', () => {
@@ -559,5 +559,169 @@ describe('importRaw()', () => {
 
     const result = importUtil.resolveOperationId('nonExistentOpId');
     expect(result).toBeUndefined();
+  });
+});
+
+describe('export/import round-trip is deterministic', () => {
+  // Exports a workspace to v5 YAML, imports it into a fresh project, and
+  // returns the single workspace that was created from the import.
+  const roundTrip = async (workspaceId: string) => {
+    const exported = await getInsomniaV5DataExport({ workspaceId, includePrivateEnvironments: true });
+    expect(exported).not.toBe('');
+
+    const scanResult = await importUtil.scanResources([{ contentStr: exported }]);
+    expect(scanResult[0].errors).toEqual([]);
+
+    const targetProject = await services.project.create();
+    const imported = await importUtil.importResourcesToProject({ projectId: targetProject._id });
+    expect(imported).toHaveLength(1);
+
+    return { exported, workspace: imported[0] };
+  };
+
+  it('preserves a design-doc spec without prepending the Insomnia v5 wrapper', async () => {
+    const openApiContents = [
+      'openapi: 3.0.4',
+      'info:',
+      '  title: Bookings API',
+      '  version: 1.0.0',
+      'paths:',
+      '  /bookings:',
+      '    get:',
+      '      summary: List bookings.',
+      '      responses:',
+      "        '200':",
+      '          description: Successful operation.',
+      '',
+    ].join('\n');
+
+    const sourceWorkspace = await services.workspace.create({ name: 'Bookings', scope: 'design' });
+    await services.environment.getOrCreateForParentId(sourceWorkspace._id);
+    await services.apiSpec.updateOrCreateForParentId(sourceWorkspace._id, {
+      contents: openApiContents,
+      contentType: 'yaml',
+      fileName: 'Bookings',
+    });
+
+    const { workspace } = await roundTrip(sourceWorkspace._id);
+    expect(workspace.scope).toBe('design');
+
+    const importedSpec = await services.apiSpec.getByParentId(workspace._id);
+    expect(importedSpec).toBeTruthy();
+
+    // The spec must round-trip as the OpenAPI document only - it must NOT carry
+    // the Insomnia v5 envelope (type/schema_version/collection/meta).
+    expect(importedSpec?.contents).not.toContain('type: spec.insomnia.rest/5.0');
+    expect(importedSpec?.contents).not.toContain('schema_version');
+
+    const parsed = parse(importedSpec?.contents || '');
+    expect(parsed?.openapi).toBe('3.0.4');
+    expect(parsed?.info?.title).toBe('Bookings API');
+    expect(parsed?.paths?.['/bookings']).toBeTruthy();
+  });
+
+  it('preserves a collection with a folder and request', async () => {
+    const sourceWorkspace = await services.workspace.create({ name: 'My Collection', scope: 'collection' });
+    await services.environment.getOrCreateForParentId(sourceWorkspace._id);
+
+    const folder = await services.requestGroup.create({ name: 'Folder A', parentId: sourceWorkspace._id });
+    await services.request.create({
+      name: 'Create booking',
+      parentId: folder._id,
+      url: '{{ _.base_url }}/bookings',
+      method: 'POST',
+      body: { mimeType: 'application/json', text: '{"hello":"world"}' },
+    });
+
+    const { workspace } = await roundTrip(sourceWorkspace._id);
+    expect(workspace.scope).toBe('collection');
+
+    const folders = await services.requestGroup.findByParentId(workspace._id);
+    expect(folders.map(f => f.name)).toEqual(['Folder A']);
+
+    const requests = await services.request.findByParentId(folders[0]._id);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      name: 'Create booking',
+      url: '{{ _.base_url }}/bookings',
+      method: 'POST',
+      body: { mimeType: 'application/json', text: '{"hello":"world"}' },
+    });
+  });
+
+  it('preserves an environment workspace with sub-environment data', async () => {
+    const sourceWorkspace = await services.workspace.create({ name: 'Dev Environment', scope: 'environment' });
+    const baseEnv = await services.environment.getOrCreateForParentId(sourceWorkspace._id);
+    await services.environment.create({
+      name: 'Dev',
+      parentId: baseEnv._id,
+      data: { base_url: 'http://localhost:8000', auth_token: 'secret-token' },
+    });
+
+    const { workspace } = await roundTrip(sourceWorkspace._id);
+    expect(workspace.scope).toBe('environment');
+
+    const importedBase = await services.environment.getByParentId(workspace._id);
+    const subEnvs = await services.environment.findByParentId(importedBase!._id);
+    expect(subEnvs).toHaveLength(1);
+    expect(subEnvs[0].name).toBe('Dev');
+    expect(subEnvs[0].data).toEqual({ base_url: 'http://localhost:8000', auth_token: 'secret-token' });
+  });
+
+  it('preserves a mock server with its routes', async () => {
+    const sourceWorkspace = await services.workspace.create({ name: 'My Mock', scope: 'mock-server' });
+    await services.environment.getOrCreateForParentId(sourceWorkspace._id);
+    const mockServer = await services.mockServer.create({
+      name: 'My Mock',
+      parentId: sourceWorkspace._id,
+      url: 'http://localhost:8080',
+      useInsomniaCloud: false,
+    });
+    await services.mockRoute.create({
+      name: '/auth/login',
+      parentId: mockServer._id,
+      method: 'POST',
+      mimeType: 'application/json',
+      statusCode: 200,
+      body: '{"token":"abc"}',
+      headers: [{ name: 'Content-Type', value: 'application/json' }],
+    });
+
+    const { workspace } = await roundTrip(sourceWorkspace._id);
+    expect(workspace.scope).toBe('mock-server');
+
+    const importedServer = await services.mockServer.getByParentId(workspace._id);
+    expect(importedServer).toMatchObject({ url: 'http://localhost:8080', useInsomniaCloud: false });
+
+    const routes = await services.mockRoute.findByParentId(importedServer!._id);
+    expect(routes).toHaveLength(1);
+    expect(routes[0]).toMatchObject({
+      name: '/auth/login',
+      method: 'POST',
+      statusCode: 200,
+      body: '{"token":"abc"}',
+    });
+  });
+
+  it('preserves an MCP client request', async () => {
+    const sourceWorkspace = await services.workspace.create({ name: 'My MCP', scope: 'mcp' });
+    await services.environment.getOrCreateForParentId(sourceWorkspace._id);
+    await services.mcpRequest.create({
+      name: 'MCP',
+      parentId: sourceWorkspace._id,
+      url: 'https://example.com/mcp',
+      transportType: 'streamable-http',
+      headers: [{ name: 'User-Agent', value: 'insomnia' }],
+    });
+
+    const { workspace } = await roundTrip(sourceWorkspace._id);
+    expect(workspace.scope).toBe('mcp');
+
+    const importedRequest = await services.mcpRequest.getByParentId(workspace._id);
+    expect(importedRequest).toMatchObject({
+      url: 'https://example.com/mcp',
+      transportType: 'streamable-http',
+      headers: [{ name: 'User-Agent', value: 'insomnia' }],
+    });
   });
 });

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -592,15 +592,20 @@ export const importResourcesToNewWorkspace = async ({
   const ResourceIdMap = new Map();
   let newWorkspace: Workspace;
   // support import from both insomnia export and api spec yaml
-  if (resources.find(isApiSpec) || isApiSpecImport(resourceCacheItem.importer)) {
+  const apiSpecResource = resources.find(isApiSpec);
+  if (apiSpecResource || isApiSpecImport(resourceCacheItem.importer)) {
     newWorkspace = await services.workspace.create({
       name: workspaceToImport?.name,
       scope: 'design',
       parentId: projectId,
     });
 
+    // For an Insomnia v5 export the parsed spec resource already holds just the
+    // OpenAPI document. Use it directly so the round-trip stays deterministic.
+    // For a raw API spec import (openapi3/swagger2) there is no spec resource,
+    // so fall back to the imported file content, which is the spec itself.
     await services.apiSpec.updateOrCreateForParentId(newWorkspace._id, {
-      contents: resourceCacheItem.content as string | undefined,
+      contents: apiSpecResource ? apiSpecResource.contents : (resourceCacheItem.content as string | undefined),
       contentType: 'yaml',
       fileName: workspaceToImport?.name,
     });


### PR DESCRIPTION
## Summary

Importing an Insomnia v5 **Design Document** export was storing the *entire* v5
file (the `type:`/`schema_version:`/`meta:`/`collection:` envelope) as the API
spec contents, instead of just the OpenAPI document it wraps. The result: after
a re-import the spec editor showed Insomnia's internal metadata at the top and
the docs preview failed with *"Unable to render… Supported: swagger 2.0,
OpenAPI 3.x"*.

This PR fixes the import so export → import is consistent for design docs, and
adds automated round-trip tests (including real-world exports) so it stays that
way.

## Root cause

In `importResourcesToNewWorkspace`,
the design-doc branch set the API spec `contents` to `resourceCacheItem.content`
— the raw imported file. That's correct for a *raw* OpenAPI/Swagger import (the
file genuinely is the spec), but wrong for an Insomnia v5 design doc, where the
v5 importer has already parsed out the OpenAPI document into an `ApiSpec`
resource whose `contents` field holds exactly what we want.

## Fix

Use the parsed `ApiSpec` resource's `contents` when present (v5 design-doc
import), and only fall back to the raw file content for raw `openapi3`/`swagger2`
imports.

## Tests

- **`import.test.ts`** — round-trip tests for all 5 workspace types
  (design / collection / environment / mock server / MCP), with an explicit
  assertion that a design-doc spec round-trips as OpenAPI only and never carries
  the v5 envelope.
- **`import-export-roundtrip.test.ts`** — a fixed-point determinism test driven
  by 14 real exports (an airline-demo project): each fixture is imported →
  exported → re-imported → re-exported, and the two exports are asserted equal
  (ids/timestamps normalized). Covers design specs, collections, environments,
  an MCP client, and a raw OpenAPI document.

## How to verify manually

1. Import one of the design-doc fixtures (e.g. `bookings.yaml`) — it imports as a
   Design Document.
2. Open it: the spec editor shows the OpenAPI document (`openapi: 3.0.4`, `info`,
   `paths`…) and the docs preview renders. Before this fix, it showed the
   Insomnia `type:/schema_version:/collection:` metadata with the "Unable to
   render" error.
3. Export it and re-import — the spec stays clean and renders.