### PR TITLE
security(electron): enable contextIsolation on the main window

### DIFF
--- a/packages/insomnia/src/entry.client.tsx
+++ b/packages/insomnia/src/entry.client.tsx
@@ -13,6 +13,7 @@ import { rendererRuntime } from '~/runtimes/runtime.renderer';
 import { migrateFromLocalStorage, type SessionData, setSessionData, setVaultSessionData } from '~/ui/account/session';
 import { database as clientDatabase } from '~/ui/database.client';
 import { applyColorScheme } from '~/ui/plugins/misc';
+import { createServicesProxy } from '~/ui/services-proxy';
 import { clearOAuthWindowSessionId } from '~/ui/spawn-oauth-window';
 import { getInitialEntry } from '~/ui/utils/router';
 
@@ -29,14 +30,19 @@ initializeSentry();
 
 // Initialize database for renderer process
 await initDatabase(clientDatabase);
-// Initialize services for renderer process
-if (!window._dataServices) {
+// Initialize services for renderer process.
+// With contextIsolation the preload exposes a flat invoke (a Proxy can't cross
+// the bridge), so rebuild the Proxy here. Without it, the Proxy is on window directly.
+const dataServices =
+  window._dataServices ?? (window._dataServicesInvoke ? createServicesProxy(window._dataServicesInvoke) : undefined);
+if (!dataServices) {
   throw new Error(
-    'window._dataServices is not available. This entrypoint must run in an environment with the preload bridge.',
+    'Services bridge is not available. This entrypoint must run in an environment with the preload bridge.',
   );
 }
-initServices(window._dataServices);
+initServices(dataServices);
 // Remove the global services reference after initialization to improve security by preventing unintended access from the global scope.
+// (no-op under contextIsolation, where the property is never set on window)
 delete window._dataServices;
 initRuntime(rendererRuntime);
 

--- a/packages/insomnia/src/entry.client.tsx
+++ b/packages/insomnia/src/entry.client.tsx
@@ -41,9 +41,6 @@ if (!dataServices) {
   );
 }
 initServices(dataServices);
-// Remove the global services reference after initialization to improve security by preventing unintended access from the global scope.
-// (no-op under contextIsolation, where the property is never set on window)
-delete window._dataServices;
 initRuntime(rendererRuntime);
 
 configureFetch(options => insomniaFetch({ ...options, onDeepLink: (uri: string) => window.main.openDeepLink(uri) }));

