### PR TITLE
feat(security): deny-by-default session permission handler

### DIFF
--- a/packages/insomnia/src/entry.main.ts
+++ b/packages/insomnia/src/entry.main.ts
@@ -41,6 +41,7 @@ import { registerSocketIOHandlers } from './main/network/socket-io';
 import { registerWebSocketHandlers } from './main/network/websocket';
 import { watchProxySettings } from './main/proxy';
 import { initializeSentry, sentryWatchAnalyticsEnabled } from './main/sentry';
+import { registerPermissionHandlers } from './main/session-security';
 import { checkIfRestartNeeded } from './main/squirrel-startup';
 import * as updates from './main/updates';
 import * as windowUtils from './main/window-utils';
@@ -118,6 +119,10 @@ app.on('ready', async () => {
     electron.session.defaultSession.setSpellCheckerDictionaryDownloadURL('https://00.00/');
   };
   disableSpellcheckerDownload();
+
+  // Deny-by-default permission handling for remote content (Electron security
+  // checklist item 5). See ./main/session-security.
+  registerPermissionHandlers(electron.session.defaultSession);
 
   if (isDevelopment()) {
     try {

--- a/packages/insomnia/src/main/session-security.test.ts
+++ b/packages/insomnia/src/main/session-security.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ALLOWED_PERMISSIONS, isPermissionAllowed, registerPermissionHandlers } from './session-security';
+
+describe('session permission posture', () => {
+  it('allows only clipboard permissions', () => {
+    expect([...ALLOWED_PERMISSIONS]).toEqual(['clipboard-read', 'clipboard-sanitized-write']);
+  });
+
+  it.each(['clipboard-read', 'clipboard-sanitized-write'])('allows %s', permission => {
+    expect(isPermissionAllowed(permission)).toBe(true);
+  });
+
+  it.each([
+    'media',
+    'geolocation',
+    'notifications',
+    'midi',
+    'midiSysex',
+    'pointerLock',
+    'fullscreen',
+    'openExternal',
+    'unknown',
+  ])('denies %s', permission => {
+    expect(isPermissionAllowed(permission)).toBe(false);
+  });
+
+  it('wires deny-by-default handlers onto the session', () => {
+    const fakeSession = {
+      setPermissionRequestHandler: vi.fn(),
+      setPermissionCheckHandler: vi.fn(),
+    } as any;
+
+    registerPermissionHandlers(fakeSession);
+
+    const requestHandler = fakeSession.setPermissionRequestHandler.mock.calls[0][0];
+    const checkHandler = fakeSession.setPermissionCheckHandler.mock.calls[0][0];
+
+    const grant = vi.fn();
+    requestHandler(null, 'clipboard-read', grant);
+    expect(grant).toHaveBeenCalledWith(true);
+
+    const deny = vi.fn();
+    requestHandler(null, 'geolocation', deny);
+    expect(deny).toHaveBeenCalledWith(false);
+
+    expect(checkHandler(null, 'clipboard-sanitized-write')).toBe(true);
+    expect(checkHandler(null, 'media')).toBe(false);
+  });
+});

--- a/packages/insomnia/src/main/session-security.test.ts
+++ b/packages/insomnia/src/main/session-security.test.ts
@@ -3,15 +3,16 @@ import { describe, expect, it, vi } from 'vitest';
 import { ALLOWED_PERMISSIONS, isPermissionAllowed, registerPermissionHandlers } from './session-security';
 
 describe('session permission posture', () => {
-  it('allows only clipboard permissions', () => {
-    expect([...ALLOWED_PERMISSIONS]).toEqual(['clipboard-read', 'clipboard-sanitized-write']);
+  it('allows only clipboard write', () => {
+    expect([...ALLOWED_PERMISSIONS]).toEqual(['clipboard-sanitized-write']);
   });
 
-  it.each(['clipboard-read', 'clipboard-sanitized-write'])('allows %s', permission => {
-    expect(isPermissionAllowed(permission)).toBe(true);
+  it('allows clipboard-sanitized-write', () => {
+    expect(isPermissionAllowed('clipboard-sanitized-write')).toBe(true);
   });
 
   it.each([
+    'clipboard-read',
     'media',
     'geolocation',
     'notifications',
@@ -37,11 +38,11 @@ describe('session permission posture', () => {
     const checkHandler = fakeSession.setPermissionCheckHandler.mock.calls[0][0];
 
     const grant = vi.fn();
-    requestHandler(null, 'clipboard-read', grant);
+    requestHandler(null, 'clipboard-sanitized-write', grant);
     expect(grant).toHaveBeenCalledWith(true);
 
     const deny = vi.fn();
-    requestHandler(null, 'geolocation', deny);
+    requestHandler(null, 'clipboard-read', deny);
     expect(deny).toHaveBeenCalledWith(false);
 
     expect(checkHandler(null, 'clipboard-sanitized-write')).toBe(true);

--- a/packages/insomnia/src/main/session-security.ts
+++ b/packages/insomnia/src/main/session-security.ts
@@ -12,14 +12,15 @@ import { type Session } from 'electron';
  * camera, microphone, geolocation, notifications, MIDI, etc. We therefore deny
  * by default and allow only the small set the app actually uses.
  *
- * Clipboard write backs `navigator.clipboard.writeText` (e.g. the "copy routes"
- * action in the project navigation sidebar). `clipboard-read` is included so a
- * future paste affordance does not silently fail; remove it if unused.
+ * Only clipboard write is allowed — it backs `navigator.clipboard.writeText`
+ * (e.g. the "copy routes" action in the project navigation sidebar). Clipboard
+ * *read* is deliberately not allowed: nothing in the renderer reads the
+ * clipboard via the web API, and granting silent read access is a privacy risk.
  *
  * This module is intentionally free of side effects so the allow-list logic can
  * be unit tested (see `session-security.test.ts`).
  */
-export const ALLOWED_PERMISSIONS = ['clipboard-read', 'clipboard-sanitized-write'] as const;
+export const ALLOWED_PERMISSIONS = ['clipboard-sanitized-write'] as const;
 
 export const isPermissionAllowed = (permission: string): boolean =>
   (ALLOWED_PERMISSIONS as readonly string[]).includes(permission);

--- a/packages/insomnia/src/main/session-security.ts
+++ b/packages/insomnia/src/main/session-security.ts
@@ -1,0 +1,41 @@
+import { type Session } from 'electron';
+
+/**
+ * Session permission posture for the main renderer.
+ *
+ * The Electron security checklist (item 5, "Handle session permission requests
+ * from remote content") recommends explicitly handling permission requests
+ * rather than relying on Chromium's defaults, which auto-approve several
+ * permissions for loaded content.
+ *
+ * The renderer is first-party content, but it has no legitimate need for
+ * camera, microphone, geolocation, notifications, MIDI, etc. We therefore deny
+ * by default and allow only the small set the app actually uses.
+ *
+ * Clipboard write backs `navigator.clipboard.writeText` (e.g. the "copy routes"
+ * action in the project navigation sidebar). `clipboard-read` is included so a
+ * future paste affordance does not silently fail; remove it if unused.
+ *
+ * This module is intentionally free of side effects so the allow-list logic can
+ * be unit tested (see `session-security.test.ts`).
+ */
+export const ALLOWED_PERMISSIONS = ['clipboard-read', 'clipboard-sanitized-write'] as const;
+
+export const isPermissionAllowed = (permission: string): boolean =>
+  (ALLOWED_PERMISSIONS as readonly string[]).includes(permission);
+
+/**
+ * Register deny-by-default permission handlers on the given session.
+ * Denied requests are logged so unexpected requests are diagnosable.
+ */
+export function registerPermissionHandlers(targetSession: Session): void {
+  targetSession.setPermissionRequestHandler((_webContents, permission, callback) => {
+    const granted = isPermissionAllowed(permission);
+    if (!granted) {
+      console.log(`[security] Denied permission request: ${permission}`);
+    }
+    callback(granted);
+  });
+
+  targetSession.setPermissionCheckHandler((_webContents, permission) => isPermissionAllowed(permission));
+}


### PR DESCRIPTION
## Summary
Implements **item 5** of the [Electron security checklist](https://www.electronjs.org/docs/latest/tutorial/security) ("Handle session permission requests from remote content") for the main window's session.

Electron auto-approves several permissions (notifications, pointer-lock, etc.) for loaded content when no handler is registered. This adds an explicit **deny-by-default** posture on `session.defaultSession`:

- `setPermissionRequestHandler` + `setPermissionCheckHandler` deny everything except clipboard.
- Clipboard is allowed because the renderer uses `navigator.clipboard.writeText` (e.g. the "copy routes" action in `project-navigation-sidebar.tsx`).
- Denied requests are `console.log`ged so unexpected requests are diagnosable.

## Design
- Allow-list logic lives in a side-effect-free module (`src/main/session-security.ts`), mirroring the existing `window-security.ts` pattern, so it can be unit-tested.
- Registered in the `app.on('ready')` handler in `entry.main.ts`, next to the existing `defaultSession` setup.

## Risk
Low. The renderer is first-party content and has no legitimate use for camera/mic/geolocation/MIDI/notifications. The only web-permission API in the renderer is `navigator.clipboard`, which remains allowed. Draft pending a quick smoke check that clipboard copy still works.

## Test plan
- [x] `vitest run packages/insomnia/src/main/session-security.test.ts` (13 tests)
- [x] eslint + tsc clean on changed files
- [ ] Manual: copy actions (e.g. copy routes / copy as cURL) still write to clipboard

## Checklist context
This is 1 of 2 follow-up PRs from a security-checklist audit of the main window. The other addresses item 7 (Content-Security-Policy). Item 12 (webview options) is handled by #9942.