### PR TITLE
fix: project setup modal positioning

### DIFF
--- a/packages/insomnia/src/ui/components/modals/project-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/project-modal.tsx
@@ -58,11 +58,11 @@ export const ProjectModal = ({
             if (!open) requestClose();
           }}
           isDismissable={false}
-          className="fixed top-0 right-0 bottom-0 left-0 z-10 flex items-start justify-center bg-black/30 pt-[200px]"
+          className="fixed top-0 left-0 z-10 flex h-(--visual-viewport-height) w-full items-center justify-center bg-black/30"
         >
           <Modal
             ref={modalRef}
-            className="flex max-h-[calc(var(--visual-viewport-height)-140px)] w-full max-w-3xl flex-col overflow-hidden rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) text-(--color-font)"
+            className="flex h-max max-h-[calc(100%-var(--padding-xl))] w-full max-w-3xl flex-col overflow-hidden rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) text-(--color-font)"
           >
             <Dialog
               aria-label="Create or update dialog"


### PR DESCRIPTION
On shorter viewports, the `Scan for Files` button cannot be reached since the content only scrolls the form, not the modal footer. Changes the overlay to fill the viewport and centers the dialog within so the modal footer is always visible.

Previously:
<img width="759" height="794" alt="Screenshot 2026-06-23 at 09 30 10" src="https://github.com/user-attachments/assets/56960cf9-ad5f-426d-b299-1b0104fac106" />


After this change:
<img width="758" height="795" alt="Screenshot 2026-06-23 at 09 31 06" src="https://github.com/user-attachments/assets/1aa4e274-8313-491f-99c6-abac0be01b22" />

