### PR TITLE
fix: prevent empty commit when nothing is staged in Git Sync [INS-2795]

### DIFF
--- a/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
@@ -612,7 +612,11 @@ const ManualCommitForm: FC<ManualCommitFormProps> = ({
 
   const stagedCount = changes.staged.length;
   const unstagedCount = changes.unstaged.length;
+  const hasNoChanges = stagedCount === 0 && unstagedCount === 0;
   const [message, setMessage] = useState('');
+  // Holds the pending commit details while we ask the user whether to stage all
+  // changes (VSCode-like behaviour when nothing is staged).
+  const [pendingCommit, setPendingCommit] = useState<{ message: string; push: boolean } | null>(null);
   const committingActionRef = useRef<'commit' | 'commit-push' | null>(null);
   const [operationError, setOperationError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
@@ -644,6 +648,15 @@ const ManualCommitForm: FC<ManualCommitFormProps> = ({
   const isCommitting = commitFetcher.state !== 'idle';
   const canCommitAndPull = stagedCount > 0 && unstagedCount === 0;
 
+  const submitCommit = (commitMessage: string, push: boolean) => {
+    committingActionRef.current = push ? 'commit-push' : 'commit';
+    commitFetcher.submit({
+      projectId,
+      message: commitMessage,
+      push,
+    });
+  };
+
   useEffect(() => {
     if (!commitFetcher.data || !committingActionRef.current || isCommitting) {
       return;
@@ -674,14 +687,14 @@ const ManualCommitForm: FC<ManualCommitFormProps> = ({
           const message = formData.get('message')?.toString() || '';
           const push = Boolean(formData.get('push') === 'true');
 
-          const action = push ? 'commit-push' : 'commit';
-          committingActionRef.current = action;
+          // Nothing staged: instead of creating an empty commit (and losing the
+          // message), ask whether to stage all changes and commit them directly.
+          if (stagedCount === 0) {
+            setPendingCommit({ message, push });
+            return;
+          }
 
-          commitFetcher.submit({
-            projectId,
-            message,
-            push,
-          });
+          submitCommit(message, push);
         }}
         className="flex flex-col gap-2"
       >
@@ -747,7 +760,7 @@ const ManualCommitForm: FC<ManualCommitFormProps> = ({
           <div className="flex shrink-0 items-center justify-stretch gap-2">
             <Button
               type="submit"
-              isDisabled={(committingActionRef.current === 'commit' && isCommitting) || stagedCount === 0}
+              isDisabled={(committingActionRef.current === 'commit' && isCommitting) || hasNoChanges}
               className="flex h-8 flex-1 items-center justify-center gap-2 rounded-xs bg-(--hl-xxs) px-4 text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
             >
               <Icon
@@ -777,7 +790,7 @@ const ManualCommitForm: FC<ManualCommitFormProps> = ({
             ) : (
               <Button
                 type="submit"
-                isDisabled={committingActionRef.current === 'commit-push' && isCommitting}
+                isDisabled={(committingActionRef.current === 'commit-push' && isCommitting) || hasNoChanges}
                 name="push"
                 value="true"
                 className="flex h-8 flex-1 items-center justify-center gap-2 rounded-xs bg-(--hl-xxs) px-4 text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
@@ -1118,6 +1131,19 @@ const ManualCommitForm: FC<ManualCommitFormProps> = ({
           </TooltipTrigger>
         </div>
       </div>
+
+      {pendingCommit && (
+        <ConfirmCommitAllModal
+          onConfirm={async () => {
+            const pending = pendingCommit;
+            setPendingCommit(null);
+            // Stage every change, then commit (and push) directly.
+            await stageChanges(changes.unstaged.map(entry => entry.path));
+            submitCommit(pending.message, pending.push);
+          }}
+          onClose={() => setPendingCommit(null)}
+        />
+      )}
     </>
   );
 };
@@ -1657,6 +1683,69 @@ const ConfirmDiscardModal = ({ message, onConfirm, onClose }: ConfirmModalProps)
                   }}
                 >
                   Discard
+                </Button>
+              </div>
+            </div>
+          )}
+        </Dialog>
+      </Modal>
+    </ModalOverlay>
+  );
+};
+
+// Asks the user whether to stage all changes and commit them directly when
+// nothing is staged (mirrors VSCode, without the "Always"/"Never" options).
+const ConfirmCommitAllModal = ({ onConfirm, onClose }: Omit<ConfirmModalProps, 'message'>) => {
+  return (
+    <ModalOverlay
+      isOpen
+      onOpenChange={isOpen => {
+        !isOpen && onClose?.();
+      }}
+      isDismissable
+      className="fixed top-[50%] left-0 z-10 flex h-(--visual-viewport-height) w-full translate-y-[-50%] items-center justify-center bg-black/30"
+    >
+      <Modal
+        onOpenChange={isOpen => {
+          !isOpen && onClose?.();
+        }}
+        className="flex w-full max-w-2xl flex-col rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) p-(--padding-lg) text-(--color-font)"
+      >
+        <Dialog className="flex h-full flex-1 flex-col overflow-hidden outline-hidden data-loading:animate-pulse">
+          {({ close }) => (
+            <div className="flex flex-1 flex-col gap-4 overflow-hidden">
+              <div className="flex shrink-0 items-center justify-between gap-2">
+                <Heading slot="title" className="flex items-center gap-2 text-2xl">
+                  Stage All Changes
+                </Heading>
+
+                <Button
+                  className="flex aspect-square h-6 shrink-0 items-center justify-center rounded-xs text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
+                  onPress={close}
+                >
+                  <Icon icon="x" />
+                </Button>
+              </div>
+              <div className="">
+                There are no staged changes to commit. Would you like to stage all your changes and commit them directly?
+              </div>
+              <div className="flex h-10 shrink-0 items-center justify-end gap-2">
+                <Button
+                  className="h-full gap-2 rounded-md bg-(--color-bg) px-4 py-2 text-sm font-semibold ring-1 ring-transparent transition-all hover:bg-(--hl-xs)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm) aria-pressed:opacity-80"
+                  onPress={() => close?.()}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  data-testid="stage-all-and-commit-confirm-button"
+                  className="flex h-full items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
+                  onPress={() => {
+                    if (typeof onConfirm === 'function') {
+                      onConfirm();
+                    }
+                  }}
+                >
+                  Yes
                 </Button>
               </div>
             </div>


### PR DESCRIPTION
## Problem

In the Git Sync project staging modal, clicking **Commit & Push** without staging
any files created an empty commit and silently discarded the commit message you'd
typed. The **Commit** button was disabled when nothing was staged, but
**Commit & Push** was not, leaving the two buttons inconsistent.

## Changes

Adopts the same behavior as VSCode (without the *Always* / *Never* options):

- **Commit** and **Commit & Push** are now disabled only when there are no changes
  at all (nothing staged *and* nothing unstaged).
- Committing with nothing staged shows a confirmation:
  *"There are no staged changes to commit. Would you like to stage all your changes
  and commit them directly?"* — **Yes** stages everything and commits (and pushes
  if applicable), **Cancel** backs out.
- The commit message is preserved in every case; it's only cleared on a successful
  commit.

When changes are already staged, behavior is unchanged — it commits the staged set
directly.

## How to test

1. Open a Git Sync project and make a change (don't stage it).
2. Open the staging modal, write a commit message, and click **Commit & Push**.
3. Confirm you're prompted to stage all changes, the commit succeeds after **Yes**,
   and the message is retained if you **Cancel**.