### PR TITLE
fix: deep-link MCP handling [INS-2631]

### DIFF
--- a/packages/insomnia-data/node-src/services/helpers/request-operations.ts
+++ b/packages/insomnia-data/node-src/services/helpers/request-operations.ts
@@ -15,11 +15,13 @@ export function findRequestByParentId(
     grpcRequestService.findByParentId(parentId),
     webSocketRequestService.findByParentId(parentId),
     socketIORequestService.findByParentId(parentId),
-  ]).then(([requests, grpcRequests, webSocketRequests, socketIORequests]) => [
+    mcpRequestService.findByParentId(parentId),
+  ]).then(([requests, grpcRequests, webSocketRequests, socketIORequests, mcpRequests]) => [
     ...requests,
     ...grpcRequests,
     ...webSocketRequests,
     ...socketIORequests,
+    ...mcpRequests,
   ]);
 }
 

--- a/packages/insomnia-data/node-src/services/mcp-request.ts
+++ b/packages/insomnia-data/node-src/services/mcp-request.ts
@@ -24,6 +24,10 @@ export function getByParentId(parentId: string) {
   return db.findOne<McpRequest>(type, { parentId });
 }
 
+export function findByParentId(parentId: string) {
+  return db.find<McpRequest>(type, { parentId });
+}
+
 export function getById(id: string) {
   return db.findOne<McpRequest>(type, { _id: id });
 }

--- a/packages/insomnia/src/common/__tests__/import-deep-link.test.ts
+++ b/packages/insomnia/src/common/__tests__/import-deep-link.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseDeepLinkUrl, resolveImportDeepLink, sanitizeUrlAndExtractOrigin } from '../import-deep-link';
+
+describe('parseDeepLinkUrl', () => {
+  it('splits path from decoded params', () => {
+    const parsed = parseDeepLinkUrl('insomnia://app/import?mcp=' + encodeURIComponent('https://example.com/mcp?v=2'));
+    expect(parsed).toEqual({
+      urlWithoutParams: 'insomnia://app/import',
+      params: { mcp: 'https://example.com/mcp?v=2' },
+    });
+  });
+
+  it('returns null for unparseable input', () => {
+    expect(parseDeepLinkUrl('not-a-url')).toBeNull();
+  });
+
+  it('normalizes insomniadev:// only in development', () => {
+    expect(parseDeepLinkUrl('insomniadev://app/import', true)?.urlWithoutParams).toBe('insomnia://app/import');
+    expect(parseDeepLinkUrl('insomniadev://app/import', false)?.urlWithoutParams).toBe('insomniadev://app/import');
+  });
+});
+
+describe('sanitizeUrlAndExtractOrigin', () => {
+  it('returns the origin or an empty string', () => {
+    expect(sanitizeUrlAndExtractOrigin('https://app.insomnia.rest/run/?mcp=x')).toBe('https://app.insomnia.rest');
+    expect(sanitizeUrlAndExtractOrigin()).toBe('');
+    expect(sanitizeUrlAndExtractOrigin('not a url')).toBe('');
+  });
+});
+
+describe('resolveImportDeepLink', () => {
+  it('dispatches uri with endpoint/operationId', () => {
+    expect(resolveImportDeepLink({ uri: 'https://example.com/openapi.yaml', endpoint: 'GET,/pets', operationId: 'listPets' })).toEqual({
+      type: 'uri',
+      defaultValue: 'https://example.com/openapi.yaml',
+      origin: '',
+      endpoint: 'GET,/pets',
+      operationId: 'listPets',
+    });
+  });
+
+  it('dispatches mcp without endpoint/operationId', () => {
+    expect(resolveImportDeepLink({ mcp: 'https://example.com/mcp', endpoint: 'GET,/pets' })).toEqual({
+      type: 'mcp',
+      defaultValue: 'https://example.com/mcp',
+      origin: '',
+    });
+  });
+
+  it('prefers uri over mcp over curl and trims values', () => {
+    expect(resolveImportDeepLink({ uri: ' https://x/spec.yaml ', mcp: 'https://x/mcp' })?.defaultValue).toBe('https://x/spec.yaml');
+    expect(resolveImportDeepLink({ mcp: 'https://x/mcp', curl: 'curl https://x' })?.type).toBe('mcp');
+  });
+
+  it('returns null when no resource param is present', () => {
+    expect(resolveImportDeepLink({ origin: 'https://app.insomnia.rest' })).toBeNull();
+    expect(resolveImportDeepLink({ mcp: '   ' })).toBeNull();
+  });
+});

