### PR TITLE
chore: harden electron web permissions [INS-2367]

### DIFF
--- a/packages/insomnia/src/entry.main.ts
+++ b/packages/insomnia/src/entry.main.ts
@@ -18,6 +18,7 @@ import { initElectronStorage } from '~/main/electron-storage';
 import { runGitCredentialsMigration } from '~/main/git/migrations';
 import { registerPathHandlers } from '~/main/ipc/path';
 import { registerLLMConfigServiceAPI } from '~/main/llm-config-service';
+import { isPermissionAllowed } from '~/main/permission-policy';
 import { initRuntime } from '~/runtimes';
 import { nodeRuntime } from '~/runtimes/runtime.node';
 
@@ -120,6 +121,10 @@ app.on('ready', async () => {
     electron.session.defaultSession.setSpellCheckerDictionaryDownloadURL('https://00.00/');
   };
   disableSpellcheckerDownload();
+
+  // Default-deny web-API permissions; only allow-listed ones are granted (see permission-policy.ts).
+  session.defaultSession.setPermissionRequestHandler((_webContents, permission, callback) => callback(isPermissionAllowed(permission)));
+  session.defaultSession.setPermissionCheckHandler((_webContents, permission) => isPermissionAllowed(permission));
 
   if (isDevelopment()) {
     try {

--- a/packages/insomnia/src/main/permission-policy.ts
+++ b/packages/insomnia/src/main/permission-policy.ts
@@ -1,0 +1,7 @@
+const ALLOWED_PERMISSIONS = new Set<string>([
+  'clipboard-sanitized-write',
+]);
+
+export function isPermissionAllowed(permission: string): boolean {
+  return ALLOWED_PERMISSIONS.has(permission);
+}

--- a/packages/insomnia/src/main/permission-policy.ts
+++ b/packages/insomnia/src/main/permission-policy.ts
@@ -1,5 +1,6 @@
 const ALLOWED_PERMISSIONS = new Set<string>([
   'clipboard-sanitized-write',
+  'fileSystem',
 ]);
 
 export function isPermissionAllowed(permission: string): boolean {


### PR DESCRIPTION
The only plugin I could find that would be negatively affected by this is:
https://github.com/gatzjames/insomnia-plugin-graphql-codegen-import
Since it uses the `showOpenFilePicker` method which would be blocked by the `fileSystem` denial.