### PR TITLE
feat: editor-scoped undo/redo via a data-layer operation interceptor

### DIFF
--- a/packages/insomnia-data/node-src/database/database-nedb.ts
+++ b/packages/insomnia-data/node-src/database/database-nedb.ts
@@ -20,8 +20,10 @@ import type {
   GitRepository,
   IDatabase,
   Operation,
+  OperationDescriptor,
   ProjectLintRuleset,
   Query,
+  UndoableOperation,
   Workspace,
   WorkspaceMeta,
 } from 'insomnia-data';
@@ -394,6 +396,9 @@ export const createNedbDatabase = <O = initOptions>(
     insert: async function <T extends BaseModel>(doc: T) {
       const docWithDefaults = await initModel<T>(doc.type, doc);
       const newDoc = await nedbBucket[doc.type].insertAsync(docWithDefaults);
+      if (isUndoableMutation(newDoc.type)) {
+        emitOperation({ apply: { kind: 'insert', doc: newDoc }, invert: { kind: 'remove', doc: newDoc } });
+      }
       notifyOfChange('insert', newDoc);
       return newDoc;
     },
@@ -424,7 +429,12 @@ export const createNedbDatabase = <O = initOptions>(
         ),
       );
 
-      docs.map(d => notifyOfChange('remove', d));
+      docs.forEach(d => {
+        if (isUndoableMutation(d.type)) {
+          emitOperation({ apply: { kind: 'remove', doc: d }, invert: { kind: 'insert', doc: d } });
+        }
+        notifyOfChange('remove', d);
+      });
       await database.flushChanges(flushId);
     },
 
