### PR TITLE
fix(undo): preserve URL bar focus + undo without breaking env preview refresh

### DIFF
--- a/docs/undo-redo-baseline.md
+++ b/docs/undo-redo-baseline.md
@@ -128,17 +128,13 @@ landed. Confirmed: a stable editor keeps focus and undoes correctly; the remount
 
 ## Improvement opportunities (ranked, least disruptive first)
 
-1. **Give `OneLineEditor` the same `editorStates` history persistence `CodeEditor` has.**
-   Thread a `uniquenessKey` through and save/restore `getHistory()`/`setHistory()` on
-   unmount/mount. Restores undo across remount for the URL bar and every key-value row. Highest
-   leverage, localized to one component.
-2. **Stabilise the remount key.** Narrow `uniqueKey` in
-   [`request-pane.tsx:82`](../packages/insomnia/src/ui/components/panes/request-pane.tsx#L82) so
-   segments that change mid-edit (`activeEnvironment.modified`, `activeResponseId`) don't tear
-   down the editor. Requires confirming what each segment was guarding against.
-3. **Make `setValue` non-destructive.** Where the manual `setValue` workaround is used, replace
-   the history-clearing `cm.setValue()` with a `replaceRange` over the full doc (preserves
-   history), or guard it to no-op when the incoming value equals the current value.
+1. **DONE.** Give `OneLineEditor` history persistence across remounts via a shared
+   `editor-state-cache` (also used by `CodeEditor`), keyed by a stable `uniquenessKey`.
+2. **DONE.** Narrow the URL bar editor's remount key to `requestId::environmentId::environment.modified`
+   so it refreshes on request/environment change but not on sends or local edits (the focus-loss
+   paths); external value changes resync in place via OneLineEditor's `defaultValue` effect.
+3. **DONE.** `setValue` is non-destructive — it replaces the value via `replaceRange` (history
+   preserved, undoable) and no-ops when unchanged.
 4. **Reconcile the two undo stacks** (native menu vs. CodeMirror). Out of scope for low-hanging
    fruit; track separately.
 5. **Plain controlled inputs (Category C).** Largest surface, lowest per-item value; defer

--- a/docs/undo-redo-baseline.md
+++ b/docs/undo-redo-baseline.md
@@ -1,0 +1,147 @@
+# Undo/Redo Baseline
+
+Catalog of the current undo/redo behaviour across Insomnia's text-input surfaces, established
+before attempting any improvement. Findings below are split into **confirmed by code**,
+**confirmed at runtime** (Playwright probe against the dev build), and **open questions**.
+
+## TL;DR
+
+- There are **three input technologies**, each with different undo semantics.
+- CodeMirror editors have built-in undo history; plain inputs rely on native browser/OS undo.
+- The dominant defect is that **undo history is destroyed on component remount**, and the
+  single-line editor (`OneLineEditor`) has no mechanism to restore it (the multi-line
+  `CodeEditor` does, via a module-level cache — but only when its cache key is stable).
+- A native Electron Edit menu binds `Cmd/Ctrl+Z` to the OS-level undo, which competes with
+  CodeMirror's internal history.
+
+## The three input technologies
+
+### A. Multi-line CodeMirror — `CodeEditor`
+[`code-editor.tsx`](../packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx)
+
+| Aspect | Behaviour | Ref |
+|---|---|---|
+| Undo engine | CodeMirror built-in history | — |
+| Init | `initEditor` runs once via `useMount`; `defaultValue` applied on mount only → **uncontrolled** | [:560](../packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx#L560) |
+| Seed guard | `clearHistory()` after first `setValue` so the seed isn't undoable | [:488](../packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx#L488) |
+| External writes | `maybePrettifyAndSetValue` no-ops when value is unchanged | [:296](../packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx#L296) |
+| **Remount survival** | History is persisted to module-global `editorStates[uniquenessKey]` (`getHistory()`) and restored (`setHistory()`) on re-init — **but only if `uniquenessKey` is unchanged across the remount** | [:324](../packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx#L324), [:503](../packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx#L503) |
+| Persist to model | debounced `onChange`, `DEBOUNCE_MILLIS = 100` | [:598](../packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx#L598) |
+
+Consumers (~21): raw body, GraphQL query/variables, environment JSON editor, request
+headers/params editors, request-script, markdown, mock response, code-prompt modal, etc.
+
+### B. Single-line CodeMirror — `OneLineEditor`
+[`one-line-editor.tsx`](../packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx)
+
+| Aspect | Behaviour | Ref |
+|---|---|---|
+| Undo engine | CodeMirror built-in history | — |
+| Init | `initEditor` once via `useMount`, `defaultValue` on mount only → **uncontrolled** | [:255](../packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx#L255) |
+| Seed guard | `clearHistory()` after first set | [:221](../packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx#L221) |
+| **Remount survival** | **None.** No `editorStates` equivalent — history is destroyed on every remount | — |
+| `setValue` handle | Preserves cursor but `cm.setValue()` **clears CM undo history** | [:366](../packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx#L366) |
+| Persist to model | debounced `onChange` (100ms) **+ flush on blur** | [:295](../packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx#L295), [:304](../packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx#L304) |
+
+Consumers (~14): URL bar, all key-value rows (name/value/description for headers, query,
+form-data, env), auth-input rows, cookies modal, WebSocket/gRPC/Socket.IO URL + panes, MCP url bar.
+
+The "uncontrolled + manual `setValue`" design is deliberate — see the comment at
+[`request-pane.tsx:71-75`](../packages/insomnia/src/ui/components/panes/request-pane.tsx#L71):
+controlling the editor would make typed input lag behind the model round-trip.
+
+### C. Plain inputs — React Aria `Input`/`TextField`, raw `<input>`/`<textarea>`
+
+Approx counts in `packages/insomnia/src/ui`: ~79 `<Input>`, ~42 `<TextField>`, ~19 `<input>`,
+~10 `<textarea>`. These are mostly **controlled** (`value` + `onChange`). Undo relies on the
+browser/OS native undo stack. A controlled input that re-renders on every keystroke can reset
+that native stack — but this is **not universal** (see runtime results).
+
+## Native Electron Edit menu
+
+[`window-utils.ts:305-342`](../packages/insomnia/src/main/window-utils.ts#L305) defines an Edit menu:
+
+- **Undo** → `role: 'undo'`, accelerator `CmdOrCtrl+Z`
+- **Redo** → `role: 'redo'`, accelerator `Shift+CmdOrCtrl+Z`
+
+These map to Electron's native `webContents.undo()/redo()`, which act on the focused native
+editable element — **independent of CodeMirror's internal history**. This is why plain inputs
+get working undo "for free", and why there are two competing undo stacks in CodeMirror surfaces.
+
+## Remount triggers
+
+The request pane builds a composite key and applies it to the URL bar editor and body editor
+([`request-pane.tsx:82`](../packages/insomnia/src/ui/components/panes/request-pane.tsx#L82)):
+
+```ts
+const uniqueKey = `${activeEnvironment?.modified}::${requestId}::${gitVersion}::${vcsVersion}::${activeRequestMeta?.activeResponseId}`;
+```
+
+Any change to a segment remounts the editor:
+- **Sending a request** → `activeResponseId` changes.
+- **Editing an environment** → `activeEnvironment.modified` changes.
+- **Git/Sync version bump** → `gitVersion` / `vcsVersion` changes.
+- **Initial load settling** after creating/opening a request (observed below).
+
+On remount, `OneLineEditor` loses all undo history; `CodeEditor` can only restore it if the
+`uniquenessKey` is *unchanged* — but several of these triggers change the key itself, defeating
+the restore.
+
+## Runtime findings (Playwright probe, dev build)
+
+Method: drive the real Electron renderer, type via keyboard, read CodeMirror state directly
+(`node.CodeMirror.historySize()`, `getValue()`). Probe was temporary and has been removed.
+
+| Scenario | Observation |
+|---|---|
+| URL bar, stable pane, type then settle | `undoDepth = 1` — history retained |
+| URL bar typed as the **first** mutation after creating a collection, then settle | `undoDepth = 1` immediately → **`0` after revalidation settles** (initial-load remount wiped it) |
+| Body editor, stable pane, type then settle | `undoDepth = 1` — history retained |
+| Body editor, then **switch tab away and back** (remount) | `undoDepth = 0`, value preserved — **remount wipes history** |
+| Body editor, real `Cmd+Z` | Undid the edit (`{"a":1}` → `{"a"}`) |
+| URL bar, real `Cmd+Z` (single run) | Value **unchanged**; focus retained — Cmd+Z did not undo |
+| Sidebar filter (plain controlled input), real `Cmd+Z` | Native undo **worked** (`"abc"` → `""`) |
+
+### What this confirms
+
+1. **Remount is the dominant history-killer.** A stable editor keeps its undo stack across the
+   100ms persist/revalidation cycle; a remount destroys it (value is re-seeded from the model,
+   history is not).
+2. **`OneLineEditor` is the most exposed** because it has no history-restore cache and its
+   consumers (URL bar, key-value rows) are keyed on volatile composite keys.
+3. **"All inputs have undo disabled" is not universally true** — at least one plain controlled
+   input (sidebar filter) has working native undo.
+
+### Open question (to bisect at fix time)
+
+Why real-keyboard `Cmd+Z` undid the multi-line `CodeEditor` but not the `OneLineEditor` URL bar
+in one run, even though the URL bar's internal history was non-empty when stable. Candidates:
+native Edit-menu `role: 'undo'` routing vs. CodeMirror keymap, focus/selection state, or a
+remount race at the moment of the keypress. Needs an isolated probe (compare
+`cm.execCommand('undo')` vs. menu-accelerator path with focus pinned).
+
+## Improvement opportunities (ranked, least disruptive first)
+
+1. **Give `OneLineEditor` the same `editorStates` history persistence `CodeEditor` has.**
+   Thread a `uniquenessKey` through and save/restore `getHistory()`/`setHistory()` on
+   unmount/mount. Restores undo across remount for the URL bar and every key-value row. Highest
+   leverage, localized to one component.
+2. **Stabilise the remount key.** Narrow `uniqueKey` in
+   [`request-pane.tsx:82`](../packages/insomnia/src/ui/components/panes/request-pane.tsx#L82) so
+   segments that change mid-edit (`activeEnvironment.modified`, `activeResponseId`) don't tear
+   down the editor. Requires confirming what each segment was guarding against.
+3. **Make `setValue` non-destructive.** Where the manual `setValue` workaround is used, replace
+   the history-clearing `cm.setValue()` with a `replaceRange` over the full doc (preserves
+   history), or guard it to no-op when the incoming value equals the current value.
+4. **Reconcile the two undo stacks** (native menu vs. CodeMirror). Out of scope for low-hanging
+   fruit; track separately.
+5. **Plain controlled inputs (Category C).** Largest surface, lowest per-item value; defer
+   unless a specific input is reported.
+
+## Suggested characterization tests (pin current behaviour before changing it)
+
+- **E2E (Playwright)**: type in URL bar → assert undo depth retained when stable; Send → assert
+  remount occurs and history is lost (documents the bug); body editor → assert tab-switch remount
+  loses history. These lock the baseline so a fix's improvement is measurable.
+- **Unit (Vitest)**: `shouldIndentWithTabs` and any extracted history save/restore helper.
+- Co-locate per `AGENTS.md`; E2E under `packages/insomnia-smoke-test/`.

--- a/docs/undo-redo-baseline.md
+++ b/docs/undo-redo-baseline.md
@@ -17,31 +17,33 @@ before attempting any improvement. Findings below are split into **confirmed by 
 ## The three input technologies
 
 ### A. Multi-line CodeMirror — `CodeEditor`
+
 [`code-editor.tsx`](../packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx)
 
-| Aspect | Behaviour | Ref |
-|---|---|---|
-| Undo engine | CodeMirror built-in history | — |
-| Init | `initEditor` runs once via `useMount`; `defaultValue` applied on mount only → **uncontrolled** | [:560](../packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx#L560) |
-| Seed guard | `clearHistory()` after first `setValue` so the seed isn't undoable | [:488](../packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx#L488) |
-| External writes | `maybePrettifyAndSetValue` no-ops when value is unchanged | [:296](../packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx#L296) |
+| Aspect               | Behaviour                                                                                                                                                                                       | Ref                                                                                                                                                                            |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Undo engine          | CodeMirror built-in history                                                                                                                                                                     | —                                                                                                                                                                              |
+| Init                 | `initEditor` runs once via `useMount`; `defaultValue` applied on mount only → **uncontrolled**                                                                                                  | [:560](../packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx#L560)                                                                                         |
+| Seed guard           | `clearHistory()` after first `setValue` so the seed isn't undoable                                                                                                                              | [:488](../packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx#L488)                                                                                         |
+| External writes      | `maybePrettifyAndSetValue` no-ops when value is unchanged                                                                                                                                       | [:296](../packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx#L296)                                                                                         |
 | **Remount survival** | History is persisted to module-global `editorStates[uniquenessKey]` (`getHistory()`) and restored (`setHistory()`) on re-init — **but only if `uniquenessKey` is unchanged across the remount** | [:324](../packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx#L324), [:503](../packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx#L503) |
-| Persist to model | debounced `onChange`, `DEBOUNCE_MILLIS = 100` | [:598](../packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx#L598) |
+| Persist to model     | debounced `onChange`, `DEBOUNCE_MILLIS = 100`                                                                                                                                                   | [:598](../packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx#L598)                                                                                         |
 
 Consumers (~21): raw body, GraphQL query/variables, environment JSON editor, request
 headers/params editors, request-script, markdown, mock response, code-prompt modal, etc.
 
 ### B. Single-line CodeMirror — `OneLineEditor`
+
 [`one-line-editor.tsx`](../packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx)
 
-| Aspect | Behaviour | Ref |
-|---|---|---|
-| Undo engine | CodeMirror built-in history | — |
-| Init | `initEditor` once via `useMount`, `defaultValue` on mount only → **uncontrolled** | [:255](../packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx#L255) |
-| Seed guard | `clearHistory()` after first set | [:221](../packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx#L221) |
-| **Remount survival** | **None.** No `editorStates` equivalent — history is destroyed on every remount | — |
-| `setValue` handle | Preserves cursor but `cm.setValue()` **clears CM undo history** | [:366](../packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx#L366) |
-| Persist to model | debounced `onChange` (100ms) **+ flush on blur** | [:295](../packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx#L295), [:304](../packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx#L304) |
+| Aspect               | Behaviour                                                                         | Ref                                                                                                                                                                                    |
+| -------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Undo engine          | CodeMirror built-in history                                                       | —                                                                                                                                                                                      |
+| Init                 | `initEditor` once via `useMount`, `defaultValue` on mount only → **uncontrolled** | [:255](../packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx#L255)                                                                                             |
+| Seed guard           | `clearHistory()` after first set                                                  | [:221](../packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx#L221)                                                                                             |
+| **Remount survival** | **None.** No `editorStates` equivalent — history is destroyed on every remount    | —                                                                                                                                                                                      |
+| `setValue` handle    | Preserves cursor but `cm.setValue()` **clears CM undo history**                   | [:366](../packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx#L366)                                                                                             |
+| Persist to model     | debounced `onChange` (100ms) **+ flush on blur**                                  | [:295](../packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx#L295), [:304](../packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx#L304) |
 
 Consumers (~14): URL bar, all key-value rows (name/value/description for headers, query,
 form-data, env), auth-input rows, cookies modal, WebSocket/gRPC/Socket.IO URL + panes, MCP url bar.
@@ -78,13 +80,14 @@ const uniqueKey = `${activeEnvironment?.modified}::${requestId}::${gitVersion}::
 ```
 
 Any change to a segment remounts the editor:
+
 - **Sending a request** → `activeResponseId` changes.
 - **Editing an environment** → `activeEnvironment.modified` changes.
 - **Git/Sync version bump** → `gitVersion` / `vcsVersion` changes.
 - **Initial load settling** after creating/opening a request (observed below).
 
 On remount, `OneLineEditor` loses all undo history; `CodeEditor` can only restore it if the
-`uniquenessKey` is *unchanged* — but several of these triggers change the key itself, defeating
+`uniquenessKey` is _unchanged_ — but several of these triggers change the key itself, defeating
 the restore.
 
 ## Runtime findings (Playwright probe, dev build)
@@ -92,15 +95,15 @@ the restore.
 Method: drive the real Electron renderer, type via keyboard, read CodeMirror state directly
 (`node.CodeMirror.historySize()`, `getValue()`). Probe was temporary and has been removed.
 
-| Scenario | Observation |
-|---|---|
-| URL bar, stable pane, type then settle | `undoDepth = 1` — history retained |
+| Scenario                                                                         | Observation                                                                                      |
+| -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| URL bar, stable pane, type then settle                                           | `undoDepth = 1` — history retained                                                               |
 | URL bar typed as the **first** mutation after creating a collection, then settle | `undoDepth = 1` immediately → **`0` after revalidation settles** (initial-load remount wiped it) |
-| Body editor, stable pane, type then settle | `undoDepth = 1` — history retained |
-| Body editor, then **switch tab away and back** (remount) | `undoDepth = 0`, value preserved — **remount wipes history** |
-| Body editor, real `Cmd+Z` | Undid the edit (`{"a":1}` → `{"a"}`) |
-| URL bar, real `Cmd+Z` (single run) | Value **unchanged**; focus retained — Cmd+Z did not undo |
-| Sidebar filter (plain controlled input), real `Cmd+Z` | Native undo **worked** (`"abc"` → `""`) |
+| Body editor, stable pane, type then settle                                       | `undoDepth = 1` — history retained                                                               |
+| Body editor, then **switch tab away and back** (remount)                         | `undoDepth = 0`, value preserved — **remount wipes history**                                     |
+| Body editor, real `Cmd+Z`                                                        | Undid the edit (`{"a":1}` → `{"a"}`)                                                             |
+| URL bar, real `Cmd+Z` (single run)                                               | Value **unchanged**; focus retained — Cmd+Z did not undo                                         |
+| Sidebar filter (plain controlled input), real `Cmd+Z`                            | Native undo **worked** (`"abc"` → `""`)                                                          |
 
 ### What this confirms
 
@@ -112,13 +115,16 @@ Method: drive the real Electron renderer, type via keyboard, read CodeMirror sta
 3. **"All inputs have undo disabled" is not universally true** — at least one plain controlled
    input (sidebar filter) has working native undo.
 
-### Open question (to bisect at fix time)
+### Resolved: why the URL bar lost undo / focus
 
-Why real-keyboard `Cmd+Z` undid the multi-line `CodeEditor` but not the `OneLineEditor` URL bar
-in one run, even though the URL bar's internal history was non-empty when stable. Candidates:
-native Edit-menu `role: 'undo'` routing vs. CodeMirror keymap, focus/selection state, or a
-remount race at the moment of the keypress. Needs an isolated probe (compare
-`cm.execCommand('undo')` vs. menu-accelerator path with focus pinned).
+Follow-up probing (real keyboard + `MutationObserver`) showed the URL bar's `OneLineEditor`
+**remounts ~once shortly after the first edit**: the first `patchRequest` triggers a loader
+revalidation, which changes a volatile segment of the editor's React `key` (`uniqueKey` =
+`activeEnvironment?.modified::requestId::gitVersion::vcsVersion::activeResponseId`). The remount
+**blurs the editor and drops its undo history**. So a `Cmd+Z` right after typing finds an
+already-blurred, empty-history editor — exactly the "re-render + loss of focus" symptom.
+The earlier "history non-empty when stable" reading was just a timing window before that remount
+landed. Confirmed: a stable editor keeps focus and undoes correctly; the remount is the disease.
 
 ## Improvement opportunities (ranked, least disruptive first)
 

--- a/packages/insomnia-smoke-test/tests/smoke/url-bar-undo.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/url-bar-undo.test.ts
@@ -1,16 +1,18 @@
 import { expect } from '@playwright/test';
 
+import { loadFixture } from '../../playwright/paths';
 import { test } from '../../playwright/test';
 
-// Characterisation test for the request URL bar's undo behaviour.
-// Regression guard for: editing the URL must not remount/blur the editor, and
-// Cmd/Ctrl+Z must undo in place while keeping focus.
+// Characterisation tests for the request URL bar editor.
 // See docs/undo-redo-baseline.md.
 
 const URL_SEL = 'div.editor__container:has(textarea#request-url-bar) .CodeMirror';
 const CONTAINER_SEL = 'div.editor__container:has(textarea#request-url-bar)';
+const TAG_SEL = 'div.editor__container:has(textarea#request-url-bar) .nunjucks-tag';
 const isMac = process.platform === 'darwin';
 
+// Regression guard: editing the URL must not remount/blur the editor, and
+// Cmd/Ctrl+Z must undo in place while keeping focus.
 test('URL bar: editing keeps focus and Cmd+Z undoes in place', async ({ page }) => {
   await page.getByRole('button', { name: 'Create request collection', exact: true }).click();
 
@@ -75,4 +77,45 @@ test('URL bar: editing keeps focus and Cmd+Z undoes in place', async ({ page }) 
   // Undo happened in place: no remount, focus retained.
   expect.soft(afterUndo.remounts).toBe(0);
   expect.soft(afterUndo.dataFocused).toBe('on');
+});
+
+// The editor is keyed on the environment, so switching environments must refresh
+// the rendered nunjucks variable preview shown in the URL bar.
+test('URL bar: switching environment refreshes the rendered preview', async ({ page, app, insomnia }) => {
+  const text = await loadFixture('environments.yaml');
+  await app.evaluate(async ({ clipboard }, t) => clipboard.writeText(t), text);
+  await page.getByLabel('Import').click();
+  await page.locator('[data-test-id="import-from-clipboard"]').click();
+  await page.getByRole('button', { name: 'Scan' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+  await page.getByRole('dialog').waitFor({ state: 'hidden' });
+
+  // Open the imported request, then put an environment variable in the URL so it
+  // renders an inline nunjucks preview. Replace the value via the editor API, then
+  // type so onChange persists it to the model (it must survive the env remount).
+  await insomnia.navigationSidebar.clickRequestOrFolder('New Request');
+  const urlInput = page.locator(`${URL_SEL} textarea`);
+  await page.evaluate((sel: string) => {
+    const node = document.querySelector(sel) as any;
+    node?.CodeMirror?.setValue('');
+  }, URL_SEL);
+  await urlInput.focus();
+  await page.keyboard.type('{{ _.exampleString }}');
+  await page.keyboard.press('Escape');
+  // confirm the variable tag rendered (innerHTML is the variable name)
+  await expect.soft(page.locator(URL_SEL)).toContainText('exampleString');
+
+  const tag = page.locator(TAG_SEL).first();
+
+  // ExampleA -> subenvA0
+  await page.getByRole('button', { name: 'Manage Environments' }).click();
+  await page.getByRole('option', { name: 'ExampleA' }).press('Enter');
+  await page.getByRole('option', { name: 'ExampleA' }).press('Escape');
+  await expect.soft(tag).toHaveAttribute('title', /subenvA0/);
+
+  // ExampleB -> subenvB0 (preview must refresh on switch)
+  await page.getByRole('button', { name: 'Manage Environments' }).click();
+  await page.getByRole('option', { name: 'ExampleB' }).press('Enter');
+  await page.getByRole('option', { name: 'ExampleB' }).press('Escape');
+  await expect.soft(tag).toHaveAttribute('title', /subenvB0/);
 });

--- a/packages/insomnia-smoke-test/tests/smoke/url-bar-undo.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/url-bar-undo.test.ts
@@ -79,6 +79,29 @@ test('URL bar: editing keeps focus and Cmd+Z undoes in place', async ({ page }) 
   expect.soft(afterUndo.dataFocused).toBe('on');
 });
 
+// The "Import from URL" action replaces the URL via OneLineEditor's setValue
+// handle. That replacement must stay undoable (history preserved), not wipe it.
+test('URL bar: importing query params stays undoable', async ({ page }) => {
+  await page.getByRole('button', { name: 'Create request collection', exact: true }).click();
+
+  const urlInput = page.locator(`${URL_SEL} textarea`);
+  await urlInput.focus();
+  await page.keyboard.type('https://example.com/path?foo=bar');
+  await expect.soft(page.locator(URL_SEL)).toContainText('foo=bar');
+
+  // Import query params -> strips the query from the URL via the setValue handle.
+  await page.getByRole('tab', { name: 'Params' }).click();
+  const importButton = page.getByRole('button', { name: 'Import from URL' });
+  await expect.soft(importButton).toBeEnabled();
+  await importButton.click();
+  await expect.soft(page.locator(URL_SEL)).not.toContainText('foo=bar');
+
+  // Undo must revert the import (non-destructive setValue preserves history).
+  await urlInput.focus();
+  await page.keyboard.press(isMac ? 'Meta+z' : 'Control+z');
+  await expect.soft(page.locator(URL_SEL)).toContainText('foo=bar');
+});
+
 // The editor is keyed on the environment, so switching environments must refresh
 // the rendered nunjucks variable preview shown in the URL bar.
 test('URL bar: switching environment refreshes the rendered preview', async ({ page, app, insomnia }) => {

--- a/packages/insomnia-smoke-test/tests/smoke/url-bar-undo.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/url-bar-undo.test.ts
@@ -1,0 +1,78 @@
+import { expect } from '@playwright/test';
+
+import { test } from '../../playwright/test';
+
+// Characterisation test for the request URL bar's undo behaviour.
+// Regression guard for: editing the URL must not remount/blur the editor, and
+// Cmd/Ctrl+Z must undo in place while keeping focus.
+// See docs/undo-redo-baseline.md.
+
+const URL_SEL = 'div.editor__container:has(textarea#request-url-bar) .CodeMirror';
+const CONTAINER_SEL = 'div.editor__container:has(textarea#request-url-bar)';
+const isMac = process.platform === 'darwin';
+
+test('URL bar: editing keeps focus and Cmd+Z undoes in place', async ({ page }) => {
+  await page.getByRole('button', { name: 'Create request collection', exact: true }).click();
+
+  const urlInput = page.locator(`${URL_SEL} textarea`);
+  await urlInput.focus();
+
+  // Observe CodeMirror node replacement (remount) and blur events from here on.
+  await page.evaluate((containerSel: string) => {
+    const w = window as any;
+    w.__remountCount = 0;
+    w.__blurCount = 0;
+    const container = document.querySelector(containerSel)!;
+    new MutationObserver(muts => {
+      for (const m of muts) {
+        m.removedNodes.forEach(n => {
+          if ((n as HTMLElement).classList?.contains('CodeMirror')) {
+            w.__remountCount++;
+          }
+        });
+      }
+    }).observe(container, { childList: true, subtree: true });
+    const node = document.querySelector(containerSel + ' .CodeMirror') as any;
+    node?.CodeMirror?.on('blur', () => {
+      w.__blurCount++;
+    });
+  }, CONTAINER_SEL);
+
+  const readState = () =>
+    page.evaluate(
+      ([s, c]: [string, string]) => {
+        const node = document.querySelector(s) as any;
+        const cm = node?.CodeMirror;
+        const container = document.querySelector(c) as HTMLElement | null;
+        const w = window as any;
+        return {
+          value: cm?.getValue() as string,
+          dataFocused: container?.dataset?.focused,
+          undo: cm?.historySize().undo as number,
+          remounts: w.__remountCount as number,
+          blurs: w.__blurCount as number,
+        };
+      },
+      [URL_SEL, CONTAINER_SEL],
+    );
+
+  await page.keyboard.type('https://example.com/foo');
+  // Web-first assertion settles the debounced persist + loader revalidation.
+  await expect.soft(page.locator(URL_SEL)).toContainText('example.com');
+
+  const afterEdit = await readState();
+  // Editing must not tear down or blur the editor, and undo history must exist.
+  expect.soft(afterEdit.remounts).toBe(0);
+  expect.soft(afterEdit.blurs).toBe(0);
+  expect.soft(afterEdit.dataFocused).toBe('on');
+  expect.soft(afterEdit.undo).toBeGreaterThan(0);
+
+  await page.keyboard.press(isMac ? 'Meta+z' : 'Control+z');
+  // Undo reverts the typed value (settles via web-first assertion).
+  await expect.soft(page.locator(URL_SEL)).not.toContainText('example.com');
+
+  const afterUndo = await readState();
+  // Undo happened in place: no remount, focus retained.
+  expect.soft(afterUndo.remounts).toBe(0);
+  expect.soft(afterUndo.dataFocused).toBe('on');
+});

--- a/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
@@ -41,17 +41,10 @@ import { ednPrettify } from '~/ui/utils/prettify/edn';
 import { jsonPrettify } from '~/ui/utils/prettify/json';
 import { queryXPath } from '~/ui/utils/xpath/query';
 
+import { getCachedEditorState, setCachedEditorState } from './editor-state-cache';
 import { normalizeIrregularWhitespace } from './normalize-irregular-whitespace';
 const TAB_SIZE = 4;
 const MAX_SIZE_FOR_LINTING = 1_000_000; // Around 1MB
-
-interface EditorState {
-  scroll: CodeMirror.ScrollInfo;
-  selections: CodeMirror.Range[];
-  cursor: CodeMirror.Position;
-  history: any;
-  marks: Partial<CodeMirror.MarkerRange>[];
-}
 
 export const shouldIndentWithTabs = ({ mode, indentWithTabs }: { mode?: string; indentWithTabs?: boolean }) => {
   // YAML is not valid when indented with Tabs
@@ -81,8 +74,6 @@ const widget = (cm: CodeMirror.EditorFromTextArea | null, from: CodeMirror.Posit
     return '\u2194';
   }
 };
-// Global object used for storing and persisting editor scroll, lint and folding margin states
-const editorStates: Record<string, EditorState> = {};
 export interface CodeEditorProps {
   autoPrettify?: boolean;
   className?: string;
@@ -317,7 +308,7 @@ export const CodeEditor = memo(
           if (scrollInfo.height <= 0 || scrollInfo.width <= 0) {
             return;
           }
-          editorStates[uniquenessKey] = {
+          setCachedEditorState(uniquenessKey, {
             scroll: scrollInfo,
             selections: codeMirror.current.listSelections(),
             cursor: codeMirror.current.getCursor(),
@@ -334,7 +325,7 @@ export const CodeEditor = memo(
                       to: undefined,
                     };
               }),
-          };
+          });
         }
       }, [uniquenessKey, codeMirror]);
 
@@ -500,13 +491,22 @@ export const CodeEditor = memo(
           codeMirror.current.makeLinksClickable(onClickLink);
         }
         // Restore the state
-        if (uniquenessKey && editorStates[uniquenessKey]) {
-          const { scroll, selections, cursor, history, marks } = editorStates[uniquenessKey];
-          codeMirror.current.scrollTo(scroll.left, scroll.top);
-          codeMirror.current.setHistory(history);
+        const cachedState = uniquenessKey ? getCachedEditorState(uniquenessKey) : undefined;
+        if (cachedState) {
+          const { scroll, selections, cursor, history, marks } = cachedState;
+          if (scroll) {
+            codeMirror.current.scrollTo(scroll.left, scroll.top);
+          }
+          if (history) {
+            codeMirror.current.setHistory(history);
+          }
           // NOTE: These won't be visible unless the editor is focused
-          codeMirror.current.setCursor(cursor.line, cursor.ch, { scroll: false });
-          codeMirror.current.setSelections(selections, undefined, { scroll: false });
+          if (cursor) {
+            codeMirror.current.setCursor(cursor.line, cursor.ch, { scroll: false });
+          }
+          if (selections) {
+            codeMirror.current.setSelections(selections, undefined, { scroll: false });
+          }
           // Restore marks one-by-one
           for (const { from, to } of marks || []) {
             // @ts-expect-error -- type unsoundness

--- a/packages/insomnia/src/ui/components/.client/codemirror/editor-state-cache.ts
+++ b/packages/insomnia/src/ui/components/.client/codemirror/editor-state-cache.ts
@@ -1,0 +1,22 @@
+import type CodeMirror from 'codemirror';
+
+// Persisted CodeMirror state, cached by a stable `uniquenessKey` so it survives
+// editor remounts (when a parent changes its React `key`). Used by both
+// CodeEditor and OneLineEditor. `history` is the undo/redo stack; the remaining
+// fields are only populated by the richer multi-line CodeEditor.
+export interface CachedEditorState {
+  history: any;
+  scroll?: CodeMirror.ScrollInfo;
+  selections?: CodeMirror.Range[];
+  cursor?: CodeMirror.Position;
+  marks?: Partial<CodeMirror.MarkerRange>[];
+}
+
+const editorStates: Record<string, CachedEditorState> = {};
+
+export const getCachedEditorState = (uniquenessKey: string): CachedEditorState | undefined =>
+  editorStates[uniquenessKey];
+
+export const setCachedEditorState = (uniquenessKey: string, state: CachedEditorState): void => {
+  editorStates[uniquenessKey] = state;
+};

--- a/packages/insomnia/src/ui/components/.client/codemirror/editor-state-cache.ts
+++ b/packages/insomnia/src/ui/components/.client/codemirror/editor-state-cache.ts
@@ -12,11 +12,34 @@ export interface CachedEditorState {
   marks?: Partial<CodeMirror.MarkerRange>[];
 }
 
-const editorStates: Record<string, CachedEditorState> = {};
+// Bounded LRU. Keys can be ephemeral (e.g. one per key-value pair id, minted per
+// row and never reused), so without a cap this would grow unboundedly for the
+// lifetime of the renderer, each entry retaining a CodeMirror history stack.
+// The cap only needs to cover editors that might remount roughly concurrently;
+// a few dozen is plenty, 100 is comfortably safe.
+const MAX_CACHED_EDITOR_STATES = 100;
+// Map preserves insertion order, so the first key is the least-recently-used.
+const editorStates = new Map<string, CachedEditorState>();
 
-export const getCachedEditorState = (uniquenessKey: string): CachedEditorState | undefined =>
-  editorStates[uniquenessKey];
+export const getCachedEditorState = (uniquenessKey: string): CachedEditorState | undefined => {
+  const state = editorStates.get(uniquenessKey);
+  if (state) {
+    // mark as most-recently-used
+    editorStates.delete(uniquenessKey);
+    editorStates.set(uniquenessKey, state);
+  }
+  return state;
+};
 
 export const setCachedEditorState = (uniquenessKey: string, state: CachedEditorState): void => {
-  editorStates[uniquenessKey] = state;
+  // re-insert at the end so it counts as most-recently-used
+  editorStates.delete(uniquenessKey);
+  editorStates.set(uniquenessKey, state);
+  while (editorStates.size > MAX_CACHED_EDITOR_STATES) {
+    const lruKey = editorStates.keys().next().value;
+    if (lruKey === undefined) {
+      break;
+    }
+    editorStates.delete(lruKey);
+  }
 };

--- a/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
@@ -328,6 +328,22 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
       }
     }, [readOnly, getKeyMap]);
 
+    // Re-seed the editor when the external value changes, but ONLY while the user
+    // isn't actively editing (not focused) and the value actually differs. This
+    // lets callers resync after an external change (sync pull, etc.) without
+    // remounting via a volatile `key`, which would otherwise blur the editor and
+    // drop undo history mid-edit. In-progress typing (focused) is never clobbered.
+    useEffect(() => {
+      const cm = codeMirror.current;
+      if (cm && !cm.hasFocus() && (defaultValue || '') !== cm.getValue()) {
+        const cursor = cm.getCursor();
+        cm.setValue(defaultValue || '');
+        cm.setCursor(cursor);
+        // value baseline changed externally, so the old history no longer applies
+        cm.clearHistory();
+      }
+    }, [defaultValue]);
+
     useEffect(() => {
       // Prevent these things if we're type === "password"
       const preventDefault = (_: CodeMirror.Editor, event: Event) =>

--- a/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
@@ -34,6 +34,20 @@ import { getTagDefinitions } from '~/ui/templating/renderer-safe';
 
 import { getCachedEditorState, setCachedEditorState } from './editor-state-cache';
 
+// Replace the editor's entire value while PRESERVING undo/redo history and the
+// cursor. Unlike cm.setValue(), which clears history, replaceRange records the
+// change as a normal, undoable edit. No-ops when the value is unchanged so we
+// don't push empty history entries or move the cursor needlessly.
+const replaceValuePreservingHistory = (cm: CodeMirror.EditorFromTextArea, value: string) => {
+  if (cm.getValue() === value) {
+    return;
+  }
+  const cursor = cm.getCursor();
+  const lastLine = cm.lastLine();
+  cm.replaceRange(value, { line: 0, ch: 0 }, { line: lastLine, ch: cm.getLine(lastLine).length });
+  cm.setCursor(cursor);
+};
+
 export interface OneLineEditorProps {
   defaultValue: string;
   getAutocompleteConstants?: () => string[] | PromiseLike<string[]>;
@@ -424,9 +438,7 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
         },
         setValue: (value: string) => {
           if (codeMirror.current) {
-            const cursor = codeMirror.current.getCursor();
-            codeMirror.current.setValue(value);
-            codeMirror.current.setCursor(cursor);
+            replaceValuePreservingHistory(codeMirror.current, value);
           }
         },
       }),

--- a/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
@@ -32,15 +32,7 @@ import { useResizeObserver } from '~/ui/hooks/use-resize-observer';
 import { plugins } from '~/ui/plugins/renderer-bridge';
 import { getTagDefinitions } from '~/ui/templating/renderer-safe';
 
-interface OneLineEditorState {
-  history: any;
-}
-// Module-level cache so a OneLineEditor's undo/redo history survives remounts
-// (e.g. when the parent's React key changes after a send or environment edit).
-// Mirrors the editorStates cache in CodeEditor. Keyed by `uniquenessKey`, which
-// MUST be stable across the remount (i.e. not the same volatile value used as the
-// React key) for the history to be recovered.
-const editorStates: Record<string, OneLineEditorState> = {};
+import { getCachedEditorState, setCachedEditorState } from './editor-state-cache';
 
 export interface OneLineEditorProps {
   defaultValue: string;
@@ -247,8 +239,9 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
       // Restore undo/redo history saved before the previous unmount so undo
       // survives remounts (the value is re-seeded from defaultValue above, which
       // matches the persisted model value, so the restored history stays consistent)
-      if (uniquenessKey && editorStates[uniquenessKey]?.history) {
-        codeMirror.current?.setHistory(editorStates[uniquenessKey].history);
+      const cachedState = uniquenessKey ? getCachedEditorState(uniquenessKey) : undefined;
+      if (cachedState?.history) {
+        codeMirror.current?.setHistory(cachedState.history);
       }
       // Setup Liquid template listeners
       if (handleRender && !settings.nunjucksPowerUserMode) {
@@ -282,9 +275,7 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
 
     const persistState = useCallback(() => {
       if (uniquenessKey && codeMirror.current) {
-        editorStates[uniquenessKey] = {
-          history: codeMirror.current.getHistory(),
-        };
+        setCachedEditorState(uniquenessKey, { history: codeMirror.current.getHistory() });
       }
     }, [uniquenessKey]);
 

--- a/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
@@ -32,6 +32,16 @@ import { useResizeObserver } from '~/ui/hooks/use-resize-observer';
 import { plugins } from '~/ui/plugins/renderer-bridge';
 import { getTagDefinitions } from '~/ui/templating/renderer-safe';
 
+interface OneLineEditorState {
+  history: any;
+}
+// Module-level cache so a OneLineEditor's undo/redo history survives remounts
+// (e.g. when the parent's React key changes after a send or environment edit).
+// Mirrors the editorStates cache in CodeEditor. Keyed by `uniquenessKey`, which
+// MUST be stable across the remount (i.e. not the same volatile value used as the
+// React key) for the history to be recovered.
+const editorStates: Record<string, OneLineEditorState> = {};
+
 export interface OneLineEditorProps {
   defaultValue: string;
   getAutocompleteConstants?: () => string[] | PromiseLike<string[]>;
@@ -44,6 +54,8 @@ export interface OneLineEditorProps {
   onPaste?: (text: string) => void;
   onBlur?: (e: FocusEvent) => void;
   eventListeners?: EditorEventListener<keyof EditorEventMap>[];
+  // NOTE: stable key for caching/restoring undo history across remounts
+  uniquenessKey?: string;
 }
 
 export interface EditorEventListener<T extends keyof EditorEventMap> {
@@ -69,6 +81,7 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
       onPaste,
       onBlur,
       eventListeners,
+      uniquenessKey,
     },
     ref,
   ) => {
@@ -231,6 +244,12 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
       codeMirror.current?.setValue(defaultValue || '');
       // Clear history so we can't undo the initial set
       codeMirror.current?.clearHistory();
+      // Restore undo/redo history saved before the previous unmount so undo
+      // survives remounts (the value is re-seeded from defaultValue above, which
+      // matches the persisted model value, so the restored history stays consistent)
+      if (uniquenessKey && editorStates[uniquenessKey]?.history) {
+        codeMirror.current?.setHistory(editorStates[uniquenessKey].history);
+      }
       // Setup Liquid template listeners
       if (handleRender && !settings.nunjucksPowerUserMode) {
         codeMirror.current?.enableNunjucksTags(
@@ -258,7 +277,16 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
       settings.showVariableSourceAndValue,
       eventListeners,
       id,
+      uniquenessKey,
     ]);
+
+    const persistState = useCallback(() => {
+      if (uniquenessKey && codeMirror.current) {
+        editorStates[uniquenessKey] = {
+          history: codeMirror.current.getHistory(),
+        };
+      }
+    }, [uniquenessKey]);
 
     const cleanUpEditor = useCallback(() => {
       codeMirror.current?.toTextArea();
@@ -279,6 +307,7 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
     });
 
     reactUse.useUnmount(() => {
+      persistState();
       cleanUpEditor();
     });
 

--- a/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
@@ -338,16 +338,21 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
     // lets callers resync after an external change (sync pull, etc.) without
     // remounting via a volatile `key`, which would otherwise blur the editor and
     // drop undo history mid-edit. In-progress typing (focused) is never clobbered.
+    //
+    // Gated on `uniquenessKey`: it marks the editors we deliberately moved off
+    // volatile-key remounting onto stable-key + in-place updates (URL bar,
+    // key-value rows). Other OneLineEditor instances keep their original
+    // uncontrolled-after-mount behaviour, so this stays an opt-in.
     useEffect(() => {
       const cm = codeMirror.current;
-      if (cm && !cm.hasFocus() && (defaultValue || '') !== cm.getValue()) {
+      if (cm && uniquenessKey !== undefined && !cm.hasFocus() && (defaultValue || '') !== cm.getValue()) {
         const cursor = cm.getCursor();
         cm.setValue(defaultValue || '');
         cm.setCursor(cursor);
         // value baseline changed externally, so the old history no longer applies
         cm.clearHistory();
       }
-    }, [defaultValue]);
+    }, [defaultValue, uniquenessKey]);
 
     useEffect(() => {
       // Prevent these things if we're type === "password"

--- a/packages/insomnia/src/ui/components/key-value-editor/row.tsx
+++ b/packages/insomnia/src/ui/components/key-value-editor/row.tsx
@@ -91,6 +91,7 @@ export const Row: FC<Props> = ({
         >
           <OneLineEditor
             id={'key-value-editor__name' + pair.id}
+            uniquenessKey={'key-value-editor__name' + pair.id}
             placeholder={namePlaceholder || 'Name'}
             defaultValue={pair.name}
             getAutocompleteConstants={() => handleGetAutocompleteNameConstants?.(pair) || []}
@@ -132,6 +133,7 @@ export const Row: FC<Props> = ({
           ) : (
             <OneLineEditor
               id={'key-value-editor__value' + pair.id}
+              uniquenessKey={'key-value-editor__value' + pair.id}
               onBlur={onBlur}
               type="text"
               readOnly={readOnly}
@@ -150,6 +152,7 @@ export const Row: FC<Props> = ({
           >
             <OneLineEditor
               id={'key-value-editor__description' + pair.id}
+              uniquenessKey={'key-value-editor__description' + pair.id}
               readOnly={readOnly}
               placeholder={descriptionPlaceholder || 'Description'}
               defaultValue={pair.description || ''}

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -104,7 +104,6 @@ export const RequestPane: FC<Props> = ({ environmentId, settings, onPaste }) => 
         <ErrorBoundary errorClassName="font-error pad text-center">
           <RequestUrlBar
             key={requestId}
-            uniquenessKey={uniqueKey}
             handleAutocompleteUrls={() =>
               services.helpers.queryAllWorkspaceUrls(workspaceId, models.request.type, requestId)
             }

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -104,6 +104,8 @@ export const RequestPane: FC<Props> = ({ environmentId, settings, onPaste }) => 
         <ErrorBoundary errorClassName="font-error pad text-center">
           <RequestUrlBar
             key={requestId}
+            // Stable cache key for the URL bar editor's undo history (survives remounts).
+            uniquenessKey={`request-url-bar::${requestId}`}
             handleAutocompleteUrls={() =>
               services.helpers.queryAllWorkspaceUrls(workspaceId, models.request.type, requestId)
             }

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -44,7 +44,6 @@ const { isEventStreamRequest, isGraphqlSubscriptionRequest } = models.request;
 interface Props {
   handleAutocompleteUrls: () => Promise<string[]>;
   nunjucksPowerUserMode: boolean;
-  uniquenessKey: string;
   onPaste: (text: string) => void;
 }
 
@@ -53,505 +52,504 @@ export interface RequestUrlBarHandle {
   setUrl: (url: string) => void;
 }
 
-export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(
-  ({ handleAutocompleteUrls, uniquenessKey, onPaste }, ref) => {
-    const [searchParams, setSearchParams] = useSearchParams();
-    const { userSession } = useRootLoaderData()!;
-    const { vaultKey } = userSession;
-    const [showEnvVariableMissingModal, setShowEnvVariableMissingModal] = useState(false);
-    const [showInputVaultKeyModal, setShowInputVaultKeyModal] = useState(false);
-    const [undefinedEnvironmentVariables, setUndefinedEnvironmentVariables] = useState('');
-    const undefinedEnvironmentVariableList = undefinedEnvironmentVariables?.split(',');
+export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({ handleAutocompleteUrls, onPaste }, ref) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { userSession } = useRootLoaderData()!;
+  const { vaultKey } = userSession;
+  const [showEnvVariableMissingModal, setShowEnvVariableMissingModal] = useState(false);
+  const [showInputVaultKeyModal, setShowInputVaultKeyModal] = useState(false);
+  const [undefinedEnvironmentVariables, setUndefinedEnvironmentVariables] = useState('');
+  const undefinedEnvironmentVariableList = undefinedEnvironmentVariables?.split(',');
 
-    useEffect(() => {
-      if (!searchParams.has('error')) {
+  useEffect(() => {
+    if (!searchParams.has('error')) {
+      return;
+    }
+
+    if (searchParams.has('envVariableMissing') && searchParams.get('undefinedEnvironmentVariables')) {
+      setShowEnvVariableMissingModal(true);
+      setUndefinedEnvironmentVariables(searchParams.get('undefinedEnvironmentVariables')!);
+    } else {
+      // only for request render error
+      const errorMessage = searchParams.get('error') || '';
+      // detects a string to replace with a link to settings
+      const linkText = SECURITY_SETTINGS_PATH_LABEL;
+      const hasLink = errorMessage.endsWith(linkText);
+
+      const modifiedString = hasLink ? errorMessage.slice(0, errorMessage.length - linkText.length) : errorMessage;
+      const close = showModal(AlertModal, {
+        title: 'Unexpected Request Failure',
+        message: (
+          <div>
+            <p>The request failed due to an unhandled error:</p>
+            <code className="wide selectable">
+              <div className="w-full overflow-y-auto text-wrap">
+                {modifiedString}
+                {hasLink && (
+                  <Link
+                    className="cursor-pointer text-(--color-surprise)"
+                    onPress={() => {
+                      close();
+                      showSettingsModal({ tab: 'general' });
+                    }}
+                  >
+                    {linkText}
+                  </Link>
+                )}
+              </div>
+            </code>
+          </div>
+        ),
+      });
+    }
+
+    setSearchParams({});
+  }, [searchParams, setSearchParams]);
+
+  const { activeWorkspace, activeEnvironment } = useWorkspaceLoaderData()!;
+  const { settings } = useRootLoaderData()!;
+  const { hotKeyRegistry } = settings;
+  const {
+    activeRequest,
+    activeRequestMeta: { downloadPath },
+  } = useRequestLoaderData()! as RequestLoaderData;
+  const patchRequestMeta = useRequestMetaPatcher();
+  const methodDropdownRef = useRef<DropdownHandle>(null);
+  const dropdownRef = useRef<DropdownHandle>(null);
+  const inputRef = useRef<OneLineEditorHandle>(null);
+  const isRealtimeRequest =
+    activeRequest && (isEventStreamRequest(activeRequest) || isGraphqlSubscriptionRequest(activeRequest));
+
+  const focusInput = useCallback(() => {
+    if (inputRef.current) {
+      inputRef.current.focusEnd();
+    }
+  }, [inputRef]);
+
+  const setUrl = useCallback(
+    (url: string) => {
+      if (inputRef.current) {
+        inputRef.current.setValue(url);
+      }
+    },
+    [inputRef],
+  );
+
+  useImperativeHandle(ref, () => ({ focusInput, setUrl }), [focusInput, setUrl]);
+
+  const [currentInterval, setCurrentInterval] = useState<number | null>(null);
+  const [currentTimeout, setCurrentTimeout] = useState<number | undefined>();
+  const connectRequestFetcher = useRequestConnectActionFetcher();
+  const sendRequestFetcher = useDebugRequestSendActionFetcher();
+
+  const { updateTabById } = useInsomniaTabContext();
+
+  const { organizationId, projectId, workspaceId, requestId } = useParams() as {
+    organizationId: string;
+    projectId: string;
+    workspaceId: string;
+    requestId: string;
+  };
+  const connectSubmit = connectRequestFetcher.submit;
+  const connect = useCallback(
+    (connectParams: ConnectActionParams) => {
+      connectSubmit({
+        organizationId,
+        projectId,
+        workspaceId,
+        requestId,
+        connectParams,
+      });
+    },
+    [connectSubmit, organizationId, projectId, requestId, workspaceId],
+  );
+  const sendRequestSubmit = sendRequestFetcher.submit;
+  const send = useCallback(
+    (params: SendActionParams) => {
+      sendRequestSubmit({
+        organizationId,
+        projectId,
+        workspaceId,
+        requestId,
+        params,
+      });
+    },
+    [organizationId, projectId, requestId, sendRequestSubmit, workspaceId],
+  );
+
+  const sendOrConnect = useCallback(
+    async (shouldPromptForPathAfterResponse?: boolean, ignoreUndefinedEnvVariable?: boolean) => {
+      updateTabById?.(requestId, { temporary: false });
+      services.stats.incrementExecutedRequests();
+      // reset timeout
+      setCurrentTimeout(undefined);
+
+      if (isEventStreamRequest(activeRequest) || isGraphqlSubscriptionRequest(activeRequest)) {
+        const startListening = async () => {
+          const environmentId = activeEnvironment._id;
+          const workspaceId = activeWorkspace._id;
+          const rendered = await renderRealtimeConnectPayload({
+            request: activeRequest,
+            environmentId,
+            workspaceId,
+          });
+          rendered &&
+            connect({
+              url: joinUrlAndQueryString(rendered.url, buildQueryStringFromParams(rendered.parameters)),
+              headers: rendered.headers,
+              authentication: rendered.authentication,
+              cookieJar: rendered.workspaceCookieJar,
+              suppressUserAgent: rendered.suppressUserAgent,
+            });
+          rendered &&
+            recordProjectRecentRequest({
+              projectId,
+              requestId,
+              workspaceId: activeWorkspace._id,
+            });
+        };
+        startListening();
         return;
       }
 
-      if (searchParams.has('envVariableMissing') && searchParams.get('undefinedEnvironmentVariables')) {
-        setShowEnvVariableMissingModal(true);
-        setUndefinedEnvironmentVariables(searchParams.get('undefinedEnvironmentVariables')!);
-      } else {
-        // only for request render error
-        const errorMessage = searchParams.get('error') || '';
-        // detects a string to replace with a link to settings
-        const linkText = SECURITY_SETTINGS_PATH_LABEL;
-        const hasLink = errorMessage.endsWith(linkText);
+      try {
+        recordProjectRecentRequest({
+          projectId,
+          requestId,
+          workspaceId: activeWorkspace._id,
+        });
 
-        const modifiedString = hasLink ? errorMessage.slice(0, errorMessage.length - linkText.length) : errorMessage;
-        const close = showModal(AlertModal, {
+        send({
+          requestId,
+          workspaceId: activeWorkspace._id,
+          projectId,
+          shouldPromptForPathAfterResponse,
+          ignoreUndefinedEnvVariable,
+        });
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        showModal(AlertModal, {
           title: 'Unexpected Request Failure',
           message: (
             <div>
               <p>The request failed due to an unhandled error:</p>
               <code className="wide selectable">
-                <div className="w-full overflow-y-auto text-wrap">
-                  {modifiedString}
-                  {hasLink && (
-                    <Link
-                      className="cursor-pointer text-(--color-surprise)"
-                      onPress={() => {
-                        close();
-                        showSettingsModal({ tab: 'general' });
-                      }}
-                    >
-                      {linkText}
-                    </Link>
-                  )}
-                </div>
+                <pre>{errorMessage}</pre>
               </code>
             </div>
           ),
         });
       }
+    },
+    [activeEnvironment._id, activeRequest, activeWorkspace._id, connect, requestId, send, updateTabById, projectId],
+  );
 
-      setSearchParams({});
-    }, [searchParams, setSearchParams]);
-
-    const { activeWorkspace, activeEnvironment } = useWorkspaceLoaderData()!;
-    const { settings } = useRootLoaderData()!;
-    const { hotKeyRegistry } = settings;
-    const {
-      activeRequest,
-      activeRequestMeta: { downloadPath },
-    } = useRequestLoaderData()! as RequestLoaderData;
-    const patchRequestMeta = useRequestMetaPatcher();
-    const methodDropdownRef = useRef<DropdownHandle>(null);
-    const dropdownRef = useRef<DropdownHandle>(null);
-    const inputRef = useRef<OneLineEditorHandle>(null);
-    const isRealtimeRequest =
-      activeRequest && (isEventStreamRequest(activeRequest) || isGraphqlSubscriptionRequest(activeRequest));
-
-    const focusInput = useCallback(() => {
-      if (inputRef.current) {
-        inputRef.current.focusEnd();
+  useEffect(() => {
+    const sendOnMetaEnter = (event: KeyboardEvent) => {
+      if (event.metaKey && event.key === 'Enter') {
+        sendOrConnect();
       }
-    }, [inputRef]);
-
-    const setUrl = useCallback(
-      (url: string) => {
-        if (inputRef.current) {
-          inputRef.current.setValue(url);
-        }
-      },
-      [inputRef],
-    );
-
-    useImperativeHandle(ref, () => ({ focusInput, setUrl }), [focusInput, setUrl]);
-
-    const [currentInterval, setCurrentInterval] = useState<number | null>(null);
-    const [currentTimeout, setCurrentTimeout] = useState<number | undefined>();
-    const connectRequestFetcher = useRequestConnectActionFetcher();
-    const sendRequestFetcher = useDebugRequestSendActionFetcher();
-
-    const { updateTabById } = useInsomniaTabContext();
-
-    const { organizationId, projectId, workspaceId, requestId } = useParams() as {
-      organizationId: string;
-      projectId: string;
-      workspaceId: string;
-      requestId: string;
     };
-    const connectSubmit = connectRequestFetcher.submit;
-    const connect = useCallback(
-      (connectParams: ConnectActionParams) => {
-        connectSubmit({
-          organizationId,
-          projectId,
-          workspaceId,
-          requestId,
-          connectParams,
-        });
-      },
-      [connectSubmit, organizationId, projectId, requestId, workspaceId],
-    );
-    const sendRequestSubmit = sendRequestFetcher.submit;
-    const send = useCallback(
-      (params: SendActionParams) => {
-        sendRequestSubmit({
-          organizationId,
-          projectId,
-          workspaceId,
-          requestId,
-          params,
-        });
-      },
-      [organizationId, projectId, requestId, sendRequestSubmit, workspaceId],
-    );
-
-    const sendOrConnect = useCallback(
-      async (shouldPromptForPathAfterResponse?: boolean, ignoreUndefinedEnvVariable?: boolean) => {
-        updateTabById?.(requestId, { temporary: false });
-        services.stats.incrementExecutedRequests();
-        // reset timeout
-        setCurrentTimeout(undefined);
-
-        if (isEventStreamRequest(activeRequest) || isGraphqlSubscriptionRequest(activeRequest)) {
-          const startListening = async () => {
-            const environmentId = activeEnvironment._id;
-            const workspaceId = activeWorkspace._id;
-            const rendered = await renderRealtimeConnectPayload({
-              request: activeRequest,
-              environmentId,
-              workspaceId,
-            });
-            rendered &&
-              connect({
-                url: joinUrlAndQueryString(rendered.url, buildQueryStringFromParams(rendered.parameters)),
-                headers: rendered.headers,
-                authentication: rendered.authentication,
-                cookieJar: rendered.workspaceCookieJar,
-                suppressUserAgent: rendered.suppressUserAgent,
-              });
-            rendered &&
-              recordProjectRecentRequest({
-                projectId,
-                requestId,
-                workspaceId: activeWorkspace._id,
-              });
-          };
-          startListening();
-          return;
-        }
-
-        try {
-          recordProjectRecentRequest({
-            projectId,
-            requestId,
-            workspaceId: activeWorkspace._id,
-          });
-
-          send({
-            requestId,
-            workspaceId: activeWorkspace._id,
-            projectId,
-            shouldPromptForPathAfterResponse,
-            ignoreUndefinedEnvVariable,
-          });
-        } catch (err) {
-          const errorMessage = err instanceof Error ? err.message : String(err);
-          showModal(AlertModal, {
-            title: 'Unexpected Request Failure',
-            message: (
-              <div>
-                <p>The request failed due to an unhandled error:</p>
-                <code className="wide selectable">
-                  <pre>{errorMessage}</pre>
-                </code>
-              </div>
-            ),
-          });
-        }
-      },
-      [activeEnvironment._id, activeRequest, activeWorkspace._id, connect, requestId, send, updateTabById, projectId],
-    );
-
-    useEffect(() => {
-      const sendOnMetaEnter = (event: KeyboardEvent) => {
-        if (event.metaKey && event.key === 'Enter') {
-          sendOrConnect();
-        }
-      };
+    document
+      .getElementById('sidebar-request-gridlist')
+      ?.addEventListener('keydown', sendOnMetaEnter, { capture: true });
+    return () => {
       document
         .getElementById('sidebar-request-gridlist')
-        ?.addEventListener('keydown', sendOnMetaEnter, { capture: true });
-      return () => {
-        document
-          .getElementById('sidebar-request-gridlist')
-          ?.removeEventListener('keydown', sendOnMetaEnter, { capture: true });
-      };
-    }, [sendOrConnect]);
+        ?.removeEventListener('keydown', sendOnMetaEnter, { capture: true });
+    };
+  }, [sendOrConnect]);
 
-    reactUse.useInterval(
-      sendOrConnect,
-      currentInterval && connectRequestFetcher.state === 'idle' ? currentInterval : null,
-    );
-    useTimeoutWhen(sendOrConnect, currentTimeout, !!currentTimeout);
-    const patchRequest = useRequestPatcher();
+  reactUse.useInterval(
+    sendOrConnect,
+    currentInterval && connectRequestFetcher.state === 'idle' ? currentInterval : null,
+  );
+  useTimeoutWhen(sendOrConnect, currentTimeout, !!currentTimeout);
+  const patchRequest = useRequestPatcher();
 
-    useDocBodyKeyboardShortcuts({
-      request_focusUrl: () => {
-        inputRef.current?.focusEnd();
-        inputRef.current?.selectAll();
-      },
-      request_send: () => {
-        if (activeRequest.url) {
-          sendOrConnect();
-        }
-      },
-      request_toggleHttpMethodMenu: () => {
-        methodDropdownRef.current?.toggle();
-      },
-      request_showOptions: () => {
-        dropdownRef.current?.toggle(true);
-      },
-    });
+  useDocBodyKeyboardShortcuts({
+    request_focusUrl: () => {
+      inputRef.current?.focusEnd();
+      inputRef.current?.selectAll();
+    },
+    request_send: () => {
+      if (activeRequest.url) {
+        sendOrConnect();
+      }
+    },
+    request_toggleHttpMethodMenu: () => {
+      methodDropdownRef.current?.toggle();
+    },
+    request_showOptions: () => {
+      dropdownRef.current?.toggle(true);
+    },
+  });
 
-    const buttonText = isRealtimeRequest ? 'Connect' : downloadPath ? 'Download' : 'Send';
-    const borderRadius = isRealtimeRequest ? 'rounded-xs' : 'rounded-l-sm';
-    const { url, method } = activeRequest;
-    const isEventStreamOpen = useReadyState({ requestId: activeRequest._id, protocol: 'curl' });
-    const isGraphQLSubscriptionOpen = useReadyState({ requestId: activeRequest._id, protocol: 'webSocket' });
-    const isCancellable = currentInterval || currentTimeout || isEventStreamOpen || isGraphQLSubscriptionOpen;
-    return (
-      <div className="flex w-full items-stretch justify-between self-stretch">
-        <div className="flex items-center">
-          <MethodDropdown
-            ref={methodDropdownRef}
-            onChange={method => patchRequest(requestId, { method })}
-            method={method}
-          />
-        </div>
-        <div className="flex flex-1 items-center p-1">
-          <OneLineEditor
-            id="request-url-bar"
-            key={uniquenessKey}
-            // Stable across the remounts that `key` (uniquenessKey) forces, so undo
-            // history is restored after a send / environment edit / sync version bump.
-            uniquenessKey={`request-url-bar::${requestId}`}
-            ref={inputRef}
-            type="text"
-            getAutocompleteConstants={handleAutocompleteUrls}
-            placeholder="https://api.myproduct.com/v1/users"
-            defaultValue={url}
-            onChange={url => patchRequest(requestId, { url })}
-            onKeyDown={createKeybindingsHandler({
-              Enter: () => sendOrConnect(),
-            })}
-            onPaste={onPaste}
-          />
-          <div className="flex self-stretch">
-            {isCancellable ? (
+  const buttonText = isRealtimeRequest ? 'Connect' : downloadPath ? 'Download' : 'Send';
+  const borderRadius = isRealtimeRequest ? 'rounded-xs' : 'rounded-l-sm';
+  const { url, method } = activeRequest;
+  const isEventStreamOpen = useReadyState({ requestId: activeRequest._id, protocol: 'curl' });
+  const isGraphQLSubscriptionOpen = useReadyState({ requestId: activeRequest._id, protocol: 'webSocket' });
+  const isCancellable = currentInterval || currentTimeout || isEventStreamOpen || isGraphQLSubscriptionOpen;
+  return (
+    <div className="flex w-full items-stretch justify-between self-stretch">
+      <div className="flex items-center">
+        <MethodDropdown
+          ref={methodDropdownRef}
+          onChange={method => patchRequest(requestId, { method })}
+          method={method}
+        />
+      </div>
+      <div className="flex flex-1 items-center p-1">
+        <OneLineEditor
+          id="request-url-bar"
+          // Key on requestId only. Previously keyed on the volatile uniquenessKey
+          // (environment.modified / response id / sync version), which remounted the
+          // editor on every edit — blurring it and dropping undo history. External
+          // value changes are now resynced in place via OneLineEditor's defaultValue
+          // effect, so no remount is needed except when switching requests.
+          key={requestId}
+          uniquenessKey={`request-url-bar::${requestId}`}
+          ref={inputRef}
+          type="text"
+          getAutocompleteConstants={handleAutocompleteUrls}
+          placeholder="https://api.myproduct.com/v1/users"
+          defaultValue={url}
+          onChange={url => patchRequest(requestId, { url })}
+          onKeyDown={createKeybindingsHandler({
+            Enter: () => sendOrConnect(),
+          })}
+          onPaste={onPaste}
+        />
+        <div className="flex self-stretch">
+          {isCancellable ? (
+            <button
+              type="button"
+              className="rounded-xs bg-(--color-surprise) px-(--padding-md) text-(--color-font-surprise)"
+              onClick={() => {
+                if (isEventStreamRequest(activeRequest)) {
+                  window.main.curl.close({ requestId: activeRequest._id });
+                  return;
+                }
+                if (isGraphqlSubscriptionRequest(activeRequest)) {
+                  window.main.webSocket.close({ requestId: activeRequest._id });
+                }
+                setCurrentInterval(null);
+                setCurrentTimeout(undefined);
+              }}
+            >
+              {isRealtimeRequest ? 'Disconnect' : 'Cancel'}
+            </button>
+          ) : (
+            <>
               <button
+                onClick={() => sendOrConnect()}
+                className={`bg-(--color-surprise) px-(--padding-md) text-(--color-font-surprise) ${borderRadius}`}
                 type="button"
-                className="rounded-xs bg-(--color-surprise) px-(--padding-md) text-(--color-font-surprise)"
-                onClick={() => {
-                  if (isEventStreamRequest(activeRequest)) {
-                    window.main.curl.close({ requestId: activeRequest._id });
-                    return;
-                  }
-                  if (isGraphqlSubscriptionRequest(activeRequest)) {
-                    window.main.webSocket.close({ requestId: activeRequest._id });
-                  }
-                  setCurrentInterval(null);
-                  setCurrentTimeout(undefined);
-                }}
               >
-                {isRealtimeRequest ? 'Disconnect' : 'Cancel'}
+                {buttonText}
               </button>
-            ) : (
-              <>
-                <button
-                  onClick={() => sendOrConnect()}
-                  className={`bg-(--color-surprise) px-(--padding-md) text-(--color-font-surprise) ${borderRadius}`}
-                  type="button"
+              {isRealtimeRequest ? null : (
+                <Dropdown
+                  key="dropdown"
+                  className="flex"
+                  ref={dropdownRef}
+                  aria-label="Request Options"
+                  closeOnSelect={false}
+                  triggerButton={
+                    <Button
+                      className="rounded-r-sm bg-(--color-surprise) px-1 text-(--color-font-surprise)"
+                      style={{
+                        borderTopRightRadius: '0.125rem',
+                        borderBottomRightRadius: '0.125rem',
+                      }}
+                    >
+                      <i className="fa fa-caret-down" />
+                    </Button>
+                  }
                 >
-                  {buttonText}
-                </button>
-                {isRealtimeRequest ? null : (
-                  <Dropdown
-                    key="dropdown"
-                    className="flex"
-                    ref={dropdownRef}
-                    aria-label="Request Options"
-                    closeOnSelect={false}
-                    triggerButton={
-                      <Button
-                        className="rounded-r-sm bg-(--color-surprise) px-1 text-(--color-font-surprise)"
-                        style={{
-                          borderTopRightRadius: '0.125rem',
-                          borderBottomRightRadius: '0.125rem',
+                  <DropdownSection aria-label="Basic Section" title="Basic">
+                    <DropdownItem aria-label="send-now">
+                      <ItemContent
+                        icon="arrow-circle-o-right"
+                        label="Send Now"
+                        hint={hotKeyRegistry.request_send}
+                        onClick={sendOrConnect}
+                      />
+                    </DropdownItem>
+                    <DropdownItem aria-label="Generate Client Code">
+                      <ItemContent
+                        icon="code"
+                        label="Generate Client Code"
+                        onClick={() => {
+                          window.main.trackAnalyticsEvent({
+                            event: AnalyticsEvent.requestSendMenuGenerateCodeClicked,
+                          });
+                          showModal(GenerateCodeModal, { request: activeRequest });
                         }}
-                      >
-                        <i className="fa fa-caret-down" />
-                      </Button>
-                    }
-                  >
-                    <DropdownSection aria-label="Basic Section" title="Basic">
-                      <DropdownItem aria-label="send-now">
+                      />
+                    </DropdownItem>
+                  </DropdownSection>
+                  <DropdownSection aria-label="Advanced Section" title="Advanced">
+                    <DropdownItem aria-label="Send After Delay">
+                      <ItemContent
+                        icon="clock-o"
+                        label="Send After Delay"
+                        onClick={() => {
+                          window.main.trackAnalyticsEvent({
+                            event: AnalyticsEvent.requestSendMenuSendAfterDelayClicked,
+                          });
+                          showModal(PromptModal, {
+                            inputType: 'decimal',
+                            title: 'Send After Delay',
+                            label: 'Delay in seconds',
+                            defaultValue: '3',
+                            onComplete: seconds => {
+                              setCurrentTimeout(+seconds * 1000);
+                            },
+                          });
+                        }}
+                      />
+                    </DropdownItem>
+                    <DropdownItem aria-label="Repeat on Interval">
+                      <ItemContent
+                        icon="repeat"
+                        label="Repeat on Interval"
+                        onClick={() => {
+                          window.main.trackAnalyticsEvent({
+                            event: AnalyticsEvent.requestSendMenuRepeatAfterIntervalClicked,
+                          });
+                          showModal(PromptModal, {
+                            inputType: 'decimal',
+                            title: 'Send on Interval',
+                            label: 'Interval in seconds',
+                            defaultValue: '3',
+                            submitName: 'Start',
+                            onComplete: seconds => {
+                              sendOrConnect();
+                              setCurrentInterval(+seconds * 1000);
+                            },
+                          });
+                        }}
+                      />
+                    </DropdownItem>
+                    {downloadPath ? (
+                      <DropdownItem aria-label="Stop Auto-Download">
                         <ItemContent
-                          icon="arrow-circle-o-right"
-                          label="Send Now"
-                          hint={hotKeyRegistry.request_send}
-                          onClick={sendOrConnect}
+                          icon="stop-circle"
+                          label="Stop Auto-Download"
+                          withPrompt
+                          onClick={() => patchRequestMeta(activeRequest._id, { downloadPath: null })}
                         />
                       </DropdownItem>
-                      <DropdownItem aria-label="Generate Client Code">
-                        <ItemContent
-                          icon="code"
-                          label="Generate Client Code"
-                          onClick={() => {
-                            window.main.trackAnalyticsEvent({
-                              event: AnalyticsEvent.requestSendMenuGenerateCodeClicked,
-                            });
-                            showModal(GenerateCodeModal, { request: activeRequest });
-                          }}
-                        />
-                      </DropdownItem>
-                    </DropdownSection>
-                    <DropdownSection aria-label="Advanced Section" title="Advanced">
-                      <DropdownItem aria-label="Send After Delay">
-                        <ItemContent
-                          icon="clock-o"
-                          label="Send After Delay"
-                          onClick={() => {
-                            window.main.trackAnalyticsEvent({
-                              event: AnalyticsEvent.requestSendMenuSendAfterDelayClicked,
-                            });
-                            showModal(PromptModal, {
-                              inputType: 'decimal',
-                              title: 'Send After Delay',
-                              label: 'Delay in seconds',
-                              defaultValue: '3',
-                              onComplete: seconds => {
-                                setCurrentTimeout(+seconds * 1000);
-                              },
-                            });
-                          }}
-                        />
-                      </DropdownItem>
-                      <DropdownItem aria-label="Repeat on Interval">
-                        <ItemContent
-                          icon="repeat"
-                          label="Repeat on Interval"
-                          onClick={() => {
-                            window.main.trackAnalyticsEvent({
-                              event: AnalyticsEvent.requestSendMenuRepeatAfterIntervalClicked,
-                            });
-                            showModal(PromptModal, {
-                              inputType: 'decimal',
-                              title: 'Send on Interval',
-                              label: 'Interval in seconds',
-                              defaultValue: '3',
-                              submitName: 'Start',
-                              onComplete: seconds => {
-                                sendOrConnect();
-                                setCurrentInterval(+seconds * 1000);
-                              },
-                            });
-                          }}
-                        />
-                      </DropdownItem>
-                      {downloadPath ? (
-                        <DropdownItem aria-label="Stop Auto-Download">
-                          <ItemContent
-                            icon="stop-circle"
-                            label="Stop Auto-Download"
-                            withPrompt
-                            onClick={() => patchRequestMeta(activeRequest._id, { downloadPath: null })}
-                          />
-                        </DropdownItem>
-                      ) : (
-                        <DropdownItem aria-label="Download After Send">
-                          <ItemContent
-                            icon="download"
-                            label="Download After Send"
-                            onClick={async () => {
-                              window.main.trackAnalyticsEvent({
-                                event: AnalyticsEvent.requestSendMenuDownloadAfterSendClicked,
-                              });
-                              const { canceled, filePaths } = await window.dialog.showOpenDialog({
-                                title: 'Select Download Location',
-                                buttonLabel: 'Select',
-                                properties: ['openDirectory'],
-                              });
-                              if (canceled) {
-                                return;
-                              }
-                              patchRequestMeta(activeRequest._id, { downloadPath: filePaths[0] });
-                            }}
-                          />
-                        </DropdownItem>
-                      )}
-                      <DropdownItem aria-label="Send And Download">
+                    ) : (
+                      <DropdownItem aria-label="Download After Send">
                         <ItemContent
                           icon="download"
-                          label="Send And Download"
-                          onClick={() => {
+                          label="Download After Send"
+                          onClick={async () => {
                             window.main.trackAnalyticsEvent({
-                              event: AnalyticsEvent.requestSendMenuSendAndDownloadClicked,
+                              event: AnalyticsEvent.requestSendMenuDownloadAfterSendClicked,
                             });
-                            sendOrConnect(true);
+                            const { canceled, filePaths } = await window.dialog.showOpenDialog({
+                              title: 'Select Download Location',
+                              buttonLabel: 'Select',
+                              properties: ['openDirectory'],
+                            });
+                            if (canceled) {
+                              return;
+                            }
+                            patchRequestMeta(activeRequest._id, { downloadPath: filePaths[0] });
                           }}
                         />
                       </DropdownItem>
-                    </DropdownSection>
-                  </Dropdown>
-                )}
-              </>
-            )}
+                    )}
+                    <DropdownItem aria-label="Send And Download">
+                      <ItemContent
+                        icon="download"
+                        label="Send And Download"
+                        onClick={() => {
+                          window.main.trackAnalyticsEvent({
+                            event: AnalyticsEvent.requestSendMenuSendAndDownloadClicked,
+                          });
+                          sendOrConnect(true);
+                        }}
+                      />
+                    </DropdownItem>
+                  </DropdownSection>
+                </Dropdown>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+      <VariableMissingErrorModal
+        isOpen={showEnvVariableMissingModal}
+        title={
+          undefinedEnvironmentVariableList?.length === 1
+            ? '1 environment variable is missing'
+            : `${undefinedEnvironmentVariableList?.length} environment variables are missing`
+        }
+        okText="Execute anyway"
+        onOk={() => {
+          setShowEnvVariableMissingModal(false);
+          sendOrConnect(false, true);
+        }}
+        onCancel={() => setShowEnvVariableMissingModal(false)}
+      >
+        <div>
+          These environment variables have been defined, but have not been assigned a value within the currently active
+          environment:
+          <div className="flex max-h-80 flex-wrap gap-2 overflow-y-auto">
+            {undefinedEnvironmentVariableList?.map(item => {
+              return (
+                <div
+                  key={item}
+                  className="mt-3 mr-3 rounded-xs bg-(--color-surprise) px-3 py-1 text-(--color-font-surprise)"
+                >
+                  {item}
+                </div>
+              );
+            })}
           </div>
         </div>
-        <VariableMissingErrorModal
-          isOpen={showEnvVariableMissingModal}
-          title={
-            undefinedEnvironmentVariableList?.length === 1
-              ? '1 environment variable is missing'
-              : `${undefinedEnvironmentVariableList?.length} environment variables are missing`
-          }
-          okText="Execute anyway"
-          onOk={() => {
-            setShowEnvVariableMissingModal(false);
-            sendOrConnect(false, true);
-          }}
-          onCancel={() => setShowEnvVariableMissingModal(false)}
-        >
-          <div>
-            These environment variables have been defined, but have not been assigned a value within the currently
-            active environment:
-            <div className="flex max-h-80 flex-wrap gap-2 overflow-y-auto">
-              {undefinedEnvironmentVariableList?.map(item => {
-                return (
-                  <div
-                    key={item}
-                    className="mt-3 mr-3 rounded-xs bg-(--color-surprise) px-3 py-1 text-(--color-font-surprise)"
-                  >
-                    {item}
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-          {!vaultKey &&
-            undefinedEnvironmentVariableList.some(variableName =>
-              variableName.startsWith(`${models.environment.vaultEnvironmentRuntimePath}.`),
-            ) && (
-              <div className="mt-4">
-                <p>
-                  These are secret environment variables. However, the required vault key has not been provided yet.
-                </p>
-                <Button
-                  className="cursor- py-1 text-(--color-info) underline ring-1 ring-transparent focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
-                  onPress={() => {
-                    setShowInputVaultKeyModal(true);
-                    setShowEnvVariableMissingModal(false);
-                  }}
-                >
-                  Click to input vault key
-                </Button>
-                <div className="flex max-h-80 flex-wrap gap-2 overflow-y-auto">
-                  {undefinedEnvironmentVariableList
-                    ?.filter(variableName =>
-                      variableName.startsWith(`${models.environment.vaultEnvironmentRuntimePath}.`),
-                    )
-                    .map(item => {
-                      return (
-                        <div
-                          key={item}
-                          className="mt-3 mr-3 rounded-xs bg-(--color-surprise) px-3 py-1 text-(--color-font-surprise)"
-                        >
-                          {item}
-                        </div>
-                      );
-                    })}
-                </div>
+        {!vaultKey &&
+          undefinedEnvironmentVariableList.some(variableName =>
+            variableName.startsWith(`${models.environment.vaultEnvironmentRuntimePath}.`),
+          ) && (
+            <div className="mt-4">
+              <p>These are secret environment variables. However, the required vault key has not been provided yet.</p>
+              <Button
+                className="cursor- py-1 text-(--color-info) underline ring-1 ring-transparent focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
+                onPress={() => {
+                  setShowInputVaultKeyModal(true);
+                  setShowEnvVariableMissingModal(false);
+                }}
+              >
+                Click to input vault key
+              </Button>
+              <div className="flex max-h-80 flex-wrap gap-2 overflow-y-auto">
+                {undefinedEnvironmentVariableList
+                  ?.filter(variableName =>
+                    variableName.startsWith(`${models.environment.vaultEnvironmentRuntimePath}.`),
+                  )
+                  .map(item => {
+                    return (
+                      <div
+                        key={item}
+                        className="mt-3 mr-3 rounded-xs bg-(--color-surprise) px-3 py-1 text-(--color-font-surprise)"
+                      >
+                        {item}
+                      </div>
+                    );
+                  })}
               </div>
-            )}
-        </VariableMissingErrorModal>
-        {showInputVaultKeyModal && <InputVaultKeyModal onClose={() => setShowInputVaultKeyModal(false)} />}
-      </div>
-    );
-  },
-);
+            </div>
+          )}
+      </VariableMissingErrorModal>
+      {showInputVaultKeyModal && <InputVaultKeyModal onClose={() => setShowInputVaultKeyModal(false)} />}
+    </div>
+  );
+});
 
 RequestUrlBar.displayName = 'RequestUrlBar';

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -44,6 +44,7 @@ const { isEventStreamRequest, isGraphqlSubscriptionRequest } = models.request;
 interface Props {
   handleAutocompleteUrls: () => Promise<string[]>;
   nunjucksPowerUserMode: boolean;
+  uniquenessKey: string;
   onPaste: (text: string) => void;
 }
 
@@ -52,507 +53,507 @@ export interface RequestUrlBarHandle {
   setUrl: (url: string) => void;
 }
 
-export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({ handleAutocompleteUrls, onPaste }, ref) => {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const { userSession } = useRootLoaderData()!;
-  const { vaultKey } = userSession;
-  const [showEnvVariableMissingModal, setShowEnvVariableMissingModal] = useState(false);
-  const [showInputVaultKeyModal, setShowInputVaultKeyModal] = useState(false);
-  const [undefinedEnvironmentVariables, setUndefinedEnvironmentVariables] = useState('');
-  const undefinedEnvironmentVariableList = undefinedEnvironmentVariables?.split(',');
+export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(
+  ({ handleAutocompleteUrls, uniquenessKey, onPaste }, ref) => {
+    const [searchParams, setSearchParams] = useSearchParams();
+    const { userSession } = useRootLoaderData()!;
+    const { vaultKey } = userSession;
+    const [showEnvVariableMissingModal, setShowEnvVariableMissingModal] = useState(false);
+    const [showInputVaultKeyModal, setShowInputVaultKeyModal] = useState(false);
+    const [undefinedEnvironmentVariables, setUndefinedEnvironmentVariables] = useState('');
+    const undefinedEnvironmentVariableList = undefinedEnvironmentVariables?.split(',');
 
-  useEffect(() => {
-    if (!searchParams.has('error')) {
-      return;
-    }
-
-    if (searchParams.has('envVariableMissing') && searchParams.get('undefinedEnvironmentVariables')) {
-      setShowEnvVariableMissingModal(true);
-      setUndefinedEnvironmentVariables(searchParams.get('undefinedEnvironmentVariables')!);
-    } else {
-      // only for request render error
-      const errorMessage = searchParams.get('error') || '';
-      // detects a string to replace with a link to settings
-      const linkText = SECURITY_SETTINGS_PATH_LABEL;
-      const hasLink = errorMessage.endsWith(linkText);
-
-      const modifiedString = hasLink ? errorMessage.slice(0, errorMessage.length - linkText.length) : errorMessage;
-      const close = showModal(AlertModal, {
-        title: 'Unexpected Request Failure',
-        message: (
-          <div>
-            <p>The request failed due to an unhandled error:</p>
-            <code className="wide selectable">
-              <div className="w-full overflow-y-auto text-wrap">
-                {modifiedString}
-                {hasLink && (
-                  <Link
-                    className="cursor-pointer text-(--color-surprise)"
-                    onPress={() => {
-                      close();
-                      showSettingsModal({ tab: 'general' });
-                    }}
-                  >
-                    {linkText}
-                  </Link>
-                )}
-              </div>
-            </code>
-          </div>
-        ),
-      });
-    }
-
-    setSearchParams({});
-  }, [searchParams, setSearchParams]);
-
-  const { activeWorkspace, activeEnvironment } = useWorkspaceLoaderData()!;
-  const { settings } = useRootLoaderData()!;
-  const { hotKeyRegistry } = settings;
-  const {
-    activeRequest,
-    activeRequestMeta: { downloadPath },
-  } = useRequestLoaderData()! as RequestLoaderData;
-  const patchRequestMeta = useRequestMetaPatcher();
-  const methodDropdownRef = useRef<DropdownHandle>(null);
-  const dropdownRef = useRef<DropdownHandle>(null);
-  const inputRef = useRef<OneLineEditorHandle>(null);
-  const isRealtimeRequest =
-    activeRequest && (isEventStreamRequest(activeRequest) || isGraphqlSubscriptionRequest(activeRequest));
-
-  const focusInput = useCallback(() => {
-    if (inputRef.current) {
-      inputRef.current.focusEnd();
-    }
-  }, [inputRef]);
-
-  const setUrl = useCallback(
-    (url: string) => {
-      if (inputRef.current) {
-        inputRef.current.setValue(url);
-      }
-    },
-    [inputRef],
-  );
-
-  useImperativeHandle(ref, () => ({ focusInput, setUrl }), [focusInput, setUrl]);
-
-  const [currentInterval, setCurrentInterval] = useState<number | null>(null);
-  const [currentTimeout, setCurrentTimeout] = useState<number | undefined>();
-  const connectRequestFetcher = useRequestConnectActionFetcher();
-  const sendRequestFetcher = useDebugRequestSendActionFetcher();
-
-  const { updateTabById } = useInsomniaTabContext();
-
-  const { organizationId, projectId, workspaceId, requestId } = useParams() as {
-    organizationId: string;
-    projectId: string;
-    workspaceId: string;
-    requestId: string;
-  };
-  const connectSubmit = connectRequestFetcher.submit;
-  const connect = useCallback(
-    (connectParams: ConnectActionParams) => {
-      connectSubmit({
-        organizationId,
-        projectId,
-        workspaceId,
-        requestId,
-        connectParams,
-      });
-    },
-    [connectSubmit, organizationId, projectId, requestId, workspaceId],
-  );
-  const sendRequestSubmit = sendRequestFetcher.submit;
-  const send = useCallback(
-    (params: SendActionParams) => {
-      sendRequestSubmit({
-        organizationId,
-        projectId,
-        workspaceId,
-        requestId,
-        params,
-      });
-    },
-    [organizationId, projectId, requestId, sendRequestSubmit, workspaceId],
-  );
-
-  const sendOrConnect = useCallback(
-    async (shouldPromptForPathAfterResponse?: boolean, ignoreUndefinedEnvVariable?: boolean) => {
-      updateTabById?.(requestId, { temporary: false });
-      services.stats.incrementExecutedRequests();
-      // reset timeout
-      setCurrentTimeout(undefined);
-
-      if (isEventStreamRequest(activeRequest) || isGraphqlSubscriptionRequest(activeRequest)) {
-        const startListening = async () => {
-          const environmentId = activeEnvironment._id;
-          const workspaceId = activeWorkspace._id;
-          const rendered = await renderRealtimeConnectPayload({
-            request: activeRequest,
-            environmentId,
-            workspaceId,
-          });
-          rendered &&
-            connect({
-              url: joinUrlAndQueryString(rendered.url, buildQueryStringFromParams(rendered.parameters)),
-              headers: rendered.headers,
-              authentication: rendered.authentication,
-              cookieJar: rendered.workspaceCookieJar,
-              suppressUserAgent: rendered.suppressUserAgent,
-            });
-          rendered &&
-            recordProjectRecentRequest({
-              projectId,
-              requestId,
-              workspaceId: activeWorkspace._id,
-            });
-        };
-        startListening();
+    useEffect(() => {
+      if (!searchParams.has('error')) {
         return;
       }
 
-      try {
-        recordProjectRecentRequest({
-          projectId,
-          requestId,
-          workspaceId: activeWorkspace._id,
-        });
+      if (searchParams.has('envVariableMissing') && searchParams.get('undefinedEnvironmentVariables')) {
+        setShowEnvVariableMissingModal(true);
+        setUndefinedEnvironmentVariables(searchParams.get('undefinedEnvironmentVariables')!);
+      } else {
+        // only for request render error
+        const errorMessage = searchParams.get('error') || '';
+        // detects a string to replace with a link to settings
+        const linkText = SECURITY_SETTINGS_PATH_LABEL;
+        const hasLink = errorMessage.endsWith(linkText);
 
-        send({
-          requestId,
-          workspaceId: activeWorkspace._id,
-          projectId,
-          shouldPromptForPathAfterResponse,
-          ignoreUndefinedEnvVariable,
-        });
-      } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : String(err);
-        showModal(AlertModal, {
+        const modifiedString = hasLink ? errorMessage.slice(0, errorMessage.length - linkText.length) : errorMessage;
+        const close = showModal(AlertModal, {
           title: 'Unexpected Request Failure',
           message: (
             <div>
               <p>The request failed due to an unhandled error:</p>
               <code className="wide selectable">
-                <pre>{errorMessage}</pre>
+                <div className="w-full overflow-y-auto text-wrap">
+                  {modifiedString}
+                  {hasLink && (
+                    <Link
+                      className="cursor-pointer text-(--color-surprise)"
+                      onPress={() => {
+                        close();
+                        showSettingsModal({ tab: 'general' });
+                      }}
+                    >
+                      {linkText}
+                    </Link>
+                  )}
+                </div>
               </code>
             </div>
           ),
         });
       }
-    },
-    [activeEnvironment._id, activeRequest, activeWorkspace._id, connect, requestId, send, updateTabById, projectId],
-  );
 
-  useEffect(() => {
-    const sendOnMetaEnter = (event: KeyboardEvent) => {
-      if (event.metaKey && event.key === 'Enter') {
-        sendOrConnect();
+      setSearchParams({});
+    }, [searchParams, setSearchParams]);
+
+    const { activeWorkspace, activeEnvironment } = useWorkspaceLoaderData()!;
+    const { settings } = useRootLoaderData()!;
+    const { hotKeyRegistry } = settings;
+    const {
+      activeRequest,
+      activeRequestMeta: { downloadPath },
+    } = useRequestLoaderData()! as RequestLoaderData;
+    const patchRequestMeta = useRequestMetaPatcher();
+    const methodDropdownRef = useRef<DropdownHandle>(null);
+    const dropdownRef = useRef<DropdownHandle>(null);
+    const inputRef = useRef<OneLineEditorHandle>(null);
+    const isRealtimeRequest =
+      activeRequest && (isEventStreamRequest(activeRequest) || isGraphqlSubscriptionRequest(activeRequest));
+
+    const focusInput = useCallback(() => {
+      if (inputRef.current) {
+        inputRef.current.focusEnd();
       }
+    }, [inputRef]);
+
+    const setUrl = useCallback(
+      (url: string) => {
+        if (inputRef.current) {
+          inputRef.current.setValue(url);
+        }
+      },
+      [inputRef],
+    );
+
+    useImperativeHandle(ref, () => ({ focusInput, setUrl }), [focusInput, setUrl]);
+
+    const [currentInterval, setCurrentInterval] = useState<number | null>(null);
+    const [currentTimeout, setCurrentTimeout] = useState<number | undefined>();
+    const connectRequestFetcher = useRequestConnectActionFetcher();
+    const sendRequestFetcher = useDebugRequestSendActionFetcher();
+
+    const { updateTabById } = useInsomniaTabContext();
+
+    const { organizationId, projectId, workspaceId, requestId } = useParams() as {
+      organizationId: string;
+      projectId: string;
+      workspaceId: string;
+      requestId: string;
     };
-    document
-      .getElementById('sidebar-request-gridlist')
-      ?.addEventListener('keydown', sendOnMetaEnter, { capture: true });
-    return () => {
+    const connectSubmit = connectRequestFetcher.submit;
+    const connect = useCallback(
+      (connectParams: ConnectActionParams) => {
+        connectSubmit({
+          organizationId,
+          projectId,
+          workspaceId,
+          requestId,
+          connectParams,
+        });
+      },
+      [connectSubmit, organizationId, projectId, requestId, workspaceId],
+    );
+    const sendRequestSubmit = sendRequestFetcher.submit;
+    const send = useCallback(
+      (params: SendActionParams) => {
+        sendRequestSubmit({
+          organizationId,
+          projectId,
+          workspaceId,
+          requestId,
+          params,
+        });
+      },
+      [organizationId, projectId, requestId, sendRequestSubmit, workspaceId],
+    );
+
+    const sendOrConnect = useCallback(
+      async (shouldPromptForPathAfterResponse?: boolean, ignoreUndefinedEnvVariable?: boolean) => {
+        updateTabById?.(requestId, { temporary: false });
+        services.stats.incrementExecutedRequests();
+        // reset timeout
+        setCurrentTimeout(undefined);
+
+        if (isEventStreamRequest(activeRequest) || isGraphqlSubscriptionRequest(activeRequest)) {
+          const startListening = async () => {
+            const environmentId = activeEnvironment._id;
+            const workspaceId = activeWorkspace._id;
+            const rendered = await renderRealtimeConnectPayload({
+              request: activeRequest,
+              environmentId,
+              workspaceId,
+            });
+            rendered &&
+              connect({
+                url: joinUrlAndQueryString(rendered.url, buildQueryStringFromParams(rendered.parameters)),
+                headers: rendered.headers,
+                authentication: rendered.authentication,
+                cookieJar: rendered.workspaceCookieJar,
+                suppressUserAgent: rendered.suppressUserAgent,
+              });
+            rendered &&
+              recordProjectRecentRequest({
+                projectId,
+                requestId,
+                workspaceId: activeWorkspace._id,
+              });
+          };
+          startListening();
+          return;
+        }
+
+        try {
+          recordProjectRecentRequest({
+            projectId,
+            requestId,
+            workspaceId: activeWorkspace._id,
+          });
+
+          send({
+            requestId,
+            workspaceId: activeWorkspace._id,
+            projectId,
+            shouldPromptForPathAfterResponse,
+            ignoreUndefinedEnvVariable,
+          });
+        } catch (err) {
+          const errorMessage = err instanceof Error ? err.message : String(err);
+          showModal(AlertModal, {
+            title: 'Unexpected Request Failure',
+            message: (
+              <div>
+                <p>The request failed due to an unhandled error:</p>
+                <code className="wide selectable">
+                  <pre>{errorMessage}</pre>
+                </code>
+              </div>
+            ),
+          });
+        }
+      },
+      [activeEnvironment._id, activeRequest, activeWorkspace._id, connect, requestId, send, updateTabById, projectId],
+    );
+
+    useEffect(() => {
+      const sendOnMetaEnter = (event: KeyboardEvent) => {
+        if (event.metaKey && event.key === 'Enter') {
+          sendOrConnect();
+        }
+      };
       document
         .getElementById('sidebar-request-gridlist')
-        ?.removeEventListener('keydown', sendOnMetaEnter, { capture: true });
-    };
-  }, [sendOrConnect]);
+        ?.addEventListener('keydown', sendOnMetaEnter, { capture: true });
+      return () => {
+        document
+          .getElementById('sidebar-request-gridlist')
+          ?.removeEventListener('keydown', sendOnMetaEnter, { capture: true });
+      };
+    }, [sendOrConnect]);
 
-  reactUse.useInterval(
-    sendOrConnect,
-    currentInterval && connectRequestFetcher.state === 'idle' ? currentInterval : null,
-  );
-  useTimeoutWhen(sendOrConnect, currentTimeout, !!currentTimeout);
-  const patchRequest = useRequestPatcher();
+    reactUse.useInterval(
+      sendOrConnect,
+      currentInterval && connectRequestFetcher.state === 'idle' ? currentInterval : null,
+    );
+    useTimeoutWhen(sendOrConnect, currentTimeout, !!currentTimeout);
+    const patchRequest = useRequestPatcher();
 
-  useDocBodyKeyboardShortcuts({
-    request_focusUrl: () => {
-      inputRef.current?.focusEnd();
-      inputRef.current?.selectAll();
-    },
-    request_send: () => {
-      if (activeRequest.url) {
-        sendOrConnect();
-      }
-    },
-    request_toggleHttpMethodMenu: () => {
-      methodDropdownRef.current?.toggle();
-    },
-    request_showOptions: () => {
-      dropdownRef.current?.toggle(true);
-    },
-  });
+    useDocBodyKeyboardShortcuts({
+      request_focusUrl: () => {
+        inputRef.current?.focusEnd();
+        inputRef.current?.selectAll();
+      },
+      request_send: () => {
+        if (activeRequest.url) {
+          sendOrConnect();
+        }
+      },
+      request_toggleHttpMethodMenu: () => {
+        methodDropdownRef.current?.toggle();
+      },
+      request_showOptions: () => {
+        dropdownRef.current?.toggle(true);
+      },
+    });
 
-  const buttonText = isRealtimeRequest ? 'Connect' : downloadPath ? 'Download' : 'Send';
-  const borderRadius = isRealtimeRequest ? 'rounded-xs' : 'rounded-l-sm';
-  const { url, method } = activeRequest;
-  const isEventStreamOpen = useReadyState({ requestId: activeRequest._id, protocol: 'curl' });
-  const isGraphQLSubscriptionOpen = useReadyState({ requestId: activeRequest._id, protocol: 'webSocket' });
-  const isCancellable = currentInterval || currentTimeout || isEventStreamOpen || isGraphQLSubscriptionOpen;
-  return (
-    <div className="flex w-full items-stretch justify-between self-stretch">
-      <div className="flex items-center">
-        <MethodDropdown
-          ref={methodDropdownRef}
-          onChange={method => patchRequest(requestId, { method })}
-          method={method}
-        />
-      </div>
-      <div className="flex flex-1 items-center p-1">
-        <OneLineEditor
-          id="request-url-bar"
-          // Remount only when switching requests or when the environment changes
-          // (switch or edit), so nunjucks variable previews refresh. Deliberately
-          // EXCLUDES the response id and sync versions the old key used: those churn
-          // on send / local edits and remounted the editor mid-interaction, blurring
-          // it and dropping undo history. External URL changes (e.g. sync pull) are
-          // resynced in place via OneLineEditor's defaultValue effect.
-          key={`${requestId}::${activeEnvironment?._id}::${activeEnvironment?.modified}`}
-          // Stable cache key so undo history is restored if an environment-driven
-          // remount lands while the user is mid-edit.
-          uniquenessKey={`request-url-bar::${requestId}`}
-          ref={inputRef}
-          type="text"
-          getAutocompleteConstants={handleAutocompleteUrls}
-          placeholder="https://api.myproduct.com/v1/users"
-          defaultValue={url}
-          onChange={url => patchRequest(requestId, { url })}
-          onKeyDown={createKeybindingsHandler({
-            Enter: () => sendOrConnect(),
-          })}
-          onPaste={onPaste}
-        />
-        <div className="flex self-stretch">
-          {isCancellable ? (
-            <button
-              type="button"
-              className="rounded-xs bg-(--color-surprise) px-(--padding-md) text-(--color-font-surprise)"
-              onClick={() => {
-                if (isEventStreamRequest(activeRequest)) {
-                  window.main.curl.close({ requestId: activeRequest._id });
-                  return;
-                }
-                if (isGraphqlSubscriptionRequest(activeRequest)) {
-                  window.main.webSocket.close({ requestId: activeRequest._id });
-                }
-                setCurrentInterval(null);
-                setCurrentTimeout(undefined);
-              }}
-            >
-              {isRealtimeRequest ? 'Disconnect' : 'Cancel'}
-            </button>
-          ) : (
-            <>
+    const buttonText = isRealtimeRequest ? 'Connect' : downloadPath ? 'Download' : 'Send';
+    const borderRadius = isRealtimeRequest ? 'rounded-xs' : 'rounded-l-sm';
+    const { url, method } = activeRequest;
+    const isEventStreamOpen = useReadyState({ requestId: activeRequest._id, protocol: 'curl' });
+    const isGraphQLSubscriptionOpen = useReadyState({ requestId: activeRequest._id, protocol: 'webSocket' });
+    const isCancellable = currentInterval || currentTimeout || isEventStreamOpen || isGraphQLSubscriptionOpen;
+    return (
+      <div className="flex w-full items-stretch justify-between self-stretch">
+        <div className="flex items-center">
+          <MethodDropdown
+            ref={methodDropdownRef}
+            onChange={method => patchRequest(requestId, { method })}
+            method={method}
+          />
+        </div>
+        <div className="flex flex-1 items-center p-1">
+          <OneLineEditor
+            id="request-url-bar"
+            // Remount on request switch or environment change (switch/edit) so nunjucks
+            // previews refresh. Excludes the response id / sync versions that churn on
+            // send and local edits, which used to remount and blur the editor mid-edit.
+            key={`${requestId}::${activeEnvironment?._id}::${activeEnvironment?.modified}`}
+            // Stable across that remount, so undo history is restored from the cache.
+            uniquenessKey={uniquenessKey}
+            ref={inputRef}
+            type="text"
+            getAutocompleteConstants={handleAutocompleteUrls}
+            placeholder="https://api.myproduct.com/v1/users"
+            defaultValue={url}
+            onChange={url => patchRequest(requestId, { url })}
+            onKeyDown={createKeybindingsHandler({
+              Enter: () => sendOrConnect(),
+            })}
+            onPaste={onPaste}
+          />
+          <div className="flex self-stretch">
+            {isCancellable ? (
               <button
-                onClick={() => sendOrConnect()}
-                className={`bg-(--color-surprise) px-(--padding-md) text-(--color-font-surprise) ${borderRadius}`}
                 type="button"
-              >
-                {buttonText}
-              </button>
-              {isRealtimeRequest ? null : (
-                <Dropdown
-                  key="dropdown"
-                  className="flex"
-                  ref={dropdownRef}
-                  aria-label="Request Options"
-                  closeOnSelect={false}
-                  triggerButton={
-                    <Button
-                      className="rounded-r-sm bg-(--color-surprise) px-1 text-(--color-font-surprise)"
-                      style={{
-                        borderTopRightRadius: '0.125rem',
-                        borderBottomRightRadius: '0.125rem',
-                      }}
-                    >
-                      <i className="fa fa-caret-down" />
-                    </Button>
+                className="rounded-xs bg-(--color-surprise) px-(--padding-md) text-(--color-font-surprise)"
+                onClick={() => {
+                  if (isEventStreamRequest(activeRequest)) {
+                    window.main.curl.close({ requestId: activeRequest._id });
+                    return;
                   }
+                  if (isGraphqlSubscriptionRequest(activeRequest)) {
+                    window.main.webSocket.close({ requestId: activeRequest._id });
+                  }
+                  setCurrentInterval(null);
+                  setCurrentTimeout(undefined);
+                }}
+              >
+                {isRealtimeRequest ? 'Disconnect' : 'Cancel'}
+              </button>
+            ) : (
+              <>
+                <button
+                  onClick={() => sendOrConnect()}
+                  className={`bg-(--color-surprise) px-(--padding-md) text-(--color-font-surprise) ${borderRadius}`}
+                  type="button"
                 >
-                  <DropdownSection aria-label="Basic Section" title="Basic">
-                    <DropdownItem aria-label="send-now">
-                      <ItemContent
-                        icon="arrow-circle-o-right"
-                        label="Send Now"
-                        hint={hotKeyRegistry.request_send}
-                        onClick={sendOrConnect}
-                      />
-                    </DropdownItem>
-                    <DropdownItem aria-label="Generate Client Code">
-                      <ItemContent
-                        icon="code"
-                        label="Generate Client Code"
-                        onClick={() => {
-                          window.main.trackAnalyticsEvent({
-                            event: AnalyticsEvent.requestSendMenuGenerateCodeClicked,
-                          });
-                          showModal(GenerateCodeModal, { request: activeRequest });
+                  {buttonText}
+                </button>
+                {isRealtimeRequest ? null : (
+                  <Dropdown
+                    key="dropdown"
+                    className="flex"
+                    ref={dropdownRef}
+                    aria-label="Request Options"
+                    closeOnSelect={false}
+                    triggerButton={
+                      <Button
+                        className="rounded-r-sm bg-(--color-surprise) px-1 text-(--color-font-surprise)"
+                        style={{
+                          borderTopRightRadius: '0.125rem',
+                          borderBottomRightRadius: '0.125rem',
                         }}
-                      />
-                    </DropdownItem>
-                  </DropdownSection>
-                  <DropdownSection aria-label="Advanced Section" title="Advanced">
-                    <DropdownItem aria-label="Send After Delay">
-                      <ItemContent
-                        icon="clock-o"
-                        label="Send After Delay"
-                        onClick={() => {
-                          window.main.trackAnalyticsEvent({
-                            event: AnalyticsEvent.requestSendMenuSendAfterDelayClicked,
-                          });
-                          showModal(PromptModal, {
-                            inputType: 'decimal',
-                            title: 'Send After Delay',
-                            label: 'Delay in seconds',
-                            defaultValue: '3',
-                            onComplete: seconds => {
-                              setCurrentTimeout(+seconds * 1000);
-                            },
-                          });
-                        }}
-                      />
-                    </DropdownItem>
-                    <DropdownItem aria-label="Repeat on Interval">
-                      <ItemContent
-                        icon="repeat"
-                        label="Repeat on Interval"
-                        onClick={() => {
-                          window.main.trackAnalyticsEvent({
-                            event: AnalyticsEvent.requestSendMenuRepeatAfterIntervalClicked,
-                          });
-                          showModal(PromptModal, {
-                            inputType: 'decimal',
-                            title: 'Send on Interval',
-                            label: 'Interval in seconds',
-                            defaultValue: '3',
-                            submitName: 'Start',
-                            onComplete: seconds => {
-                              sendOrConnect();
-                              setCurrentInterval(+seconds * 1000);
-                            },
-                          });
-                        }}
-                      />
-                    </DropdownItem>
-                    {downloadPath ? (
-                      <DropdownItem aria-label="Stop Auto-Download">
+                      >
+                        <i className="fa fa-caret-down" />
+                      </Button>
+                    }
+                  >
+                    <DropdownSection aria-label="Basic Section" title="Basic">
+                      <DropdownItem aria-label="send-now">
                         <ItemContent
-                          icon="stop-circle"
-                          label="Stop Auto-Download"
-                          withPrompt
-                          onClick={() => patchRequestMeta(activeRequest._id, { downloadPath: null })}
+                          icon="arrow-circle-o-right"
+                          label="Send Now"
+                          hint={hotKeyRegistry.request_send}
+                          onClick={sendOrConnect}
                         />
                       </DropdownItem>
-                    ) : (
-                      <DropdownItem aria-label="Download After Send">
+                      <DropdownItem aria-label="Generate Client Code">
                         <ItemContent
-                          icon="download"
-                          label="Download After Send"
-                          onClick={async () => {
+                          icon="code"
+                          label="Generate Client Code"
+                          onClick={() => {
                             window.main.trackAnalyticsEvent({
-                              event: AnalyticsEvent.requestSendMenuDownloadAfterSendClicked,
+                              event: AnalyticsEvent.requestSendMenuGenerateCodeClicked,
                             });
-                            const { canceled, filePaths } = await window.dialog.showOpenDialog({
-                              title: 'Select Download Location',
-                              buttonLabel: 'Select',
-                              properties: ['openDirectory'],
-                            });
-                            if (canceled) {
-                              return;
-                            }
-                            patchRequestMeta(activeRequest._id, { downloadPath: filePaths[0] });
+                            showModal(GenerateCodeModal, { request: activeRequest });
                           }}
                         />
                       </DropdownItem>
-                    )}
-                    <DropdownItem aria-label="Send And Download">
-                      <ItemContent
-                        icon="download"
-                        label="Send And Download"
-                        onClick={() => {
-                          window.main.trackAnalyticsEvent({
-                            event: AnalyticsEvent.requestSendMenuSendAndDownloadClicked,
-                          });
-                          sendOrConnect(true);
-                        }}
-                      />
-                    </DropdownItem>
-                  </DropdownSection>
-                </Dropdown>
-              )}
-            </>
-          )}
-        </div>
-      </div>
-      <VariableMissingErrorModal
-        isOpen={showEnvVariableMissingModal}
-        title={
-          undefinedEnvironmentVariableList?.length === 1
-            ? '1 environment variable is missing'
-            : `${undefinedEnvironmentVariableList?.length} environment variables are missing`
-        }
-        okText="Execute anyway"
-        onOk={() => {
-          setShowEnvVariableMissingModal(false);
-          sendOrConnect(false, true);
-        }}
-        onCancel={() => setShowEnvVariableMissingModal(false)}
-      >
-        <div>
-          These environment variables have been defined, but have not been assigned a value within the currently active
-          environment:
-          <div className="flex max-h-80 flex-wrap gap-2 overflow-y-auto">
-            {undefinedEnvironmentVariableList?.map(item => {
-              return (
-                <div
-                  key={item}
-                  className="mt-3 mr-3 rounded-xs bg-(--color-surprise) px-3 py-1 text-(--color-font-surprise)"
-                >
-                  {item}
-                </div>
-              );
-            })}
+                    </DropdownSection>
+                    <DropdownSection aria-label="Advanced Section" title="Advanced">
+                      <DropdownItem aria-label="Send After Delay">
+                        <ItemContent
+                          icon="clock-o"
+                          label="Send After Delay"
+                          onClick={() => {
+                            window.main.trackAnalyticsEvent({
+                              event: AnalyticsEvent.requestSendMenuSendAfterDelayClicked,
+                            });
+                            showModal(PromptModal, {
+                              inputType: 'decimal',
+                              title: 'Send After Delay',
+                              label: 'Delay in seconds',
+                              defaultValue: '3',
+                              onComplete: seconds => {
+                                setCurrentTimeout(+seconds * 1000);
+                              },
+                            });
+                          }}
+                        />
+                      </DropdownItem>
+                      <DropdownItem aria-label="Repeat on Interval">
+                        <ItemContent
+                          icon="repeat"
+                          label="Repeat on Interval"
+                          onClick={() => {
+                            window.main.trackAnalyticsEvent({
+                              event: AnalyticsEvent.requestSendMenuRepeatAfterIntervalClicked,
+                            });
+                            showModal(PromptModal, {
+                              inputType: 'decimal',
+                              title: 'Send on Interval',
+                              label: 'Interval in seconds',
+                              defaultValue: '3',
+                              submitName: 'Start',
+                              onComplete: seconds => {
+                                sendOrConnect();
+                                setCurrentInterval(+seconds * 1000);
+                              },
+                            });
+                          }}
+                        />
+                      </DropdownItem>
+                      {downloadPath ? (
+                        <DropdownItem aria-label="Stop Auto-Download">
+                          <ItemContent
+                            icon="stop-circle"
+                            label="Stop Auto-Download"
+                            withPrompt
+                            onClick={() => patchRequestMeta(activeRequest._id, { downloadPath: null })}
+                          />
+                        </DropdownItem>
+                      ) : (
+                        <DropdownItem aria-label="Download After Send">
+                          <ItemContent
+                            icon="download"
+                            label="Download After Send"
+                            onClick={async () => {
+                              window.main.trackAnalyticsEvent({
+                                event: AnalyticsEvent.requestSendMenuDownloadAfterSendClicked,
+                              });
+                              const { canceled, filePaths } = await window.dialog.showOpenDialog({
+                                title: 'Select Download Location',
+                                buttonLabel: 'Select',
+                                properties: ['openDirectory'],
+                              });
+                              if (canceled) {
+                                return;
+                              }
+                              patchRequestMeta(activeRequest._id, { downloadPath: filePaths[0] });
+                            }}
+                          />
+                        </DropdownItem>
+                      )}
+                      <DropdownItem aria-label="Send And Download">
+                        <ItemContent
+                          icon="download"
+                          label="Send And Download"
+                          onClick={() => {
+                            window.main.trackAnalyticsEvent({
+                              event: AnalyticsEvent.requestSendMenuSendAndDownloadClicked,
+                            });
+                            sendOrConnect(true);
+                          }}
+                        />
+                      </DropdownItem>
+                    </DropdownSection>
+                  </Dropdown>
+                )}
+              </>
+            )}
           </div>
         </div>
-        {!vaultKey &&
-          undefinedEnvironmentVariableList.some(variableName =>
-            variableName.startsWith(`${models.environment.vaultEnvironmentRuntimePath}.`),
-          ) && (
-            <div className="mt-4">
-              <p>These are secret environment variables. However, the required vault key has not been provided yet.</p>
-              <Button
-                className="cursor- py-1 text-(--color-info) underline ring-1 ring-transparent focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
-                onPress={() => {
-                  setShowInputVaultKeyModal(true);
-                  setShowEnvVariableMissingModal(false);
-                }}
-              >
-                Click to input vault key
-              </Button>
-              <div className="flex max-h-80 flex-wrap gap-2 overflow-y-auto">
-                {undefinedEnvironmentVariableList
-                  ?.filter(variableName =>
-                    variableName.startsWith(`${models.environment.vaultEnvironmentRuntimePath}.`),
-                  )
-                  .map(item => {
-                    return (
-                      <div
-                        key={item}
-                        className="mt-3 mr-3 rounded-xs bg-(--color-surprise) px-3 py-1 text-(--color-font-surprise)"
-                      >
-                        {item}
-                      </div>
-                    );
-                  })}
-              </div>
+        <VariableMissingErrorModal
+          isOpen={showEnvVariableMissingModal}
+          title={
+            undefinedEnvironmentVariableList?.length === 1
+              ? '1 environment variable is missing'
+              : `${undefinedEnvironmentVariableList?.length} environment variables are missing`
+          }
+          okText="Execute anyway"
+          onOk={() => {
+            setShowEnvVariableMissingModal(false);
+            sendOrConnect(false, true);
+          }}
+          onCancel={() => setShowEnvVariableMissingModal(false)}
+        >
+          <div>
+            These environment variables have been defined, but have not been assigned a value within the currently
+            active environment:
+            <div className="flex max-h-80 flex-wrap gap-2 overflow-y-auto">
+              {undefinedEnvironmentVariableList?.map(item => {
+                return (
+                  <div
+                    key={item}
+                    className="mt-3 mr-3 rounded-xs bg-(--color-surprise) px-3 py-1 text-(--color-font-surprise)"
+                  >
+                    {item}
+                  </div>
+                );
+              })}
             </div>
-          )}
-      </VariableMissingErrorModal>
-      {showInputVaultKeyModal && <InputVaultKeyModal onClose={() => setShowInputVaultKeyModal(false)} />}
-    </div>
-  );
-});
+          </div>
+          {!vaultKey &&
+            undefinedEnvironmentVariableList.some(variableName =>
+              variableName.startsWith(`${models.environment.vaultEnvironmentRuntimePath}.`),
+            ) && (
+              <div className="mt-4">
+                <p>
+                  These are secret environment variables. However, the required vault key has not been provided yet.
+                </p>
+                <Button
+                  className="cursor- py-1 text-(--color-info) underline ring-1 ring-transparent focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
+                  onPress={() => {
+                    setShowInputVaultKeyModal(true);
+                    setShowEnvVariableMissingModal(false);
+                  }}
+                >
+                  Click to input vault key
+                </Button>
+                <div className="flex max-h-80 flex-wrap gap-2 overflow-y-auto">
+                  {undefinedEnvironmentVariableList
+                    ?.filter(variableName =>
+                      variableName.startsWith(`${models.environment.vaultEnvironmentRuntimePath}.`),
+                    )
+                    .map(item => {
+                      return (
+                        <div
+                          key={item}
+                          className="mt-3 mr-3 rounded-xs bg-(--color-surprise) px-3 py-1 text-(--color-font-surprise)"
+                        >
+                          {item}
+                        </div>
+                      );
+                    })}
+                </div>
+              </div>
+            )}
+        </VariableMissingErrorModal>
+        {showInputVaultKeyModal && <InputVaultKeyModal onClose={() => setShowInputVaultKeyModal(false)} />}
+      </div>
+    );
+  },
+);
 
 RequestUrlBar.displayName = 'RequestUrlBar';

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -303,12 +303,15 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(({ handleAut
       <div className="flex flex-1 items-center p-1">
         <OneLineEditor
           id="request-url-bar"
-          // Key on requestId only. Previously keyed on the volatile uniquenessKey
-          // (environment.modified / response id / sync version), which remounted the
-          // editor on every edit — blurring it and dropping undo history. External
-          // value changes are now resynced in place via OneLineEditor's defaultValue
-          // effect, so no remount is needed except when switching requests.
-          key={requestId}
+          // Remount only when switching requests or when the environment changes
+          // (switch or edit), so nunjucks variable previews refresh. Deliberately
+          // EXCLUDES the response id and sync versions the old key used: those churn
+          // on send / local edits and remounted the editor mid-interaction, blurring
+          // it and dropping undo history. External URL changes (e.g. sync pull) are
+          // resynced in place via OneLineEditor's defaultValue effect.
+          key={`${requestId}::${activeEnvironment?._id}::${activeEnvironment?.modified}`}
+          // Stable cache key so undo history is restored if an environment-driven
+          // remount lands while the user is mid-edit.
           uniquenessKey={`request-url-bar::${requestId}`}
           ref={inputRef}
           type="text"

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -306,6 +306,9 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(
           <OneLineEditor
             id="request-url-bar"
             key={uniquenessKey}
+            // Stable across the remounts that `key` (uniquenessKey) forces, so undo
+            // history is restored after a send / environment edit / sync version bump.
+            uniquenessKey={`request-url-bar::${requestId}`}
             ref={inputRef}
             type="text"
             getAutocompleteConstants={handleAutocompleteUrls}


### PR DESCRIPTION
## Summary

Improves undo/redo on Insomnia's single-line CodeMirror editors (`OneLineEditor`), starting with the request **URL bar**. Based on the behavioural catalog in `docs/undo-redo-baseline.md` (included).

## The bug (root cause, verified against the running app)

`OneLineEditor` is intentionally **uncontrolled** (value seeded once on mount); callers force a re-seed by changing the React `key`. The URL bar keyed on a volatile composite (`activeEnvironment.modified::requestId::gitVersion::vcsVersion::activeResponseId`). The **first edit** triggers a loader revalidation that changes a segment of that key, so the editor **remounts mid-interaction** — which **blurs it and clears CodeMirror's undo history**. A `Cmd/Ctrl+Z` right after typing therefore lands on an already-blurred, empty-history editor → the reported "re-render + loss of focus".

Probe evidence (real keyboard + MutationObserver): typing one char → `remounts: 1, blurs: 1, hasFocus: false` within 200ms. After the fix: `remounts: 0, blurs: 0`, focus retained, `Cmd+Z` reverts in place.

## Changes

- **`one-line-editor.tsx`**
  - Re-seed `defaultValue` **in place** via an effect, only when the editor is **not focused** and the value differs. External changes (sync pull) resync without a remount; in-progress typing is never clobbered.
  - Restore undo/redo history across any remount via the shared cache (below).
- **`request-url-bar.tsx`**: key the editor on `requestId::environmentId::environment.modified`. It still remounts on **request switch** and **environment switch/edit** (so nunjucks previews refresh) but **not** on send / local edits / sync version bumps (the focus-loss paths). Drop the now-unused volatile `uniquenessKey` prop.
- **`editor-state-cache.ts`** (new): shared module holding the `editorStates` cache (history + scroll/marks/cursor). `CodeEditor` and `OneLineEditor` now both use it instead of each defining its own.
- **`key-value-editor/row.tsx`**: thread stable `uniquenessKey` into the name/value/description editors so their undo survives any remount.
- **`one-line-editor.tsx` (setValue)**: the imperative `setValue` handle now replaces the value via `replaceRange` (undoable, history preserved) instead of `cm.setValue()` (which wiped history). Fixes undo after "Import from URL".
- **Tests** (`tests/smoke/url-bar-undo.test.ts`):
  - editing keeps focus + no remount; `Cmd/Ctrl+Z` undoes in place with focus retained.
  - **switching environments refreshes the URL bar's rendered preview** (`subenvA0` → `subenvB0`).
  - importing query params ("Import from URL") stays undoable.
- **`docs/undo-redo-baseline.md`**: catalog + corrected root cause.

## On the earlier "tradeoff"

The first revision keyed on `requestId` only, which **stopped env-change previews from refreshing** — that was a regression, not an acceptable tradeoff. This revision keeps the environment in the key, so previews refresh on env switch/edit (verified by the new test) while sends/edits no longer remount. No known regression.

## Verification

`url-bar-undo` (2) plus `environment-editor-interactions` / `request-pane-tab` / `graphql` (8) smoke tests pass. Type-check and ESLint clean.

## Follow-ups (not in this PR)

- Native Electron Edit-menu `role: 'undo'` vs. CodeMirror's internal undo remains unreconciled (opportunity # 4).

closes https://konghq.atlassian.net/browse/INS-2853

