### PR TITLE
fix: prevent data loss when connecting a repo to an existing Git Sync project [INS-2794]

### DIFF
--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -2462,7 +2462,10 @@ export const discardChangesAction = async ({
 
     await GitVCS.discardChanges(files);
 
-    await repoFileWatcherRegistry.importAllFiles(gitRepository._id);
+    // Discarding an untracked, never-committed workspace deletes its YAML from disk.
+    // Remove the orphaned workspace from the DB instead of resurrecting it, otherwise
+    // the discarded change reappears immediately.
+    await repoFileWatcherRegistry.importAllFiles(gitRepository._id, { removeLocalOnlyOrphans: true });
 
     await services.gitRepository.update(gitRepository, {
       cachedGitLastCommitTime: Date.now(),

--- a/packages/insomnia/src/sync/git/__tests__/repo-file-watcher.test.ts
+++ b/packages/insomnia/src/sync/git/__tests__/repo-file-watcher.test.ts
@@ -1,0 +1,89 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { services } from 'insomnia-data';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { database as db } from '../../../common/database';
+import { RepoFileWatcherRegistry } from '../repo-file-watcher';
+
+vi.mock('../../../common/insomnia-v5', () => ({
+  getInsomniaV5DataExport: vi.fn().mockResolvedValue('type: collection.insomnia.rest/5.0\nname: Preserved\n'),
+  tryImportV5Data: vi.fn().mockReturnValue({ data: undefined, error: undefined }),
+}));
+
+const REPO_ID = 'git_repo_test';
+const PROJECT_ID = 'proj_test';
+
+const makeRegistry = () =>
+  new RepoFileWatcherRegistry({
+    onDbSynced: vi.fn(),
+    onProblemsChanged: vi.fn(),
+  });
+
+const createWorkspaceWithMeta = async (gitFilePath: string, gitFileLastSyncTime: number | null) => {
+  const workspace = await services.workspace.create({
+    name: 'My Collection',
+    scope: 'collection',
+    parentId: PROJECT_ID,
+  });
+  const meta = await services.workspaceMeta.getOrCreateByParentId(workspace._id);
+  await services.workspaceMeta.update(meta, { gitFilePath, gitFileLastSyncTime });
+  return workspace;
+};
+
+describe('RepoFileWatcher orphan reconciliation', () => {
+  let repoDir: string;
+  let registry: RepoFileWatcherRegistry;
+
+  beforeEach(async () => {
+    await db.init({ inMemoryOnly: true }, true);
+    repoDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'insomnia-repo-watcher-'));
+    registry = makeRegistry();
+  });
+
+  afterEach(async () => {
+    registry.stopAll();
+    await fs.promises.rm(repoDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  // Regression for the Git Sync data-loss bug: connecting an empty repo to a
+  // project that already has local data must NOT delete that data.
+  it('preserves a never-synced workspace whose YAML is absent from disk', async () => {
+    const workspace = await createWorkspaceWithMeta('insomnia.wrk_local.yaml', null);
+
+    await registry.startWatcher(REPO_ID, repoDir, PROJECT_ID);
+
+    // Workspace must still exist in the DB.
+    const stillThere = await services.workspace.getById(workspace._id);
+    expect(stillThere).not.toBeNull();
+
+    // And it must have been written to disk so the user can commit it.
+    const written = await fs.promises
+      .access(path.join(repoDir, 'insomnia.wrk_local.yaml'))
+      .then(() => true)
+      .catch(() => false);
+    expect(written).toBe(true);
+  });
+
+  it('removes a previously-synced workspace whose YAML was deleted on the remote', async () => {
+    const workspace = await createWorkspaceWithMeta('insomnia.wrk_synced.yaml', Date.now());
+
+    await registry.startWatcher(REPO_ID, repoDir, PROJECT_ID);
+
+    const removed = await services.workspace.getById(workspace._id);
+    expect(removed).toBeFalsy();
+  });
+
+  it('keeps a workspace whose YAML is present on disk', async () => {
+    const workspace = await createWorkspaceWithMeta('insomnia.wrk_present.yaml', Date.now());
+    await fs.promises.writeFile(path.join(repoDir, 'insomnia.wrk_present.yaml'), 'name: Present\n', 'utf8');
+
+    await registry.startWatcher(REPO_ID, repoDir, PROJECT_ID);
+
+    const stillThere = await services.workspace.getById(workspace._id);
+    expect(stillThere).not.toBeNull();
+  });
+});

--- a/packages/insomnia/src/sync/git/repo-file-watcher.ts
+++ b/packages/insomnia/src/sync/git/repo-file-watcher.ts
@@ -863,9 +863,16 @@ class RepoFileWatcher {
   }
 
   /**
-   * Remove workspaces from the DB whose YAML file no longer exists on disk.
-   * Handles the case where a workspace was deleted on the remote and the user
-   * pulls / checks out a branch that doesn't contain it.
+   * Reconcile DB workspaces whose YAML file is not present on disk.
+   *
+   *  • Previously-synced workspace (has `gitFileLastSyncTime`): the YAML was
+   *    deleted on the remote / is absent from the checked-out branch — remove
+   *    the workspace from the DB.
+   *  • Never-synced workspace (no `gitFileLastSyncTime`): this is local-only
+   *    content (e.g. created before a repo was connected, or not yet committed).
+   *    It is NOT an orphan — write it to disk so it is preserved and can be
+   *    committed. Without this, connecting an empty repo to a project that
+   *    already has local data would silently delete that data.
    */
   private async removeOrphanedWorkspaces(currentDiskFiles: string[]): Promise<void> {
     const diskFileSet = new Set(currentDiskFiles.map(f => path.normalize(f)));
@@ -876,11 +883,59 @@ class RepoFileWatcher {
       }
 
       const absPath = path.normalize(path.join(this.repoDir, meta.gitFilePath));
-      if (!diskFileSet.has(absPath)) {
-        // Workspace YAML no longer on disk — remove from DB
-        console.log('[repo-file-watcher] Removing orphaned workspace:', workspace._id);
-        await this.removeWorkspaceWithDescendants(workspace);
+      if (diskFileSet.has(absPath)) {
+        continue;
       }
+
+      if (!meta.gitFileLastSyncTime) {
+        // Local-only content never synced to git — preserve it instead of deleting.
+        await this.flushWorkspaceToDisk(workspace, absPath);
+        continue;
+      }
+
+      // Workspace YAML no longer on disk — remove from DB
+      console.log('[repo-file-watcher] Removing orphaned workspace:', workspace._id);
+      await this.removeWorkspaceWithDescendants(workspace);
+    }
+  }
+
+  /**
+   * Write a workspace's current DB state to its on-disk YAML file and record
+   * tracking state so the FS→DB import skips the echo. Used to preserve
+   * local-only workspaces (never synced to git) that are not yet on disk.
+   */
+  private async flushWorkspaceToDisk(workspace: Workspace, absPath: string): Promise<void> {
+    // Path-traversal guard
+    const rel = path.relative(this.repoDir, absPath);
+    if (rel.startsWith('..') || path.isAbsolute(rel)) {
+      return;
+    }
+
+    try {
+      const yamlContent = await getInsomniaV5DataExport({
+        workspaceId: workspace._id,
+        includePrivateEnvironments: false,
+      });
+      if (!yamlContent?.trim()) {
+        return;
+      }
+
+      await fs.promises.mkdir(path.dirname(absPath), { recursive: true });
+      await fs.promises.writeFile(absPath, yamlContent, 'utf8');
+
+      const normalised = path.normalize(absPath);
+      this.lastWrittenHash.set(normalised, contentHash(yamlContent));
+      const stat = await fs.promises.stat(absPath);
+      this.lastSyncMtime.set(normalised, stat.mtimeMs);
+      this.lastKnownGitFilePath.set(workspace._id, normalised);
+
+      console.log(
+        '[repo-file-watcher] Preserved local-only workspace on disk:',
+        workspace._id,
+        this.toPosixRelPath(absPath),
+      );
+    } catch (err) {
+      console.warn('[repo-file-watcher] Could not preserve local-only workspace on disk:', workspace._id, err);
     }
   }
 

--- a/packages/insomnia/src/sync/git/repo-file-watcher.ts
+++ b/packages/insomnia/src/sync/git/repo-file-watcher.ts
@@ -313,7 +313,7 @@ class RepoFileWatcher {
    * Also detects workspace YAML files that were removed from disk (e.g. deleted
    * on the remote) and removes the corresponding workspaces from the DB.
    */
-  async importAllFiles(): Promise<void> {
+  async importAllFiles(options: { removeLocalOnlyOrphans?: boolean } = {}): Promise<void> {
     if (this.stopped) {
       return;
     }
@@ -329,7 +329,7 @@ class RepoFileWatcher {
     }
 
     // Detect deleted files: workspaces in DB whose YAML is no longer on disk.
-    this.queue.enqueue(() => this.removeOrphanedWorkspaces(yamlFiles));
+    this.queue.enqueue(() => this.removeOrphanedWorkspaces(yamlFiles, options.removeLocalOnlyOrphans));
 
     await this.queue.waitUntilDone();
   }
@@ -873,8 +873,13 @@ class RepoFileWatcher {
    *    It is NOT an orphan — write it to disk so it is preserved and can be
    *    committed. Without this, connecting an empty repo to a project that
    *    already has local data would silently delete that data.
+   *
+   * `removeLocalOnlyOrphans` overrides the preservation above: when the missing
+   * file is the result of an explicit user action (e.g. discarding an untracked,
+   * never-committed workspace), the workspace should be removed rather than
+   * resurrected back to disk.
    */
-  private async removeOrphanedWorkspaces(currentDiskFiles: string[]): Promise<void> {
+  private async removeOrphanedWorkspaces(currentDiskFiles: string[], removeLocalOnlyOrphans = false): Promise<void> {
     const diskFileSet = new Set(currentDiskFiles.map(f => path.normalize(f)));
     const entries = await this.getWorkspacesWithMeta();
     for (const { workspace, meta } of entries) {
@@ -887,7 +892,7 @@ class RepoFileWatcher {
         continue;
       }
 
-      if (!meta.gitFileLastSyncTime) {
+      if (!meta.gitFileLastSyncTime && !removeLocalOnlyOrphans) {
         // Local-only content never synced to git — preserve it instead of deleting.
         await this.flushWorkspaceToDisk(workspace, absPath);
         continue;
@@ -1115,12 +1120,12 @@ export class RepoFileWatcherRegistry {
    * Call after bulk git operations (clone, pull, merge, checkout) so the DB
    * reflects the new disk state. Content-hash dedup makes repeated calls cheap.
    */
-  importAllFiles(repoId: string): Promise<void> {
+  importAllFiles(repoId: string, options: { removeLocalOnlyOrphans?: boolean } = {}): Promise<void> {
     const watcher = this.watchers.get(repoId);
     if (!watcher) {
       return Promise.resolve();
     }
-    return watcher.importAllFiles();
+    return watcher.importAllFiles(options);
   }
 
   /**


### PR DESCRIPTION
### Problem

Connecting a repo to a "connect repository later" Git Sync project deleted all local data with no way to recover it.

**Steps to reproduce**
1. Create a Git Sync project, choose "Connect repository later"
2. Add some collections/requests
3. Click "Connect a repo", select an empty repo, continue
4. Scan for files, click "Update"‚ all local files deleted

### Root cause

The file watcher's `removeOrphanedWorkspaces` treats a workspace as deleted-on-remote when its `gitFilePath` is missing from disk. Connect-later workspaces live only in NeDB (never written to disk), so connecting an empty repo made the watcher wipe them from the DB.

### Fix

`removeOrphanedWorkspaces` now uses `gitFileLastSyncTime` to tell the cases apart:
- **Previously synced** + missing from disk‚ deleted on remote, remove (unchanged)
- **Never synced** + missing from disk‚ local-only content‚ write to disk and preserve** instead of deleting

Also covers connecting a non-empty repo that lacks your existing local collections.

### Tests

Added `repo-file-watcher.test.ts`: never-synced workspace preserved (regression), synced workspace removed when YAML gone, workspace kept when YAML present.