--- a/packages/insomnia/src/common/__tests__/import.test.ts
+++ b/packages/insomnia/src/common/__tests__/import.test.ts
@@ -1,13 +1,14 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { EnvironmentKvPairDataType, EnvironmentType, services } from 'insomnia-data';
+import type { McpRequest } from 'insomnia-data';
+import { EnvironmentKvPairDataType, EnvironmentType, models, services } from 'insomnia-data';
 import { describe, expect, it, vi } from 'vitest';
 import { parse } from 'yaml';
 
 import * as importUtil from '../import';
 import { INSOMNIA_SCHEMA_VERSION } from '../insomnia-schema-migrations/schema-version';
-import { getInsomniaV5DataExport, tryImportV5Data } from '../insomnia-v5';
+import { getInsomniaV5DataExport, mcpUrlToInsomniaV5Yaml, tryImportV5Data } from '../insomnia-v5';
 import { generateId } from '../misc';
 
 describe('pathPatternMatches', () => {
@@ -723,5 +724,27 @@ describe('export/import round-trip is deterministic', () => {
       transportType: 'streamable-http',
       headers: [{ name: 'User-Agent', value: 'insomnia' }],
     });
+  });
+});
+
+describe('MCP run deep-link import', () => {
+  const mcpUrl = 'https://mcp.deepwiki.com/mcp';
+
+  it('imports an MCP url into an MCP workspace and exposes its client', async () => {
+    const project = await services.project.create();
+    const scanResult = await importUtil.scanResources([{ contentStr: mcpUrlToInsomniaV5Yaml(mcpUrl), oriFileName: 'mcp' }]);
+
+    expect(scanResult[0].errors).toEqual([]);
+    expect(scanResult[0].mcpRequests).toHaveLength(1);
+    expect(scanResult[0].requests).toHaveLength(0);
+
+    const workspaces = await importUtil.importResourcesToProject({ projectId: project._id });
+    expect(workspaces).toHaveLength(1);
+    expect(workspaces[0].scope).toBe('mcp');
+
+    const requests = await services.helpers.findRequestByParentId(workspaces[0]._id);
+    expect(requests).toHaveLength(1);
+    expect(models.mcpRequest.isMcpRequest(requests[0])).toBe(true);
+    expect((requests[0] as McpRequest).url).toBe(mcpUrl);
   });
 });

