### PR TITLE
feat(undo): reconcile native + CodeMirror undo via one app-level handler

### DIFF
--- a/docs/undo-redo-baseline.md
+++ b/docs/undo-redo-baseline.md
@@ -66,9 +66,11 @@ that native stack — but this is **not universal** (see runtime results).
 - **Undo** → `role: 'undo'`, accelerator `CmdOrCtrl+Z`
 - **Redo** → `role: 'redo'`, accelerator `Shift+CmdOrCtrl+Z`
 
-These map to Electron's native `webContents.undo()/redo()`, which act on the focused native
-editable element — **independent of CodeMirror's internal history**. This is why plain inputs
-get working undo "for free", and why there are two competing undo stacks in CodeMirror surfaces.
+These originally mapped to Electron's native `webContents.undo()/redo()`, which act on the focused
+native editable element — **independent of CodeMirror's internal history**. This is why plain inputs
+got working undo "for free", and why there were two competing undo stacks in CodeMirror surfaces.
+**This is now reconciled** — the menu items route through one app-level handler (see opportunity 4
+below).
 
 ## Remount triggers
 
@@ -135,8 +137,14 @@ landed. Confirmed: a stable editor keeps focus and undoes correctly; the remount
    paths); external value changes resync in place via OneLineEditor's `defaultValue` effect.
 3. **DONE.** `setValue` is non-destructive — it replaces the value via `replaceRange` (history
    preserved, undoable) and no-ops when unchanged.
-4. **Reconcile the two undo stacks** (native menu vs. CodeMirror). Out of scope for low-hanging
-   fruit; track separately.
+4. **DONE.** Reconcile the two undo stacks (native menu vs. CodeMirror) through one app-level
+   handler. The Edit menu's `Undo`/`Redo` no longer use `role: 'undo'`/`'redo'` (which only drove
+   the native stack and left CodeMirror's Cmd+Z inert behind the menu accelerator); they now send
+   `edit:undo`/`edit:redo` to the focused window. A single renderer handler
+   ([`editor-undo.ts`](../packages/insomnia/src/ui/components/.client/codemirror/editor-undo.ts),
+   wired in [`renderer-listeners.ts`](../packages/insomnia/src/ui/renderer-listeners.ts)) routes by
+   focus: a CodeMirror surface drives `cm.undo()/redo()`; anything else replays the browser's native
+   edit command (`execCommand`), preserving the old behaviour for plain inputs.
 5. **Plain controlled inputs (Category C).** Largest surface, lowest per-item value; defer
    unless a specific input is reported.
 

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -269,6 +269,8 @@ export type MainOnChannels =
 export type RendererOnChannels =
   | 'contextMenuCommand'
   | 'db.changes'
+  | 'edit:undo'
+  | 'edit:redo'
   | 'plugins.uiAlert'
   | 'plugins.uiDialog'
   | 'ui.prompt'

