### PR TITLE
fix: filter cookies using raw representation

### DIFF
--- a/packages/insomnia/src/ui/components/modals/cookies-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/cookies-modal.tsx
@@ -25,7 +25,6 @@ import { useUpdateCookieJarActionFetcher } from '~/routes/organization.$organiza
 import { OneLineEditor } from '~/ui/components/.client/codemirror/one-line-editor';
 import { useIsLightTheme } from '~/ui/hooks/theme';
 
-import { fuzzyMatch } from '../../../common/misc';
 import { useWorkspaceLoaderData } from '../../../routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
 import { useNunjucks } from '../../context/nunjucks/use-nunjucks';
 import { PromptButton } from '../base/prompt-button';
@@ -79,6 +78,8 @@ export const CookiesModal = ({ setIsOpen }: Props) => {
 
   const handleFilterChange = async (value: string) => {
     setFilter(value);
+    setPage(0);
+
     const renderedCookies: Cookie[] = [];
 
     for (const cookie of activeCookieJar?.cookies || []) {
@@ -94,15 +95,12 @@ export const CookiesModal = ({ setIsOpen }: Props) => {
       return;
     }
 
-    const filteredCookies: Cookie[] = [];
+    const query = value.toLowerCase();
+    const cookieStrings = await Promise.all(
+      renderedCookies.map(cookie => window.main.cookies.toString(cookie).catch(() => '')),
+    );
 
-    renderedCookies.forEach(cookie => {
-      if (fuzzyMatch(value, JSON.stringify(cookie), { splitSpace: true })) {
-        filteredCookies.push(cookie);
-      }
-    });
-
-    setFilteredCookies(chunkArray(filteredCookies));
+    setFilteredCookies(chunkArray(renderedCookies.filter((_, i) => cookieStrings[i].toLowerCase().includes(query))));
   };
 
   const handleCookieDelete = (cookieId: string) => {


### PR DESCRIPTION
Simplifies the filtering so that parts of raw cookie strings can be used as search criteria:

<img width="927" height="503" alt="Screenshot 2026-06-26 at 11 45 00" src="https://github.com/user-attachments/assets/6a3be75e-9c64-4326-92fa-5044036b35aa" />
