### PR TITLE
fix(git-sync): simplify repo URL entry and remove credential base URL requirement [INS-2124]

### DIFF
--- a/packages/insomnia-data/__tests__/git-credentials.test.ts
+++ b/packages/insomnia-data/__tests__/git-credentials.test.ts
@@ -149,7 +149,6 @@ describe('create()', () => {
       credentials: {
         username: 'myusername',
         password: 'my_personal_access_token',
-        baseURI: 'https://git.mycompany.com',
       },
     };
 
@@ -168,7 +167,6 @@ describe('create()', () => {
       credentials: {
         username: 'myusername',
         password: 'my_personal_access_token',
-        baseURI: 'https://git.mycompany.com',
       },
     });
 

--- a/packages/insomnia-data/src/models/git-credentials.ts
+++ b/packages/insomnia-data/src/models/git-credentials.ts
@@ -113,7 +113,6 @@ interface CustomCredential extends BaseCredentialData {
   credentials: {
     username: string;
     password: string; // Personal access token
-    baseURI?: string; // For custom providers
   };
 }
 

--- a/packages/insomnia-smoke-test/playwright/pages/preferences/credentials-tab.ts
+++ b/packages/insomnia-smoke-test/playwright/pages/preferences/credentials-tab.ts
@@ -31,8 +31,6 @@ export class PreferencesCredentialsTab extends BasePage {
     await this.page.getByRole('textbox', { name: 'Username' }).fill('username');
     await this.page.getByRole('textbox', { name: 'Git Access Token' }).click();
     await this.page.getByRole('textbox', { name: 'Git Access Token' }).fill('accesstoken');
-    await this.page.getByRole('textbox', { name: 'Repository base URL' }).click();
-    await this.page.getByRole('textbox', { name: 'Repository base URL' }).fill('http://localhost:4010/git/');
     await this.page.getByRole('button', { name: 'Save Credential' }).click();
   }
 }

