### PR TITLE
fix: datetime picker color scheme match

### DIFF
--- a/packages/insomnia/src/ui/components/modals/cookies-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/cookies-modal.tsx
@@ -23,6 +23,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { useUpdateCookieJarActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.update-cookie-jar';
 import { OneLineEditor } from '~/ui/components/.client/codemirror/one-line-editor';
+import { useIsLightTheme } from '~/ui/hooks/theme';
 
 import { fuzzyMatch } from '../../../common/misc';
 import { useWorkspaceLoaderData } from '../../../routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
@@ -414,6 +415,7 @@ interface CookieModifyModalProps {
 const CookieModifyModal = ({ cookie, isOpen, setIsOpen, onUpdateCookie }: CookieModifyModalProps) => {
   const [editCookie, setEditCookie] = useState<Cookie>(cookie);
   const [rawValue, setRawValue] = useState('');
+  const isLightTheme = useIsLightTheme();
 
   useEffect(() => {
     window.main.cookies
@@ -515,7 +517,7 @@ const CookieModifyModal = ({ cookie, isOpen, setIsOpen, onUpdateCookie }: Cookie
                             <input
                               type="datetime-local"
                               defaultValue={localDateTime}
-                              className="calendar-invert"
+                              style={{ colorScheme: isLightTheme ? 'light' : 'dark' }}
                               onChange={event => setEditCookie({ ...editCookie, expires: event.target.value })}
                             />
                           </label>

--- a/packages/insomnia/src/ui/css/main.css
+++ b/packages/insomnia/src/ui/css/main.css
@@ -1869,9 +1869,6 @@ html {
 .changelog hr {
   margin: var(--padding-lg) 0 !important;
 }
-.calendar-invert::-webkit-calendar-picker-indicator {
-  filter: invert(1);
-}
 .graphql-editor {
   position: relative;
   display: grid;


### PR DESCRIPTION
before:
<img width="456" height="449" alt="Screenshot 2026-06-26 at 11 15 35" src="https://github.com/user-attachments/assets/4c7881f2-ee94-4656-aae1-182ab0d48a55" />

after:
<img width="452" height="447" alt="Screenshot 2026-06-26 at 11 15 18" src="https://github.com/user-attachments/assets/ec275354-1b0c-4bc0-9e01-6fe90ce0057f" />

<img width="448" height="441" alt="Screenshot 2026-06-26 at 11 16 04" src="https://github.com/user-attachments/assets/4f2db1fa-2b1b-48f1-a741-92e11706d72c" />
