### PR TITLE
fix: make update notice changelog url a link

### DIFF
--- a/packages/insomnia/src/entry.main.ts
+++ b/packages/insomnia/src/entry.main.ts
@@ -407,7 +407,11 @@ async function _trackStats() {
           content: {
             title: `Updated to ${currentVersion}`,
             status: 'info',
-            description: "See What's New https://insomnia.rest/changelog",
+            link: {
+              label: "See What's New",
+              url: 'https://insomnia.rest/changelog',
+              external: true,
+            },
           },
         });
       }

--- a/packages/insomnia/src/ui/components/toast-notification.tsx
+++ b/packages/insomnia/src/ui/components/toast-notification.tsx
@@ -12,6 +12,8 @@ import {
 } from 'react-aria-components';
 import { flushSync } from 'react-dom';
 
+import { Link } from '~/ui/components/base/link';
+
 type Status = 'info' | 'success' | 'warning' | 'error';
 
 // Define the type for your toast content.
@@ -19,6 +21,11 @@ export interface RAToastContent {
   icon?: IconProp;
   title: string;
   description?: string | React.ReactNode;
+  link?: {
+    label: string;
+    url: string;
+    external: boolean;
+  };
   status?: Status;
   time?: string;
 }
@@ -129,6 +136,16 @@ export const Toaster = () => (
                 <Text slot="description" className="max-w-md text-xs">
                   {toast.content.description}
                 </Text>
+              )}
+              {toast.content.link && (
+                <Link
+                  href={toast.content.link.url}
+                  noTheme
+                  className="inline-flex w-fit items-center gap-1 text-xs text-(--color-surprise) hover:opacity-80"
+                >
+                  <span className="underline">{toast.content.link.label}</span>
+                  {toast.content.link.external && <FontAwesomeIcon icon="arrow-up-right-from-square" className="size-3" />}
+                </Link>
               )}
             </div>
           </div>


### PR DESCRIPTION
Before:
<img width="306" height="71" alt="Screenshot 2026-06-23 at 15 11 38" src="https://github.com/user-attachments/assets/6016afd7-601a-46fb-a106-ff8d2962d8a0" />


After:
<img width="273" height="75" alt="Screenshot 2026-06-23 at 15 21 03" src="https://github.com/user-attachments/assets/ddad6dc4-87c3-4080-ad22-b0b4c18a8a5c" />
