### PR TITLE
fix: align empty-state "Create" menu styling with sidebar context menus [INS-2789]

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/request-group-actions-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/request-group-actions-dropdown.tsx
@@ -199,6 +199,27 @@ export const RequestGroupActionsDropdown = ({
       icon: 'plus',
       items: [
         {
+          id: 'New Folder',
+          name: 'New Folder',
+          icon: 'folder',
+          action: () =>
+            showModal(PromptModal, {
+              title: 'New Folder',
+              defaultValue: 'My Folder',
+              submitName: 'Create',
+              label: 'Name',
+              selectText: true,
+              onComplete: name =>
+                newRequestGroupFetcher.submit({
+                  organizationId,
+                  projectId,
+                  workspaceId,
+                  parentId: requestGroup._id,
+                  name,
+                }),
+            }),
+        },
+        {
           id: 'HTTP',
           name: 'HTTP Request',
           icon: 'plus-circle',
@@ -257,27 +278,6 @@ export const RequestGroupActionsDropdown = ({
             createRequest({
               requestType: 'SocketIO',
               parentId: requestGroup._id,
-            }),
-        },
-        {
-          id: 'New Folder',
-          name: 'New Folder',
-          icon: 'folder',
-          action: () =>
-            showModal(PromptModal, {
-              title: 'New Folder',
-              defaultValue: 'My Folder',
-              submitName: 'Create',
-              label: 'Name',
-              selectText: true,
-              onComplete: name =>
-                newRequestGroupFetcher.submit({
-                  organizationId,
-                  projectId,
-                  workspaceId,
-                  parentId: requestGroup._id,
-                  name,
-                }),
             }),
         },
       ],

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/empty-node.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/empty-node.tsx
@@ -4,6 +4,7 @@ import type { WorkspaceScope } from 'insomnia-data';
 import { useState } from 'react';
 import { Button, Menu, MenuItem, MenuTrigger, Popover } from 'react-aria-components';
 
+import { scopeToBgColorMap, scopeToTextColorMap } from '~/common/get-workspace-label';
 import { useRequestNewActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new';
 import { useRequestGroupNewActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.new';
 import { showModal } from '~/ui/components/modals';
@@ -24,6 +25,7 @@ interface ActionItem {
   id: string;
   name: string;
   icon: IconProp;
+  scope?: WorkspaceScope;
   action: () => void;
 }
 
@@ -81,6 +83,12 @@ export const EmptyNode = ({ item, storageRules }: EmptyNodeProps) => {
 
   const createRequestActionItems: ActionItem[] = [
     {
+      id: 'New Folder',
+      name: 'New Folder',
+      icon: 'folder',
+      action: createFolder,
+    },
+    {
       id: 'HTTP',
       name: 'HTTP Request',
       icon: 'plus-circle',
@@ -134,30 +142,27 @@ export const EmptyNode = ({ item, storageRules }: EmptyNodeProps) => {
           requestType: 'SocketIO',
         }),
     },
-    {
-      id: 'New Folder',
-      name: 'New Folder',
-      icon: 'folder',
-      action: createFolder,
-    },
   ];
 
   const createInProjectActionList: ActionItem[] = [
     {
       id: 'new-collection',
       name: 'Request collection',
+      scope: 'collection',
       icon: 'bars',
       action: createNewCollection,
     },
     {
       id: 'new-document',
       name: 'Design document',
+      scope: 'design',
       icon: 'file',
       action: createNewDocument,
     },
     {
       id: 'new-mcp-client',
       name: 'MCP Client',
+      scope: 'mcp',
       icon: ['fac', 'mcp'] as unknown as IconProp,
       action: createNewMcpClient,
     },
@@ -165,6 +170,7 @@ export const EmptyNode = ({ item, storageRules }: EmptyNodeProps) => {
     {
       id: 'new-mock-server',
       name: 'Mock Server',
+      scope: 'mock-server',
       icon: 'server' as IconName,
       action: createNewMockServer,
     },
@@ -172,6 +178,7 @@ export const EmptyNode = ({ item, storageRules }: EmptyNodeProps) => {
     {
       id: 'new-environment',
       name: 'Environment',
+      scope: 'environment',
       icon: 'code',
       action: createNewGlobalEnvironment,
     },
@@ -249,7 +256,7 @@ export const EmptyNode = ({ item, storageRules }: EmptyNodeProps) => {
               }
             }}
             items={kind === 'emptyProject' ? createInProjectActionList : createRequestActionItems}
-            className="min-w-max overflow-y-auto rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) py-2 text-base shadow-lg select-none focus:outline-hidden"
+            className="min-w-max overflow-y-auto rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) py-2 text-sm shadow-lg select-none focus:outline-hidden"
           >
             {item => (
               <MenuItem
@@ -258,7 +265,15 @@ export const EmptyNode = ({ item, storageRules }: EmptyNodeProps) => {
                 className="flex h-(--line-height-xs) w-full items-center gap-2 bg-transparent px-(--padding-md) whitespace-nowrap text-(--color-font) transition-colors hover:bg-(--hl-sm) focus:bg-(--hl-xs) focus:outline-hidden disabled:cursor-not-allowed aria-selected:font-bold"
                 aria-label={item.name}
               >
-                <Icon icon={item.icon} />
+                {item.scope ? (
+                  <div
+                    className={`${scopeToBgColorMap[item.scope]} ${scopeToTextColorMap[item.scope]} flex h-4 w-4 items-center justify-center rounded-sm p-1`}
+                  >
+                    <Icon icon={item.icon} className="h-3 w-3 shrink-0" />
+                  </div>
+                ) : (
+                  <Icon icon={item.icon} className="h-4 w-3" />
+                )}
                 <span>{item.name}</span>
               </MenuItem>
             )}


### PR DESCRIPTION
## Summary

The "+ Create" dropdown shown on empty projects and empty collections/folders
used different styling from the "..." context menus on project/collection rows,
making it look visually inconsistent (larger font, plain icons).

This PR brings the empty-state menu in line with the context menus.

## Changes

- **Font size:** the empty-state Create menu used `text-base` (16px) while the
  context menus use `text-sm` (14px) — switched to `text-sm`.
- **Icons:** empty-state items rendered bare, unsized icons. They now match the
  context menus:
  - Project create items (Collection, Document, MCP Client, Mock Server,
    Environment) render the colored scope badge (`scopeToBgColorMap` /
    `scopeToTextColorMap`), same as the project context menu.
  - Request/folder items render `h-4 w-3` icons, same as the collection
    context menu.
- Minor reordering/styling tidy-up in `request-group-actions-dropdown.tsx`.

## Testing

- `npm run type-check` passes.
- Verified the empty-project and empty-collection Create menus now match the
  corresponding context menus for font size and icon styling.