### PR TITLE
refactor: persist request-pane sub-tab selection on RequestMeta

### DIFF
--- a/packages/insomnia-data/__tests__/request-meta.test.ts
+++ b/packages/insomnia-data/__tests__/request-meta.test.ts
@@ -1,4 +1,4 @@
-import { services } from 'insomnia-data';
+import { models, services } from 'insomnia-data';
 import { describe, expect, it } from 'vitest';
 
 describe('create()', () => {
@@ -13,4 +13,10 @@ describe('create()', () => {
   //     'Expected the parent of RequestMeta to be a Request',
   //   );
   // });
+});
+
+describe('init()', () => {
+  it('defaults activeRequestPaneTab to params', () => {
+    expect(models.requestMeta.init().activeRequestPaneTab).toBe('params');
+  });
 });

--- a/packages/insomnia-data/src/models/request-meta.ts
+++ b/packages/insomnia-data/src/models/request-meta.ts
@@ -10,12 +10,17 @@ export const canSync = false;
 
 export type RequestAccordionKeys = 'OAuth2AdvancedOptions';
 
+/** The request-pane sub-tabs whose selection is persisted per request. */
+export type RequestPaneTab = 'params' | 'content-type' | 'auth' | 'headers' | 'scripts' | 'docs';
+
 export interface BaseRequestMeta {
   parentId: string;
   previewMode: PreviewMode;
   responseFilter: string;
   responseFilterHistory: string[];
   activeResponseId: string | null;
+  /** Selected request-pane sub-tab, restored when the request is reopened. */
+  activeRequestPaneTab: RequestPaneTab;
   savedRequestBody: Record<string, any>;
   pinned: boolean;
   lastActive: number;
@@ -35,6 +40,7 @@ export function init() {
     responseFilter: '',
     responseFilterHistory: [],
     activeResponseId: null,
+    activeRequestPaneTab: 'params',
     savedRequestBody: {},
     pinned: false,
     lastActive: 0,

--- a/packages/insomnia-data/src/models/types.ts
+++ b/packages/insomnia-data/src/models/types.ts
@@ -65,7 +65,7 @@ export type {
 } from './request';
 export type { RequestGroup } from './request-group';
 export type { RequestGroupMeta } from './request-group-meta';
-export type { RequestAccordionKeys, RequestMeta } from './request-meta';
+export type { RequestAccordionKeys, RequestMeta, RequestPaneTab } from './request-meta';
 export type { RequestVersion } from './request-version';
 export type { Compression, Response, ResponseHeader, ResponseTimelineEntry } from './response';
 export type { McpRequest, McpTransportType, McpServerPrimitiveTypes } from './mcp-request';

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -1,7 +1,7 @@
-import type { RequestParameter, Settings } from 'insomnia-data';
+import type { RequestPaneTab, RequestParameter, Settings } from 'insomnia-data';
 import { models, services } from 'insomnia-data';
 import { deconstructQueryStringToParams, getContentTypeFromHeaders } from 'insomnia-data/common';
-import React, { type FC, Fragment, useRef, useState } from 'react';
+import React, { type FC, Fragment, useEffect, useRef, useState } from 'react';
 import { Button, Heading, Tab, TabList, TabPanel, Tabs, ToggleButton } from 'react-aria-components';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { useParams } from 'react-router';
@@ -17,7 +17,7 @@ import {
   useRequestLoaderData,
 } from '../../../routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId';
 import { AnalyticsEvent } from '../../../ui/analytics';
-import { useRequestPatcher, useSettingsPatcher } from '../../hooks/use-request';
+import { useRequestMetaPatcher, useRequestPatcher, useSettingsPatcher } from '../../hooks/use-request';
 import { useGitVCSVersion } from '../../hooks/use-vcs-version';
 import { AuthWrapper } from '../editors/auth/auth-wrapper';
 import { BodyEditor } from '../editors/body/body-editor';
@@ -48,6 +48,23 @@ export const RequestPane: FC<Props> = ({ environmentId, settings, onPaste }) => 
   const patchSettings = useSettingsPatcher();
   const [isRequestSettingsModalOpen, setIsRequestSettingsModalOpen] = useState(false);
   const patchRequest = useRequestPatcher();
+  const patchRequestMeta = useRequestMetaPatcher();
+
+  // Selected sub-tab is persisted per request on RequestMeta. Local state mirrors it for an
+  // instant switch (no DB round-trip). Legacy meta docs predate this field, so default to 'params'.
+  const persistedSubTab = activeRequestMeta?.activeRequestPaneTab ?? 'params';
+  const [activeSubTab, setActiveSubTab] = useState<RequestPaneTab>(persistedSubTab);
+  // Sync local state to the persisted value when switching requests, and reflect external writes.
+  // (Clicking a tab sets local state first, then persists, so this re-sync is a no-op for own edits.)
+  useEffect(() => {
+    setActiveSubTab(persistedSubTab);
+  }, [requestId, persistedSubTab]);
+
+  const handleSubTabChange = (key: string) => {
+    const subTab = key as RequestPaneTab;
+    setActiveSubTab(subTab);
+    patchRequestMeta(requestId, { activeRequestPaneTab: subTab });
+  };
 
   const requestUrlBarRef = useRef<RequestUrlBarHandle>(null);
   const [dismissPathParameterTip, setDismissPathParameterTip] = reactUse.useLocalStorage('dismissPathParameterTip', '');
@@ -114,7 +131,12 @@ export const RequestPane: FC<Props> = ({ environmentId, settings, onPaste }) => 
           />
         </ErrorBoundary>
       </PaneHeader>
-      <Tabs aria-label="Request pane tabs" className="flex h-full w-full flex-1 flex-col">
+      <Tabs
+        aria-label="Request pane tabs"
+        className="flex h-full w-full flex-1 flex-col"
+        selectedKey={activeSubTab}
+        onSelectionChange={key => handleSubTabChange(String(key))}
+      >
         <TabList
           className="scrollbar-thin flex h-(--line-height-sm) w-full shrink-0 items-center overflow-x-auto border-b border-solid border-b-(--hl-md) bg-(--color-bg)"
           aria-label="Request pane tabs"


### PR DESCRIPTION
## Summary

Persist the HTTP request-pane **sub-tab** selection per request on `RequestMeta`, instead of it being globally sticky across requests (the incidental behaviour of the previously-uncontrolled `<Tabs>`).

- Adds `RequestMeta.activeRequestPaneTab` (default `'params'`), re-exported as the `RequestPaneTab` type.
- Drives the request-pane `<Tabs>` from it via `useRequestMetaPatcher`, with local state mirroring for an **instant** switch (no DB round-trip); legacy meta docs (predating the field) fall back to `'params'`.

## Why

Foundational refactor extracted ahead of the global undo/redo work (#10126). Making the tab addressable **per request** lets undo reveal the relevant tab by writing that request's meta, removing the need for the bespoke `registerActivePane`/`consumePendingReveal` reveal protocol in that PR.

## Behaviour change

The selected sub-tab is now remembered **per request** rather than staying globally sticky when navigating between requests. This is the intended model for per-request persistence.

## Testing

- `type-check`, `lint`, and a unit test for the new `init()` default all pass.