@@ -463,9 +473,38 @@ export const createNedbDatabase = <O = initOptions>(
 
     update: async function <T extends BaseModel>(doc: T, patches: Partial<T>[] = []) {
       const docWithDefaults = await initModel<T>(doc.type, doc);
+      // Capture the prior state so the inverse operation can restore it. Gated to undoable types so
+      // the extra read only happens for documents that participate in undo.
+      const priorDoc = isUndoableMutation(doc.type)
+        ? await nedbBucket[doc.type].findOneAsync<T>({ _id: docWithDefaults._id })
+        : null;
       await nedbBucket[doc.type].updateAsync({ _id: docWithDefaults._id }, docWithDefaults, { upsert: true });
+      if (isUndoableMutation(docWithDefaults.type)) {
+        emitOperation({
+          apply: { kind: 'update', doc: docWithDefaults },
+          // An upsert with no prior doc was really an insert; its inverse is a remove.
+          invert: priorDoc ? { kind: 'update', doc: priorDoc } : { kind: 'remove', doc: docWithDefaults },
+          keys: [...new Set(patches.flatMap(patch => (patch ? Object.keys(patch) : [])))],
+        });
+      }
       notifyOfChange('update', docWithDefaults, patches);
       return docWithDefaults;
+    },
+
+    /** Write a prior/next document state for undo/redo without emitting a new operation (so it isn't itself recorded). */
+    applyUndoOperation: async function (descriptor: OperationDescriptor) {
+      suppressOperationEmit = true;
+      try {
+        if (descriptor.kind === 'remove') {
+          await database.remove(descriptor.doc);
+        } else if (descriptor.kind === 'insert') {
+          await database.insert(descriptor.doc);
+        } else {
+          await database.update(descriptor.doc);
+        }
+      } finally {
+        suppressOperationEmit = false;
+      }
     },
 
     /** get all ancestors of specified types of a document including the original, the order of the returned array is leaf to root */
@@ -588,6 +627,40 @@ let changeBuffer: ChangeBufferEvent[] = [];
 
 let changeListeners: ChangeListener[] = [];
 
+// ~~~~~~~~~~~~~~~~~~~ //
+// Undo Operations     //
+// ~~~~~~~~~~~~~~~~~~~ //
+
+/**
+ * Model types whose mutations are recorded as undoable operations. Limited to the request types
+ * edited in the debug request pane, so the extra prior-state read on `update` is only paid where
+ * the undo feature actually consumes it.
+ */
+const UNDOABLE_TYPES = new Set<string>(['Request', 'GrpcRequest', 'WebSocketRequest', 'SocketIORequest', 'McpRequest']);
+const isUndoableMutation = (type: string) => UNDOABLE_TYPES.has(type);
+
+// Set true while applyUndoOperation writes, so undoing/redoing does not emit a fresh operation.
+let suppressOperationEmit = false;
+
+// Operations gathered since the last flush. Emitted (and cleared) by flushChangesImpl, aligned with
+// the change batch they belong to.
+let operationBuffer: UndoableOperation[] = [];
+
+// The renderer-facing sink for operations, registered by the main process. When unset (e.g. the
+// send-request Node context), operations are simply dropped on flush.
+let operationEmitter: ((operations: UndoableOperation[]) => void) | null = null;
+
+/** Register the sink that forwards undoable operations to consumers (the main process wires this to IPC). */
+export const setOperationEmitter = (emitter: ((operations: UndoableOperation[]) => void) | null) => {
+  operationEmitter = emitter;
+};
+
+const emitOperation = (operation: UndoableOperation) => {
+  if (!suppressOperationEmit) {
+    operationBuffer.push(operation);
+  }
+};
+
 /** trigger all changeListeners */
 export const flushChangesImpl = async function (id = 0, fake = false): Promise<ChangeBufferEvent[] | void> {
   // Only flush if ID is 0 or the current flush ID is the same as passed
@@ -606,11 +679,19 @@ export const flushChangesImpl = async function (id = 0, fake = false): Promise<C
 
   if (fake) {
     console.log(`[db] Dropped ${changes.length} changes.`);
+    operationBuffer = [];
     return;
   }
   // Notify local listeners too
   for (const fn of changeListeners) {
     await fn(changes);
+  }
+
+  // Forward any undoable operations gathered during these changes to the registered sink.
+  const operations = operationBuffer;
+  operationBuffer = [];
+  if (operations.length > 0 && operationEmitter) {
+    operationEmitter(operations);
   }
 
   return changes;

--- a/packages/insomnia-data/node-src/index.ts
+++ b/packages/insomnia-data/node-src/index.ts
@@ -1,3 +1,3 @@
-export { createNedbDatabase, flushChangesImpl } from './database/database-nedb';
+export { createNedbDatabase, flushChangesImpl, setOperationEmitter } from './database/database-nedb';
 
 export { servicesNodeImpl } from './services';

--- a/packages/insomnia-data/src/database/types.ts
+++ b/packages/insomnia-data/src/database/types.ts
@@ -39,6 +39,24 @@ export type ChangeBufferEvent<T extends BaseModel = BaseModel> = [event: ChangeT
 
 export type ChangeListener = (changes: ChangeBufferEvent[]) => void;
 
+/** A single reversible database mutation, expressed as a concrete document write. */
+export interface OperationDescriptor {
+  kind: ChangeType;
+  doc: BaseModel;
+}
+
+/**
+ * A mutation paired with its inverse: `apply` re-performs the change (redo) and `invert` reverses it (undo).
+ * The data layer emits one of these for every mutation to an undoable model type, so a consumer can build an
+ * undo stack centrally instead of each call site opting in.
+ */
+export interface UndoableOperation {
+  apply: OperationDescriptor;
+  invert: OperationDescriptor;
+  /** For `update` operations: the field names that changed. Used by consumers to coalesce edits. */
+  keys?: string[];
+}
+
 /**
  * Database interface for IoC pattern.
  * Main process uses NeDBDatabaseImpl, renderer uses BridgeDatabaseImpl.
@@ -138,6 +156,13 @@ export interface IDatabase<O = DataStoreOptions> {
    * Update a document.
    */
   update<T extends BaseModel>(doc: T, patches?: Partial<T>[]): Promise<T>;
+
+  /**
+   * Apply an undo/redo operation descriptor (writing a prior or next document state). The resulting
+   * write still notifies change listeners so the UI revalidates, but is NOT re-emitted on the
+   * operation stream, so undoing/redoing does not itself create a new undo entry.
+   */
+  applyUndoOperation(descriptor: OperationDescriptor): Promise<void>;
 
   /**
    * Get all ancestors of a document including the original.

--- a/packages/insomnia/src/main/database.main.ts
+++ b/packages/insomnia/src/main/database.main.ts
@@ -1,6 +1,6 @@
 import electron from 'electron';
 import type { DataStoreOptions, IDatabase } from 'insomnia-data';
-import { createNedbDatabase, flushChangesImpl } from 'insomnia-data/node';
+import { createNedbDatabase, flushChangesImpl, setOperationEmitter } from 'insomnia-data/node';
 
 export const mainDatabase: IDatabase = createNedbDatabase(nedbDatabase => ({
   ...nedbDatabase,
@@ -21,6 +21,13 @@ export const mainDatabase: IDatabase = createNedbDatabase(nedbDatabase => ({
         throw new TypeError(`Unknown database method: ${fnName}`);
       }
       return fn(...args);
+    });
+
+    // Forward undoable operations to every renderer so the editor undo manager can record them.
+    setOperationEmitter(operations => {
+      for (const window of electron.BrowserWindow.getAllWindows()) {
+        window.webContents.send('db.operations', operations);
+      }
     });
   },
   flushChanges: async function (id = 0, fake = false) {

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -262,8 +262,11 @@ export type MainOnChannels =
   | 'writeText';
 
 export type RendererOnChannels =
+  | 'app-undo'
+  | 'app-redo'
   | 'contextMenuCommand'
   | 'db.changes'
+  | 'db.operations'
   | 'plugins.uiAlert'
   | 'plugins.uiDialog'
   | 'ui.prompt'

--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -305,15 +305,15 @@ export function createWindow(): ElectronBrowserWindow {
   const editMenu: MenuItemConstructorOptions = {
     label: `${MNEMONIC_SYM}Edit`,
     submenu: [
+      // No accelerator/role: the renderer owns Cmd/Ctrl+Z so it can drive the editor undo stack
+      // (and let multiline CodeMirror keep its native undo). Native inputs still undo via Chromium.
       {
         label: `${MNEMONIC_SYM}Undo`,
-        accelerator: 'CmdOrCtrl+Z',
-        role: 'undo',
+        click: () => BrowserWindow.getFocusedWindow()?.webContents.send('app-undo'),
       },
       {
         label: `${MNEMONIC_SYM}Redo`,
-        accelerator: 'Shift+CmdOrCtrl+Z',
-        role: 'redo',
+        click: () => BrowserWindow.getFocusedWindow()?.webContents.send('app-redo'),
       },
       {
         type: 'separator',

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
@@ -89,6 +89,7 @@ import { showResourceNotFoundToast } from '~/ui/components/toast-notification';
 import { RealtimeResponsePane } from '~/ui/components/websockets/realtime-response-pane';
 import { WebSocketRequestPane } from '~/ui/components/websockets/websocket-request-pane';
 import WorkspacePaneHeader from '~/ui/components/workspace/workspace-pane-header';
+import { EditorUndoProvider } from '~/ui/context/app/editor-undo-context';
 import { useExecutionState } from '~/ui/hooks/use-execution-state';
 import { useFilteredRequests } from '~/ui/hooks/use-filtered-requests';
 import { useTabNavigate } from '~/ui/hooks/use-insomnia-tab';
@@ -1151,6 +1152,7 @@ const Debug = () => {
           </>
         )}
         <Panel id="workspace-content" order={2} className="flex flex-col">
+          <EditorUndoProvider>
           <PanelGroup autoSaveId="insomnia-panels" id="insomnia-panels" direction={direction}>
             {isRunner ? (
               <Runner />
@@ -1217,6 +1219,7 @@ const Debug = () => {
               </>
             )}
           </PanelGroup>
+          </EditorUndoProvider>
         </Panel>
       </PanelGroup>
     </div>

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -1,7 +1,7 @@
 import type { RequestParameter, Settings } from 'insomnia-data';
 import { models, services } from 'insomnia-data';
 import { deconstructQueryStringToParams, getContentTypeFromHeaders } from 'insomnia-data/common';
-import React, { type FC, Fragment, useRef, useState } from 'react';
+import React, { type FC, Fragment, useEffect, useRef, useState } from 'react';
 import { Button, Heading, Tab, TabList, TabPanel, Tabs, ToggleButton } from 'react-aria-components';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { useParams } from 'react-router';
@@ -9,6 +9,7 @@ import * as reactUse from 'react-use';
 
 import { extractQueryStringFromUrl } from '~/common/utils/url/querystring';
 import { OneLineEditor } from '~/ui/components/.client/codemirror/one-line-editor';
+import { type RequestSubTab, useEditorUndoContext } from '~/ui/context/app/editor-undo-context';
 
 import { getAuthObjectOrNull } from '../../../network/authentication';
 import { useWorkspaceLoaderData } from '../../../routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
@@ -50,6 +51,15 @@ export const RequestPane: FC<Props> = ({ environmentId, settings, onPaste }) => 
   const patchRequest = useRequestPatcher();
 
   const requestUrlBarRef = useRef<RequestUrlBarHandle>(null);
+
+  // Editor-scoped undo: report the visible form (request + sub-tab) so undo records against it, and
+  // fold undoRevision into editor remount keys so uncontrolled editors refresh after an undo write.
+  const { registerActiveForm, finalizeGroup, undoRevision } = useEditorUndoContext();
+  const [activeSubTab, setActiveSubTab] = useState<RequestSubTab>('params');
+  useEffect(() => {
+    registerActiveForm(requestId, activeSubTab);
+  }, [requestId, activeSubTab, registerActiveForm]);
+
   const [dismissPathParameterTip, setDismissPathParameterTip] = reactUse.useLocalStorage('dismissPathParameterTip', '');
   const handleImportQueryFromUrl = () => {
     let query;
@@ -78,8 +88,9 @@ export const RequestPane: FC<Props> = ({ environmentId, settings, onPaste }) => 
   const gitVersion = useGitVCSVersion();
 
   const { activeEnvironment, vcsVersion } = useWorkspaceLoaderData()!;
-  // Force re-render when we switch requests, the environment gets modified, or the (Git|Sync)VCS version changes
-  const uniqueKey = `${activeEnvironment?.modified}::${requestId}::${gitVersion}::${vcsVersion}::${activeRequestMeta?.activeResponseId}`;
+  // Force re-render when we switch requests, the environment gets modified, the (Git|Sync)VCS version
+  // changes, or an undo/redo write lands (so uncontrolled editors refresh to the reverted value).
+  const uniqueKey = `${activeEnvironment?.modified}::${requestId}::${gitVersion}::${vcsVersion}::${activeRequestMeta?.activeResponseId}::${undoRevision}`;
 
   if (!activeRequest) {
     return <PlaceholderRequestPane />;
@@ -114,7 +125,15 @@ export const RequestPane: FC<Props> = ({ environmentId, settings, onPaste }) => 
           />
         </ErrorBoundary>
       </PaneHeader>
-      <Tabs aria-label="Request pane tabs" className="flex h-full w-full flex-1 flex-col">
+      <Tabs
+        aria-label="Request pane tabs"
+        className="flex h-full w-full flex-1 flex-col"
+        onSelectionChange={key => {
+          // Switching sub-tabs ends the current coalescing group and moves undo to the new visible form.
+          finalizeGroup();
+          setActiveSubTab(key as RequestSubTab);
+        }}
+      >
         <TabList
           className="scrollbar-thin flex h-(--line-height-sm) w-full shrink-0 items-center overflow-x-auto border-b border-solid border-b-(--hl-md) bg-(--color-bg)"
           aria-label="Request pane tabs"
@@ -259,7 +278,7 @@ export const RequestPane: FC<Props> = ({ environmentId, settings, onPaste }) => 
                           </span>
                           <div className="flex h-full items-center border-b border-solid border-(--hl-md) px-2">
                             <OneLineEditor
-                              key={activeRequest._id}
+                              key={`${activeRequest._id}::${undoRevision}`}
                               id={'key-value-editor__name' + pathParameter.name}
                               placeholder="Parameter value"
                               defaultValue={pathParameter.value || ''}

--- a/packages/insomnia/src/ui/context/app/editor-undo-context.tsx
+++ b/packages/insomnia/src/ui/context/app/editor-undo-context.tsx
@@ -1,0 +1,204 @@
+import { database, type UndoableOperation } from 'insomnia-data';
+import React, { createContext, type FC, type PropsWithChildren, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { useRevalidator } from 'react-router';
+
+import { emptyStacks, type FormStacks, recordOperation, type RequestSubTab, sealTop } from './editor-undo-stack';
+
+export type { RequestSubTab } from './editor-undo-stack';
+
+interface ActiveForm {
+  requestId: string;
+  subTab: RequestSubTab;
+}
+
+interface EditorUndoContextValue {
+  /** The request pane reports which request + sub-tab is currently visible (the active "form"). */
+  registerActiveForm: (requestId: string, subTab: RequestSubTab) => void;
+  /** Ends the current coalescing group (called on blur and sub-tab change). */
+  finalizeGroup: () => void;
+  /**
+   * Increments after an undo/redo write is revalidated. The request pane folds this into its editor
+   * remount keys so uncontrolled OneLineEditors refresh to the reverted value.
+   */
+  undoRevision: number;
+}
+
+const noop = () => {};
+
+const EditorUndoContext = createContext<EditorUndoContextValue>({
+  registerActiveForm: noop,
+  finalizeGroup: noop,
+  undoRevision: 0,
+});
+
+/** True when focus is in a single-line editor (OneLineEditor) inside the request pane. */
+const focusedInScopeSingleLineEditor = (): boolean => {
+  const el = document.activeElement;
+  return !!el && !!el.closest('.editor--single-line') && !!el.closest('[data-testid="request-pane"]');
+};
+
+/** When focus is in a multiline CodeMirror (body/scripts), return its instance so native undo can run. */
+const focusedMultilineCodeMirror = (): { undo: () => void; redo: () => void } | null => {
+  const el = document.activeElement;
+  if (!el) {
+    return null;
+  }
+  const codeMirror = el.closest('.CodeMirror');
+  if (!codeMirror || codeMirror.closest('.editor--single-line')) {
+    return null;
+  }
+  return (codeMirror as unknown as { CodeMirror?: { undo: () => void; redo: () => void } }).CodeMirror ?? null;
+};
+
+const formKeyOf = (form: ActiveForm) => `${form.requestId}::${form.subTab}`;
+
+export const EditorUndoProvider: FC<PropsWithChildren> = ({ children }) => {
+  const revalidator = useRevalidator();
+
+  // One undo/redo stack pair per visible form (request + sub-tab). Refs: these never need to re-render.
+  const stacksRef = useRef<Map<string, FormStacks>>(new Map());
+  const activeFormRef = useRef<ActiveForm | null>(null);
+
+  // Remount key for uncontrolled editors, bumped once an undo/redo write has been revalidated.
+  const [undoRevision, setUndoRevision] = useState(0);
+  const pendingBumpRef = useRef(false);
+  useEffect(() => {
+    if (revalidator.state === 'idle' && pendingBumpRef.current) {
+      pendingBumpRef.current = false;
+      setUndoRevision(revision => revision + 1);
+    }
+  }, [revalidator.state]);
+
+  const stacksForActiveForm = useCallback((): FormStacks | null => {
+    const form = activeFormRef.current;
+    if (!form) {
+      return null;
+    }
+    const key = formKeyOf(form);
+    let stacks = stacksRef.current.get(key);
+    if (!stacks) {
+      stacks = emptyStacks();
+      stacksRef.current.set(key, stacks);
+    }
+    return stacks;
+  }, []);
+
+  const applyOperation = useCallback(
+    async (operation: UndoableOperation, direction: 'undo' | 'redo') => {
+      const descriptor = direction === 'undo' ? operation.invert : operation.apply;
+      pendingBumpRef.current = true;
+      await database.applyUndoOperation(descriptor);
+      // The write doesn't go through a route action, so revalidate manually to refresh the loader.
+      revalidator.revalidate();
+    },
+    [revalidator],
+  );
+
+  const undo = useCallback(async () => {
+    const stacks = stacksForActiveForm();
+    const entry = stacks?.undo.pop();
+    if (!stacks || !entry) {
+      return;
+    }
+    await applyOperation(entry.operation, 'undo');
+    stacks.redo.push(entry);
+  }, [applyOperation, stacksForActiveForm]);
+
+  const redo = useCallback(async () => {
+    const stacks = stacksForActiveForm();
+    const entry = stacks?.redo.pop();
+    if (!stacks || !entry) {
+      return;
+    }
+    await applyOperation(entry.operation, 'redo');
+    stacks.undo.push(entry);
+  }, [applyOperation, stacksForActiveForm]);
+
+  // Record operations emitted by the data layer onto the active form's stack.
+  useEffect(() => {
+    const unsubscribe = window.main.on('db.operations', (_event, operations: UndoableOperation[]) => {
+      const form = activeFormRef.current;
+      if (!form) {
+        return;
+      }
+      const stacks = stacksForActiveForm();
+      if (!stacks) {
+        return;
+      }
+      for (const operation of operations) {
+        // Only field edits to the currently visible request participate; whole add/delete are ignored.
+        if (operation.apply.kind !== 'update' || operation.apply.doc._id !== form.requestId) {
+          continue;
+        }
+        recordOperation(stacks.undo, operation, Date.now());
+        // A fresh user edit invalidates the redo timeline for this form.
+        stacks.redo = [];
+      }
+    });
+    return () => unsubscribe();
+  }, [stacksForActiveForm]);
+
+  // Keyboard: capture-phase so a single-line editor doesn't also self-undo. Only acts when focus is in
+  // an in-scope single-line editor; multiline CodeMirror and native fields keep their own undo.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const mod = event.metaKey || event.ctrlKey;
+      const isUndo = mod && event.key.toLowerCase() === 'z' && !event.shiftKey;
+      const isRedo = mod && ((event.key.toLowerCase() === 'z' && event.shiftKey) || event.key.toLowerCase() === 'y');
+      if (!isUndo && !isRedo) {
+        return;
+      }
+      if (!focusedInScopeSingleLineEditor()) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      if (isRedo) {
+        redo();
+      } else {
+        undo();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => window.removeEventListener('keydown', onKeyDown, true);
+  }, [undo, redo]);
+
+  // Edit-menu path (no accelerator, so it never competes with the keyboard handler above).
+  useEffect(() => {
+    const onMenu = (direction: 'undo' | 'redo') => () => {
+      const codeMirror = focusedMultilineCodeMirror();
+      if (codeMirror) {
+        codeMirror[direction]();
+        return;
+      }
+      if (focusedInScopeSingleLineEditor()) {
+        if (direction === 'undo') {
+          undo();
+        } else {
+          redo();
+        }
+      }
+    };
+    const unsubscribers = [window.main.on('app-undo', onMenu('undo')), window.main.on('app-redo', onMenu('redo'))];
+    return () => unsubscribers.forEach(unsubscribe => unsubscribe());
+  }, [undo, redo]);
+
+  const registerActiveForm = useCallback((requestId: string, subTab: RequestSubTab) => {
+    activeFormRef.current = { requestId, subTab };
+  }, []);
+
+  const finalizeGroup = useCallback(() => {
+    const stacks = stacksForActiveForm();
+    if (stacks) {
+      sealTop(stacks.undo);
+    }
+  }, [stacksForActiveForm]);
+
+  return (
+    <EditorUndoContext.Provider value={{ registerActiveForm, finalizeGroup, undoRevision }}>
+      {children}
+    </EditorUndoContext.Provider>
+  );
+};
+
+export const useEditorUndoContext = () => useContext(EditorUndoContext);

--- a/packages/insomnia/src/ui/context/app/editor-undo-stack.test.ts
+++ b/packages/insomnia/src/ui/context/app/editor-undo-stack.test.ts
@@ -1,0 +1,98 @@
+import type { UndoableOperation } from 'insomnia-data';
+import { describe, expect, it } from 'vitest';
+
+import { COALESCE_MS, recordOperation, sealTop, UNDO_STACK_MAX, type UndoEntry } from './editor-undo-stack';
+
+const makeOp = (before: Record<string, any>, after: Record<string, any>, keys: string[]): UndoableOperation => ({
+  apply: { kind: 'update', doc: { _id: 'req_1', type: 'Request', ...after } as any },
+  invert: { kind: 'update', doc: { _id: 'req_1', type: 'Request', ...before } as any },
+  keys,
+});
+
+describe('recordOperation', () => {
+  it('pushes a new entry onto an empty stack', () => {
+    const undo: UndoEntry[] = [];
+    const result = recordOperation(undo, makeOp({ url: 'a' }, { url: 'ab' }, ['url']), 0);
+    expect(result.merged).toBe(false);
+    expect(undo).toHaveLength(1);
+  });
+
+  it('coalesces consecutive edits to the same field within the window', () => {
+    const undo: UndoEntry[] = [];
+    recordOperation(undo, makeOp({ url: 'a' }, { url: 'ab' }, ['url']), 0);
+    const result = recordOperation(undo, makeOp({ url: 'ab' }, { url: 'abc' }, ['url']), 100);
+
+    expect(result.merged).toBe(true);
+    expect(undo).toHaveLength(1);
+    // Keeps the oldest before-state and the newest after-state.
+    expect(undo[0].operation.invert.doc).toMatchObject({ url: 'a' });
+    expect(undo[0].operation.apply.doc).toMatchObject({ url: 'abc' });
+  });
+
+  it('starts a new entry once the coalescing window has passed', () => {
+    const undo: UndoEntry[] = [];
+    recordOperation(undo, makeOp({ url: 'a' }, { url: 'ab' }, ['url']), 0);
+    const result = recordOperation(undo, makeOp({ url: 'ab' }, { url: 'abc' }, ['url']), COALESCE_MS + 1);
+
+    expect(result.merged).toBe(false);
+    expect(undo).toHaveLength(2);
+  });
+
+  it('does not coalesce edits to different fields', () => {
+    const undo: UndoEntry[] = [];
+    recordOperation(undo, makeOp({ url: 'a' }, { url: 'ab' }, ['url']), 0);
+    const result = recordOperation(undo, makeOp({ description: '' }, { description: 'x' }, ['description']), 50);
+
+    expect(result.merged).toBe(false);
+    expect(undo).toHaveLength(2);
+  });
+
+  it('treats an array shape change (add/remove row) as a sealed, atomic step', () => {
+    const undo: UndoEntry[] = [];
+    // Adding a row changes the array shape, so it must not merge with a subsequent value edit.
+    recordOperation(undo, makeOp({ headers: [{ id: '1' }] }, { headers: [{ id: '1' }, { id: '2' }] }, ['headers']), 0);
+    expect(undo[0].sealed).toBe(true);
+
+    const result = recordOperation(
+      undo,
+      makeOp({ headers: [{ id: '1' }, { id: '2' }] }, { headers: [{ id: '1' }, { id: '2', value: 'v' }] }, ['headers']),
+      50,
+    );
+    expect(result.merged).toBe(false);
+    expect(undo).toHaveLength(2);
+  });
+
+  it('coalesces value edits within an array of stable shape', () => {
+    const undo: UndoEntry[] = [];
+    recordOperation(undo, makeOp({ headers: [{ id: '1', value: 'a' }] }, { headers: [{ id: '1', value: 'ab' }] }, ['headers']), 0);
+    const result = recordOperation(
+      undo,
+      makeOp({ headers: [{ id: '1', value: 'ab' }] }, { headers: [{ id: '1', value: 'abc' }] }, ['headers']),
+      50,
+    );
+    expect(result.merged).toBe(true);
+    expect(undo).toHaveLength(1);
+  });
+
+  it('enforces the max stack size by dropping the oldest entry', () => {
+    const undo: UndoEntry[] = [];
+    for (let i = 0; i < UNDO_STACK_MAX + 5; i++) {
+      // Space edits past the window so each becomes its own entry.
+      recordOperation(undo, makeOp({ url: String(i) }, { url: String(i + 1) }, ['url']), i * (COALESCE_MS + 1));
+    }
+    expect(undo).toHaveLength(UNDO_STACK_MAX);
+    // Oldest dropped: the first surviving entry should no longer revert to '0'.
+    expect(undo[0].operation.invert.doc).not.toMatchObject({ url: '0' });
+  });
+});
+
+describe('sealTop', () => {
+  it('seals the top entry so the next edit will not coalesce', () => {
+    const undo: UndoEntry[] = [];
+    recordOperation(undo, makeOp({ url: 'a' }, { url: 'ab' }, ['url']), 0);
+    sealTop(undo);
+    const result = recordOperation(undo, makeOp({ url: 'ab' }, { url: 'abc' }, ['url']), 50);
+    expect(result.merged).toBe(false);
+    expect(undo).toHaveLength(2);
+  });
+});

--- a/packages/insomnia/src/ui/context/app/editor-undo-stack.ts
+++ b/packages/insomnia/src/ui/context/app/editor-undo-stack.ts
@@ -1,0 +1,86 @@
+import type { UndoableOperation } from 'insomnia-data';
+
+/** The request-pane sub-tabs an undo stack can belong to. The URL bar shares the active sub-tab's stack. */
+export type RequestSubTab = 'params' | 'content-type' | 'auth' | 'headers' | 'scripts' | 'docs';
+
+/** Maximum entries kept per form stack. Bounded so the in-memory history stays small. */
+export const UNDO_STACK_MAX = 50;
+
+/** Consecutive edits to the same field(s) within this window coalesce into a single undo step. */
+export const COALESCE_MS = 700;
+
+export interface UndoEntry {
+  /** `apply` re-performs the edit (redo); `invert` reverses it (undo). */
+  operation: UndoableOperation;
+  /** The field names this edit changed, used to decide coalescing. */
+  keys: string[];
+  /** Signature of the array-valued changed fields; a change to it seals the entry (structural edit). */
+  shape: string;
+  /** Sealed entries never coalesce further (e.g. add/remove/reorder a row is its own atomic step). */
+  sealed: boolean;
+  createdAt: number;
+}
+
+export interface FormStacks {
+  undo: UndoEntry[];
+  redo: UndoEntry[];
+}
+
+export const emptyStacks = (): FormStacks => ({ undo: [], redo: [] });
+
+/** A signature of the array-valued changed fields (ids/names in order), or "scalar" for non-arrays. */
+export const shapeOf = (doc: Record<string, any> | undefined, keys: string[]): string =>
+  keys
+    .map(key => {
+      const value = doc?.[key];
+      if (Array.isArray(value)) {
+        return value.map(item => item?.id ?? item?.name ?? '').join(',');
+      }
+      return 'scalar';
+    })
+    .join('|');
+
+/**
+ * Record an operation onto a form's undo stack, coalescing consecutive edits to the same field(s)
+ * within {@link COALESCE_MS} into one step. Structural edits (where the array shape changes, e.g.
+ * adding/removing a row) are sealed so later typing does not merge into them. Mutates `undo` in place
+ * and reports whether it merged into the current step.
+ */
+export const recordOperation = (undo: UndoEntry[], operation: UndoableOperation, now: number): { merged: boolean } => {
+  const keys = operation.keys ?? [];
+  const afterShape = shapeOf(operation.apply.doc as Record<string, any>, keys);
+  const beforeShape = shapeOf(operation.invert.doc as Record<string, any>, keys);
+  const isStructural = afterShape !== beforeShape;
+
+  const top = undo[undo.length - 1];
+  const canMerge =
+    !!top &&
+    !top.sealed &&
+    !isStructural &&
+    keys.length > 0 &&
+    top.keys.length === keys.length &&
+    top.keys.every(key => keys.includes(key)) &&
+    top.shape === afterShape &&
+    now - top.createdAt < COALESCE_MS;
+
+  if (canMerge) {
+    // Keep the original `invert` (oldest before-state); advance `apply` to the newest after-state.
+    top.operation = { apply: operation.apply, invert: top.operation.invert, keys };
+    top.createdAt = now;
+    return { merged: true };
+  }
+
+  undo.push({ operation, keys, shape: afterShape, sealed: isStructural, createdAt: now });
+  while (undo.length > UNDO_STACK_MAX) {
+    undo.shift();
+  }
+  return { merged: false };
+};
+
+/** Ends the current coalescing group so the next edit starts a fresh step. */
+export const sealTop = (undo: UndoEntry[]): void => {
+  const top = undo[undo.length - 1];
+  if (top) {
+    top.sealed = true;
+  }
+};

--- a/packages/insomnia/src/ui/database.client.ts
+++ b/packages/insomnia/src/ui/database.client.ts
@@ -1,7 +1,7 @@
 // Bridge Database implementation for renderer process
 // Uses window.database.invoke API exposed by contextBridge from preload
 
-import type { AllTypes, BaseModel, IDatabase, Operation, Query } from 'insomnia-data';
+import type { AllTypes, BaseModel, IDatabase, Operation, OperationDescriptor, Query } from 'insomnia-data';
 
 /**
  * Bridge database implementation for renderer process.
@@ -83,6 +83,10 @@ export const database: IDatabase = {
 
   update: async function <T extends BaseModel>(doc: T, patches: Partial<T>[] = []) {
     return window.database.invoke<T>('update', doc, patches);
+  },
+
+  applyUndoOperation: async function (descriptor: OperationDescriptor) {
+    return window.database.invoke<void>('applyUndoOperation', descriptor);
   },
 
   withAncestors: async function <T extends BaseModel>(doc: T | undefined, types: AllTypes[] = []) {


### PR DESCRIPTION
## What

Adds <kbd>Ctrl/Cmd+Z</kbd> (and <kbd>Shift</kbd> to redo) for the **single-line editors in the request pane** — URL bar, header/param/auth rows, and path parameters. Multiline CodeMirror editors (request body, pre/after scripts) keep their native char-by-char undo.

This is a ground-up rework of the earlier global-undo approach (#10126). Instead of each call site opting into recording, undo is built on a single **data-layer interceptor** that makes every mutation reversible, with the undo *behaviour* scoped narrowly to the editors by focus.

## How it works

**Data layer (`insomnia-data`)** — the NeDB layer emits an `{ apply, invert }` operation for every mutation to a request type:
- `update` reads the prior document before the upsert, so `invert` can restore it.
- the inverse of an `insert` is a `remove`, and vice versa.
- operations are forwarded to the renderer over a new `db.operations` IPC channel (alongside the existing `db.changes`).
- `applyUndoOperation` writes a prior/next state back; its write still fires change listeners (so the UI revalidates) but is **suppressed from the operation stream**, so undo/redo never record themselves.
- the prior-state read is gated to the request model types, so the extra read is only paid where undo consumes it.

**Renderer** — a per-`(request, sub-tab)` undo manager:
- records operations for the currently visible form (the URL bar shares the active sub-tab's stack, matching what's on screen).
- reverts on <kbd>Cmd+Z</kbd> only when focus is in an in-scope single-line editor; multiline CodeMirror and plain inputs keep their own undo.
- coalesces consecutive edits to the same field within 700ms; structural edits (add/remove/reorder a row) are atomic.
- the Edit-menu Undo/Redo lose their accelerators so the renderer owns the shortcut (native inputs still undo via Chromium).

## Scope decisions

- **Per visible form**: a single <kbd>Cmd+Z</kbd> never reverts something off-screen.
- **CodeEditor keeps native undo**: body/script typing stays per-keystroke.
- **Request pane only**: response-pane editors are read-only.

## Testing

- `insomnia-data`: full suite green (423 tests), incl. the change to core `update`.
- `editor-undo-stack`: new unit tests for coalescing / sealing / structural detection / max-size (8 tests).
- type-check + lint clean across `insomnia` and `insomnia-data`.
- ⚠️ **E2E pending**: the keyboard round-trip needs manual verification in a running app (the operation round-trip can't be deterministically awaited from a smoke test without a fixed timeout). Recommend a manual pass before merge.

## Notes

Supersedes #10126 — that PR's global-undo approach can be closed if this direction is preferred.