### PR TITLE
fix: enforce webview security prefs from main process

### DIFF
--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -246,6 +246,33 @@ export function createWindow(): ElectronBrowserWindow {
     return { action: 'deny' };
   });
 
+  // Enforce safe webview preferences from the main process. The renderer supplies
+  // a `webpreferences` string with user-controlled settings (javascript on/off,
+  // disableDialogs) but we must not let it enable node integration or inject a
+  // preload script. We parse the renderer string for the one pref we trust
+  // (javascript) and rebuild the object ourselves so nothing unexpected survives.
+  mainBrowserWindow.webContents.on('will-attach-webview', (_event, webPreferences, params) => {
+    // Strip any preload the renderer might have set.
+    delete (webPreferences as Electron.WebPreferences & { preload?: string; preloadURL?: string }).preload;
+    delete (webPreferences as Electron.WebPreferences & { preload?: string; preloadURL?: string }).preloadURL;
+
+    // Parse the renderer-supplied webpreferences string for the javascript pref.
+    // Everything else is ignored — security-critical flags are pinned here.
+    let javascriptEnabled = true;
+    for (const part of (params.webpreferences ?? '').split(',')) {
+      const [key, val] = part.trim().split('=');
+      if (key === 'javascript') {
+        javascriptEnabled = val !== 'no' && val !== 'false' && val !== '0';
+      }
+    }
+
+    webPreferences.nodeIntegration = false;
+    webPreferences.nodeIntegrationInSubFrames = false;
+    webPreferences.allowRunningInsecureContent = false;
+    webPreferences.javascript = javascriptEnabled;
+    webPreferences.disableDialogs = true;
+  });
+
   // Load the html of the app.
   const appUrl = process.env.APP_RENDER_URL || 'https://insomnia-app.local';
 


### PR DESCRIPTION
## Summary

- Adds a `will-attach-webview` handler on `mainBrowserWindow.webContents` in `window-utils.ts`
- Security-critical `WebPreferences` (`nodeIntegration`, `nodeIntegrationInSubFrames`, `allowRunningInsecureContent`, `preload`, `preloadURL`) are now pinned in the main process and cannot be overridden by renderer-supplied attributes
- The renderer's `webpreferences` string is still parsed for the one pref we trust: `javascript` (controls JS execution in HTML response preview — a legitimate user setting)
- `disableDialogs=true` is always enforced from main regardless of renderer input

## Background

`window-utils.ts` enables `webviewTag: true` for the main window (line 208). `ResponseWebView` renders untrusted response bodies inside a `<webview>` and sets prefs via a renderer-side string attribute (`disableDialogs=true, javascript=yes/no`). Without a `will-attach-webview` guard, a renderer compromise could supply arbitrary `webpreferences` values (e.g. `nodeIntegration=true`, a custom `preload` script) and the main process would apply them. This change moves enforcement to the main process.

## Test plan

- [ ] Open an HTTP response with HTML content type — verify the webview renders with JS enabled/disabled matching the "Disable JS" toggle
- [ ] Confirm no regression in HTML preview rendering
- [ ] Verify `nodeIntegration` is still `false` for webviews (default Electron behaviour, now also explicitly enforced)