### PR TITLE
refactor: sync OneLineEditor to external value changes without remounting

### DIFF
--- a/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
@@ -276,6 +276,22 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
       }
     }, [readOnly, getKeyMap]);
 
+    // Reflect external `defaultValue` changes (programmatic url updates, undo/redo, etc.) into the
+    // editor without remounting. Skipped while focused so it never clobbers in-progress typing; the
+    // user's own edits flow out via onChange and arrive back equal to the current value (a no-op
+    // here). Mirrors the imperative `setValue` handle, which is already used in production.
+    useEffect(() => {
+      const editor = codeMirror.current;
+      if (!editor || editor.hasFocus()) {
+        return;
+      }
+      if (defaultValue !== editor.getValue()) {
+        const cursor = editor.getCursor();
+        editor.setValue(defaultValue || '');
+        editor.setCursor(cursor);
+      }
+    }, [defaultValue]);
+
     useEffect(() => {
       // Prevent these things if we're type === "password"
       const preventDefault = (_: CodeMirror.Editor, event: Event) =>


### PR DESCRIPTION
## Summary

Make `OneLineEditor` reflect external `defaultValue` changes into its CodeMirror instance **without remounting**.

- New effect pushes external value changes into the editor (cursor preserved), **skipped while the editor is focused** so it never clobbers in-progress typing.
- The user's own edits flow out via `onChange` and arrive back equal to the current value, so they are no-ops here.

## Why

Today, callers refresh an uncontrolled `OneLineEditor` to a new external value by changing a React `key` and forcing a full remount (e.g. the request URL bar's `uniquenessKey`). This effect lets a changed value reflect directly, which is a foundation for the global undo/redo work (#10126) to drop its `undoRevision` remount key and have value reverts reflect (including key/value rows, which aren't keyed on `uniquenessKey`).

The implementation mirrors the existing imperative `setValue` handle (already used in production by the url bar's `setUrl`), so the nunjucks-tag path is already exercised.

## Scope

Deliberately **does not** remove the request-pane `uniquenessKey` remount: that key also drives nunjucks **preview** refresh on environment changes, which value-sync does not cover.

## Testing

- `type-check` and `lint` pass.
- Behavioural validation (external value reflecting without remount) is naturally exercised by the undo smoke test once #10126 rebases onto this; the develop-level regression risk is limited to normal typing, guarded by the `hasFocus()` check.
