### PR TITLE
feat: support unique method+path in cloud mock routes [INS-2629]

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.mock-route.$mockRouteId.update.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.mock-route.$mockRouteId.update.tsx
@@ -4,6 +4,7 @@ import { href } from 'react-router';
 
 import { invariant } from '~/common/utils/invariant';
 import { AnalyticsEvent } from '~/ui/analytics';
+import { findConflictingMockRoute } from '~/ui/utils/mock-route';
 import { createFetcherSubmitHook } from '~/ui/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.mock-route.$mockRouteId.update';
@@ -21,27 +22,19 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
       invariant(typeof patch.name === 'string', 'Name is required');
       invariant(patch.name.startsWith('/'), 'Path must begin with a /');
 
-      const mockServer = await services.mockServer.getById(mockRoute.parentId);
       const existingRoutes = await services.mockRoute.findByParentId(mockRoute.parentId);
-
-      if (mockServer?.useInsomniaCloud) {
-        const hasRouteInServer = existingRoutes.filter(m => m._id !== mockRouteId).find(m => m.name === patch.name);
-        if (hasRouteInServer) {
-          invariant(false, `Path "${patch.name}" already exists. Please enter a different path.`);
-        }
-      } else {
-        const hasRouteInServer = existingRoutes
-          .filter(m => m._id !== mockRouteId)
-          .find(
-            m => m.name === patch.name && m.method.toUpperCase() === (patch.method || mockRoute.method).toUpperCase(),
-          );
-
-        if (hasRouteInServer) {
-          invariant(
-            false,
-            `Path "${patch.name}" with ${patch.method || mockRoute.method} method already exists. Please enter a different path or method.`,
-          );
-        }
+      const method = patch.method || mockRoute.method;
+      const hasRouteInServer = findConflictingMockRoute({
+        existingRoutes,
+        name: patch.name,
+        method,
+        excludeId: mockRouteId, // allow edits
+      });
+      if (hasRouteInServer) {
+        invariant(
+          false,
+          `Path "${patch.name}" with ${method} method already exists. Please enter a different path or method.`,
+        );
       }
     }
 

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.mock-route.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.mock-route.new.tsx
@@ -1,9 +1,10 @@
 import type { MockRoute } from 'insomnia-data';
-import { services } from 'insomnia-data';
+import { models, services } from 'insomnia-data';
 import { href, redirect } from 'react-router';
 
 import { invariant } from '~/common/utils/invariant';
 import { AnalyticsEvent } from '~/ui/analytics';
+import { findConflictingMockRoute } from '~/ui/utils/mock-route';
 import { createFetcherSubmitHook } from '~/ui/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.mock-route.new';
