### PR TITLE
fix: ignore malformed proxy value if setting is off

### DIFF
--- a/packages/insomnia-scripting-environment/src/objects/__tests__/proxy-configs.test.ts
+++ b/packages/insomnia-scripting-environment/src/objects/__tests__/proxy-configs.test.ts
@@ -58,4 +58,15 @@ describe('test ProxyConfig object', () => {
       expect(proxy.getProxyUrl()).toEqual(url);
     });
   });
+
+  it('does not parse a malformed proxy host when the proxy is disabled', () => {
+    expect(() => transformToSdkProxyOptions('', 'fasdf', '', false, '')).not.toThrow();
+    const options = transformToSdkProxyOptions('', 'fasdf', '', false, '');
+    expect(options.disabled).toBe(true);
+    expect(options.host).toEqual('');
+  });
+
+  it('throws on a malformed proxy host when the proxy is enabled', () => {
+    expect(() => transformToSdkProxyOptions('', 'fasdf', '', true, '')).toThrow(/Failed to parse proxy/);
+  });
 });

--- a/packages/insomnia-scripting-environment/src/objects/proxy-configs.ts
+++ b/packages/insomnia-scripting-environment/src/objects/proxy-configs.ts
@@ -339,7 +339,7 @@ export function transformToSdkProxyOptions(
     protocol: 'http',
   };
 
-  if (proxyHost !== '') {
+  if (enabledProxy && proxyHost !== '') {
     try {
       const sanitizedProxy = proxyHost.includes('://') ? proxyHost : `${protocol}//${proxyHost}`;
       const sanitizedProxyUrlOptions = new URL(sanitizedProxy);

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -369,8 +369,8 @@ export const createConfiguredCurlInstance = ({
     const { httpProxy, httpsProxy, noProxy } = settings;
     const proxyHost = protocol === 'https:' ? httpsProxy : httpProxy;
     const proxy = proxyHost ? setDefaultProtocol(proxyHost) : '';
-    debugTimeline.push({ value: `Using proxy: ${proxy}`, name: 'Text', timestamp: Date.now() });
     if (proxy) {
+      debugTimeline.push({ value: `Using proxy: ${proxy}`, name: 'Text', timestamp: Date.now() });
       curl.setOpt(Curl.option.PROXY, proxy);
       curl.setOpt(Curl.option.PROXYAUTH, CurlAuth.Any);
     }

--- a/packages/insomnia/src/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/settings-modal.tsx
@@ -42,7 +42,7 @@ type SettingsModalTabKey =
 
 export const SettingsModal = forwardRef<SettingsModalHandle, ModalProps>((props, ref) => {
   const [defaultTabKey, setDefaultTabKey] = useState('general');
-  const { userSession, settings } = useRootLoaderData()!;
+  const { userSession } = useRootLoaderData()!;
   const modalRef = useRef<ModalHandle>(null);
   const [keyboardClosable, setKeyboardClosable] = useState(true);
   const { organizationId } = useParams() as { organizationId?: string };
@@ -181,21 +181,18 @@ export const SettingsModal = forwardRef<SettingsModalHandle, ModalProps>((props,
                 setting="httpProxy"
                 help="Enter a HTTP or SOCKS4/5 proxy starting with appropriate prefix from the following (http://, socks4://, socks5://)"
                 placeholder="localhost:8005"
-                disabled={!settings.proxyEnabled}
               />
               <MaskedSetting
                 label="Proxy for HTTPS"
                 setting="httpsProxy"
                 help="Enter a HTTPS or SOCKS4/5 proxy starting with appropriate prefix from the following (https://, socks4://, socks5://)"
                 placeholder="localhost:8005"
-                disabled={!settings.proxyEnabled}
               />
               <TextSetting
                 label="No proxy"
                 setting="noProxy"
                 help="Enter a comma-separated list of hostnames that do not require a proxy. To include all subdomains of a domain, prefix it with a dot (e.g., .example.com)."
                 placeholder="localhost,127.0.0.1"
-                disabled={!settings.proxyEnabled}
               />
             </div>
           </TabPanel>


### PR DESCRIPTION
When a malformed proxy URL is set, but proxy use is disabled, requests still attempt to parse it and error out. This change prevents the use of the the proxy value(s) at all when not enabled in preferences. Also allows you to edit the values without needing the proxy setting enabled first