### PR TITLE
fix(sidebar): show change indicator at workspace level

### DIFF
--- a/packages/insomnia/src/common/project.test.ts
+++ b/packages/insomnia/src/common/project.test.ts
@@ -1,0 +1,47 @@
+import { services } from 'insomnia-data';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { database as db } from '~/common/database';
+
+import { checkAllProjectSyncStatus } from './project';
+
+describe('checkAllProjectSyncStatus', () => {
+  beforeEach(async () => {
+    await db.init({ inMemoryOnly: true }, true);
+  });
+
+  it('ignores stale sync flags on purely local projects, but reports them for git and cloud projects', async () => {
+    // Local: no remote, no git. Git: has gitRepositoryId (remoteId is still null). Cloud: has remoteId.
+    const local = await services.project.create({ _id: 'proj_local', name: 'Local', parentId: 'org_1' });
+    const git = await services.project.create({
+      _id: 'proj_git',
+      name: 'Git',
+      parentId: 'org_1',
+      gitRepositoryId: 'gr_1',
+    });
+    const cloud = await services.project.create({
+      _id: 'proj_cloud',
+      name: 'Cloud',
+      parentId: 'org_1',
+      remoteId: 'proj_org_1',
+    });
+
+    // Every project has a workspace with stale uncommitted-changes flags persisted on its meta.
+    for (const project of [local, git, cloud]) {
+      const workspace = await services.workspace.create({
+        name: `${project.name} ws`,
+        parentId: project._id,
+        scope: 'collection',
+      });
+      await services.workspaceMeta.create({ parentId: workspace._id, hasUncommittedChanges: true });
+    }
+
+    const status = await checkAllProjectSyncStatus([local, git, cloud]);
+
+    expect(status).toEqual({
+      proj_local: false,
+      proj_git: true,
+      proj_cloud: true,
+    });
+  });
+});

--- a/packages/insomnia/src/common/project.ts
+++ b/packages/insomnia/src/common/project.ts
@@ -98,8 +98,13 @@ export const checkSingleProjectSyncStatus = async (projectId: string) => {
   return workspaceMetas.some(item => item.hasUncommittedChanges || item.hasUnpushedChanges);
 };
 
