### PR TITLE
feat: allow logging of insomnia.environment [INS-2806]

### DIFF
--- a/packages/insomnia-scripting-environment/src/objects/__tests__/environments.test.ts
+++ b/packages/insomnia-scripting-environment/src/objects/__tests__/environments.test.ts
@@ -119,3 +119,10 @@ describe('test Variables object', () => {
     expect(variables.get('value')).toEqual('folder1ValueOverride');
   });
 });
+
+describe('Environment serialization', () => {
+  it('serializes its key-values when logged instead of an empty Map', () => {
+    const environment = new Environment('Base Environment', { user_id: 'abc', count: 1 });
+    expect(JSON.stringify(environment)).toEqual(JSON.stringify({ user_id: 'abc', count: 1 }));
+  });
+});

--- a/packages/insomnia-scripting-environment/src/objects/environments.ts
+++ b/packages/insomnia-scripting-environment/src/objects/environments.ts
@@ -142,6 +142,10 @@ export class Environment {
   toObject = () => {
     return Object.fromEntries(this.kvs.entries());
   };
+
+  toJSON() {
+    return this.toObject();
+  }
 }
 
 /** @ignore */


### PR DESCRIPTION
previously, logging an environment would produce less helpful output, and none of the available key-value pairs:
<img width="440" height="183" alt="Screenshot 2026-06-25 at 13 38 47" src="https://github.com/user-attachments/assets/bc7fbc0e-6665-4903-ba1b-49c6e5fb2db9" />


the name of the environment can still be accessed via `insomnia.environment._name`:
<img width="1142" height="322" alt="Screenshot 2026-06-25 at 13 40 16" src="https://github.com/user-attachments/assets/fe594369-f66d-4056-89be-29de7172145b" />

