### PR TITLE
fix(ci): change release build workflow to manual trigger

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,9 +1,6 @@
 name: Release Build
 
 on:
-  push:
-    branches:
-      - 'release/**'
   workflow_dispatch:
 
 permissions: {}
@@ -15,6 +12,7 @@ concurrency:
 jobs:
   # shared kong github action for security checking
   generate-sbom-and-upload-assets:
+    if: startsWith(github.ref_name, 'release/')
     runs-on: ubuntu-24.04
     permissions:
       contents: read # Required for actions/checkout
@@ -34,6 +32,7 @@ jobs:
           dir: .
           upload-sbom-release-assets: false
   build-and-upload-release-artifacts:
+    if: startsWith(github.ref_name, 'release/')
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     permissions:
@@ -368,6 +367,7 @@ jobs:
             !packages/insomnia/build/yarn-standalone.js
 
   update-pull-request:
+    if: startsWith(github.ref_name, 'release/')
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     needs: build-and-upload-release-artifacts
     runs-on: ubuntu-24.04


### PR DESCRIPTION
[INS-2818](https://konghq.atlassian.net/browse/INS-2818)

Previously, the release build pipeline was triggered automatically upon pushing to the release branch. This resulted in excessive wastage of Windows EV certificate signatures on intermediate commits.

This change switches the workflow to a manual trigger, ensuring code-signing is only executed on-demand for finalized release builds.

[INS-2818]: https://konghq.atlassian.net/browse/INS-2818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