@@ -19,24 +20,18 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
     invariant(patch.name.startsWith('/'), 'Path must begin with a /');
 
     if (patch.parentId) {
-      const mockServer = await services.mockServer.getById(patch.parentId);
       const existingRoutes = await services.mockRoute.findByParentId(patch.parentId);
-
-      if (mockServer?.useInsomniaCloud) {
-        const hasRouteInServer = existingRoutes.find(m => m.name === patch.name);
-        if (hasRouteInServer) {
-          invariant(false, `Path "${patch.name}" already exists. Please enter a different path.`);
-        }
-      } else {
-        const hasRouteInServer = existingRoutes.find(
-          m => m.name === patch.name && m.method.toUpperCase() === patch.method?.toUpperCase(),
+      const method = patch.method ?? models.mockRoute.init().method;
+      const hasRouteInServer = findConflictingMockRoute({
+        existingRoutes,
+        name: patch.name,
+        method,
+      });
+      if (hasRouteInServer) {
+        invariant(
+          false,
+          `Path "${patch.name}" with ${method} method already exists. Please enter a different path or method.`,
         );
-        if (hasRouteInServer) {
-          invariant(
-            false,
-            `Path "${patch.name}" with ${patch.method} method already exists. Please enter a different path or method.`,
-          );
-        }
       }
     }
     // TODO: remove this hack which enables a mock server to be created alongside a route

--- a/packages/insomnia/src/ui/utils/mock-route.test.ts
+++ b/packages/insomnia/src/ui/utils/mock-route.test.ts
@@ -1,0 +1,110 @@
+import type { MockRoute } from 'insomnia-data';
+import { describe, expect, it } from 'vitest';
+
+import { findConflictingMockRoute, isSameMockRouteTarget } from './mock-route';
+
+const buildRoute = (overrides: Partial<MockRoute> = {}): MockRoute =>
+  ({
+    _id: 'mock-route',
+    type: 'MockRoute',
+    parentId: 'mock-server_pokedex',
+    modified: 0,
+    created: 0,
+    isPrivate: false,
+    name: '/pokedex/134',
+    method: 'GET',
+    body: '',
+    headers: [],
+    statusCode: 200,
+    statusText: '',
+    mimeType: 'application/json',
+    ...overrides,
+  }) as MockRoute;
+
+describe('isSameMockRouteTarget', () => {
+  it('matches identical method and path', () => {
+    expect(isSameMockRouteTarget({ name: '/pokedex/134', method: 'GET' }, { name: '/pokedex/134', method: 'GET' })).toBe(true);
+  });
+
+  it('treats method comparison as case-insensitive', () => {
+    expect(isSameMockRouteTarget({ name: '/pokedex/134', method: 'get' }, { name: '/pokedex/134', method: 'GET' })).toBe(true);
+  });
+
+  it('does not match when the method differs', () => {
+    expect(isSameMockRouteTarget({ name: '/pokedex/134', method: 'GET' }, { name: '/pokedex/134', method: 'POST' })).toBe(false);
+  });
+
+  it('does not match when the path differs', () => {
+    expect(isSameMockRouteTarget({ name: '/pokedex/134', method: 'GET' }, { name: '/pokedex/133', method: 'GET' })).toBe(false);
+  });
+});
+
+describe('findConflictingMockRoute', () => {
+  it('rejects same path with same method (uniqueness on the method+path pair)', () => {
+    const existingRoutes = [buildRoute({ _id: 'a', name: '/pokedex/134', method: 'GET' })];
+
+    const conflict = findConflictingMockRoute({ existingRoutes, name: '/pokedex/134', method: 'GET' });
+
+    expect(conflict?._id).toBe('a');
+  });
+
+  it('allows same path with a different method (GET /member and POST /member)', () => {
+    const existingRoutes = [buildRoute({ _id: 'a', name: '/pokedex/134', method: 'GET' })];
+
+    const conflict = findConflictingMockRoute({ existingRoutes, name: '/pokedex/134', method: 'POST' });
+
+    expect(conflict).toBeUndefined();
+  });
+
+  it('allows a different path with the same method', () => {
+    const existingRoutes = [buildRoute({ _id: 'a', name: '/pokedex/134', method: 'GET' })];
+
+    const conflict = findConflictingMockRoute({ existingRoutes, name: '/pokedex/133', method: 'GET' });
+
+    expect(conflict).toBeUndefined();
+  });
+
+  it('ignores method casing when detecting a conflict', () => {
+    const existingRoutes = [buildRoute({ _id: 'a', name: '/pokedex/134', method: 'GET' })];
+
+    const conflict = findConflictingMockRoute({ existingRoutes, name: '/pokedex/134', method: 'get' });
+
+    expect(conflict?._id).toBe('a');
+  });
+
+  it('excludes the route currently being edited so it does not conflict with itself', () => {
+    const existingRoutes = [buildRoute({ _id: 'a', name: '/pokedex/134', method: 'GET' })];
+
+    const conflict = findConflictingMockRoute({
+      existingRoutes,
+      name: '/pokedex/134',
+      method: 'GET',
+      excludeId: 'a',
+    });
+
+    expect(conflict).toBeUndefined();
+  });
+
+  it('still detects a conflict with a sibling route when editing', () => {
+    const existingRoutes = [
+      buildRoute({ _id: 'a', name: '/pokedex/134', method: 'GET' }),
+      buildRoute({ _id: 'b', name: '/pokedex/135', method: 'POST' }),
+    ];
+
+    // Editing route "b" to collide with route "a".
+    const conflict = findConflictingMockRoute({
+      existingRoutes,
+      name: '/pokedex/134',
+      method: 'GET',
+      excludeId: 'b',
+    });
+
+    expect(conflict?._id).toBe('a');
+  });
+
+  it('returns undefined when there are no existing routes', () => {
+    const conflict = findConflictingMockRoute({ existingRoutes: [], name: '/pokedex/134', method: 'GET' });
+
+    expect(conflict).toBeUndefined();
+  });
+});

--- a/packages/insomnia/src/ui/utils/mock-route.ts
+++ b/packages/insomnia/src/ui/utils/mock-route.ts
@@ -1,0 +1,24 @@
+import type { MockRoute } from 'insomnia-data';
+
+export const isSameMockRouteTarget = (
+  a: { name: string; method: string },
+  b: { name: string; method: string },
+): boolean => a.name === b.name && a.method.toUpperCase() === b.method.toUpperCase();
+
+/**
+ * Returns an existing mock route that conflicts with the method+path pair or undefined
+ */
+export const findConflictingMockRoute = ({
+  existingRoutes,
+  name,
+  method,
+  excludeId,
+}: {
+  existingRoutes: MockRoute[];
+  name: string;
+  method: string;
+  excludeId?: string;
+}): MockRoute | undefined =>
+  existingRoutes
+    .filter(route => route._id !== excludeId)
+    .find(route => isSameMockRouteTarget(route, { name, method }));


### PR DESCRIPTION
Aligns both cloud-hosted and self-hosted mock server route features to allow for unique `method`+`path` instead of just `path` on the cloud-hosted server.

https://github.com/user-attachments/assets/476b6e7d-1c49-4a17-a6e0-6e3e74dc1a0d

