### PR TITLE
fix(linting): grouped lint occurrences and update CodeMirror lint tooltip icons

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx
@@ -923,6 +923,7 @@ const Component = ({ params }: Route.ComponentProps) => {
               icon={expandedLintMessageCodes.includes(item.code) ? 'chevron-down' : 'chevron-right'}
               className="h-2.5 w-2.5"
             />
+            ({item.occurrences.length})
             <Icon
               className={item.type === 'error' ? 'text-(--color-danger)' : 'text-(--color-warning)'}
               icon={item.type === 'error' ? 'circle-xmark' : 'triangle-exclamation'}

--- a/packages/insomnia/src/ui/css/main.css
+++ b/packages/insomnia/src/ui/css/main.css
@@ -1539,12 +1539,25 @@ html {
   padding: var(--padding-xs) var(--padding-sm);
   z-index: 99999;
 }
-.CodeMirror-lint-tooltip .CodeMirror-lint-message-error {
+.CodeMirror-lint-tooltip .CodeMirror-lint-message-error,
+.CodeMirror-lint-tooltip .CodeMirror-lint-message-warning {
   background-image: none;
-  padding-left: 0;
+  position: relative;
 }
-.CodeMirror-lint-tooltip::after {
-  display: none;
+.CodeMirror-lint-tooltip .CodeMirror-lint-message-error::before,
+.CodeMirror-lint-tooltip .CodeMirror-lint-message-warning::before {
+  position: absolute;
+  left: 0;
+  font-family: 'Font Awesome 6 Free';
+  font-weight: 900;
+}
+.CodeMirror-lint-tooltip .CodeMirror-lint-message-error::before {
+  content: '\f057'; /* FontAwesome circle-xmark icon */
+  color: var(--color-danger);
+}
+.CodeMirror-lint-tooltip .CodeMirror-lint-message-warning::before {
+  content: '\f071'; /* FontAwesome triangle-exclamation icon */
+  color: var(--color-warning);
 }
 .CodeMirror-hints {
   border: 0;


### PR DESCRIPTION
Addresses [INS-2885](https://konghq.atlassian.net/browse/INS-2885)

- Added text for lint warning/error count in the linting pane for better visibility. 
- Replaced CodeMirror's default lint tooltip icons with Font Awesome glyphs, which is consistent with the icons used in the linting pane. 

before:
<img width="996" height="496" alt="Screenshot 2026-06-29 at 11 53 10 AM" src="https://github.com/user-attachments/assets/984414e3-c53b-4a88-b00f-738913ac6628" />

after: 
<img width="1003" height="536" alt="Screenshot 2026-06-29 at 11 53 36 AM" src="https://github.com/user-attachments/assets/b07a3c7b-57b9-4bbb-a1ce-dfbdfcd1301e" />



[INS-2885]: https://konghq.atlassian.net/browse/INS-2885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