--- a/packages/insomnia/src/common/import-deep-link.ts
+++ b/packages/insomnia/src/common/import-deep-link.ts
@@ -1,0 +1,67 @@
+import type { ImportSourceType } from './import';
+
+export interface ParsedDeepLink {
+  urlWithoutParams: string;
+  params: Record<string, string>;
+}
+
+export const parseDeepLinkUrl = (url: string, isDevelopment = false): ParsedDeepLink | null => {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    console.log('[deep-link] Invalid args, expected insomnia://x/y/z', url);
+    return null;
+  }
+  let urlWithoutParams = url.slice(0, Math.max(0, url.indexOf('?'))) || url;
+  const params = Object.fromEntries(parsedUrl.searchParams);
+
+  // Normalize the dev protocol so the path matches the production switch cases
+  if (isDevelopment) {
+    urlWithoutParams = urlWithoutParams.replace('insomniadev://', 'insomnia://');
+  }
+  return { urlWithoutParams, params };
+};
+
+export const sanitizeUrlAndExtractOrigin = (url?: string): string => {
+  if (!url) {
+    return '';
+  }
+  try {
+    return new URL(url).origin;
+  } catch {
+    return '';
+  }
+};
+
+export interface ImportDeepLinkResource {
+  type: Extract<ImportSourceType, 'uri' | 'mcp' | 'curl'>;
+  defaultValue: string;
+  origin: string;
+  endpoint?: string;
+  operationId?: string;
+}
+
+// Resolution order is uri -> mcp -> curl; endpoint/operationId don't apply to mcp.
+export const resolveImportDeepLink = (params: Record<string, string>): ImportDeepLinkResource | null => {
+  const origin = sanitizeUrlAndExtractOrigin(params.origin);
+  const endpoint = params.endpoint || undefined;
+  const operationId = params.operationId || undefined;
+
+  const uri = params.uri?.trim();
+  if (uri) {
+    return { type: 'uri', defaultValue: uri, origin, endpoint, operationId };
+  }
+
+  const mcp = params.mcp?.trim();
+  if (mcp) {
+    return { type: 'mcp', defaultValue: mcp, origin };
+  }
+
+  const curl = params.curl?.trim();
+  if (curl) {
+    return { type: 'curl', defaultValue: curl, origin, endpoint, operationId };
+  }
+
+  return null;
+};

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -24,6 +24,7 @@ import {
 import { useLatest } from 'react-use';
 
 import { EXTERNAL_VAULT_PLUGIN_NAME, isDevelopment } from '~/common/constants';
+import { parseDeepLinkUrl as parseImportDeepLinkUrl, resolveImportDeepLink } from '~/common/import-deep-link';
 import { useAuthorizeActionFetcher } from '~/routes/auth.authorize';
 import { useDefaultBrowserRedirectActionFetcher } from '~/routes/auth.default-browser-redirect';
 import { useLogoutFetcher } from '~/routes/auth.logout';
@@ -82,37 +83,9 @@ const locationHistoryMiddleware: Route.ClientMiddlewareFunction = async ({ reque
     console.log('[locationHistoryMiddleware] Failed to store location history entry', err);
   }
 };
-const sanitizeUrlAndExtractOrigin = (url: string) => {
-  try {
-    const parsed = new URL(url);
-    return parsed.origin;
-  } catch {
-    return '';
-  }
-};
 export const clientMiddleware: Route.ClientMiddlewareFunction[] = [locationHistoryMiddleware];
 
-// Shared URL-parsing utility used by both useAuthDeepLinkHandler and Root's
-// full deep-link handler to avoid duplicating the try/catch and dev-protocol
-// normalisation logic.
-const parseDeepLinkUrl = (url: string) => {
-  // Get the url without params
-  let parsedUrl;
-  try {
-    parsedUrl = new URL(url);
-  } catch {
-    console.log('[deep-link] Invalid args, expected insomnia://x/y/z', url);
-    return;
-  }
-  let urlWithoutParams = url.slice(0, Math.max(0, url.indexOf('?'))) || url;
-  const params = Object.fromEntries(parsedUrl.searchParams);
-
-  // Change protocol for dev redirects to match switch case
-  if (isDevelopment()) {
-    urlWithoutParams = urlWithoutParams.replace('insomniadev://', 'insomnia://');
-  }
-  return { urlWithoutParams, params };
-};
+const parseDeepLinkUrl = (url: string) => parseImportDeepLinkUrl(url, isDevelopment());
 
 // Handles the auth/logout deep-link (insomnia://app/auth/login) independently
 // of the Root component so that it continues to work even when Root is replaced
@@ -450,38 +423,17 @@ const Root = () => {
         }
         trackImportEvent(AnalyticsEvent.importStarted, { source: 'import-url' });
 
-        if (params.uri) {
-          return setImportObject({
-            type: 'uri',
-            defaultValue: params.uri,
-            origin: sanitizeUrlAndExtractOrigin(params.origin),
-            endpoint: params.endpoint,
-            operationId: params.operationId,
-            autoScan: true,
-            startedAt: Date.now(),
-          });
+        const resource = resolveImportDeepLink(params);
+        if (!resource) {
+          return;
         }
-        if (params.mcp) {
-          return setImportObject({
-            type: 'mcp',
-            defaultValue: params.mcp,
-            origin: sanitizeUrlAndExtractOrigin(params.origin),
-            autoScan: true,
-            startedAt: Date.now(),
-          });
-        }
-        if (params.curl) {
-          const { isValid } = await validateCurl(params.curl);
-          return setImportObject({
-            type: 'curl',
-            defaultValue: params.curl,
-            origin: sanitizeUrlAndExtractOrigin(params.origin),
-            endpoint: params.endpoint,
-            operationId: params.operationId,
-            autoScan: isValid,
-            startedAt: Date.now(),
-          });
-        }
+        // Only cURL gates auto-scan on async validation
+        const autoScan = resource.type === 'curl' ? (await validateCurl(resource.defaultValue)).isValid : true;
+        return setImportObject({
+          ...resource,
+          autoScan,
+          startedAt: Date.now(),
+        });
       }
       if (urlWithoutParams === 'insomnia://plugins/install') {
         if (!params.name || params.name.trim() === '') {

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -391,9 +391,10 @@ export const ImportModal: FC<ImportModalProps> = ({
               importFetcher.submit({
                 organizationId,
                 projectId: targetProjectId,
-                workspaceId: hasApiSpecScanResult
-                  ? undefined
-                  : selectedWorkspaceId || (shouldImportToWorkspace ? defaultWorkspaceId : undefined),
+                workspaceId:
+                  hasApiSpecScanResult || newProjectName
+                    ? undefined
+                    : selectedWorkspaceId || (shouldImportToWorkspace ? defaultWorkspaceId : undefined),
                 endpoint: from.endpoint,
                 operationId: from.operationId,
                 skipImportIfDuplicate: autoScan,


### PR DESCRIPTION
Extracts and tests deep-link import logic, makes existing MCP clients discoverable (existing workspaces in a project are not duplicated), and fixes the import into new project path

https://github.com/user-attachments/assets/733b33d4-5ed0-4d05-84f3-63c9df1ab58b