+const isNotSyncProject = (project: Project) =>
+  models.project.isLocalProject(project) && !models.project.isGitProject(project);
+
 export const checkAllProjectSyncStatus = async (projects: Project[]) => {
-  const taskList = projects.map(project => checkSingleProjectSyncStatus(project._id));
+  const taskList = projects.map(project =>
+    isNotSyncProject(project) ? Promise.resolve(false) : checkSingleProjectSyncStatus(project._id),
+  );
   const res = await Promise.all(taskList);
   const obj: Record<string, boolean> = {};
   projects.forEach((project, index) => {

--- a/packages/insomnia/src/ui/components/dropdowns/sidebar-project-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/sidebar-project-dropdown.tsx
@@ -274,7 +274,7 @@ export const ProjectDropdown: FC<Props> = ({
         </TooltipTrigger>
       )}
       {project.hasUncommittedOrUnpushedChanges && (
-        <div className="flex aspect-square h-6 items-center justify-center group-hover:hidden group-focus:hidden">
+        <div className="flex aspect-square h-6 shrink-0 items-center justify-center">
           <Icon icon="circle" className="h-2 w-2" color="var(--color-warning)" />
         </div>
       )}

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar-utils.test.ts
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar-utils.test.ts
@@ -129,6 +129,31 @@ describe('getWorkspacesByProjectIds', () => {
     expect(result.get('proj_has_ws')).toHaveLength(1);
     expect(result.get('proj_no_ws')).toEqual([]);
   });
+
+  it('attaches uncommitted/unpushed git sync flags from the workspace meta', async () => {
+    await services.workspace.create({ _id: 'wrk_dirty', name: 'Dirty', parentId: 'proj_1', scope: 'collection' });
+    await services.workspace.create({ _id: 'wrk_ahead', name: 'Ahead', parentId: 'proj_1', scope: 'design' });
+    await services.workspace.create({ _id: 'wrk_clean', name: 'Clean', parentId: 'proj_1', scope: 'collection' });
+    await services.workspaceMeta.create({ parentId: 'wrk_dirty', hasUncommittedChanges: true });
+    await services.workspaceMeta.create({ parentId: 'wrk_ahead', hasUnpushedChanges: true });
+    await services.workspaceMeta.create({ parentId: 'wrk_clean' });
+
+    const workspaces = (await getWorkspacesByProjectIds(['proj_1'])).get('proj_1')!;
+    const byId = new Map(workspaces.map(w => [w._id, w]));
+
+    expect(byId.get('wrk_dirty')).toMatchObject({ hasUncommittedChanges: true, hasUnpushedChanges: false });
+    expect(byId.get('wrk_ahead')).toMatchObject({ hasUncommittedChanges: false, hasUnpushedChanges: true });
+    expect(byId.get('wrk_clean')).toMatchObject({ hasUncommittedChanges: false, hasUnpushedChanges: false });
+  });
+
+  it('leaves sync flags undefined for workspaces without a meta', async () => {
+    await services.workspace.create({ _id: 'wrk_no_meta', name: 'No Meta', parentId: 'proj_1', scope: 'collection' });
+
+    const workspace = (await getWorkspacesByProjectIds(['proj_1'])).get('proj_1')![0];
+
+    expect(workspace.hasUncommittedChanges).toBeUndefined();
+    expect(workspace.hasUnpushedChanges).toBeUndefined();
+  });
 });
 
 describe('getAllRequestsAndMetaByWorkspace', () => {

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar-utils.ts
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar-utils.ts
@@ -10,6 +10,7 @@ import type {
   WebSocketRequest,
   WebSocketRequestMeta,
   Workspace,
+  WorkspaceMeta,
 } from 'insomnia-data';
 import type { BaseModel } from 'insomnia-data';
 import { models } from 'insomnia-data';
@@ -50,13 +51,32 @@ export interface AllRequestsAndMetaInWorkspace {
 //   created: r.created,
 // });
 
+export type WorkspaceWithSyncStatus = Workspace & {
+  hasUncommittedChanges?: boolean;
+  hasUnpushedChanges?: boolean;
+};
+
 export async function getWorkspacesByProjectIds(projectIds: string[]) {
   const workspaces = await database.find<Workspace>(models.workspace.type, {
     parentId: { $in: projectIds },
   });
-  const workspacesByProjectId = new Map<string, Workspace[]>();
+  const workspaceMetas = await database.find<WorkspaceMeta>(models.workspaceMeta.type, {
+    parentId: { $in: workspaces.map(w => w._id) },
+  });
+  const metaByWorkspaceId = new Map(workspaceMetas.map(meta => [meta.parentId, meta]));
+  const workspacesByProjectId = new Map<string, WorkspaceWithSyncStatus[]>();
   projectIds.forEach(projectId => {
-    workspacesByProjectId.set(projectId, workspaces.filter(w => w.parentId === projectId) || []);
+    const projectWorkspaces = workspaces
+      .filter(w => w.parentId === projectId)
+      .map(w => {
+        const meta = metaByWorkspaceId.get(w._id);
+        return {
+          ...w,
+          hasUncommittedChanges: meta?.hasUncommittedChanges,
+          hasUnpushedChanges: meta?.hasUnpushedChanges,
+        };
+      });
+    workspacesByProjectId.set(projectId, projectWorkspaces);
   });
   return workspacesByProjectId;
 }

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
@@ -64,6 +64,7 @@ import {
   flattenCollectionChildren,
   getAllRequestsAndMetaByWorkspace,
   getWorkspacesByProjectIds,
+  type WorkspaceWithSyncStatus,
 } from './project-navigation-sidebar-utils';
 import { ProjectNode } from './project-node';
 import { PinnedHeaderNode, RequestNode } from './request-node';
@@ -270,7 +271,7 @@ const ProjectNavigationSidebarInner = (
   reactUse.useDebounce(() => setKonnectFilter(konnectFilterInputValue), 300, [konnectFilterInputValue]);
   const activeFilter = ((isProjectTabActive ? projectNavigationSidebarFilter : konnectFilter) || '').trim();
   // ref to cache queried workspaces by project id
-  const cachedWorkspacesRef = useRef<Map<string, Workspace[]>>(new Map());
+  const cachedWorkspacesRef = useRef<Map<string, WorkspaceWithSyncStatus[]>>(new Map());
   // ref to cache queried collection children (request & requestGroups) data and meta by workspace id
   const cachedCollectionChildrenAndMetaRef = useRef<Map<string, AllRequestsAndMetaInWorkspace>>(new Map());
   // ref to track whether we are currently fetching unsynced files for cloud sync projects to avoid duplicate requests
@@ -609,20 +610,25 @@ const ProjectNavigationSidebarInner = (
               hidden: activeFilter ? !unsyncedWorkspaceMatchesFilter : isProjectCollapsed,
             });
           } else {
-            const { scope, _id: workspaceId } = workspace as Workspace;
+            const workspaceWithSyncStatus = workspace as WorkspaceWithSyncStatus;
+            const { scope, _id: workspaceId } = workspaceWithSyncStatus;
             const isCollection = scope === 'collection';
             // Only collection workspace has nested children
             const isWorkspaceCollapsed = !(
               isCollection && (expandedProjectAndWorkspaceIds ?? []).includes(workspaceId)
             );
+            // Change indicators apply to git and cloud (remote) projects only
+            const showSyncStatus = models.project.isRemoteProject(project) || models.project.isGitProject(project);
 
             items.push({
               kind: 'workspace',
               organizationId,
               project: project,
-              doc: workspace as Workspace,
+              doc: workspaceWithSyncStatus,
               collapsed: isWorkspaceCollapsed,
               hidden: isProjectCollapsed,
+              hasUncommittedChanges: showSyncStatus ? workspaceWithSyncStatus.hasUncommittedChanges : false,
+              hasUnpushedChanges: showSyncStatus ? workspaceWithSyncStatus.hasUnpushedChanges : false,
             });
 
             const allRequestsAndMetaInWorkspace = collectionChildrenAndMetaByWorkspaceId.get(workspaceId);

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/types.ts
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/types.ts
@@ -36,6 +36,9 @@ export interface WorkspaceFlatItem extends BaseFlatItem<Workspace> {
   kind: 'workspace';
   // parent project
   project: ProjectWithPresence;
+  // sync flags from the workspace meta, used to show the uncommitted/unpushed changes indicator
+  hasUncommittedChanges?: boolean;
+  hasUnpushedChanges?: boolean;
 }
 
 // Unsynced workspace in cloud sync project

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/workspace-node.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/workspace-node.tsx
@@ -33,7 +33,7 @@ export const WorkspaceNode = ({
   highlighted,
   nodeRef,
 }: WorkspaceNodeProps) => {
-  const { doc, collapsed, project, organizationId } = item;
+  const { doc, collapsed, project, organizationId, hasUncommittedChanges, hasUnpushedChanges } = item;
   const { name: workspaceName, _id: workspaceId, scope: workspaceScope } = doc;
   const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
   const isCollection = workspaceScope === 'collection';
@@ -69,6 +69,11 @@ export const WorkspaceNode = ({
 
         <span className="min-w-0 flex-1 truncate text-base">{workspaceName}</span>
       </div>
+      {(hasUncommittedChanges || hasUnpushedChanges) && (
+        <div className="flex aspect-square h-6 shrink-0 items-center justify-center">
+          <Icon icon="circle" className="h-2 w-2" color="var(--color-warning)" />
+        </div>
+      )}
       <div className="shrink-0">
         <SidebarWorkspaceDropdown
           workspace={doc}


### PR DESCRIPTION
Sidebar now shows matching indicators to the project dashboard cards:
<img width="1411" height="278" alt="Screenshot 2026-06-23 at 09 14 12" src="https://github.com/user-attachments/assets/ad963223-f881-451c-97b9-d6e7a2eda3f9" />
Also for unpushed changes:
<img width="899" height="252" alt="Screenshot 2026-06-23 at 09 14 44" src="https://github.com/user-attachments/assets/7cc61998-0ffc-4840-a2f9-b8b5c17b0d7f" />
Specifically exempts local projects from the indicators