### PR TITLE
docs: update tool links to HTTPS

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@ The purpose of this document is to provide a general overview of the application
 
 ## Technologies
 
-Insomnia is a desktop application built on top of [Electron](http://electronjs.org/). Electron provides a Chromium runtime for the Insomnia web app to run inside, as well as additional tools to provide access to operating system features.
+Insomnia is a desktop application built on top of [Electron](https://electronjs.org/). Electron provides a Chromium runtime for the Insomnia web app to run inside, as well as additional tools to provide access to operating system features.
 
 There are a few more technologies and tools worth mentioning:
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ If you are on Windows and have problems, you may need to install [Windows Build 
 
 You can use any editor you'd like, but make sure to have support/plugins for the following tools:
 
-- [ESLint](http://eslint.org/) - For catching syntax problems and common errors
+- [ESLint](https://eslint.org/) - For catching syntax problems and common errors
 - [JSX Syntax](https://facebook.github.io/react/docs/jsx-in-depth.html) - For React components
 
 </details>


### PR DESCRIPTION
## Summary
- update Electron and ESLint documentation links to HTTPS

## Verification
- verified both HTTPS URLs resolve successfully with `curl -I -L`
- ran `git diff --check`

No issue linked; this is a small documentation link cleanup.