--- a/packages/insomnia-smoke-test/playwright/pages/project/index.ts
+++ b/packages/insomnia-smoke-test/playwright/pages/project/index.ts
@@ -160,7 +160,7 @@ export class ProjectPage extends BasePage {
     await this.page.getByRole('button', { name: 'Access Token author Git' }).click();
     await this.page.getByRole('option', { name: 'Custom Git Credential' }).click();
     await this.page.getByRole('textbox', { name: 'Repository URL' }).click();
-    await this.page.getByRole('textbox', { name: 'Repository URL' }).fill('git-server.git');
+    await this.page.getByRole('textbox', { name: 'Repository URL' }).fill('http://localhost:4010/git/git-server.git');
     await this.page.getByRole('button', { name: 'Show suggestions Branch' }).click();
     await this.page.getByRole('option', { name: 'master' }).click();
     await this.page.getByRole('button', { name: 'Scan for files' }).click();

--- a/packages/insomnia-smoke-test/tests/smoke/disable-git-sync.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/disable-git-sync.test.ts
@@ -7,7 +7,6 @@ const mockCredentials = {
   gitUsername: 'insomnia-test',
   username: 'insomnia',
   token: '12345',
-  baseUrl: 'https://fakeurl.com/',
 };
 
 test.describe('Git Sync', () => {
@@ -53,7 +52,6 @@ test.describe('Git Sync', () => {
       await page.getByRole('textbox', { name: 'Author Name' }).fill(mockCredentials.gitUsername);
       await page.getByRole('textbox', { name: 'Username', exact: true }).fill(mockCredentials.username);
       await page.getByRole('textbox', { name: 'Git Access Token' }).fill(mockCredentials.token);
-      await page.getByRole('textbox', { name: 'Repository base URL' }).fill(mockCredentials.baseUrl);
       await page.getByRole('button', { name: 'Save Credential' }).click();
       await page.getByRole('button', { name: 'Modal Close Button' }).click();
       await page.getByRole('button', { name: 'Create new Project' }).click();

--- a/packages/insomnia/src/sync/git/__tests__/utils.test.ts
+++ b/packages/insomnia/src/sync/git/__tests__/utils.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { addDotGit, expiresAtFromOAuthExpiresIn } from '../utils';
+import { addDotGit, ensureGitRepoUrlSuffix, isAzureDevOpsUrl } from '../url-utils';
+import { expiresAtFromOAuthExpiresIn } from '../utils';
 
 const links = {
   scp: {
@@ -34,6 +35,41 @@ describe('addDotGit', () => {
     expect(addDotGit(links.ssh.dotGit)).toEqual(links.ssh.dotGit);
     expect(addDotGit(links.http.dotGit)).toEqual(links.http.dotGit);
     expect(addDotGit(links.https.dotGit)).toEqual(links.https.dotGit);
+  });
+});
+
+describe('isAzureDevOpsUrl', () => {
+  it('detects Azure DevOps hosts and the /_git/ path marker', () => {
+    expect(isAzureDevOpsUrl('https://dev.azure.com/declankeane/SE-Repo/_git/SE-Repo')).toBe(true);
+    expect(isAzureDevOpsUrl('https://declankeane.visualstudio.com/SE-Repo/_git/SE-Repo')).toBe(true);
+    // self-hosted Azure DevOps Server identified by the /_git/ marker
+    expect(isAzureDevOpsUrl('https://tfs.mycompany.com/collection/project/_git/repo')).toBe(true);
+  });
+
+  it('returns false for other providers and invalid input', () => {
+    expect(isAzureDevOpsUrl('https://github.com/a/b')).toBe(false);
+    expect(isAzureDevOpsUrl('https://gitlab.com/a/b.git')).toBe(false);
+    expect(isAzureDevOpsUrl('not a url')).toBe(false);
+  });
+});
+
+describe('ensureGitRepoUrlSuffix', () => {
+  it('appends .git for GitHub/GitLab-style URLs', () => {
+    expect(ensureGitRepoUrlSuffix('https://github.com/a/b')).toEqual('https://github.com/a/b.git');
+    expect(ensureGitRepoUrlSuffix('https://github.com/a/b.git')).toEqual('https://github.com/a/b.git');
+  });
+
+  it('trims trailing slashes before appending', () => {
+    expect(ensureGitRepoUrlSuffix('https://github.com/a/b/')).toEqual('https://github.com/a/b.git');
+  });
+
+  it('does not append .git for Azure DevOps URLs', () => {
+    const azure = 'https://dev.azure.com/declankeane/SE-Repo/_git/SE-Repo';
+    expect(ensureGitRepoUrlSuffix(azure)).toEqual(azure);
+  });
+
+  it('handles empty/whitespace input', () => {
+    expect(ensureGitRepoUrlSuffix('   ')).toEqual('');
   });
 });
 

--- a/packages/insomnia/src/sync/git/url-utils.ts
+++ b/packages/insomnia/src/sync/git/url-utils.ts
@@ -1,0 +1,36 @@
+/**
+ * Pure git URL helpers.
+ *
+ * Kept free of any Electron/provider-registry imports so this module is safe to
+ * import from the renderer (e.g. the create-project form) without pulling the
+ * main-process-only provider graph into the renderer bundle.
+ */
+
+export const addDotGit = (url: string): string => (url.endsWith('.git') ? url : `${url}.git`);
+
+/**
+ * Azure DevOps repositories are addressed via a `/_git/<repo>` path segment and
+ * must NOT have a `.git` suffix appended, unlike GitHub/GitLab/Bitbucket.
+ * Detects the modern (dev.azure.com) and legacy (*.visualstudio.com) hosts as
+ * well as the `/_git/` path marker for self-hosted Azure DevOps Server.
+ */
+export const isAzureDevOpsUrl = (url: string): boolean => {
+  try {
+    const { hostname, pathname } = new URL(url);
+    return hostname === 'dev.azure.com' || hostname.endsWith('.visualstudio.com') || pathname.includes('/_git/');
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Normalize a remote repo URL entered by the user: trim trailing slashes and
+ * append a `.git` suffix when the provider expects one (Azure DevOps does not).
+ */
+export const ensureGitRepoUrlSuffix = (url: string): string => {
+  const trimmed = url.trim().replace(/\/+$/, '');
+  if (!trimmed || isAzureDevOpsUrl(trimmed)) {
+    return trimmed;
+  }
+  return addDotGit(trimmed);
+};

--- a/packages/insomnia/src/sync/git/utils.ts
+++ b/packages/insomnia/src/sync/git/utils.ts
@@ -5,9 +5,11 @@ import type { AuthCallback, AuthFailureCallback, AuthSuccessCallback, GitAuth, M
 import { invariant } from '~/common/utils/invariant';
 import { gitRemoteProviderRegistry } from '~/sync/git/providers';
 
-const { isGitCredentialsV2, isGitCredentialsV1 } = models.gitCredentials;
+// Re-exported for backwards compatibility. The pure URL helpers live in a
+// provider/electron-free module so they can be imported from the renderer.
+export { addDotGit, ensureGitRepoUrlSuffix, isAzureDevOpsUrl } from './url-utils';
 
-export const addDotGit = (url: string): string => (url.endsWith('.git') ? url : `${url}.git`);
+const { isGitCredentialsV2, isGitCredentialsV1 } = models.gitCredentials;
 
 /**
  * OAuth2 token responses often include `expires_in` (seconds until access token expires).

--- a/packages/insomnia/src/ui/components/git-credentials/git-custom-credential-form.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/git-custom-credential-form.tsx
@@ -33,7 +33,6 @@ export const GitCustomCredentialForm = ({
       credentials: {
         username: (formData.get('username') as string) || '',
         password: (formData.get('password') as string) || '',
-        baseURI: (formData.get('baseURI') as string) || '',
       },
       name: 'Custom Git Credential',
     };
@@ -86,15 +85,6 @@ export const GitCustomCredentialForm = ({
             defaultValue={gitCredentialToEdit?.credentials?.password}
           />
         </div>
-        <Input
-          name="baseURI"
-          type="url"
-          isRequired
-          label="Repository base URL"
-          description="Specify the git server base URL that correlates with this access token."
-          placeholder="e.g. https://github.your-domain.com/org-name"
-          defaultValue={gitCredentialToEdit?.credentials?.baseURI}
-        />
       </div>
       <div className="mt-2 flex justify-end gap-2">
         <Button primary type="submit">

--- a/packages/insomnia/src/ui/components/project/git-repo-form.tsx
+++ b/packages/insomnia/src/ui/components/project/git-repo-form.tsx
@@ -18,6 +18,7 @@ import { useAllConnectedReposLoaderFetcher } from '~/routes/git.all-connected-re
 import type { useGitProjectInitCloneActionFetcher } from '~/routes/git.init-clone';
 import { useGitValidateCredentialFetcher } from '~/routes/git.validate-credential';
 import type { GitProviderOption } from '~/sync/git/providers/types';
+import { ensureGitRepoUrlSuffix } from '~/sync/git/url-utils';
 import { Checkbox } from '~/ui/components/base/checkbox';
 import { Input } from '~/ui/components/base/input';
 import { GitOauthAuthBanner } from '~/ui/components/git/git-oauth-auth-banner';
@@ -29,15 +30,19 @@ import { showSettingsModal } from '~/ui/components/modals/settings-modal';
 import { ErrorBoundary } from '../error-boundary';
 import type { ActiveView, ProjectData } from './utils';
 
-const getDisplayValue = (fullUri: string | undefined, prefix: string | undefined) => {
-  if (!fullUri) return '';
-  if (prefix && fullUri.startsWith(prefix)) {
-    return fullUri.slice(prefix.length);
-  }
-  return fullUri;
-};
-
 const { isGitCredentialsV2, isOAuthCredential } = models.gitCredentials;
+
+const validateRepoUrl = (value: string): string | null => {
+  try {
+    const { protocol } = new URL(value.trim());
+    if (protocol !== 'http:' && protocol !== 'https:') {
+      return 'Enter a valid URL to a remote git repo';
+    }
+    return null;
+  } catch {
+    return 'Enter a valid URL to a remote git repo';
+  }
+};
 
 const getCredentialEmails = (credential: GitCredentials | undefined) => {
   if (credential && isGitCredentialsV2(credential) && isOAuthCredential(credential)) {
@@ -85,12 +90,6 @@ export const GitRepoForm: FC<Props> = ({
   const selectedCredential = credentials.find(c => c._id === selectedCredentialsId);
   const selectedProvider = providers.find(p => p.type === selectedCredential?.provider);
   const needToSetupCredentials = credentials.length === 0;
-  const baseURI =
-    (selectedCredential &&
-      isGitCredentialsV2(selectedCredential) &&
-      selectedCredential.provider === 'custom' &&
-      selectedCredential.credentials?.baseURI) ||
-    '';
 
   const availableEmails = getCredentialEmails(selectedCredential);
   const showEmailSelector = availableEmails.length > 1;
@@ -129,10 +128,8 @@ export const GitRepoForm: FC<Props> = ({
             e.preventDefault();
             const formData = new FormData(e.currentTarget);
             const credentialsId = formData.get('credentialsId') as string;
-            const uri = formData.get('uri') as string;
             const ref = formData.get('branch') as string;
-            const prefix = baseURI ? baseURI.replace(/\/+$/, '') + '/' : '';
-            const fullUri = prefix ? `${prefix}${uri}` : uri;
+            const fullUri = ensureGitRepoUrlSuffix((formData.get('uri') as string) || '');
             setProjectData({
               ...projectData,
               credentialsId,
@@ -316,17 +313,17 @@ export const GitRepoForm: FC<Props> = ({
               ) : (
                 <Input
                   label="Repository URL"
-                  description={'Note: Some repo should include ".git" at the end of the path.'}
-                  prefix={baseURI}
+                  description={'Enter the URL to the remote repo that includes ".git" at the end.'}
                   key={selectedCredentialsId}
-                  defaultValue={getDisplayValue(projectData.uri, baseURI)}
+                  defaultValue={projectData.uri}
                   name="uri"
-                  type={baseURI ? 'text' : 'url'}
+                  type="url"
                   isRequired
-                  onChange={async v => {
-                    const prefix = baseURI ? baseURI.replace(/\/+$/, '') + '/' : '';
-                    const fullUri = prefix ? `${prefix}${v}` : v;
-                    setProjectData(prev => ({ ...prev, uri: fullUri }));
+                  placeholder="e.g. https://github.com/organization/repo-name.git"
+                  validate={validateRepoUrl}
+                  errorMessage="Enter a valid URL to a remote git repo"
+                  onChange={v => {
+                    setProjectData(prev => ({ ...prev, uri: ensureGitRepoUrlSuffix(v) }));
                   }}
                 />
               )}


### PR DESCRIPTION
Simplifies the Git Sync setup flow by removing the confusing "Repository base URL"
requirement and letting users paste a full repo URL directly.

Previously, custom Git credentials required a "Repository base URL", which was then
used as a disabled prefix in the create-project form — forcing users to split a URL
into two boxes (base + repo name). This was unintuitive (e.g. Azure DevOps URLs with
`/_git/` don't split cleanly) and the base URL served no functional purpose: it was
never used to match credentials to repos or during clone/push auth.

## Changes

- **Credential form:** removed the "Repository base URL" input. Credentials are now
  just author + username + token.
- **Create project form:** replaced the split base-URL-prefix + repo-name inputs with
  a single URL field.
  - Helper text: _Enter the URL to the remote repo that includes ".git" at the end._
  - Placeholder: `e.g. https://github.com/organization/repo-name.git`
  - Validation: must be a valid http(s) URL, otherwise shows _Enter a valid URL to a
    remote git repo_.
- **Auto `.git` suffix:** if the user omits `.git`, we append it for them — **except**
  for Azure DevOps URLs (`dev.azure.com`, `*.visualstudio.com`, or any URL with a
  `/_git/` path), which must not have `.git` appended.
- **Model:** removed the now-unused `baseURI` field from the custom credential type.
- Extracted the pure URL helpers (`addDotGit`, `isAzureDevOpsUrl`,
  `ensureGitRepoUrlSuffix`) into a provider/electron-free `url-utils.ts` so they can be
  safely imported from the renderer.

## Notes / out of scope

- Existing credentials with a stored `baseURI` are unaffected — the field is simply
  ignored (NeDB is schemaless), and existing projects already store a fully-resolved
  `uri`.
- SSH-style remotes (`git@host:org/repo.git`) remain unsupported (custom provider is
  http(s)-only), consistent with prior behavior.

## Testing
- Added unit tests for `isAzureDevOpsUrl` and `ensureGitRepoUrlSuffix`; updated
  credential tests. All passing.