--- a/packages/insomnia/src/entry.preload.ts
+++ b/packages/insomnia/src/entry.preload.ts
@@ -468,10 +468,9 @@ const dialog: Window['dialog'] = {
 const app: Window['app'] = {
   getPath: options => ipcRenderer.sendSync('getPath', options),
   getAppPath: () => ipcRenderer.sendSync('getAppPath'),
+  // platform is constant; expose a plain value so it survives contextBridge cloning (getters are not preserved).
   process: {
-    get platform() {
-      return process.platform as NodeJS.Platform;
-    },
+    platform: process.platform as NodeJS.Platform,
   },
 };
 const shell: Window['shell'] = {
@@ -535,7 +534,13 @@ if (process.contextIsolated) {
   contextBridge.exposeInMainWorld('webUtils', webUtils);
   contextBridge.exposeInMainWorld('path', path);
   contextBridge.exposeInMainWorld('database', database);
-  contextBridge.exposeInMainWorld('_dataServices', servicesProxy);
+  // A Proxy cannot be cloned across the contextBridge, so expose a flat invoke
+  // function and rebuild the services Proxy in the isolated renderer world.
+  contextBridge.exposeInMainWorld(
+    '_dataServicesInvoke',
+    (serviceName: string, methodName: string, ...args: unknown[]) =>
+      invokeWithNormalizedError('services.invoke', serviceName, methodName, ...args),
+  );
   contextBridge.exposeInMainWorld('env', env);
 } else {
   window.main = main;

--- a/packages/insomnia/src/entry.preload.ts
+++ b/packages/insomnia/src/entry.preload.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer, webUtils as webUtilities } from 'electron';
+import { contextBridge, ipcRenderer, type IpcRendererEvent, webUtils as webUtilities } from 'electron';
 import type { AuthTypeOAuth2, OAuth2Token, RequestHeader } from 'insomnia-data';
 
 import type {
@@ -197,10 +197,6 @@ const sync: SyncBridgeAPI = {
     invokeSyncMethod('switchAndCreateBackendProjectIfNotExist', ...args),
   takeSnapshot: (...args) => invokeSyncMethod('takeSnapshot', ...args),
   unstage: (...args) => invokeSyncMethod('unstage', ...args),
-  on: (channel, listener) => {
-    ipcRenderer.on(channel, listener);
-    return () => ipcRenderer.removeListener(channel, listener);
-  },
 };
 
 const git: GitServiceAPI = {
@@ -313,8 +309,13 @@ const main: Window['main'] = {
   lintSpec: options => invokeWithNormalizedError('lintSpec', options),
   bundleSpectralRuleset: options => invokeWithNormalizedError('bundleSpectralRuleset', options),
   on: (channel, listener) => {
-    ipcRenderer.on(channel, listener);
-    return () => ipcRenderer.removeListener(channel, listener);
+    // Under contextIsolation the IpcRendererEvent can't be cloned across the
+    // contextBridge; no listener uses it, so drop it and forward only the
+    // (cloneable) payload args.
+    const handler = (_event: IpcRendererEvent, ...args: unknown[]) =>
+      (listener as (event: unknown, ...args: unknown[]) => void)(undefined, ...args);
+    ipcRenderer.on(channel, handler);
+    return () => ipcRenderer.removeListener(channel, handler);
   },
   cookies,
   webSocket,

--- a/packages/insomnia/src/main/cloud-sync/ipc.ts
+++ b/packages/insomnia/src/main/cloud-sync/ipc.ts
@@ -66,17 +66,6 @@ export interface SyncBridgeAPI extends SyncBridgeMethods {
   }>;
   resolveConflict: (options: { handlerId: string; conflicts: MergeConflict[] }) => void;
   cancelConflict: (options: { handlerId: string }) => void;
-  on: (
-    channel: 'sync.merge-conflicts',
-    listener: (
-      event: IpcRendererEvent,
-      options: {
-        handlerId: string;
-        conflicts: MergeConflict[];
-        labels: { ours: string; theirs: string };
-      },
-    ) => void,
-  ) => () => void;
 }
 
 export const registerSyncHandlers = () => {

--- a/packages/insomnia/src/main/cloud-sync/ipc.ts
+++ b/packages/insomnia/src/main/cloud-sync/ipc.ts
@@ -1,5 +1,3 @@
-import type { IpcRendererEvent } from 'electron';
-
 import type {
   BackendProject,
   BackendProjectWithTeam,

--- a/packages/insomnia/src/main/window-security.test.ts
+++ b/packages/insomnia/src/main/window-security.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { MAIN_WINDOW_SECURITY } from './window-security';
+
+// These tests are a deliberate guardrail: they fail CI if the main renderer
+// window's security posture is weakened (e.g. an AI/PR flips nodeIntegration on
+// or contextIsolation off as a shortcut to make renderer code work). Weakening
+// these re-exposes Node.js to rendered content. Do not "fix" a failure here by
+// editing the expected values — move the offending logic to the main process.
+describe('main window security posture', () => {
+  it('pins the security-critical webPreferences values', () => {
+    expect(MAIN_WINDOW_SECURITY).toEqual({
+      nodeIntegration: false,
+      nodeIntegrationInWorker: false,
+      contextIsolation: true,
+    });
+  });
+
+  it('applies the pinned values to the main BrowserWindow without weakening overrides', () => {
+    const source = readFileSync(path.join(__dirname, 'window-utils.ts'), 'utf8');
+
+    // Isolate the main window construction (the hidden window legitimately uses
+    // nodeIntegration:true / contextIsolation:false, so we must not scan it).
+    const start = source.indexOf('const mainBrowserWindow = new BrowserWindow(');
+    const end = source.indexOf("browserWindows.set('Insomnia'", start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const mainWindowBlock = source.slice(start, end);
+
+    // The block must derive its security flags from the pinned constant...
+    expect(mainWindowBlock).toContain('...MAIN_WINDOW_SECURITY');
+    // ...and must not re-introduce a weakening override.
+    expect(mainWindowBlock).not.toMatch(/nodeIntegration\s*:\s*true/);
+    expect(mainWindowBlock).not.toMatch(/contextIsolation\s*:\s*false/);
+  });
+});

--- a/packages/insomnia/src/main/window-security.ts
+++ b/packages/insomnia/src/main/window-security.ts
@@ -1,0 +1,22 @@
+/**
+ * Security-critical `webPreferences` for the MAIN renderer `BrowserWindow`.
+ *
+ * DO NOT WEAKEN these values (e.g. `nodeIntegration: true` or `contextIsolation: false`).
+ * Doing so re-exposes Node.js APIs (`require`/`Buffer`/`process`) to rendered content
+ * and is a serious security regression — not a valid shortcut for getting renderer code
+ * to work. Move Node logic to the main process via IPC instead.
+ *
+ * These values are pinned by `window-security.test.ts`, which fails CI if they change.
+ * This module is intentionally free of side effects so it can be imported in a unit test.
+ *
+ * NOTE: this applies to the main window only. The hidden script-execution window
+ * (`createHiddenBrowserWindow`) deliberately uses `nodeIntegration: true`.
+ */
+export const MAIN_WINDOW_SECURITY = {
+  // The renderer must not have direct Node.js integration.
+  nodeIntegration: false,
+  // Must remain false so the nunjucks web worker sandbox has no access to Node.js APIs.
+  nodeIntegrationInWorker: false,
+  // Isolate the preload's world from the renderer's main world.
+  contextIsolation: true,
+} as const;

--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -207,8 +207,7 @@ export function createWindow(): ElectronBrowserWindow {
       nodeIntegration: false,
       nodeIntegrationInWorker: false, // must remain false to ensure the nunjucks web worker sandbox does not have access to Node.js APIs
       webviewTag: true,
-      // TODO: enable context isolation
-      contextIsolation: false,
+      contextIsolation: true,
       disableBlinkFeatures: 'Auxclick',
     },
   });

--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -26,6 +26,7 @@ import { getElectronStorage } from './electron-storage';
 import { ipcMainOn } from './ipc/electron';
 import { getLogDirectory } from './log';
 import { createPluginWindow, destroyPluginWindow } from './plugin-window';
+import { MAIN_WINDOW_SECURITY } from './window-security';
 
 const DEFAULT_WIDTH = 1280;
 const DEFAULT_HEIGHT = 720;
@@ -204,11 +205,11 @@ export function createWindow(): ElectronBrowserWindow {
     webPreferences: {
       preload: path.join(__dirname, 'entry.preload.min.js'),
       zoomFactor: getZoomFactor(),
-      nodeIntegration: false,
-      nodeIntegrationInWorker: false, // must remain false to ensure the nunjucks web worker sandbox does not have access to Node.js APIs
       webviewTag: true,
-      contextIsolation: true,
       disableBlinkFeatures: 'Auxclick',
+      // Security-critical flags (nodeIntegration/contextIsolation). Pinned by window-security.test.ts.
+      // Spread last so nothing below can override them. Do not weaken — see ./window-security.
+      ...MAIN_WINDOW_SECURITY,
     },
   });
   browserWindows.set('Insomnia', mainBrowserWindow);

--- a/packages/insomnia/src/ui/renderer-services-proxy.ts
+++ b/packages/insomnia/src/ui/renderer-services-proxy.ts
@@ -1,17 +1,6 @@
-import type { Services } from 'insomnia-data';
-
 import { invokeWithNormalizedError } from '~/main/ipc/invoke';
+import { createServicesProxy } from '~/ui/services-proxy';
 
-export const servicesProxy = new Proxy({} as Services, {
-  get(_target, serviceName: string) {
-    return new Proxy(
-      {},
-      {
-        get(_target, methodName: string) {
-          return (...args: unknown[]) =>
-            invokeWithNormalizedError<any>('services.invoke', serviceName, methodName, ...args);
-        },
-      },
-    );
-  },
-});
+export const servicesProxy = createServicesProxy((serviceName, methodName, ...args) =>
+  invokeWithNormalizedError<unknown>('services.invoke', serviceName, methodName, ...args),
+);

--- a/packages/insomnia/src/ui/services-proxy.ts
+++ b/packages/insomnia/src/ui/services-proxy.ts
@@ -1,0 +1,20 @@
+import type { Services } from 'insomnia-data';
+
+export type ServicesInvoke = (serviceName: string, methodName: string, ...args: unknown[]) => Promise<unknown>;
+
+// Build the services proxy from a generic invoke function. Kept free of any
+// `electron` import so it can run in the isolated renderer world, where the
+// bridged invoke is the only available transport (see entry.client.tsx).
+export const createServicesProxy = (invoke: ServicesInvoke): Services =>
+  new Proxy({} as Services, {
+    get(_target, serviceName: string) {
+      return new Proxy(
+        {},
+        {
+          get(_target, methodName: string) {
+            return (...args: unknown[]) => invoke(serviceName, methodName, ...args);
+          },
+        },
+      );
+    },
+  });

--- a/packages/insomnia/src/ui/utils/__tests__/insomnia-sync.test.ts
+++ b/packages/insomnia/src/ui/utils/__tests__/insomnia-sync.test.ts
@@ -20,8 +20,8 @@ describe('insomnia-sync', () => {
 
     global.window = {
       main: {
+        on,
         sync: {
-          on,
           resolveConflict: vi.fn(),
           cancelConflict: vi.fn(),
         },
@@ -51,8 +51,8 @@ describe('insomnia-sync', () => {
 
     global.window = {
       main: {
+        on,
         sync: {
-          on,
           resolveConflict,
           cancelConflict,
         },

--- a/packages/insomnia/src/ui/utils/insomnia-sync.ts
+++ b/packages/insomnia/src/ui/utils/insomnia-sync.ts
@@ -13,7 +13,7 @@ export const registerSyncMergeConflictListener = () => {
   }
 
   hasRegisteredConflictListener = true;
-  window.main.sync.on('sync.merge-conflicts', (_event, { handlerId, conflicts, labels }) => {
+  window.main.on('sync.merge-conflicts', (_event, { handlerId, conflicts, labels }) => {
     showModal(SyncMergeModal, {
       conflicts,
       labels,

--- a/packages/insomnia/types/global.d.ts
+++ b/packages/insomnia/types/global.d.ts
@@ -39,6 +39,8 @@ declare global {
     database: DatabaseBridgeAPI;
     // This is a temporary measure to provide access to services on the global window object. It will be removed in the future once all usages are updated to import services directly from the insomnia-data package.
     _dataServices?: Services;
+    // Under contextIsolation the services Proxy can't cross the bridge; the preload exposes this flat invoke instead and the renderer rebuilds the Proxy.
+    _dataServicesInvoke?: (serviceName: string, methodName: string, ...args: unknown[]) => Promise<unknown>;
     dialog: Pick<Electron.Dialog, 'showOpenDialog' | 'showSaveDialog'>;
     app: Pick<Electron.App, 'getPath' | 'getAppPath'> & { process: { platform: NodeJS.Platform } };
     shell: Pick<Electron.Shell, 'showItemInFolder' | 'openPath'>;


### PR DESCRIPTION
## What

Enables `contextIsolation: true` on the main `BrowserWindow`. `nodeIntegration` was already `false`; this flips the remaining flag that separates the preload world from the renderer's main world (and removes the `// TODO: enable context isolation`).

## Why

With `contextIsolation: false`, the preload's Node globals (`Buffer`, `process`, `require`) leaked into the renderer's shared world. Isolation severs that, leaving the renderer only what `contextBridge` can clone — the recommended Electron security posture.

## Changes

The preload already branched on `process.contextIsolated` to expose APIs via `contextBridge`. Three constructs needed fixing for the isolated world:

- **`servicesProxy`** — a dynamic `Proxy` can't be cloned across the `contextBridge` (no own-enumerable keys; the `get` trap never crosses the boundary). The preload now exposes a flat `_dataServicesInvoke` function and the renderer rebuilds the `Proxy` from it. Extracted an electron-free `createServicesProxy(invoke)` factory (`ui/services-proxy.ts`) so the rebuild can run in the isolated renderer; `renderer-services-proxy.ts` now uses the same factory for the preload/hidden-window path.
- **`app.process.platform`** — getters aren't preserved by `contextBridge`; flattened to a plain value (platform is constant).
- **`entry.client.tsx`** — reconstructs the services `Proxy` from the bridged invoke (falls back to `window._dataServices` for the non-isolated path).

The **hidden window is unchanged** (stays `nodeIntegration: true` / `contextIsolation: false`); webviews are already isolated.

## Validation

- `npm run type-check -w insomnia` — clean (0 errors)
- `npm run lint -w insomnia` — clean (0 errors; only pre-existing warnings in untouched files)
- Renderer swept for bare `Buffer`/`process`/`require` that relied on the old preload leak — the only `Buffer` use (`vault-key.client.ts`) is the package-bundled `srp.Buffer`, not the Node global, so it survives isolation.

## Manual testing focus

- [ ] Clean boot — no `"object could not be cloned"` contextBridge errors; app hydrates
- [ ] Services-backed CRUD (exercises the rebuilt `_dataServicesInvoke` proxy)
- [ ] Vault unlock / SRP
- [ ] `webUtils.getPathForFile` via drag-drop + file pickers (a DOM `File` crossing the isolation boundary — highest-uncertainty item)
- [ ] Platform-conditional UI (flattened `app.process.platform`)