--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -306,14 +306,21 @@ export function createWindow(): ElectronBrowserWindow {
     label: `${MNEMONIC_SYM}Edit`,
     submenu: [
       {
+        // Route through the renderer (see editor-undo.ts) instead of role: 'undo'
+        // so a single app-level handler reconciles CodeMirror's history with the
+        // native undo stack; role: 'undo' only drove the latter.
         label: `${MNEMONIC_SYM}Undo`,
         accelerator: 'CmdOrCtrl+Z',
-        role: 'undo',
+        click: () => {
+          BrowserWindow.getFocusedWindow()?.webContents.send('edit:undo');
+        },
       },
       {
         label: `${MNEMONIC_SYM}Redo`,
         accelerator: 'Shift+CmdOrCtrl+Z',
-        role: 'redo',
+        click: () => {
+          BrowserWindow.getFocusedWindow()?.webContents.send('edit:redo');
+        },
       },
       {
         type: 'separator',

--- a/packages/insomnia/src/ui/components/.client/codemirror/editor-undo.test.ts
+++ b/packages/insomnia/src/ui/components/.client/codemirror/editor-undo.test.ts
@@ -1,12 +1,25 @@
 /**
  * @vitest-environment jsdom
  */
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { dispatchEditorUndo } from './editor-undo';
 
+// jsdom does not implement execCommand, so install a stub per test to observe
+// the native-fallback path. Restore the original explicitly afterwards:
+// vi.restoreAllMocks() cannot revert a direct property assignment, so leaving it
+// would leak the stub into later tests and make the suite order-dependent.
+const originalExecCommand = document.execCommand;
+let execCommand: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  execCommand = vi.fn().mockReturnValue(true);
+  document.execCommand = execCommand;
+});
+
 afterEach(() => {
   document.body.innerHTML = '';
+  document.execCommand = originalExecCommand;
   vi.restoreAllMocks();
 });
 
@@ -27,9 +40,6 @@ const mountFocusedCodeMirror = () => {
 describe('dispatchEditorUndo', () => {
   it('drives CodeMirror history when focus is inside a CodeMirror editor', () => {
     const cm = mountFocusedCodeMirror();
-    // jsdom does not implement execCommand; install a stub to observe the call.
-    const execCommand = vi.fn().mockReturnValue(true);
-    document.execCommand = execCommand;
 
     dispatchEditorUndo('undo');
     dispatchEditorUndo('redo');
@@ -44,9 +54,6 @@ describe('dispatchEditorUndo', () => {
     const input = document.createElement('input');
     document.body.append(input);
     input.focus();
-    // jsdom does not implement execCommand; install a stub to observe the call.
-    const execCommand = vi.fn().mockReturnValue(true);
-    document.execCommand = execCommand;
 
     dispatchEditorUndo('undo');
     dispatchEditorUndo('redo');
@@ -56,10 +63,6 @@ describe('dispatchEditorUndo', () => {
   });
 
   it('falls back to the native edit command when nothing is focused', () => {
-    // jsdom does not implement execCommand; install a stub to observe the call.
-    const execCommand = vi.fn().mockReturnValue(true);
-    document.execCommand = execCommand;
-
     dispatchEditorUndo('undo');
 
     expect(execCommand).toHaveBeenCalledWith('undo');

--- a/packages/insomnia/src/ui/components/.client/codemirror/editor-undo.test.ts
+++ b/packages/insomnia/src/ui/components/.client/codemirror/editor-undo.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { dispatchEditorUndo } from './editor-undo';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+// Build a focused element inside a `.CodeMirror` wrapper carrying a fake CM
+// instance, mirroring how CodeMirror attaches itself to the wrapper node.
+const mountFocusedCodeMirror = () => {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'CodeMirror';
+  const input = document.createElement('textarea');
+  wrapper.append(input);
+  document.body.append(wrapper);
+  input.focus();
+  const cm = { undo: vi.fn(), redo: vi.fn() };
+  (wrapper as unknown as { CodeMirror: typeof cm }).CodeMirror = cm;
+  return cm;
+};
+
+describe('dispatchEditorUndo', () => {
+  it('drives CodeMirror history when focus is inside a CodeMirror editor', () => {
+    const cm = mountFocusedCodeMirror();
+    // jsdom does not implement execCommand; install a stub to observe the call.
+    const execCommand = vi.fn().mockReturnValue(true);
+    document.execCommand = execCommand;
+
+    dispatchEditorUndo('undo');
+    dispatchEditorUndo('redo');
+
+    expect(cm.undo).toHaveBeenCalledTimes(1);
+    expect(cm.redo).toHaveBeenCalledTimes(1);
+    // CodeMirror surfaces must not also trigger the native stack.
+    expect(execCommand).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the native edit command for plain inputs', () => {
+    const input = document.createElement('input');
+    document.body.append(input);
+    input.focus();
+    // jsdom does not implement execCommand; install a stub to observe the call.
+    const execCommand = vi.fn().mockReturnValue(true);
+    document.execCommand = execCommand;
+
+    dispatchEditorUndo('undo');
+    dispatchEditorUndo('redo');
+
+    expect(execCommand).toHaveBeenNthCalledWith(1, 'undo');
+    expect(execCommand).toHaveBeenNthCalledWith(2, 'redo');
+  });
+
+  it('falls back to the native edit command when nothing is focused', () => {
+    // jsdom does not implement execCommand; install a stub to observe the call.
+    const execCommand = vi.fn().mockReturnValue(true);
+    document.execCommand = execCommand;
+
+    dispatchEditorUndo('undo');
+
+    expect(execCommand).toHaveBeenCalledWith('undo');
+  });
+});

--- a/packages/insomnia/src/ui/components/.client/codemirror/editor-undo.ts
+++ b/packages/insomnia/src/ui/components/.client/codemirror/editor-undo.ts
@@ -1,0 +1,32 @@
+import type CodeMirror from 'codemirror';
+
+// CodeMirror sets its instance on the `.CodeMirror` wrapper DOM node.
+type CodeMirrorWrapper = HTMLElement & { CodeMirror?: CodeMirror.Editor };
+
+/**
+ * Single app-level undo/redo dispatcher.
+ *
+ * The Electron Edit menu used to expose `role: 'undo'`/`'redo'`, which call the
+ * native `webContents.undo()/redo()`. Those only understand plain DOM inputs,
+ * and on macOS the menu accelerator swallows Cmd+Z before CodeMirror's own
+ * keymap can act on it — so CodeMirror surfaces had no working undo and the two
+ * stacks (native vs. CodeMirror) competed. The menu now routes here instead, so
+ * there is one place that decides which stack to drive based on what's focused:
+ *
+ * - focus inside a CodeMirror editor  → drive CodeMirror's own history
+ * - anything else (plain input/textarea) → replay the browser's native edit
+ *   command, exactly as the old `role` did.
+ */
+export const dispatchEditorUndo = (mode: 'undo' | 'redo'): void => {
+  const active = document.activeElement as HTMLElement | null;
+  const wrapper = active?.closest('.CodeMirror') as CodeMirrorWrapper | null;
+  const cm = wrapper?.CodeMirror;
+  if (cm) {
+    cm[mode]();
+    return;
+  }
+  // Plain inputs/textareas: execCommand is deprecated but remains the only API
+  // that drives the focused element's native undo stack, which is what the
+  // previous native menu role relied on.
+  document.execCommand(mode);
+};

--- a/packages/insomnia/src/ui/renderer-listeners.ts
+++ b/packages/insomnia/src/ui/renderer-listeners.ts
@@ -5,8 +5,14 @@ import * as themes from '~/ui/plugins/misc';
 import { plugins } from '~/ui/plugins/renderer-bridge';
 import * as templating from '~/ui/templating/renderer-safe';
 
+import { dispatchEditorUndo } from './components/.client/codemirror/editor-undo';
 import { showModal } from './components/modals';
 import { SettingsModal } from './components/modals/settings-modal';
+
+// Edit-menu Undo/Redo route here so one handler reconciles CodeMirror's history
+// with the native undo stack based on what's focused (see editor-undo.ts).
+window.main.on('edit:undo', () => dispatchEditorUndo('undo'));
+window.main.on('edit:redo', () => dispatchEditorUndo('redo'));
 
 window.main.on('toggle-preferences', () => {
   showModal(SettingsModal);


### PR DESCRIPTION
## What

Follow-up to #10152 (opportunity # 4 in `docs/undo-redo-baseline.md`). Reconciles the two competing undo stacks through a single app-level handler.

## Why

The Edit menu's **Undo**/**Redo** used `role: 'undo'`/`'redo'`, which drive only Electron's native `webContents.undo()/redo()` stack. On macOS the menu accelerator swallows `Cmd+Z` *before* CodeMirror's own keymap can act on it — so in CodeMirror surfaces `Cmd+Z` did nothing useful (the native stack doesn't understand CodeMirror's document). Two stacks, native always wins, CodeMirror inert.

## How

- Menu **Undo**/**Redo** stop using `role`; they `send('edit:undo')`/`send('edit:redo')` to the focused window (labels + accelerators unchanged).
- One renderer handler — [`editor-undo.ts`](packages/insomnia/src/ui/components/.client/codemirror/editor-undo.ts), wired in [`renderer-listeners.ts`](packages/insomnia/src/ui/renderer-listeners.ts) — routes by focus:
  - focus inside a `.CodeMirror` wrapper → `cm.undo()/redo()` (CodeMirror's own history)
  - anything else → `document.execCommand('undo'/'redo')`, replicating exactly what the native role did for plain inputs.

No double-fire: the menu accelerator still prevents CodeMirror's keymap from firing independently (confirmed by the original baseline probe, where `Cmd+Z` on the URL bar was inert).

## Test

- New unit test `editor-undo.test.ts` (3 cases): CodeMirror focus drives `cm` history and does **not** touch the native stack; plain input falls back to `execCommand`; no-focus falls back to `execCommand`.
- `tsc` + ESLint clean (no `--fix`).

closes INS-2877