### PR TITLE
fix: improve OneLineEditor initialization and resize handling

### DIFF
--- a/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
@@ -5,7 +5,7 @@ import clone from 'clone';
 import CodeMirror, { type EditorConfiguration, type EditorEventMap } from 'codemirror';
 import type { KeyCombination } from 'insomnia-data/common';
 import { isMac } from 'insomnia-data/common';
-import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useRef } from 'react';
+import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useLayoutEffect, useRef } from 'react';
 import * as reactUse from 'react-use';
 
 import { DEBOUNCE_MILLIS } from '~/common/constants';
@@ -20,6 +20,7 @@ import { isKeyCombinationInRegistry } from '~/ui/components/settings/shortcuts';
 import { useNunjucks } from '~/ui/context/nunjucks/use-nunjucks';
 import { useEditorRefresh } from '~/ui/hooks/use-editor-refresh';
 import { usePlanData } from '~/ui/hooks/use-plan';
+import { useResizeObserver } from '~/ui/hooks/use-resize-observer';
 import { plugins } from '~/ui/plugins/renderer-bridge';
 import { getTagDefinitions } from '~/ui/templating/renderer-safe';
 
@@ -63,6 +64,7 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
     },
     ref,
   ) => {
+    const editorContainerRef = useRef<HTMLDivElement>(null);
     const textAreaRef = useRef<HTMLTextAreaElement>(null);
     const codeMirror = useRef<CodeMirror.EditorFromTextArea | null>(null);
     const { settings } = useRootLoaderData()!;
@@ -77,7 +79,7 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
     }, [settings.enableKeyMapForInlineTextEditors, settings.editorKeyMap, readOnly]);
 
     const initEditor = useCallback(() => {
-      if (!textAreaRef.current) {
+      if (!textAreaRef.current || codeMirror.current) {
         return;
       }
 
@@ -252,9 +254,19 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
       codeMirror.current?.closeHintDropdown();
       codeMirror.current = null;
     }, []);
-    reactUse.useMount(() => {
-      initEditor();
+
+    useLayoutEffect(() => {
+      if (editorContainerRef.current?.offsetWidth) {
+        initEditor();
+      }
+    }, [initEditor]);
+
+    useResizeObserver(editorContainerRef, ({ width }) => {
+      if (width && width > 0) {
+        initEditor();
+      }
     });
+
     reactUse.useUnmount(() => {
       cleanUpEditor();
     });
@@ -402,7 +414,7 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
           }
         }}
       >
-        <div className="editor__container input editor--single-line">
+        <div ref={editorContainerRef} className="editor__container input editor--single-line">
           <textarea
             id={id}
             ref={textAreaRef}

--- a/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
@@ -5,7 +5,15 @@ import clone from 'clone';
 import CodeMirror, { type EditorConfiguration, type EditorEventMap } from 'codemirror';
 import type { KeyCombination } from 'insomnia-data/common';
 import { isMac } from 'insomnia-data/common';
-import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useLayoutEffect, useRef } from 'react';
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import * as reactUse from 'react-use';
 
 import { DEBOUNCE_MILLIS } from '~/common/constants';
@@ -67,6 +75,8 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
     const editorContainerRef = useRef<HTMLDivElement>(null);
     const textAreaRef = useRef<HTMLTextAreaElement>(null);
     const codeMirror = useRef<CodeMirror.EditorFromTextArea | null>(null);
+    // We need to track editor version in order to re-apply some effects when the editor is re-initialized.
+    const [editorVersion, setEditorVersion] = useState(0);
     const { settings } = useRootLoaderData()!;
     const { isOwner, isEnterprisePlan } = usePlanData();
     const { handleRender, handleGetRenderContext } = useNunjucks();
@@ -230,6 +240,7 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
           id,
         );
       }
+      setEditorVersion(version => version + 1);
     }, [
       defaultValue,
       getAutocompleteConstants,
@@ -301,7 +312,7 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
         codeMirror.current?.off('cut', preventDefault);
         codeMirror.current?.off('dragstart', preventDefault);
       };
-    }, [type]);
+    }, [editorVersion, type]);
 
     useEffect(() => {
       const fn = misc.debounce((doc: CodeMirror.Editor) => {
@@ -311,7 +322,7 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
       }, DEBOUNCE_MILLIS);
       codeMirror.current?.on('changes', fn);
       return () => codeMirror.current?.off('changes', fn);
-    }, [onChange]);
+    }, [editorVersion, onChange]);
 
     useEffect(() => {
       const flushOnBlur = (doc: CodeMirror.Editor) => {
@@ -321,7 +332,7 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
       };
       codeMirror.current?.on('blur', flushOnBlur);
       return () => codeMirror.current?.off('blur', flushOnBlur);
-    }, [onChange]);
+    }, [editorVersion, onChange]);
 
     useEffect(() => {
       const unsubscribe = window.main.on(

--- a/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
@@ -89,7 +89,7 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
     }, [settings.enableKeyMapForInlineTextEditors, settings.editorKeyMap, readOnly]);
 
     const initEditor = useCallback(() => {
-      if (!textAreaRef.current || codeMirror.current) {
+      if (!textAreaRef.current || codeMirror.current || !editorContainerRef.current?.offsetWidth) {
         return;
       }
 


### PR DESCRIPTION
## Summary

INS-2839
This PR fixes an issue where `OneLineEditor` could initialize CodeMirror while its container still had zero width, causing CodeMirror to treat the editor as hidden and skip rendering line DOM.

`OneLineEditor` now waits until its internal editor container has a measurable width before calling `CodeMirror.fromTextArea`. This keeps CodeMirror initialization inside the component boundary and protects all `OneLineEditor` usages from the same zero-width layout timing issue.

## Root Cause

CodeMirror v5 checks `display.wrapper.offsetWidth` during display updates:
https://github.com/codemirror/codemirror5/blob/9b4f0603cb042286a7ac2262b98245493d0d7e4b/src/display/update_display.js#L97
```js
this.editorIsHidden = !display.wrapper.offsetWidth
```

https://github.com/user-attachments/assets/594eca50-2d2b-43bd-9a22-add6b76c1952

