### PR TITLE
feat: add additional konnect analytics event properties

### DIFF
--- a/packages/insomnia-data/common-src/settings.ts
+++ b/packages/insomnia-data/common-src/settings.ts
@@ -129,6 +129,7 @@ export interface Settings {
   fontVariantLigatures: boolean;
   forceVerticalLayout: boolean;
   hasKonnectPat: boolean;
+  konnectOrganizationId: string | null;
   hotKeyRegistry: HotKeyRegistry;
   httpProxy: string;
   httpsProxy: string;

--- a/packages/insomnia-data/src/models/settings.ts
+++ b/packages/insomnia-data/src/models/settings.ts
@@ -51,6 +51,7 @@ export function init(): BaseSettings {
     fontVariantLigatures: false,
     forceVerticalLayout,
     hasKonnectPat: false,
+    konnectOrganizationId: null,
     hotKeyRegistry: newDefaultRegistry(),
     httpProxy: '',
     httpsProxy: '',

--- a/packages/insomnia/src/konnect/__tests__/api.test.ts
+++ b/packages/insomnia/src/konnect/__tests__/api.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { fetchAllControlPlanes, fetchAllServices, fetchRoutesForService, validatePat } from '../api';
+import {
+  fetchAllControlPlanes,
+  fetchAllServices,
+  fetchKonnectOrganizationId,
+  fetchRoutesForService,
+  validatePat,
+} from '../api';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -551,6 +557,61 @@ describe('retry on 429', () => {
 
     expect(pages).toHaveLength(1);
     expect(pages[0]).toEqual(page1Data.map(cp => ({ ...cp, region: 'us', proxy_urls: null })));
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ─── fetchKonnectOrganizationId ───────────────────────────────────────────────
+
+describe('fetchKonnectOrganizationId', () => {
+  it('returns the organization id on a 200 response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ id: 'org-abc-123' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchKonnectOrganizationId('good-token');
+
+    expect(result).toBe('org-abc-123');
+    expect(fetchMock.mock.calls[0][0]).toContain('/v3/organizations/me');
+    expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe('Bearer good-token');
+  });
+
+  it('returns undefined on a non-ok response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('', { status: 403 })));
+
+    const result = await fetchKonnectOrganizationId('bad-token');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when fetch throws', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network failure')));
+
+    const result = await fetchKonnectOrganizationId('any-token');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when the response body has no id field', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({})));
+
+    const result = await fetchKonnectOrganizationId('good-token');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('retries on 429 and returns the org id after success', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(rateLimitResponse())
+      .mockResolvedValueOnce(jsonResponse({ id: 'org-retried' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = fetchKonnectOrganizationId('good-token');
+    await drainRetryTimers();
+
+    const result = await promise;
+
+    expect(result).toBe('org-retried');
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/insomnia/src/konnect/api.ts
+++ b/packages/insomnia/src/konnect/api.ts
@@ -142,6 +142,19 @@ export async function validatePat(pat: string): Promise<PatValidationResult> {
   }
 }
 
+export async function fetchKonnectOrganizationId(pat: string, signal?: AbortSignal): Promise<string | undefined> {
+  try {
+    const response = await fetchWithRetry(`${regionalApiBase('us')}/v3/organizations/me`, pat, signal);
+    if (!response.ok) {
+      return undefined;
+    }
+    const data = (await response.json()) as { id?: string };
+    return data.id;
+  } catch {
+    return undefined;
+  }
+}
+
 export async function* fetchAllControlPlanes(
   pat: string,
   region: KonnectRegion,

--- a/packages/insomnia/src/ui/components/modals/konnect-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/konnect-settings-modal.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { Button, Dialog, Heading, Modal, ModalOverlay } from 'react-aria-components';
 
 import { database } from '~/common/database';
-import { validatePat } from '~/konnect/api';
+import { fetchKonnectOrganizationId, validatePat } from '~/konnect/api';
 import { useRootLoaderData } from '~/root';
 import { AnalyticsEvent } from '~/ui/analytics';
 
@@ -16,7 +16,7 @@ export const KonnectSettingsModal = ({
   onDisconnect,
 }: {
   onClose: () => void;
-  syncKonnectProjectsAndNotifyRef: React.MutableRefObject<() => Promise<void>>;
+  syncKonnectProjectsAndNotifyRef: React.MutableRefObject<(konnectOrganizationId?: string | null) => Promise<void>>;
   onDisconnect?: () => void;
 }) => {
   const { settings } = useRootLoaderData()!;
@@ -25,25 +25,30 @@ export const KonnectSettingsModal = ({
   const [pat, setPat] = useState('');
   const [isPatVisible, setIsPatVisible] = useState(false);
   // 'idle' | 'validating' | 'valid' | 'invalid'
-  const [status, setStatus] = useState<'idle' | 'validating' | 'valid' | 'invalid'>('idle');
+  const [status, setStatus] = useState<'idle' | 'validating' | 'valid' | 'invalid'>(settings.hasKonnectPat ? 'validating' : 'idle');
   const [validationError, setValidationError] = useState<string | null>(null);
   // Controls whether the disconnect confirmation screen is shown
   const [showDisconnectConfirm, setShowDisconnectConfirm] = useState(false);
   const [isDisconnecting, setIsDisconnecting] = useState(false);
 
-  // Validate the given PAT against the Konnect API and update status/error state accordingly.
-  const validateAndSetStatus = async (trimmed: string) => {
-    setStatus('validating');
-    setValidationError(null);
+  const validateAndSetStatus = async (trimmed: string): Promise<{ valid: boolean; orgId?: string }> => {
     const result = await validatePat(trimmed);
+    const orgId = result.valid ? await fetchKonnectOrganizationId(trimmed) : undefined;
+    window.main.trackAnalyticsEvent({
+      event: AnalyticsEvent.kongKonnectPatValidated,
+      properties: {
+        validation_status: result.valid ? 'valid' : 'invalid',
+        ...(orgId ? { konnect_organization_id: orgId } : {}),
+      },
+    });
     setStatus(result.valid ? 'valid' : 'invalid');
     if (!result.valid) {
       setValidationError(result.error ?? 'Invalid PAT. Check your input and try again.');
     }
-    return result;
+    return { valid: result.valid, orgId };
   };
 
-  // On mount: if a PAT is already stored, load it from secure storage and validate it.
+  // On mount: if a PAT is already stored, load and re-validate it to update the status indicator.
   useEffect(() => {
     if (settings.hasKonnectPat) {
       window.main.secretStorage.getSecret('konnectPat').then(secret => {
@@ -62,14 +67,16 @@ export const KonnectSettingsModal = ({
     if (!trimmed) {
       return;
     }
-    const result = await validateAndSetStatus(trimmed);
-    if (result.valid) {
-      await window.main.secretStorage.setSecret('konnectPat', trimmed);
-      patchSettings({ hasKonnectPat: true });
-      window.main.trackAnalyticsEvent({ event: AnalyticsEvent.kongKonnectPatValidated });
-      syncKonnectProjectsAndNotifyRef.current();
-      onClose();
+    setStatus('validating');
+    setValidationError(null);
+    const { valid, orgId } = await validateAndSetStatus(trimmed);
+    if (!valid) {
+      return;
     }
+    await window.main.secretStorage.setSecret('konnectPat', trimmed);
+    patchSettings({ hasKonnectPat: true, konnectOrganizationId: orgId ?? null });
+    syncKonnectProjectsAndNotifyRef.current(orgId ?? null);
+    onClose();
   };
 
   // Delete all Konnect-synced projects from the local DB, remove the stored PAT, and close the modal.
@@ -87,7 +94,7 @@ export const KonnectSettingsModal = ({
         await database.flushChanges(bufferId);
       }
       await window.main.secretStorage.deleteSecret('konnectPat');
-      patchSettings({ hasKonnectPat: false });
+      patchSettings({ hasKonnectPat: false, konnectOrganizationId: null });
       onDisconnect?.();
       onClose();
     } finally {

--- a/packages/insomnia/src/ui/components/modals/konnect-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/konnect-settings-modal.tsx
@@ -25,7 +25,7 @@ export const KonnectSettingsModal = ({
   const [pat, setPat] = useState('');
   const [isPatVisible, setIsPatVisible] = useState(false);
   // 'idle' | 'validating' | 'valid' | 'invalid'
-  const [status, setStatus] = useState<'idle' | 'validating' | 'valid' | 'invalid'>(settings.hasKonnectPat ? 'validating' : 'idle');
+  const [status, setStatus] = useState<'idle' | 'validating' | 'valid' | 'invalid'>('idle');
   const [validationError, setValidationError] = useState<string | null>(null);
   // Controls whether the disconnect confirmation screen is shown
   const [showDisconnectConfirm, setShowDisconnectConfirm] = useState(false);
@@ -48,13 +48,12 @@ export const KonnectSettingsModal = ({
     return { valid: result.valid, orgId };
   };
 
-  // On mount: if a PAT is already stored, load and re-validate it to update the status indicator.
+  // On mount: if a PAT is already stored, load it into the input field.
   useEffect(() => {
     if (settings.hasKonnectPat) {
       window.main.secretStorage.getSecret('konnectPat').then(secret => {
         if (secret) {
           setPat(secret);
-          validateAndSetStatus(secret);
         }
       });
     }
@@ -102,8 +101,7 @@ export const KonnectSettingsModal = ({
     }
   };
 
-  // A connected state means the PAT is saved and has not been found invalid.
-  const isConnected = settings.hasKonnectPat && status !== 'invalid';
+  const hasStoredPat = settings.hasKonnectPat && status !== 'invalid';
 
   return (
     <ModalOverlay
@@ -178,7 +176,7 @@ export const KonnectSettingsModal = ({
                         type={isPatVisible ? 'text' : 'password'}
                         className="w-full rounded-xs border border-solid border-(--hl-sm) bg-(--color-bg) px-2 py-1.5 pr-8 text-(--color-font) focus:border-(--hl-lg) focus:outline-hidden"
                         placeholder={
-                          isConnected
+                          hasStoredPat
                             ? 'Enter new PAT to replace existing'
                             : 'e.g. kpat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
                         }
@@ -206,9 +204,6 @@ export const KonnectSettingsModal = ({
                         {validationError ?? 'Invalid PAT. Check your input and try again.'}
                       </p>
                     )}
-                    {(status === 'valid' || (isConnected && status === 'idle')) && (
-                      <p className="text-sm text-(--color-success)">Connected</p>
-                    )}
                   </div>
 
                   <div className="flex items-center gap-2">
@@ -219,7 +214,7 @@ export const KonnectSettingsModal = ({
                     >
                       {status === 'validating' ? <Icon icon="spinner" className="animate-spin" /> : 'Connect & Sync'}
                     </Button>
-                    {isConnected && (
+                    {hasStoredPat && (
                       <Button
                         className="rounded-xs px-3 py-1.5 text-sm text-(--color-font) hover:bg-(--hl-xs)"
                         onPress={() => setShowDisconnectConfirm(true)}

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
@@ -276,7 +276,9 @@ const ProjectNavigationSidebarInner = (
   // ref to track whether we are currently fetching unsynced files for cloud sync projects to avoid duplicate requests
   const isFetchingUnsyncedFilesRef = useRef(false);
 
-  const syncKonnectProjectsAndNotifyRef = useRef<() => Promise<void>>(async () => {});
+  const syncKonnectProjectsAndNotifyRef = useRef<(konnectOrganizationId?: string | null) => Promise<void>>(
+    async () => {},
+  );
 
   const isScratchPad = activeProjectId === models.project.SCRATCHPAD_PROJECT_ID;
 
@@ -373,9 +375,12 @@ const ProjectNavigationSidebarInner = (
     return setUnsyncedFilesByProjectId(result);
   }, [organizationId, cloudSyncProjectIdsKey]);
 
-  const syncKonnectProjectsAndNotify = async () => {
+  const syncKonnectProjectsAndNotify = async (konnectOrganizationId?: string | null) => {
     const isFirstSync = lastSyncedAt == null;
-    const result = await startSync(organizationId);
+    const result = await startSync(
+      organizationId,
+      konnectOrganizationId !== undefined ? konnectOrganizationId : settings.konnectOrganizationId,
+    );
     setLastSyncResult(result ?? null);
     setShowSyncDetails(false);
     setCopiedReason(null);
@@ -1121,7 +1126,11 @@ const ProjectNavigationSidebarInner = (
                         if (routeInfo?.resourceId === docId) {
                           toggleProjectOrWorkspace(docId);
                         } else {
-                          !isScratchPad && window.main.trackAnalyticsEvent({ event: AnalyticsEvent.projectSwitched, properties: { project_id: docId } });
+                          !isScratchPad &&
+                            window.main.trackAnalyticsEvent({
+                              event: AnalyticsEvent.projectSwitched,
+                              properties: { project_id: docId },
+                            });
                           !isScratchPad && navigate(`/organization/${organizationId}/project/${docId}`);
                         }
                       } else if (item.kind === 'workspace') {
@@ -1236,11 +1245,19 @@ const ProjectNavigationSidebarInner = (
               <div className="flex min-w-0 items-start gap-3">
                 <Icon
                   icon={
-                    lastSyncResult.success && lastSyncResult.skippedRoutes.length === 0 && lastSyncResult.skippedRegions.length === 0
+                    lastSyncResult.success &&
+                    lastSyncResult.skippedRoutes.length === 0 &&
+                    lastSyncResult.skippedRegions.length === 0
                       ? 'circle-check'
                       : 'exclamation-triangle'
                   }
-                  className={lastSyncResult.success && lastSyncResult.skippedRoutes.length === 0 && lastSyncResult.skippedRegions.length === 0 ? 'mt-1.5' : 'mt-1'}
+                  className={
+                    lastSyncResult.success &&
+                    lastSyncResult.skippedRoutes.length === 0 &&
+                    lastSyncResult.skippedRegions.length === 0
+                      ? 'mt-1.5'
+                      : 'mt-1'
+                  }
                 />
                 <div className="min-w-0">
                   <p className="font-semibold text-(--color-font)">
@@ -1264,68 +1281,72 @@ const ProjectNavigationSidebarInner = (
                             lastSyncResult.routes.updated > 0 && `${lastSyncResult.routes.updated} request(s) updated`,
                             lastSyncResult.routes.deleted > 0 && `${lastSyncResult.routes.deleted} request(s) deleted`,
                             lastSyncResult.routes.skipped > 0 && `${lastSyncResult.routes.skipped} route(s) skipped`,
-                            lastSyncResult.skippedRegions.length > 0 && `${lastSyncResult.skippedRegions.length} region(s) skipped`,
+                            lastSyncResult.skippedRegions.length > 0 &&
+                              `${lastSyncResult.skippedRegions.length} region(s) skipped`,
                           ]
                             .filter(Boolean)
                             .join(', ') + '.'}
                   </p>
-                  {lastSyncResult.success && (lastSyncResult.skippedRoutes.length > 0 || lastSyncResult.skippedRegions.length > 0) && (
-                    <>
-                      <button
-                        className="mt-1 flex items-center gap-1 text-(--hl) hover:text-(--color-font)"
-                        onClick={() => setShowSyncDetails(prev => !prev)}
-                      >
-                        <Icon icon={showSyncDetails ? 'chevron-down' : 'chevron-right'} className="h-2.5 w-2.5" />
-                        {showSyncDetails ? 'Hide details' : 'Show details'}
-                      </button>
-                      {showSyncDetails && (
-                        <div className="mt-2 max-h-48 space-y-2 overflow-y-auto">
-                          {lastSyncResult.skippedRegions.length > 0 && (
-                            <div>
-                              <p className="text-(--hl)">Failed to fetch control planes for the following regions:</p>
-                              <ul className="mt-1 space-y-0.5 pl-3">
-                                {lastSyncResult.skippedRegions.map(r => (
-                                  <li key={r} className="list-disc text-(--color-font)">{r}</li>
-                                ))}
-                              </ul>
-                            </div>
-                          )}
-                          {[...skippedRoutesByReason.entries()].map(([reason, routes]) => {
-                            const MAX_SHOW = 5;
-                            const visible = routes.slice(0, MAX_SHOW);
-                            const extra = routes.length - MAX_SHOW;
-                            return (
-                              <div key={reason}>
-                                <p className="text-(--hl)">{reason} for the following routes:</p>
+                  {lastSyncResult.success &&
+                    (lastSyncResult.skippedRoutes.length > 0 || lastSyncResult.skippedRegions.length > 0) && (
+                      <>
+                        <button
+                          className="mt-1 flex items-center gap-1 text-(--hl) hover:text-(--color-font)"
+                          onClick={() => setShowSyncDetails(prev => !prev)}
+                        >
+                          <Icon icon={showSyncDetails ? 'chevron-down' : 'chevron-right'} className="h-2.5 w-2.5" />
+                          {showSyncDetails ? 'Hide details' : 'Show details'}
+                        </button>
+                        {showSyncDetails && (
+                          <div className="mt-2 max-h-48 space-y-2 overflow-y-auto">
+                            {lastSyncResult.skippedRegions.length > 0 && (
+                              <div>
+                                <p className="text-(--hl)">Failed to fetch control planes for the following regions:</p>
                                 <ul className="mt-1 space-y-0.5 pl-3">
-                                  {visible.map(r => (
+                                  {lastSyncResult.skippedRegions.map(r => (
                                     <li key={r} className="list-disc text-(--color-font)">
                                       {r}
                                     </li>
                                   ))}
                                 </ul>
-                                {extra > 0 && (
-                                  <div className="mt-1 flex items-center gap-2 pl-3 text-(--hl)">
-                                    <span>+ {extra} more</span>
-                                    <button
-                                      className="underline hover:text-(--color-font)"
-                                      onClick={() => {
-                                        navigator.clipboard.writeText(routes.join('\n'));
-                                        setCopiedReason(reason);
-                                        setTimeout(() => setCopiedReason(null), 2000);
-                                      }}
-                                    >
-                                      {copiedReason === reason ? 'Copied' : 'Copy full list'}
-                                    </button>
-                                  </div>
-                                )}
                               </div>
-                            );
-                          })}
-                        </div>
-                      )}
-                    </>
-                  )}
+                            )}
+                            {[...skippedRoutesByReason.entries()].map(([reason, routes]) => {
+                              const MAX_SHOW = 5;
+                              const visible = routes.slice(0, MAX_SHOW);
+                              const extra = routes.length - MAX_SHOW;
+                              return (
+                                <div key={reason}>
+                                  <p className="text-(--hl)">{reason} for the following routes:</p>
+                                  <ul className="mt-1 space-y-0.5 pl-3">
+                                    {visible.map(r => (
+                                      <li key={r} className="list-disc text-(--color-font)">
+                                        {r}
+                                      </li>
+                                    ))}
+                                  </ul>
+                                  {extra > 0 && (
+                                    <div className="mt-1 flex items-center gap-2 pl-3 text-(--hl)">
+                                      <span>+ {extra} more</span>
+                                      <button
+                                        className="underline hover:text-(--color-font)"
+                                        onClick={() => {
+                                          navigator.clipboard.writeText(routes.join('\n'));
+                                          setCopiedReason(reason);
+                                          setTimeout(() => setCopiedReason(null), 2000);
+                                        }}
+                                      >
+                                        {copiedReason === reason ? 'Copied' : 'Copy full list'}
+                                      </button>
+                                    </div>
+                                  )}
+                                </div>
+                              );
+                            })}
+                          </div>
+                        )}
+                      </>
+                    )}
                 </div>
               </div>
               <button

--- a/packages/insomnia/src/ui/hooks/use-konnect-sync.ts
+++ b/packages/insomnia/src/ui/hooks/use-konnect-sync.ts
@@ -15,7 +15,7 @@ interface KonnectSyncState {
 export interface UseKonnectSyncResult {
   syncing: boolean;
   progress: string;
-  startSync: (organizationId: string) => Promise<SyncResult>;
+  startSync: (organizationId: string, konnectOrganizationId?: string | null) => Promise<SyncResult>;
   cancelSync: () => void;
 }
 
@@ -25,7 +25,7 @@ export function useKonnectSync(): UseKonnectSyncResult {
   const revalidateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { revalidate } = useRevalidator();
 
-  const startSync = async (organizationId: string): Promise<SyncResult> => {
+  const startSync = async (organizationId: string, konnectOrganizationId?: string | null): Promise<SyncResult> => {
     if (abortRef.current) {
       return {
         success: false,
@@ -90,6 +90,7 @@ export function useKonnectSync(): UseKonnectSyncResult {
       properties: {
         success: result.success,
         cancelled,
+        ...(konnectOrganizationId ? { konnect_organization_id: konnectOrganizationId } : {}),
         control_planes_total: result.controlPlanes.total,
         control_planes_created: result.controlPlanes.created,
         control_planes_updated: result.controlPlanes.updated,


### PR DESCRIPTION
- Include the Konnect organization ID in the Konnect integration analytics events.
- Send the Konnect integration PAT validated analytics event when PAT validation succeeds OR fails, include a new `validation_status` property to indicate which.