### PR TITLE
fix(git-sync): set upstream tracking on push for new/empty repos [INS-2625]

### DIFF
--- a/packages/insomnia/src/sync/git/__tests__/git-vcs.test.ts
+++ b/packages/insomnia/src/sync/git/__tests__/git-vcs.test.ts
@@ -269,6 +269,63 @@ First commit!
         'Push rejected with errors: ["refs/heads/master pre-receive hook declined"].\n\nGo to View > Toggle DevTools > Console for more information.',
       );
     });
+
+    it('sets up upstream tracking for the current branch on a successful push', async () => {
+      // @ts-expect-error -- mockReturnValue is not typed
+      git.push.mockReturnValue({ ok: true });
+
+      const fsClient = MemClient.createClient();
+      await fsClient.promises.mkdir(GIT_INSOMNIA_DIR);
+      await fsClient.promises.writeFile(path.join(GIT_INSOMNIA_DIR, fooTxt), 'foo');
+
+      await GitVCS.init({
+        uri: '',
+        repoId: 'test-push-tracking',
+        directory: GIT_CLONE_DIR,
+        fs: fsClient,
+        legacyDiff: true,
+      });
+      await GitVCS.setAuthor({ name: 'Karen Brown', email: 'karen@example.com' });
+
+      const branch = await GitVCS.getCurrentBranch();
+
+      // Tracking config should not exist before the first push (git.init() leaves no upstream).
+      expect(await GitVCS.getBranchTrackingRemote()).toBeNull();
+
+      await GitVCS.push();
+
+      expect(await git.getConfig({ fs: fsClient, dir: GIT_CLONE_DIR, path: `branch.${branch}.remote` })).toBe('origin');
+      expect(await git.getConfig({ fs: fsClient, dir: GIT_CLONE_DIR, path: `branch.${branch}.merge` })).toBe(
+        `refs/heads/${branch}`,
+      );
+    });
+
+    it('does not clobber an existing non-origin upstream on push', async () => {
+      // @ts-expect-error -- mockReturnValue is not typed
+      git.push.mockReturnValue({ ok: true });
+
+      const fsClient = MemClient.createClient();
+      await fsClient.promises.mkdir(GIT_INSOMNIA_DIR);
+      await fsClient.promises.writeFile(path.join(GIT_INSOMNIA_DIR, fooTxt), 'foo');
+
+      await GitVCS.init({
+        uri: '',
+        repoId: 'test-push-no-clobber',
+        directory: GIT_CLONE_DIR,
+        fs: fsClient,
+        legacyDiff: true,
+      });
+      await GitVCS.setAuthor({ name: 'Fares', email: 'fares@example.com' });
+
+      const branch = await GitVCS.getCurrentBranch();
+      await git.setConfig({ fs: fsClient, dir: GIT_CLONE_DIR, path: `branch.${branch}.remote`, value: 'upstream' });
+
+      await GitVCS.push();
+
+      expect(await git.getConfig({ fs: fsClient, dir: GIT_CLONE_DIR, path: `branch.${branch}.remote` })).toBe(
+        'upstream',
+      );
+    });
   });
 
   describe('undoPendingChanges()', () => {

--- a/packages/insomnia/src/sync/git/__tests__/git-vcs.test.ts
+++ b/packages/insomnia/src/sync/git/__tests__/git-vcs.test.ts
@@ -300,7 +300,7 @@ First commit!
       );
     });
 
-    it('does not clobber an existing non-origin upstream on push', async () => {
+    it('does not clobber an existing fully-configured upstream on push', async () => {
       // @ts-expect-error -- mockReturnValue is not typed
       git.push.mockReturnValue({ ok: true });
 
@@ -319,11 +319,20 @@ First commit!
 
       const branch = await GitVCS.getCurrentBranch();
       await git.setConfig({ fs: fsClient, dir: GIT_CLONE_DIR, path: `branch.${branch}.remote`, value: 'upstream' });
+      await git.setConfig({
+        fs: fsClient,
+        dir: GIT_CLONE_DIR,
+        path: `branch.${branch}.merge`,
+        value: 'refs/heads/custom',
+      });
 
       await GitVCS.push();
 
       expect(await git.getConfig({ fs: fsClient, dir: GIT_CLONE_DIR, path: `branch.${branch}.remote` })).toBe(
         'upstream',
+      );
+      expect(await git.getConfig({ fs: fsClient, dir: GIT_CLONE_DIR, path: `branch.${branch}.merge` })).toBe(
+        'refs/heads/custom',
       );
     });
   });

--- a/packages/insomnia/src/sync/git/git-vcs.ts
+++ b/packages/insomnia/src/sync/git/git-vcs.ts
@@ -1230,6 +1230,22 @@ export class GitVCS {
     // NOTE: Response can be ok and have errors so we check this in the end to make sure we throw an error if there are any.
     if (response.ok) {
       console.log('[git] Push successful');
+      // Set up upstream tracking for the current branch. When linking to an empty repo,
+      // init() never configures tracking, so a later native git pull via CLI fails with "no tracking information".
+      // The push just created origin/<branch>, so this is the point where tracking becomes valid.
+      // We only write when tracking is missing - so steady-state pushes do no config writes, an existing
+      // user-set upstream is never clobbered, and already-linked repos self-heal on their next push.
+      try {
+        const branch = await this.getCurrentBranch();
+        const trackingRemote = await this.getBranchTrackingRemote(branch);
+        if (!trackingRemote) {
+          await git.setConfig({ ...this._baseOpts, path: `branch.${branch}.remote`, value: 'origin' });
+          await git.setConfig({ ...this._baseOpts, path: `branch.${branch}.merge`, value: `refs/heads/${branch}` });
+        }
+      } catch (err) {
+        console.log('[git] Failed to set upstream tracking after push', err);
+      }
+
       return;
     }
 


### PR DESCRIPTION
Addresses [INS-2625](https://konghq.atlassian.net/browse/INS-2625). When linking a git sync project to a new empty repo, the repo is set up via isomorphic-git `git.init()` which does not set upstream tracking branch. When successfully pushing a new design document to the repo via the desktop app, then navigating to git cli, a native git pull fails with `There is no tracking information for the current branch`. 

The fix is to set upstream tracking on the first successful push. It only happens if there is no remote tracking branch configured. This will fix scenarios where this happens in the future as well as existing scenarios where users linked a empty repo when creating a git sync project. 

[INS-2625]: https://konghq.atlassian.net/browse/INS-2625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