### PR TITLE
fix: konnect multi region support

### DIFF
--- a/packages/insomnia-data/src/models/project.ts
+++ b/packages/insomnia-data/src/models/project.ts
@@ -94,6 +94,7 @@ interface CommonProject {
   konnectControlPlaneId?: string | null;
   konnectClusterType?: string | null;
   konnectDeploymentType?: KonnectDeploymentType | null;
+  konnectRegion?: string | null;
 }
 
 export interface RemoteProject extends BaseModel, CommonProject {
@@ -117,7 +118,7 @@ export const isProject = (model: Pick<BaseModel, 'type'>): model is Project => m
 
 export const isProjectId = (id: string | null) => id?.startsWith(`${prefix}_`);
 
-export const optionalKeys = ['konnectControlPlaneId', 'konnectClusterType', 'konnectDeploymentType'];
+export const optionalKeys = ['konnectControlPlaneId', 'konnectClusterType', 'konnectDeploymentType', 'konnectRegion'];
 
 export function init(): Partial<Project> {
   return {

--- a/packages/insomnia-smoke-test/playwright/launch.ts
+++ b/packages/insomnia-smoke-test/playwright/launch.ts
@@ -20,6 +20,7 @@ export interface EnvOptions {
   INSOMNIA_VAULT_SALT: string;
   INSOMNIA_VAULT_SRP_SECRET: string;
   KONNECT_API_URL: string;
+  KONNECT_API_REGIONS?: string;
 }
 
 /**

--- a/packages/insomnia-smoke-test/playwright/test.ts
+++ b/packages/insomnia-smoke-test/playwright/test.ts
@@ -81,6 +81,7 @@ export const test = baseTest.extend<{
       INSOMNIA_VAULT_SALT: userConfig.vaultSalt || '',
       INSOMNIA_VAULT_SRP_SECRET: userConfig.vaultSrpSecret || '',
       KONNECT_API_URL: echoServer,
+      KONNECT_API_REGIONS: 'us',
       ...(userConfig.session ? { INSOMNIA_SESSION: JSON.stringify(userConfig.session) } : {}),
     };
 

--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -120,11 +120,11 @@ export const getMockServiceBinURL = (mockServer: MockServer, path: string) => {
 export const getAIServiceURL = () => env.INSOMNIA_AI_URL || 'https://ai-helper.insomnia.rest';
 export const getKonnectApiUrl = () => env.KONNECT_API_URL || 'api.konghq.com';
 export const getKonnectApiRegions = (): string[] => {
-   const regions = (env.KONNECT_API_REGIONS ?? '')
-     .split(',')
-     .map((r: string) => r.trim())
-     .filter(Boolean);
-   return regions.length > 0 ? regions : ['us', 'eu', 'au', 'in', 'sg'];
+  const regions = (env.KONNECT_API_REGIONS ?? '')
+    .split(',')
+    .map((r: string) => r.trim())
+    .filter(Boolean);
+  return regions.length > 0 ? regions : ['us', 'eu', 'au', 'in', 'sg'];
 };
 
 // App website

--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -119,7 +119,13 @@ export const getMockServiceBinURL = (mockServer: MockServer, path: string) => {
 
 export const getAIServiceURL = () => env.INSOMNIA_AI_URL || 'https://ai-helper.insomnia.rest';
 export const getKonnectApiUrl = () => env.KONNECT_API_URL || 'api.konghq.com';
-export const getKonnectApiRegions = (): string[] => env.KONNECT_API_REGIONS?.split(',').map((r: string) => r.trim()).filter(Boolean) ?? ['us', 'eu', 'au', 'in', 'sg'];
+export const getKonnectApiRegions = (): string[] => {
+   const regions = (env.KONNECT_API_REGIONS ?? '')
+     .split(',')
+     .map((r: string) => r.trim())
+     .filter(Boolean);
+   return regions.length > 0 ? regions : ['us', 'eu', 'au', 'in', 'sg'];
+};
 
 // App website
 export const getAppWebsiteBaseURL = () => env.INSOMNIA_APP_WEBSITE_URL || 'https://app.insomnia.rest';

--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -118,7 +118,8 @@ export const getMockServiceBinURL = (mockServer: MockServer, path: string) => {
 };
 
 export const getAIServiceURL = () => env.INSOMNIA_AI_URL || 'https://ai-helper.insomnia.rest';
-export const getKonnectApiBaseURL = () => env.KONNECT_API_URL || 'https://global.api.konghq.com';
+export const getKonnectApiUrl = () => env.KONNECT_API_URL || 'api.konghq.com';
+export const getKonnectApiRegions = (): string[] => env.KONNECT_API_REGIONS?.split(',').map((r: string) => r.trim()).filter(Boolean) ?? ['us', 'eu', 'au', 'in', 'sg'];
 
 // App website
 export const getAppWebsiteBaseURL = () => env.INSOMNIA_APP_WEBSITE_URL || 'https://app.insomnia.rest';

--- a/packages/insomnia/src/entry.preload.ts
+++ b/packages/insomnia/src/entry.preload.ts
@@ -524,6 +524,7 @@ const env: Window['env'] = {
   INSOMNIA_MOCK_API_URL: process.env.INSOMNIA_MOCK_API_URL,
   INSOMNIA_AI_URL: process.env.INSOMNIA_AI_URL,
   KONNECT_API_URL: process.env.KONNECT_API_URL,
+  KONNECT_API_REGIONS: process.env.KONNECT_API_REGIONS,
   INSOMNIA_APP_WEBSITE_URL: process.env.INSOMNIA_APP_WEBSITE_URL,
   // GitHub API URL overrides for GitHub Enterprise targets
   INSOMNIA_GITHUB_REST_API_URL: process.env.INSOMNIA_GITHUB_REST_API_URL,

--- a/packages/insomnia/src/konnect/__tests__/api.test.ts
+++ b/packages/insomnia/src/konnect/__tests__/api.test.ts
@@ -2,10 +2,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { fetchAllControlPlanes, fetchAllServices, fetchRoutesForService, validatePat } from '../api';
 
-vi.mock('../../common/constants', () => ({
-  getKonnectApiBaseURL: () => 'https://global.api.konghq.com',
-}));
-
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function jsonResponse(data: unknown, status = 200, headers: Record<string, string> = {}): Response {
@@ -130,12 +126,12 @@ describe('fetchAllControlPlanes', () => {
     );
 
     const pages: any[][] = [];
-    for await (const page of fetchAllControlPlanes('faketoken')) {
+    for await (const page of fetchAllControlPlanes('faketoken', 'us')) {
       pages.push(page);
     }
 
     expect(pages).toHaveLength(1);
-    expect(pages[0]).toEqual(page1Data.map(cp => ({ ...cp, proxy_urls: null })));
+    expect(pages[0]).toEqual(page1Data.map(cp => ({ ...cp, region: 'us', proxy_urls: null })));
   });
 
   it('yields multiple pages when total > PAGE_SIZE', async () => {
@@ -161,13 +157,13 @@ describe('fetchAllControlPlanes', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     const pages: any[][] = [];
-    for await (const page of fetchAllControlPlanes('faketoken')) {
+    for await (const page of fetchAllControlPlanes('faketoken', 'us')) {
       pages.push(page);
     }
 
     expect(pages).toHaveLength(2);
     expect(pages[0]).toHaveLength(100);
-    expect(pages[1]).toEqual(page2Data.map(cp => ({ ...cp, proxy_urls: null })));
+    expect(pages[1]).toEqual(page2Data.map(cp => ({ ...cp, region: 'us', proxy_urls: null })));
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock.mock.calls[0][0]).toContain('page[number]=1');
     expect(fetchMock.mock.calls[1][0]).toContain('page[number]=2');
@@ -176,7 +172,7 @@ describe('fetchAllControlPlanes', () => {
   it('throws on non-ok response', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('', { status: 500 })));
 
-    const gen = fetchAllControlPlanes('faketoken');
+    const gen = fetchAllControlPlanes('faketoken', 'us');
     await expect(gen.next()).rejects.toThrow('Konnect API error 500 fetching control planes');
   });
 
@@ -197,11 +193,11 @@ describe('fetchAllControlPlanes', () => {
     );
 
     const pages: any[][] = [];
-    for await (const page of fetchAllControlPlanes('faketoken')) {
+    for await (const page of fetchAllControlPlanes('faketoken', 'us')) {
       pages.push(page);
     }
 
-    expect(pages[0][0]).toEqual({ ...rawCp, proxy_urls: null });
+    expect(pages[0][0]).toEqual({ ...rawCp, region: 'us', proxy_urls: null });
   });
 
   it('yields empty data when total is 0', async () => {
@@ -211,12 +207,25 @@ describe('fetchAllControlPlanes', () => {
     );
 
     const pages: any[][] = [];
-    for await (const page of fetchAllControlPlanes('faketoken')) {
+    for await (const page of fetchAllControlPlanes('faketoken', 'us')) {
       pages.push(page);
     }
 
     expect(pages).toHaveLength(1);
     expect(pages[0]).toEqual([]);
+  });
+
+  it.each(['us', 'eu', 'au', 'me'] as const)('uses the %s regional base URL', async region => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ data: [], meta: { page: { total: 0, size: 100, number: 1 } } }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    for await (const _ of fetchAllControlPlanes('faketoken', region)) {
+      // drain
+    }
+
+    expect(fetchMock.mock.calls[0][0]).toMatch(`https://${region}.api.konghq.com/v2/control-planes`);
   });
 });
 
@@ -529,7 +538,7 @@ describe('retry on 429', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     const pages: any[][] = [];
-    const gen = fetchAllControlPlanes('faketoken');
+    const gen = fetchAllControlPlanes('faketoken', 'us');
 
     const iterPromise = (async () => {
       for await (const page of gen) {
@@ -541,7 +550,7 @@ describe('retry on 429', () => {
     await iterPromise;
 
     expect(pages).toHaveLength(1);
-    expect(pages[0]).toEqual(page1Data.map(cp => ({ ...cp, proxy_urls: null })));
+    expect(pages[0]).toEqual(page1Data.map(cp => ({ ...cp, region: 'us', proxy_urls: null })));
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/insomnia/src/konnect/__tests__/sync.test.ts
+++ b/packages/insomnia/src/konnect/__tests__/sync.test.ts
@@ -73,7 +73,7 @@ function makeRoute(overrides: Partial<KonnectRoute> = {}): KonnectRoute {
  * - Control planes: page-number pagination (meta.page.total)
  * - Services / routes: cursor pagination (offset field)
  */
-function mockFetch(cps: KonnectControlPlane[], services: KonnectService[], routes: KonnectRoute[]) {
+function mockFetch(cps: KonnectControlPlane[], services: KonnectService[], routes: KonnectRoute[], opts?: { failRegion?: string }) {
   const json = (data: unknown) =>
     new Response(JSON.stringify(data), { status: 200, headers: { 'Content-Type': 'application/json' } });
 
@@ -87,6 +87,9 @@ function mockFetch(cps: KonnectControlPlane[], services: KonnectService[], route
     }
     if (url.includes('.api.konghq.com/v2/control-planes')) {
       const region = new URL(url).hostname.split('.')[0];
+      if (opts?.failRegion === region) {
+        return new Response('Internal Server Error', { status: 500 });
+      }
       const regionalCps = cps.filter(cp => cp.config.control_plane_endpoint.includes(`.${region}.`));
       return json({ data: regionalCps, meta: { page: { total: regionalCps.length, size: 100, number: 1 } } });
     }
@@ -2183,5 +2186,25 @@ describe('Feature: Region fetch error resilience', () => {
     expect(projects).toHaveLength(1);
     expect(projects[0].konnectControlPlaneId).toBe('cp-us');
     expect(result.controlPlanes.created).toBe(1);
+  });
+
+  it('Scenario: Does not delete projects from a region that failed to fetch', async () => {
+    const usCp = makeCp({ id: 'cp-us', name: 'US Plane', region: 'us', config: { cluster_type: 'CLUSTER_TYPE_HYBRID', control_plane_endpoint: 'https://abc.us.cp0.konghq.com', cloud_gateway: true } });
+    const euCp = makeCp({ id: 'cp-eu', name: 'EU Plane', region: 'eu', config: { cluster_type: 'CLUSTER_TYPE_HYBRID', control_plane_endpoint: 'https://abc.eu.cp0.konghq.com', cloud_gateway: true } });
+
+    // First sync: both regions succeed
+    vi.stubGlobal('fetch', mockFetch([usCp, euCp], [], []));
+    await syncKonnect({ pat: 'kpat_test', organizationId: ORG_ID });
+
+    // Second sync: EU region fails — cp-eu should NOT be deleted
+    vi.stubGlobal('fetch', mockFetch([usCp], [], [], { failRegion: 'eu' }));
+    const result = await syncKonnect({ pat: 'kpat_test', organizationId: ORG_ID });
+
+    const projects = konnectProjects(await db.find(models.project.type, { parentId: ORG_ID }));
+    expect(projects).toHaveLength(2);
+    expect(projects.map((p: any) => p.konnectControlPlaneId).sort()).toEqual(['cp-eu', 'cp-us']);
+    expect(result.controlPlanes.deleted).toBe(0);
+    expect(result.skippedRegions).toHaveLength(1);
+    expect(result.skippedRegions[0]).toMatch(/^eu:/);
   });
 });

--- a/packages/insomnia/src/konnect/__tests__/sync.test.ts
+++ b/packages/insomnia/src/konnect/__tests__/sync.test.ts
@@ -25,6 +25,7 @@ function makeCp(overrides: Partial<KonnectControlPlane> = {}): KonnectControlPla
     id: 'cp-1',
     name: 'My CP',
     description: '',
+    region: 'us',
     config: {
       cluster_type: 'CLUSTER_TYPE_HYBRID',
       control_plane_endpoint: 'https://abc123.us.cp0.konghq.com',
@@ -84,8 +85,10 @@ function mockFetch(cps: KonnectControlPlane[], services: KonnectService[], route
     if (url.includes('/services')) {
       return json({ data: services, offset: null });
     }
-    if (url.includes('global.api.konghq.com/v2/control-planes')) {
-      return json({ data: cps, meta: { page: { total: cps.length, size: 100, number: 1 } } });
+    if (url.includes('.api.konghq.com/v2/control-planes')) {
+      const region = new URL(url).hostname.split('.')[0];
+      const regionalCps = cps.filter(cp => cp.config.control_plane_endpoint.includes(`.${region}.`));
+      return json({ data: regionalCps, meta: { page: { total: regionalCps.length, size: 100, number: 1 } } });
     }
     return new Response('Not found', { status: 404 });
   });
@@ -2122,5 +2125,63 @@ describe('Feature: Expression-Based Routes', () => {
 
     expect(konnectRequests(await db.find(models.request.type, { konnectRouteKey: { $ne: null } }))).toHaveLength(0);
     expect(result.routes.skipped).toBe(1);
+  });
+});
+
+// ─── Feature: Multi-Region Control Plane Sync ────────────────────────────────
+
+describe('Feature: Multi-Region Control Plane Sync', () => {
+  it('Scenario: Syncs control planes from multiple regions in a single pass', async () => {
+    const usCp = makeCp({ id: 'cp-us', name: 'US Plane', region: 'us', config: { cluster_type: 'CLUSTER_TYPE_HYBRID', control_plane_endpoint: 'https://abc.us.cp0.konghq.com', cloud_gateway: true } });
+    const euCp = makeCp({ id: 'cp-eu', name: 'EU Plane', region: 'eu', config: { cluster_type: 'CLUSTER_TYPE_HYBRID', control_plane_endpoint: 'https://abc.eu.cp0.konghq.com', cloud_gateway: true } });
+
+    vi.stubGlobal('fetch', mockFetch([usCp, euCp], [], []));
+
+    const result = await syncKonnect({ pat: 'kpat_test', organizationId: ORG_ID });
+
+    const projects = konnectProjects(await db.find(models.project.type, { parentId: ORG_ID }));
+    expect(projects).toHaveLength(2);
+    expect(projects.map((p: any) => p.konnectControlPlaneId).sort()).toEqual(['cp-eu', 'cp-us']);
+    expect(result.controlPlanes.created).toBe(2);
+  });
+
+  it('Scenario: Deletes project when CP is removed from its region', async () => {
+    const usCp = makeCp({ id: 'cp-us', name: 'US Plane', region: 'us', config: { cluster_type: 'CLUSTER_TYPE_HYBRID', control_plane_endpoint: 'https://abc.us.cp0.konghq.com', cloud_gateway: true } });
+    const euCp = makeCp({ id: 'cp-eu', name: 'EU Plane', region: 'eu', config: { cluster_type: 'CLUSTER_TYPE_HYBRID', control_plane_endpoint: 'https://abc.eu.cp0.konghq.com', cloud_gateway: true } });
+
+    vi.stubGlobal('fetch', mockFetch([usCp, euCp], [], []));
+    await syncKonnect({ pat: 'kpat_test', organizationId: ORG_ID });
+
+    // EU CP is gone on next sync
+    vi.stubGlobal('fetch', mockFetch([usCp], [], []));
+    const result = await syncKonnect({ pat: 'kpat_test', organizationId: ORG_ID });
+
+    const projects = konnectProjects(await db.find(models.project.type, { parentId: ORG_ID }));
+    expect(projects).toHaveLength(1);
+    expect(projects[0].konnectControlPlaneId).toBe('cp-us');
+    expect(result.controlPlanes.deleted).toBe(1);
+  });
+});
+
+describe('Feature: Region fetch error resilience', () => {
+  it('Scenario: Continues syncing other regions when one fails', async () => {
+    const usCp = makeCp({ id: 'cp-us', name: 'US Plane', region: 'us', config: { cluster_type: 'CLUSTER_TYPE_HYBRID', control_plane_endpoint: 'https://abc.us.cp0.konghq.com', cloud_gateway: true } });
+
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('eu.api.konghq.com/v2/control-planes')) {
+        return new Response('Internal Server Error', { status: 500 });
+      }
+      if (url.includes('.api.konghq.com/v2/control-planes')) {
+        return new Response(JSON.stringify({ data: [usCp], meta: { page: { total: 1, size: 100, number: 1 } } }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response('Not found', { status: 404 });
+    }));
+
+    const result = await syncKonnect({ pat: 'kpat_test', organizationId: ORG_ID });
+
+    const projects = konnectProjects(await db.find(models.project.type, { parentId: ORG_ID }));
+    expect(projects).toHaveLength(1);
+    expect(projects[0].konnectControlPlaneId).toBe('cp-us');
+    expect(result.controlPlanes.created).toBe(1);
   });
 });

--- a/packages/insomnia/src/konnect/__tests__/sync.test.ts
+++ b/packages/insomnia/src/konnect/__tests__/sync.test.ts
@@ -73,7 +73,12 @@ function makeRoute(overrides: Partial<KonnectRoute> = {}): KonnectRoute {
  * - Control planes: page-number pagination (meta.page.total)
  * - Services / routes: cursor pagination (offset field)
  */
-function mockFetch(cps: KonnectControlPlane[], services: KonnectService[], routes: KonnectRoute[], opts?: { failRegion?: string }) {
+function mockFetch(
+  cps: KonnectControlPlane[],
+  services: KonnectService[],
+  routes: KonnectRoute[],
+  opts?: { failRegion?: string },
+) {
   const json = (data: unknown) =>
     new Response(JSON.stringify(data), { status: 200, headers: { 'Content-Type': 'application/json' } });
 
@@ -2135,8 +2140,26 @@ describe('Feature: Expression-Based Routes', () => {
 
 describe('Feature: Multi-Region Control Plane Sync', () => {
   it('Scenario: Syncs control planes from multiple regions in a single pass', async () => {
-    const usCp = makeCp({ id: 'cp-us', name: 'US Plane', region: 'us', config: { cluster_type: 'CLUSTER_TYPE_HYBRID', control_plane_endpoint: 'https://abc.us.cp0.konghq.com', cloud_gateway: true } });
-    const euCp = makeCp({ id: 'cp-eu', name: 'EU Plane', region: 'eu', config: { cluster_type: 'CLUSTER_TYPE_HYBRID', control_plane_endpoint: 'https://abc.eu.cp0.konghq.com', cloud_gateway: true } });
+    const usCp = makeCp({
+      id: 'cp-us',
+      name: 'US Plane',
+      region: 'us',
+      config: {
+        cluster_type: 'CLUSTER_TYPE_HYBRID',
+        control_plane_endpoint: 'https://abc.us.cp0.konghq.com',
+        cloud_gateway: true,
+      },
+    });
+    const euCp = makeCp({
+      id: 'cp-eu',
+      name: 'EU Plane',
+      region: 'eu',
+      config: {
+        cluster_type: 'CLUSTER_TYPE_HYBRID',
+        control_plane_endpoint: 'https://abc.eu.cp0.konghq.com',
+        cloud_gateway: true,
+      },
+    });
 
     vi.stubGlobal('fetch', mockFetch([usCp, euCp], [], []));
 
@@ -2149,8 +2172,26 @@ describe('Feature: Multi-Region Control Plane Sync', () => {
   });
 
   it('Scenario: Deletes project when CP is removed from its region', async () => {
-    const usCp = makeCp({ id: 'cp-us', name: 'US Plane', region: 'us', config: { cluster_type: 'CLUSTER_TYPE_HYBRID', control_plane_endpoint: 'https://abc.us.cp0.konghq.com', cloud_gateway: true } });
-    const euCp = makeCp({ id: 'cp-eu', name: 'EU Plane', region: 'eu', config: { cluster_type: 'CLUSTER_TYPE_HYBRID', control_plane_endpoint: 'https://abc.eu.cp0.konghq.com', cloud_gateway: true } });
+    const usCp = makeCp({
+      id: 'cp-us',
+      name: 'US Plane',
+      region: 'us',
+      config: {
+        cluster_type: 'CLUSTER_TYPE_HYBRID',
+        control_plane_endpoint: 'https://abc.us.cp0.konghq.com',
+        cloud_gateway: true,
+      },
+    });
+    const euCp = makeCp({
+      id: 'cp-eu',
+      name: 'EU Plane',
+      region: 'eu',
+      config: {
+        cluster_type: 'CLUSTER_TYPE_HYBRID',
+        control_plane_endpoint: 'https://abc.eu.cp0.konghq.com',
+        cloud_gateway: true,
+      },
+    });
 
     vi.stubGlobal('fetch', mockFetch([usCp, euCp], [], []));
     await syncKonnect({ pat: 'kpat_test', organizationId: ORG_ID });
@@ -2168,17 +2209,32 @@ describe('Feature: Multi-Region Control Plane Sync', () => {
 
 describe('Feature: Region fetch error resilience', () => {
   it('Scenario: Continues syncing other regions when one fails', async () => {
-    const usCp = makeCp({ id: 'cp-us', name: 'US Plane', region: 'us', config: { cluster_type: 'CLUSTER_TYPE_HYBRID', control_plane_endpoint: 'https://abc.us.cp0.konghq.com', cloud_gateway: true } });
+    const usCp = makeCp({
+      id: 'cp-us',
+      name: 'US Plane',
+      region: 'us',
+      config: {
+        cluster_type: 'CLUSTER_TYPE_HYBRID',
+        control_plane_endpoint: 'https://abc.us.cp0.konghq.com',
+        cloud_gateway: true,
+      },
+    });
 
-    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
-      if (url.includes('eu.api.konghq.com/v2/control-planes')) {
-        return new Response('Internal Server Error', { status: 500 });
-      }
-      if (url.includes('.api.konghq.com/v2/control-planes')) {
-        return new Response(JSON.stringify({ data: [usCp], meta: { page: { total: 1, size: 100, number: 1 } } }), { status: 200, headers: { 'Content-Type': 'application/json' } });
-      }
-      return new Response('Not found', { status: 404 });
-    }));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        if (url.includes('eu.api.konghq.com/v2/control-planes')) {
+          return new Response('Internal Server Error', { status: 500 });
+        }
+        if (url.includes('.api.konghq.com/v2/control-planes')) {
+          return new Response(JSON.stringify({ data: [usCp], meta: { page: { total: 1, size: 100, number: 1 } } }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response('Not found', { status: 404 });
+      }),
+    );
 
     const result = await syncKonnect({ pat: 'kpat_test', organizationId: ORG_ID });
 
@@ -2189,8 +2245,26 @@ describe('Feature: Region fetch error resilience', () => {
   });
 
   it('Scenario: Does not delete projects from a region that failed to fetch', async () => {
-    const usCp = makeCp({ id: 'cp-us', name: 'US Plane', region: 'us', config: { cluster_type: 'CLUSTER_TYPE_HYBRID', control_plane_endpoint: 'https://abc.us.cp0.konghq.com', cloud_gateway: true } });
-    const euCp = makeCp({ id: 'cp-eu', name: 'EU Plane', region: 'eu', config: { cluster_type: 'CLUSTER_TYPE_HYBRID', control_plane_endpoint: 'https://abc.eu.cp0.konghq.com', cloud_gateway: true } });
+    const usCp = makeCp({
+      id: 'cp-us',
+      name: 'US Plane',
+      region: 'us',
+      config: {
+        cluster_type: 'CLUSTER_TYPE_HYBRID',
+        control_plane_endpoint: 'https://abc.us.cp0.konghq.com',
+        cloud_gateway: true,
+      },
+    });
+    const euCp = makeCp({
+      id: 'cp-eu',
+      name: 'EU Plane',
+      region: 'eu',
+      config: {
+        cluster_type: 'CLUSTER_TYPE_HYBRID',
+        control_plane_endpoint: 'https://abc.eu.cp0.konghq.com',
+        cloud_gateway: true,
+      },
+    });
 
     // First sync: both regions succeed
     vi.stubGlobal('fetch', mockFetch([usCp, euCp], [], []));

--- a/packages/insomnia/src/konnect/__tests__/transform.test.ts
+++ b/packages/insomnia/src/konnect/__tests__/transform.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 
 import {
   deriveProxyVarDefaults,
-  extractRegionFromEndpoint,
   generatePathPlaceholder,
   konnectHeadersChanged,
   mergeHeaders,
@@ -10,50 +9,6 @@ import {
   pathParametersChanged,
   sanitizeRoute,
 } from '../transform';
-
-// ─── extractRegionFromEndpoint ───────────────────────────────────────────────
-
-describe('extractRegionFromEndpoint', () => {
-  it('extracts "us" from a US control plane endpoint', () => {
-    expect(extractRegionFromEndpoint('https://abc123.us.cp0.konghq.com')).toBe('us');
-  });
-
-  it('extracts "eu" from an EU control plane endpoint', () => {
-    expect(extractRegionFromEndpoint('https://xyz789.eu.cp0.konghq.com')).toBe('eu');
-  });
-
-  it('extracts "au" from an AU control plane endpoint', () => {
-    expect(extractRegionFromEndpoint('https://def456.au.cp0.konghq.com')).toBe('au');
-  });
-
-  it('extracts "me" from a ME control plane endpoint', () => {
-    expect(extractRegionFromEndpoint('https://def456.me.cp0.konghq.com')).toBe('me');
-  });
-
-  it('extracts "in" from an IN control plane endpoint', () => {
-    expect(extractRegionFromEndpoint('https://def456.in.cp0.konghq.com')).toBe('in');
-  });
-
-  it('extracts "eu" from a EU control plane endpoint with bare "cp" subdomain', () => {
-    expect(extractRegionFromEndpoint('https://xyz789.eu.cp.konghq.com')).toBe('eu');
-  });
-
-  it('extracts "us" from a US control plane endpoint with bare "cp" subdomain', () => {
-    expect(extractRegionFromEndpoint('https://abc123.us.cp.konghq.com')).toBe('us');
-  });
-
-  it('defaults to "us" for a malformed URL', () => {
-    expect(extractRegionFromEndpoint('not-a-url')).toBe('us');
-  });
-
-  it('defaults to "us" for an unexpected hostname format (no cp0 segment)', () => {
-    expect(extractRegionFromEndpoint('https://api.konghq.com')).toBe('us');
-  });
-
-  it('defaults to "us" for an empty string', () => {
-    expect(extractRegionFromEndpoint('')).toBe('us');
-  });
-});
 
 // ─── sanitizeRoute ───────────────────────────────────────────────────────────
 

--- a/packages/insomnia/src/konnect/api.ts
+++ b/packages/insomnia/src/konnect/api.ts
@@ -86,7 +86,9 @@ async function fetchWithRetry(url: string, pat: string, signal?: AbortSignal): P
   while (true) {
     const response = await fetch(url, {
       headers: { Authorization: `Bearer ${pat}` },
-      signal: signal ? AbortSignal.any([signal, AbortSignal.timeout(REQUEST_TIMEOUT_MS)]) : AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      signal: signal
+        ? AbortSignal.any([signal, AbortSignal.timeout(REQUEST_TIMEOUT_MS)])
+        : AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
 
     if (response.status !== 429 || attempt >= MAX_RETRY_ATTEMPTS) {
@@ -140,7 +142,11 @@ export async function validatePat(pat: string): Promise<PatValidationResult> {
   }
 }
 
-export async function* fetchAllControlPlanes(pat: string, region: KonnectRegion, signal?: AbortSignal): AsyncGenerator<KonnectControlPlane[]> {
+export async function* fetchAllControlPlanes(
+  pat: string,
+  region: KonnectRegion,
+  signal?: AbortSignal,
+): AsyncGenerator<KonnectControlPlane[]> {
   let page = 1;
   let totalPages = 1;
 

--- a/packages/insomnia/src/konnect/api.ts
+++ b/packages/insomnia/src/konnect/api.ts
@@ -218,5 +218,11 @@ export async function fetchRoutesForService(
 }
 
 function regionalApiBase(region: string): string {
-  return `https://${region}.${getKonnectApiUrl()}`;
+  const url = getKonnectApiUrl();
+  // If KONNECT_API_URL is already a full URL (e.g. http://localhost:4010 in tests),
+  // use it as-is without prepending a region subdomain or https scheme.
+  if (url.startsWith('http://') || url.startsWith('https://')) {
+    return url.replace(/\/$/, '');
+  }
+  return `https://${region}.${url.replace(/\/$/, '')}`;
 }

--- a/packages/insomnia/src/konnect/api.ts
+++ b/packages/insomnia/src/konnect/api.ts
@@ -1,14 +1,13 @@
-import { getKonnectApiBaseURL } from '../common/constants';
+import { getKonnectApiRegions, getKonnectApiUrl } from '../common/constants';
 
-function getGlobalApi(): string {
-  return getKonnectApiBaseURL();
-}
+export type KonnectRegion = string;
 
 const PAGE_SIZE = 100;
 // Maximum number of retry attempts after the first 429 response (5 retries = 6 total attempts).
 const MAX_RETRY_ATTEMPTS = 5;
 const BASE_DELAY_MS = 1000;
 const MAX_DELAY_MS = 30_000;
+const REQUEST_TIMEOUT_MS = 30_000;
 
 export interface KonnectProxyUrl {
   host: string;
@@ -20,6 +19,7 @@ export interface KonnectControlPlane {
   id: string;
   name: string;
   description: string;
+  region: KonnectRegion;
   config: {
     cluster_type: string;
     control_plane_endpoint: string;
@@ -52,13 +52,15 @@ export interface KonnectRoute {
   service: { id: string } | null;
 }
 
+export const getActiveRegions = getKonnectApiRegions;
+
 // Boundary normalizers — coerce any missing nullable field to `null` so the
 // declared `T | null` types are honest. Defending against `undefined` once
 // here lets every downstream consumer use strict `=== null` checks and skip
 // the `?? null` / `arr == null` defensive plumbing that otherwise leaks
 // through sanitizeRoute, sync.ts, expression-parser, etc.
-function normalizeControlPlane(cp: KonnectControlPlane): KonnectControlPlane {
-  return { ...cp, proxy_urls: cp.proxy_urls ?? null };
+function normalizeControlPlane(cp: KonnectControlPlane, region: KonnectRegion): KonnectControlPlane {
+  return { ...cp, region, proxy_urls: cp.proxy_urls ?? null };
 }
 
 function normalizeService(s: KonnectService): KonnectService {
@@ -84,7 +86,7 @@ async function fetchWithRetry(url: string, pat: string, signal?: AbortSignal): P
   while (true) {
     const response = await fetch(url, {
       headers: { Authorization: `Bearer ${pat}` },
-      signal,
+      signal: signal ? AbortSignal.any([signal, AbortSignal.timeout(REQUEST_TIMEOUT_MS)]) : AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
 
     if (response.status !== 429 || attempt >= MAX_RETRY_ATTEMPTS) {
@@ -120,7 +122,7 @@ export interface PatValidationResult {
 
 export async function validatePat(pat: string): Promise<PatValidationResult> {
   try {
-    const response = await fetch(`${getGlobalApi()}/v2/control-planes?page[size]=1`, {
+    const response = await fetch(`${regionalApiBase('us')}/v2/control-planes?page[size]=1`, {
       headers: { Authorization: `Bearer ${pat}` },
     });
     if (response.ok) {
@@ -138,12 +140,12 @@ export async function validatePat(pat: string): Promise<PatValidationResult> {
   }
 }
 
-export async function* fetchAllControlPlanes(pat: string, signal?: AbortSignal): AsyncGenerator<KonnectControlPlane[]> {
+export async function* fetchAllControlPlanes(pat: string, region: KonnectRegion, signal?: AbortSignal): AsyncGenerator<KonnectControlPlane[]> {
   let page = 1;
   let totalPages = 1;
 
   do {
-    const url = `${getGlobalApi()}/v2/control-planes?page[size]=${PAGE_SIZE}&page[number]=${page}`;
+    const url = `${regionalApiBase(region)}/v2/control-planes?page[size]=${PAGE_SIZE}&page[number]=${page}`;
     const response = await fetchWithRetry(url, pat, signal);
 
     if (!response.ok) {
@@ -154,7 +156,7 @@ export async function* fetchAllControlPlanes(pat: string, signal?: AbortSignal):
     const total: number = body?.meta?.page?.total ?? 0;
     totalPages = Math.ceil(total / PAGE_SIZE) || 1;
 
-    yield (body.data as KonnectControlPlane[]).map(normalizeControlPlane);
+    yield (body.data as KonnectControlPlane[]).map(cp => normalizeControlPlane(cp, region));
     page++;
   } while (page <= totalPages);
 }
@@ -216,7 +218,5 @@ export async function fetchRoutesForService(
 }
 
 function regionalApiBase(region: string): string {
-  const url = new URL(getGlobalApi());
-  url.hostname = url.hostname.replace('global', region);
-  return url.origin;
+  return `https://${region}.${getKonnectApiUrl()}`;
 }

--- a/packages/insomnia/src/konnect/sync.ts
+++ b/packages/insomnia/src/konnect/sync.ts
@@ -8,6 +8,7 @@ import {
   fetchAllControlPlanes,
   fetchAllServices,
   fetchRoutesForService,
+  getActiveRegions,
   type KonnectControlPlane,
   type KonnectRoute,
   type KonnectService,
@@ -17,7 +18,6 @@ import { getKonnectDeploymentType } from './transform';
 import {
   buildRequestName,
   deriveProxyVarDefaults,
-  extractRegionFromEndpoint,
   KONNECT_PROXY_VAR_NAMES,
   konnectHeadersChanged,
   mergeHeaders,
@@ -48,6 +48,7 @@ export interface SyncResult {
   services: SyncCounts;
   routes: SyncCounts;
   skippedRoutes: SkippedRoute[];
+  skippedRegions: string[];
   durationMs: number;
   error?: string;
 }
@@ -582,6 +583,7 @@ interface ControlPlaneSyncAccumulators {
   serviceCounts: SyncCounts;
   routeCounts: SyncCounts;
   skippedRoutes: SkippedRoute[];
+  skippedRegions: string[];
 }
 
 interface SyncContext {
@@ -600,7 +602,7 @@ async function syncControlPlane(
 ): Promise<void> {
   const { pat, organizationId, existingProjectsByKonnectId, signal, onProgress } = syncCtx;
   acc.controlPlaneCounts.total++;
-  const region = extractRegionFromEndpoint(controlPlane.config.control_plane_endpoint);
+  const region = controlPlane.region;
 
   // Upsert project for this control plane
   let project = existingProjectsByKonnectId.get(controlPlane.id);
@@ -691,6 +693,7 @@ export async function syncKonnect({ pat, organizationId, signal, onProgress }: S
     serviceCounts: zeroCounts(),
     routeCounts: zeroCounts(),
     skippedRoutes: [],
+    skippedRegions: [],
   };
 
   try {
@@ -705,10 +708,20 @@ export async function syncKonnect({ pat, organizationId, signal, onProgress }: S
     const incomingControlPlaneIds = new Set<string>();
     const syncCtx: SyncContext = { pat, organizationId, existingProjectsByKonnectId, signal, onProgress };
 
-    for await (const controlPlanePage of fetchAllControlPlanes(pat, signal)) {
-      for (const controlPlane of controlPlanePage) {
-        incomingControlPlaneIds.add(controlPlane.id);
-        await syncControlPlane(controlPlane, syncCtx, acc);
+    for (const region of getActiveRegions()) {
+      try {
+        for await (const controlPlanePage of fetchAllControlPlanes(pat, region, signal)) {
+          for (const controlPlane of controlPlanePage) {
+            incomingControlPlaneIds.add(controlPlane.id);
+            await syncControlPlane(controlPlane, syncCtx, acc);
+          }
+        }
+      } catch (err) {
+        if (signal?.aborted) {
+          throw err;
+        }
+        const errMessage = err instanceof Error ? err.message : String(err);
+        acc.skippedRegions.push(`${region}: ${errMessage}`);
       }
     }
 
@@ -728,6 +741,7 @@ export async function syncKonnect({ pat, organizationId, signal, onProgress }: S
       services: acc.serviceCounts,
       routes: acc.routeCounts,
       skippedRoutes: acc.skippedRoutes,
+      skippedRegions: acc.skippedRegions,
       durationMs,
     };
   } catch (err) {
@@ -740,6 +754,7 @@ export async function syncKonnect({ pat, organizationId, signal, onProgress }: S
       services: acc.serviceCounts,
       routes: acc.routeCounts,
       skippedRoutes: acc.skippedRoutes,
+      skippedRegions: acc.skippedRegions,
       durationMs,
       error: errorMessage,
     };

--- a/packages/insomnia/src/konnect/sync.ts
+++ b/packages/insomnia/src/konnect/sync.ts
@@ -724,6 +724,9 @@ export async function syncKonnect({ pat, organizationId, signal, onProgress }: S
           throw err;
         }
         const errMessage = err instanceof Error ? err.message : String(err);
+        if (region === 'sg' && errMessage.includes('403')) {
+          continue;
+        }
         acc.skippedRegions.push(`${region}: ${errMessage}`);
       }
     }

--- a/packages/insomnia/src/konnect/sync.ts
+++ b/packages/insomnia/src/konnect/sync.ts
@@ -610,7 +610,8 @@ async function syncControlPlane(
     if (
       project.name !== controlPlane.name ||
       project.konnectClusterType !== controlPlane.config.cluster_type ||
-      getKonnectDeploymentType(controlPlane) !== project.konnectDeploymentType
+      getKonnectDeploymentType(controlPlane) !== project.konnectDeploymentType ||
+      project.konnectRegion !== controlPlane.region
     ) {
       project = await insoservices.project.update(project, {
         name: controlPlane.name,
@@ -732,7 +733,7 @@ export async function syncKonnect({ pat, organizationId, signal, onProgress }: S
     // risk deleting projects whose CPs simply weren't returned.
     const failedRegions = new Set(acc.skippedRegions.map(entry => entry.split(':')[0]));
     for (const [controlPlaneId, project] of existingProjectsByKonnectId) {
-      if (!incomingControlPlaneIds.has(controlPlaneId) && !failedRegions.has(project.konnectRegion ?? '')) {
+      if (!incomingControlPlaneIds.has(controlPlaneId) && project.konnectRegion && !failedRegions.has(project.konnectRegion)) {
         await insoservices.project.remove(project);
         acc.controlPlaneCounts.deleted++;
       }

--- a/packages/insomnia/src/konnect/sync.ts
+++ b/packages/insomnia/src/konnect/sync.ts
@@ -616,6 +616,7 @@ async function syncControlPlane(
         name: controlPlane.name,
         konnectClusterType: controlPlane.config.cluster_type,
         konnectDeploymentType: getKonnectDeploymentType(controlPlane),
+        konnectRegion: controlPlane.region,
       });
       acc.controlPlaneCounts.updated++;
     }
@@ -626,6 +627,7 @@ async function syncControlPlane(
       konnectControlPlaneId: controlPlane.id,
       konnectClusterType: controlPlane.config.cluster_type,
       konnectDeploymentType: getKonnectDeploymentType(controlPlane),
+      konnectRegion: controlPlane.region,
     });
     existingProjectsByKonnectId.set(controlPlane.id, project);
     acc.controlPlaneCounts.created++;
@@ -725,9 +727,12 @@ export async function syncKonnect({ pat, organizationId, signal, onProgress }: S
       }
     }
 
-    // Delete stale projects (Control Planes removed from Konnect)
+    // Delete stale projects, but skip any whose region failed to fetch —
+    // incomingControlPlaneIds is incomplete for those regions so we would
+    // risk deleting projects whose CPs simply weren't returned.
+    const failedRegions = new Set(acc.skippedRegions.map(entry => entry.split(':')[0]));
     for (const [controlPlaneId, project] of existingProjectsByKonnectId) {
-      if (!incomingControlPlaneIds.has(controlPlaneId)) {
+      if (!incomingControlPlaneIds.has(controlPlaneId) && !failedRegions.has(project.konnectRegion ?? '')) {
         await insoservices.project.remove(project);
         acc.controlPlaneCounts.deleted++;
       }

--- a/packages/insomnia/src/konnect/sync.ts
+++ b/packages/insomnia/src/konnect/sync.ts
@@ -733,7 +733,7 @@ export async function syncKonnect({ pat, organizationId, signal, onProgress }: S
     // risk deleting projects whose CPs simply weren't returned.
     const failedRegions = new Set(acc.skippedRegions.map(entry => entry.split(':')[0]));
     for (const [controlPlaneId, project] of existingProjectsByKonnectId) {
-      if (!incomingControlPlaneIds.has(controlPlaneId) && project.konnectRegion && !failedRegions.has(project.konnectRegion)) {
+      if (!incomingControlPlaneIds.has(controlPlaneId) && !failedRegions.has(project.konnectRegion ?? '')) {
         await insoservices.project.remove(project);
         acc.controlPlaneCounts.deleted++;
       }

--- a/packages/insomnia/src/konnect/transform.ts
+++ b/packages/insomnia/src/konnect/transform.ts
@@ -52,32 +52,6 @@ export function sanitizeRoute(route: KonnectRoute): KonnectRoute {
   };
 }
 
-// ─── Region extraction ────────────────────────────────────────────────────────
-
-/**
- * Derives the Konnect region string from a control plane endpoint URL.
- * e.g. "https://abc123.us.cp0.konghq.com" → "us"
- * e.g. "https://abc123.eu.cp.konghq.com" → "eu"
- * e.g. "https://abc123.sg.cp.konghq.com" → "sg"
- * Falls back to "us" for unrecognised or malformed values.
- */
-export function extractRegionFromEndpoint(endpoint: string): string {
-  try {
-    const hostname = new URL(endpoint).hostname;
-    const parts = hostname.split('.');
-    // Pattern: <id>.<region>.cp[N].konghq.com  (e.g. cp0, cp, cp1)
-    if (parts.length >= 4 && parts[parts.length - 2] === 'konghq' && parts[parts.length - 1] === 'com') {
-      if (/^cp\d*$/.test(parts[parts.length - 3])) {
-        return parts[parts.length - 4];
-      }
-      console.warn(`[konnect] Unexpected endpoint hostname format, defaulting region to "us": ${hostname}`);
-    }
-  } catch {
-    console.warn(`[konnect] Malformed control_plane_endpoint, defaulting region to "us": ${endpoint}`);
-  }
-  return 'us';
-}
-
 // ─── Proxy environment variables ─────────────────────────────────────────────
 
 /**

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
@@ -1228,7 +1228,7 @@ const ProjectNavigationSidebarInner = (
               className={`m-2 flex items-start justify-between gap-2 rounded-sm p-3 text-xs ${
                 !lastSyncResult.success
                   ? 'bg-[rgba(58,18,8,1)]'
-                  : lastSyncResult.skippedRoutes.length > 0
+                  : lastSyncResult.skippedRoutes.length > 0 || lastSyncResult.skippedRegions.length > 0
                     ? 'bg-[rgba(250,173,20,0.15)]'
                     : 'bg-[rgba(82,196,26,0.15)]'
               }`}
@@ -1236,16 +1236,16 @@ const ProjectNavigationSidebarInner = (
               <div className="flex min-w-0 items-start gap-3">
                 <Icon
                   icon={
-                    lastSyncResult.success && lastSyncResult.skippedRoutes.length === 0
+                    lastSyncResult.success && lastSyncResult.skippedRoutes.length === 0 && lastSyncResult.skippedRegions.length === 0
                       ? 'circle-check'
                       : 'exclamation-triangle'
                   }
-                  className={lastSyncResult.success && lastSyncResult.skippedRoutes.length === 0 ? 'mt-1.5' : 'mt-1'}
+                  className={lastSyncResult.success && lastSyncResult.skippedRoutes.length === 0 && lastSyncResult.skippedRegions.length === 0 ? 'mt-1.5' : 'mt-1'}
                 />
                 <div className="min-w-0">
                   <p className="font-semibold text-(--color-font)">
                     {lastSyncResult.success
-                      ? lastSyncResult.skippedRoutes.length > 0
+                      ? lastSyncResult.skippedRoutes.length > 0 || lastSyncResult.skippedRegions.length > 0
                         ? 'Sync complete, with warnings'
                         : 'Sync complete'
                       : 'Sync failed'}
@@ -1256,18 +1256,20 @@ const ProjectNavigationSidebarInner = (
                       : lastSyncResult.routes.created === 0 &&
                           lastSyncResult.routes.updated === 0 &&
                           lastSyncResult.routes.deleted === 0 &&
-                          lastSyncResult.routes.skipped === 0
+                          lastSyncResult.routes.skipped === 0 &&
+                          lastSyncResult.skippedRegions.length === 0
                         ? 'Already up-to-date with Konnect.'
                         : [
                             lastSyncResult.routes.created > 0 && `${lastSyncResult.routes.created} request(s) added`,
                             lastSyncResult.routes.updated > 0 && `${lastSyncResult.routes.updated} request(s) updated`,
                             lastSyncResult.routes.deleted > 0 && `${lastSyncResult.routes.deleted} request(s) deleted`,
                             lastSyncResult.routes.skipped > 0 && `${lastSyncResult.routes.skipped} route(s) skipped`,
+                            lastSyncResult.skippedRegions.length > 0 && `${lastSyncResult.skippedRegions.length} region(s) skipped`,
                           ]
                             .filter(Boolean)
                             .join(', ') + '.'}
                   </p>
-                  {lastSyncResult.success && lastSyncResult.skippedRoutes.length > 0 && (
+                  {lastSyncResult.success && (lastSyncResult.skippedRoutes.length > 0 || lastSyncResult.skippedRegions.length > 0) && (
                     <>
                       <button
                         className="mt-1 flex items-center gap-1 text-(--hl) hover:text-(--color-font)"
@@ -1278,6 +1280,16 @@ const ProjectNavigationSidebarInner = (
                       </button>
                       {showSyncDetails && (
                         <div className="mt-2 max-h-48 space-y-2 overflow-y-auto">
+                          {lastSyncResult.skippedRegions.length > 0 && (
+                            <div>
+                              <p className="text-(--hl)">Failed to fetch control planes for the following regions:</p>
+                              <ul className="mt-1 space-y-0.5 pl-3">
+                                {lastSyncResult.skippedRegions.map(r => (
+                                  <li key={r} className="list-disc text-(--color-font)">{r}</li>
+                                ))}
+                              </ul>
+                            </div>
+                          )}
                           {[...skippedRoutesByReason.entries()].map(([reason, routes]) => {
                             const MAX_SHOW = 5;
                             const visible = routes.slice(0, MAX_SHOW);

--- a/packages/insomnia/src/ui/hooks/use-konnect-sync.ts
+++ b/packages/insomnia/src/ui/hooks/use-konnect-sync.ts
@@ -34,6 +34,7 @@ export function useKonnectSync(): UseKonnectSyncResult {
         services: zeroCounts(),
         routes: zeroCounts(),
         skippedRoutes: [],
+        skippedRegions: [],
         durationMs: 0,
       };
     }
@@ -52,6 +53,7 @@ export function useKonnectSync(): UseKonnectSyncResult {
         services: zeroCounts(),
         routes: zeroCounts(),
         skippedRoutes: [],
+        skippedRegions: [],
         durationMs: 0,
       };
     }

--- a/packages/insomnia/types/global.d.ts
+++ b/packages/insomnia/types/global.d.ts
@@ -27,6 +27,7 @@ type RendererEnv = {
   INSOMNIA_MOCK_API_URL: string | undefined;
   INSOMNIA_AI_URL: string | undefined;
   KONNECT_API_URL: string | undefined;
+  KONNECT_API_REGIONS: string | undefined;
   INSOMNIA_APP_WEBSITE_URL: string | undefined;
   INSOMNIA_GITHUB_REST_API_URL: string | undefined;
   INSOMNIA_GITHUB_API_URL: string | undefined;


### PR DESCRIPTION
The Konnect integration now iterates over the `'us', 'eu', 'au', 'in', 'sg'` regional endpoints to fetch all control planes. The region is stored on the control plane object for the subsequent fetches for gateway services and routes belonging to that control plane, rather than parsing the region from the control plane endpoint.

It is possible to override the list of regions using the `KONNECT_API_REGIONS` env var, ex `KONNECT_API_REGIONS=us,eu` will only fetch control planes for those two regions. This is intended for local dev and smoke tests.

Any errors/timeouts when fetching control planes from a regional endpoint are accumulated and display in the sync summary once the sync is complete. This means that if one region errors, the subsequent regions in the list are still queried. One regional endpoint returning an error _does not_ halt processing control planes from other regions.