### PR TITLE
refactor(plugins): move node-only plugin discovery out of renderer-reachable code

### DIFF
--- a/packages/insomnia/src/common/utils/environment-utils.test.ts
+++ b/packages/insomnia/src/common/utils/environment-utils.test.ts
@@ -1,7 +1,7 @@
 import { EnvironmentKvPairDataType, models } from 'insomnia-data';
 import { describe, expect, it } from 'vitest';
 
-import { NUNJUCKS_TEMPLATE_GLOBAL_PROPERTY_NAME } from '~/templating';
+import { NUNJUCKS_TEMPLATE_GLOBAL_PROPERTY_NAME } from '~/common/templating/constants';
 
 import {
   checkNestedKeys,

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -11,7 +11,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { jarFromCookies } from '~/common/cookies';
 import { type Plugin, type TemplateTag } from '~/common/plugins/types';
 import type { PluginTemplateTag, PluginTemplateTagContext, PluginToMainAPIPaths } from '~/common/templating/types';
-import { getPluginCommonContext, getTemplateTags } from '~/plugins';
+import { getPluginCommonContext, getTemplateTags } from '~/plugins/plugin-loader.node';
 
 import { getAppBundlePlugins, RESPONSE_CODE_REASONS } from '../common/constants';
 import { isDevelopment } from '../common/constants';

--- a/packages/insomnia/src/plugins/__tests__/invoke-method.test.ts
+++ b/packages/insomnia/src/plugins/__tests__/invoke-method.test.ts
@@ -22,8 +22,8 @@ vi.mock('insomnia-data', () => ({
 
 import type { Plugin } from '~/common/plugins/types';
 
-import { _testOnlySetPlugins } from '../index';
 import { invokePluginMethod } from '../invoke-method';
+import { _testOnlySetPlugins } from '../plugin-loader.node';
 
 const makePlugin = (overrides: Partial<Plugin> = {}): Plugin => ({
   name: 'test-plugin',

--- a/packages/insomnia/src/plugins/__tests__/plugin-loader.node.test.ts
+++ b/packages/insomnia/src/plugins/__tests__/plugin-loader.node.test.ts
@@ -25,7 +25,7 @@ import { services } from 'insomnia-data';
 
 import { fetchFromTemplateWorkerDatabase } from '~/common/templating/liquid-extension-worker';
 
-import type { Plugin } from '../index';
+import type { Plugin } from '../plugin-loader.node';
 import {
   _testOnlySetPlugins,
   executePluginMainAction,
@@ -38,7 +38,7 @@ import {
   getTemplateTags,
   getThemes,
   getWorkspaceActions,
-} from '../index';
+} from '../plugin-loader.node';
 
 const makePlugin = (overrides: Partial<Plugin> = {}): Plugin => ({
   name: 'test-plugin',

--- a/packages/insomnia/src/plugins/__tests__/themes.test.ts
+++ b/packages/insomnia/src/plugins/__tests__/themes.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import type { Plugin } from '~/common/plugins/types';
 
 // No mock of '../themes' here — this file tests the built-in theme baseline.
-import { _testOnlySetPlugins, getThemes } from '../index';
+import { _testOnlySetPlugins, getThemes } from '../plugin-loader.node';
 
 const makePlugin = (overrides: Partial<Plugin> = {}): Plugin => ({
   name: 'test-plugin',

--- a/packages/insomnia/src/plugins/invoke-method.ts
+++ b/packages/insomnia/src/plugins/invoke-method.ts
@@ -28,7 +28,7 @@ import {
   getThemes,
   getWorkspaceActions,
   reloadPlugins,
-} from './index';
+} from './plugin-loader.node';
 
 export type PluginInvokeMethod =
   | 'getThemes'

--- a/packages/insomnia/src/plugins/plugin-loader.node.ts
+++ b/packages/insomnia/src/plugins/plugin-loader.node.ts
@@ -1,3 +1,10 @@
+// Node-only plugin loader. This module touches the filesystem, `process.env`, `require`
+// and `electron`, so it must only run in Node-capable contexts: the Electron main process,
+// the node network/utility runtime, the inso CLI, and the hidden plugin window
+// (`entry.plugin-window.ts`). It is NOT reachable from the contextIsolated main renderer,
+// which talks to these functions over the plugin IPC bridge (see `~/ui/plugins/renderer-bridge`).
+// The `__IS_RENDERER__` branches below refer to the plugin/hidden windows (which expose
+// `window.app`), not the main renderer.
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -145,6 +152,7 @@ export async function getPlugins(force = false): Promise<Plugin[]> {
 
     // Make sure the default directories exist
     const pluginPath = path.resolve(
+      // eslint-disable-next-line no-restricted-globals
       process.env['INSOMNIA_DATA_PATH'] || (__IS_RENDERER__ ? window : electron).app.getPath('userData'),
       'plugins',
     );
@@ -315,6 +323,7 @@ export function getPluginCommonContext({
     ...pluginNetwork.init(),
     util: {
       openInBrowser: async (url: string) =>
+        // eslint-disable-next-line no-restricted-globals
         __IS_RENDERER__ ? window.main.openInBrowser(url) : electron.shell.openExternal(url),
       models: {
         request: {

--- a/packages/insomnia/src/runtimes/network/network-adapter.node.ts
+++ b/packages/insomnia/src/runtimes/network/network-adapter.node.ts
@@ -77,7 +77,7 @@ export async function applyRequestHooks(
   renderedContext: Record<string, any>,
 ): Promise<RenderedRequest> {
   const newRenderedRequest = applyDefaultHeaders(renderedRequest, renderedContext['DEFAULT_HEADERS']);
-  const pluginIndex = await import('../../plugins/index');
+  const pluginIndex = await import('../../plugins/plugin-loader.node');
   for (const { plugin, hook } of await pluginIndex.getRequestHooks()) {
     const context = {
       ...(pluginApp.init() as Record<string, any>),
@@ -104,7 +104,7 @@ export async function applyResponseHooks(
 ): Promise<ResponsePatch> {
   const newResponse = clone(response);
   const newRequest = clone(renderedRequest);
-  const pluginIndex = await import('../../plugins/index');
+  const pluginIndex = await import('../../plugins/plugin-loader.node');
   for (const { plugin, hook } of await pluginIndex.getResponseHooks()) {
     const context = {
       ...(pluginApp.init() as Record<string, any>),

--- a/packages/insomnia/src/runtimes/templating/templating-adapter.node.ts
+++ b/packages/insomnia/src/runtimes/templating/templating-adapter.node.ts
@@ -6,6 +6,6 @@ export async function renderTemplate({
   path,
   ignoreUndefinedEnvVariable,
 }: RenderInputType): Promise<string | null> {
-  const templating = await import('../../templating/index');
+  const templating = await import('../../templating/template-renderer.node');
   return templating.render(input, { context, path, ignoreUndefinedEnvVariable });
 }

--- a/packages/insomnia/src/templating/__tests__/liquid-compat.test.ts
+++ b/packages/insomnia/src/templating/__tests__/liquid-compat.test.ts
@@ -2,7 +2,7 @@
 // worked under Nunjucks. Run with: npm test -w insomnia
 import { describe, expect, it } from 'vitest';
 
-import { render } from '../index';
+import { render } from '../template-renderer.node';
 
 describe('variable interpolation', () => {
   // Basic {{ var }} substitution from a flat context object

--- a/packages/insomnia/src/templating/index.ts
+++ b/packages/insomnia/src/templating/index.ts
@@ -1,7 +1,10 @@
 import { localTemplateTags } from 'insomnia/src/common/templating/local-template-tags';
 import type { Liquid } from 'liquidjs';
 
-import { LIQUID_TEMPLATE_GLOBAL_PROPERTY_NAME, NUNJUCKS_TEMPLATE_GLOBAL_PROPERTY_NAME } from '~/common/templating/constants';
+import {
+  LIQUID_TEMPLATE_GLOBAL_PROPERTY_NAME,
+  NUNJUCKS_TEMPLATE_GLOBAL_PROPERTY_NAME,
+} from '~/common/templating/constants';
 import { buildLiquidEngine, stripLiquidComments } from '~/common/templating/liquid-engine';
 import { extractUndefinedVariableKey, translateLiquidError } from '~/common/templating/render-error';
 
@@ -98,7 +101,7 @@ async function getLiquid(
     return { engine: liquidAll, tagMetadata: liquidAllTagMetadata };
   }
 
-  const pluginTemplateTags = await (await import('../plugins')).getTemplateTags();
+  const pluginTemplateTags = await (await import('../plugins/plugin-loader.node')).getTemplateTags();
 
   const allTags = [
     ...localTemplateTags,

--- a/packages/insomnia/src/templating/template-renderer.node.ts
+++ b/packages/insomnia/src/templating/template-renderer.node.ts
@@ -1,3 +1,9 @@
+// Node-only templating engine. This module loads Node-dependent plugin template tags
+// (via `../plugins/plugin-loader.node`) and builds the Liquid engine, so it must only run
+// in Node-capable contexts: the node templating runtime adapter, the hidden plugin window,
+// and the inso CLI. It is NOT reachable from the contextIsolated main renderer, which uses
+// the renderer-safe wrapper (`~/ui/templating/renderer-safe`) and delegates real rendering
+// to the templating web worker.
 import { localTemplateTags } from 'insomnia/src/common/templating/local-template-tags';
 import type { Liquid } from 'liquidjs';
 

--- a/packages/insomnia/src/ui/templating/renderer-safe.ts
+++ b/packages/insomnia/src/ui/templating/renderer-safe.ts
@@ -1,5 +1,5 @@
 // Renderer-safe templating utilities — no Node.js imports.
-// Use this module from renderer code instead of templating/index.
+// Use this module from renderer code instead of templating/template-renderer.node.
 
 export { NUNJUCKS_TEMPLATE_GLOBAL_PROPERTY_NAME, LIQUID_TEMPLATE_GLOBAL_PROPERTY_NAME } from '~/common/templating/constants';
 

--- a/packages/insomnia/vite.config.ts
+++ b/packages/insomnia/vite.config.ts
@@ -68,9 +68,9 @@ export default defineConfig(({ mode }) => {
     plugins: [
       // Allows us to import modules that will be resolved by Node's require() function.
       // e.g. import fs from 'fs'; will get transformed to const fs = require('fs'); so that it works in the renderer process.
-      // Still needed: renderer files (plugins/index.ts, sync/git/providers/*.ts) import `electron` as a value,
+      // Still needed: renderer-reachable files (sync/git/providers/*.ts) import `electron` as a value,
       // and non-browser-safe node builtins must not be bundled into the renderer. The plugin converts
-      // these to require() calls, which resolve correctly because contextIsolation is currently false.
+      // these to require() calls.
       electronNodeRequire({
         modules: ['electron'],
       }),


### PR DESCRIPTION
## Motivation

PR #10111 enabled \`contextIsolation: true\` / \`nodeIntegration: false\` on the main \`BrowserWindow\`. Under that config the main renderer has no \`require\`, \`process\`, or Node built-ins.

\`src/plugins/index.ts\` is the plugin discovery/loading module and touches Node-only APIs directly:
- \`node:fs\`, \`node:path\`
- \`process.env['HOME']\`, \`process.env['INSOMNIA_DATA_PATH']\`
- \`require\` (via \`getNodeRequire()\`) and \`electron\`

These would silently break (undefined / throw) if this file were reached from the contextIsolated main renderer.

## Findings (before)

The module is **not** imported by any main-renderer code. All runtime callers run in Node-capable contexts:

| Caller | Runtime |
|---|---|
| \`runtimes/network/network-adapter.node.ts\` | node network/utility runtime |
| \`main/templating-worker-database.ts\` | Electron main process |
| \`plugins/invoke-method.ts\` -> \`entry.plugin-window.ts\` | hidden plugin window (\`nodeIntegration: true\`) |
| \`templating/index.ts\` | node templating path (main/network), not the renderer worker |

The main renderer instead talks to these functions over the existing plugin IPC bridge (\`~/ui/plugins/renderer-bridge\` -> \`window.main.plugins.*\` -> plugin window). The \`__IS_RENDERER__\` branch inside the file refers to the plugin/hidden windows (which expose \`window.app\` via their preload), not the main renderer.

So nothing was actually broken — but the neutral \`plugins/index.ts\` name and a stale \`vite.config.ts\` comment calling it a "renderer file ... contextIsolation is currently false" obscured the constraint and invited a future contextIsolation regression.

## Change (after)

Smallest behavior-preserving split: make the runtime home explicit via naming, following the repo's established \`.node.ts\` convention for node-only modules (e.g. \`send-request.node.ts\`, \`write-proto-file.node.ts\`).

- Rename \`src/plugins/index.ts\` -> \`src/plugins/plugin-loader.node.ts\` and add a header comment documenting the node-only constraint.
- Rename its test \`__tests__/index.test.ts\` -> \`__tests__/plugin-loader.node.test.ts\`.
- Update all importers: \`invoke-method.ts\`, \`main/templating-worker-database.ts\`, \`runtimes/network/network-adapter.node.ts\`, \`templating/index.ts\`, and the three plugin tests.
- Fix the stale "renderer file / contextIsolation currently false" comment in \`vite.config.ts\` (kept the still-valid \`sync/git/providers/*.ts\` example).

No logic changes; no \`process.env\` reads added to any renderer path.

## Validation

- \`tsc --noEmit\` (insomnia): pass
- \`eslint\` on all changed files: pass
- \`vitest\` \`src/plugins\` + \`src/templating\`: 151 passed
- \`vitest\` \`window-security\`: 2 passed