### PR TITLE
chore: optimize meta.json writes and add file recovery

### DIFF
--- a/packages/insomnia/src/main/cloud-sync/core/__tests__/vcs.test.ts
+++ b/packages/insomnia/src/main/cloud-sync/core/__tests__/vcs.test.ts
@@ -1004,6 +1004,71 @@ describe('VCS', () => {
     });
   });
 
+  describe('_storeBackendProject()', () => {
+    let driver: MemoryDriver;
+    let vcs: VCS;
+    let backendProject: BackendProject;
+
+    beforeEach(() => {
+      driver = new MemoryDriver();
+      vcs = new VCS(driver);
+      backendProject = projectBuilder.reset().build();
+    });
+
+    it('writes backend project metadata when missing', async () => {
+      const setItemSpy = vi.spyOn(driver, 'setItem');
+
+      await vcs._storeBackendProject(backendProject);
+
+      expect(setItemSpy).toHaveBeenCalledTimes(1);
+      expect(setItemSpy).toHaveBeenCalledWith(
+        `/projects/${backendProject.id}/meta.json`,
+        expect.any(Buffer),
+      );
+      expect(await vcs._getBackendProjectById(backendProject.id)).toEqual(backendProject);
+    });
+
+    it('skips identical backend project metadata writes', async () => {
+      const setItemSpy = vi.spyOn(driver, 'setItem');
+
+      await vcs._storeBackendProject(backendProject);
+      setItemSpy.mockClear();
+
+      await vcs._storeBackendProject(backendProject);
+
+      expect(setItemSpy).not.toHaveBeenCalled();
+    });
+
+    it('writes changed backend project metadata', async () => {
+      const setItemSpy = vi.spyOn(driver, 'setItem');
+      const updatedProject = {
+        ...backendProject,
+        name: `${backendProject.name} Updated`,
+      };
+
+      await vcs._storeBackendProject(backendProject);
+      setItemSpy.mockClear();
+
+      await vcs._storeBackendProject(updatedProject);
+
+      expect(setItemSpy).toHaveBeenCalledTimes(1);
+      expect(await vcs._getBackendProjectById(backendProject.id)).toEqual(updatedProject);
+    });
+
+    it('writes backend project metadata when existing meta.json is corrupted', async () => {
+      await driver.setItem(`/projects/${backendProject.id}/meta.json`, Buffer.from('{', 'utf8'));
+      const setItemSpy = vi.spyOn(driver, 'setItem');
+
+      await vcs._storeBackendProject(backendProject);
+
+      expect(setItemSpy).toHaveBeenCalledTimes(1);
+      expect(setItemSpy).toHaveBeenCalledWith(
+        `/projects/${backendProject.id}/meta.json`,
+        expect.any(Buffer),
+      );
+    });
+  });
+
   it('validate branch names', async () => {
     expect(VCS.validateBranchName('branchA')).toEqual('');
     expect(VCS.validateBranchName('feat/branch-A')).toEqual('');

--- a/packages/insomnia/src/main/cloud-sync/core/vcs.ts
+++ b/packages/insomnia/src/main/cloud-sync/core/vcs.ts
@@ -11,6 +11,7 @@ import type { BaseModel } from 'insomnia-data';
 import * as crypt from '~/common/account/crypt';
 import * as session from '~/common/account/session';
 import { PLAYWRIGHT_TEST } from '~/common/constants';
+import { deterministicStringify } from '~/sync/lib/deterministic-stringify';
 
 import type { Operation } from '../../../common/database';
 import { generateId } from '../../../common/misc';
@@ -1347,7 +1348,7 @@ export class VCS {
 
   async _getBackendProject(): Promise<BackendProject | null> {
     const projectId = this._backendProject ? this._backendProject.id : 'n/a';
-    return this._store.getItem(`/projects/${projectId}/meta.json`);
+    return this._getBackendProjectById(projectId);
   }
 
   async _getBackendProjectById(projectId: string): Promise<BackendProject | null> {
@@ -1378,6 +1379,18 @@ export class VCS {
   }
 
   async _storeBackendProject(project: BackendProject) {
+    let existingProject: BackendProject | null = null;
+    try {
+      existingProject = await this._getBackendProjectById(project.id);
+    } catch (err) {
+      console.warn('[sync] Failed to get existing backend project %s', project.id, err);
+    }
+
+    if (existingProject && deterministicStringify(existingProject) === deterministicStringify(project)) {
+      console.debug('[sync] Skipping store due to no backend changes');
+      return;
+    }
+
     return this._store.setItem(`/projects/${project.id}/meta.json`, project);
   }
 


### PR DESCRIPTION
Following #7111

Reduces unnecessary disk I/O and improves resilience when updating meta.json:

1. Compares existing file content with the new payload before writing, avoiding redundant writes if the data hasn't changed.