### PR TITLE
fix(sidebar): prevent resize handle from covering other elements

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.tsx
@@ -259,10 +259,7 @@ const Component = ({ loaderData }: Route.ComponentProps) => {
             <SyncBar />
           </div>
         </Panel>
-        <PanelResizeHandle
-          className="relative z-10 h-full w-px bg-(--hl-md)"
-          hitAreaMargins={{ coarse: 15, fine: 15 }}
-        />
+        <PanelResizeHandle className="relative z-10 h-full w-px bg-(--hl-md)" />
         <Panel id="pane-one" className="pane-one theme--pane flex flex-col">
           <GitFileIssuesProvider value={gitFileIssues}>
             <Outlet


### PR DESCRIPTION
before:

https://github.com/user-attachments/assets/c57bebd0-f129-4d65-b259-a1ee71bc6b9a

after:

https://github.com/user-attachments/assets/de1cff48-05db-4ae2-bd42-9e3099b9999a

