### PR TITLE
feat: move to v3 spaces from v1 organizations call

### DIFF
--- a/packages/insomnia-api/src/index.ts
+++ b/packages/insomnia-api/src/index.ts
@@ -6,6 +6,7 @@ export * from './project';
 export * from './collaborators';
 export * from './invite';
 export * from './organizations';
+export * from './spaces';
 export * from './mock';
 export * from './vcs';
 

--- a/packages/insomnia-api/src/organizations.ts
+++ b/packages/insomnia-api/src/organizations.ts
@@ -1,41 +1,12 @@
+import type { Space } from '@getinsomnia/insomnia-v3-fetch';
+
 import { fetch } from './fetch';
 
-interface Branding {
-  logo_url: string;
-}
-
-export type OrganizationType = 'personal' | 'team' | 'enterprise';
-
-export interface OrganizationMetadata {
-  organizationType: OrganizationType;
-  ownerAccountId: string;
-  description?: string;
-}
-
-export interface Organization {
-  id: string;
-  name: string;
-  display_name: string;
-  branding?: Branding;
-  metadata: OrganizationMetadata;
-}
-
-export interface OrganizationsResponse {
-  start: number;
-  limit: number;
-  length: number;
-  total: number;
-  next: string;
-  organizations: Organization[];
-}
-
-export const getOrganizations = ({ sessionId }: { sessionId: string }) => {
-  return fetch<OrganizationsResponse>({
-    method: 'GET',
-    path: '/v1/organizations',
-    sessionId,
-  });
-};
+/**
+ * Re-exported as `Organization` so existing consumers stay source-compatible.
+ * Use {@link getSpaces} (from `./spaces`) to fetch the user's spaces.
+ */
+export type Organization = Space;
 
 export const needsToUpgrade = 'NEEDS_TO_UPGRADE';
 export const needsToIncreaseSeats = 'NEEDS_TO_INCREASE_SEATS';
@@ -212,10 +183,3 @@ export const getOrganizationMemberRoles = ({
   });
 };
 
-export const getOrganizationDetail = ({ organizationId, sessionId }: { organizationId: string; sessionId: string }) => {
-  return fetch<Organization>({
-    method: 'GET',
-    path: `/v1/organizations/${organizationId}`,
-    sessionId,
-  });
-};

--- a/packages/insomnia-api/src/spaces.ts
+++ b/packages/insomnia-api/src/spaces.ts
@@ -1,0 +1,95 @@
+import {
+  Configuration,
+  DefaultApi,
+  type ListCurrentUserSpaces200Response,
+  ResponseError,
+  type Space,
+} from '@getinsomnia/insomnia-v3-fetch';
+
+import { ResponseFailError } from './fetch';
+
+export type { Space } from '@getinsomnia/insomnia-v3-fetch';
+
+interface V3ClientConfig {
+  getBaseURL: () => string;
+  getClientString: () => string;
+  generateRequestId: () => string;
+}
+
+let v3Config: V3ClientConfig | null = null;
+
+export function configureV3Client(config: V3ClientConfig) {
+  if (v3Config) {
+    throw new Error('V3 client has already been configured and cannot be re-configured.');
+  }
+  v3Config = config;
+}
+
+function buildClient(sessionId: string): DefaultApi {
+  if (!v3Config) {
+    throw new Error('V3 client has not been configured. Call configureV3Client() at application startup.');
+  }
+  const baseURL = v3Config.getBaseURL();
+  const configuration = new Configuration({
+    basePath: `${baseURL}/v3`,
+    apiKey: name => (name === 'X-Session-ID' ? sessionId : ''),
+    headers: {
+      'X-Insomnia-Client': v3Config.getClientString(),
+      'X-Origin': baseURL,
+      'insomnia-request-id': v3Config.generateRequestId(),
+    },
+  });
+  return new DefaultApi(configuration);
+}
+
+function extractPageAfter(nextUri: string | null): string | undefined {
+  if (!nextUri || !v3Config) {
+    return undefined;
+  }
+  // `nextUri` is a path like `/v3/users/me/spaces?page[size]=20&page[after]=...`.
+  // URL needs an absolute base to parse; resolve against the same backend the SDK is configured against.
+  const url = new URL(nextUri, v3Config.getBaseURL());
+  return url.searchParams.get('page[after]') ?? undefined;
+}
+
+async function readProblemJson(response: Response): Promise<{ title?: string; detail?: string }> {
+  try {
+    return await response.clone().json();
+  } catch {
+    return {};
+  }
+}
+
+async function mapSdkError(error: unknown): Promise<never> {
+  if (error instanceof ResponseError) {
+    const { title, detail } = await readProblemJson(error.response);
+    throw new ResponseFailError(title || `CODE-${error.response.status}`, detail || error.response.statusText, error.response);
+  }
+  throw error;
+}
+
+/**
+ * Lists every space the current user is a member of, paginating through cursors.
+ *
+ * TODO: switch callers to true pagination — fetch the first page only and expose
+ * the cursor so the UI can request more on demand instead of fetching everything
+ * up front. Requires UI changes to handle progressive loading.
+ */
+export const getSpaces = async ({ sessionId }: { sessionId: string }): Promise<Space[]> => {
+  const client = buildClient(sessionId);
+  const all: Space[] = [];
+  let pageAfter: string | undefined;
+  try {
+    do {
+      const response: ListCurrentUserSpaces200Response = await client.listCurrentUserSpaces({
+        pageSize: 200,
+        pageAfter,
+      });
+      all.push(...response.data);
+      pageAfter = extractPageAfter(response.meta.page.next);
+    } while (pageAfter);
+  } catch (error) {
+    await mapSdkError(error);
+  }
+  return all;
+};

--- a/packages/insomnia-data/node-src/services/organization.ts
+++ b/packages/insomnia-data/node-src/services/organization.ts
@@ -1,20 +1,19 @@
-import { getOrganizations, type Organization } from 'insomnia-api';
-import { models } from 'insomnia-data';
+import { getSpaces, type Organization } from 'insomnia-api';
 
 import * as userSessionService from './user-session';
 
-function sortOrganizations(accountId: string, organizations: Organization[]): Organization[] {
+function sortOrganizations(organizations: Organization[]): Organization[] {
   const owned = organizations
-    .filter(organization => models.organization.isOwnerOfOrganization({ organization, accountId }))
-    .sort((a, b) => a.display_name.localeCompare(b.display_name));
+    .filter(organization => organization.is_owner)
+    .sort((a, b) => a.name.localeCompare(b.name));
   const notOwned = organizations
-    .filter(organization => !models.organization.isOwnerOfOrganization({ organization, accountId }))
-    .sort((a, b) => a.display_name.localeCompare(b.display_name));
+    .filter(organization => !organization.is_owner)
+    .sort((a, b) => a.name.localeCompare(b.name));
   return [...owned, ...notOwned];
 }
 
 /**
- * List organizations from the Insomnia cloud API.
+ * List organizations (spaces) from the Insomnia cloud API.
  */
 export async function list(): Promise<Organization[]> {
   const { id: sessionId, accountId } = await userSessionService.get();
@@ -23,10 +22,9 @@ export async function list(): Promise<Organization[]> {
     return [];
   }
 
-  const result = await getOrganizations({ sessionId });
-  const organizations = result?.organizations ?? [];
+  const organizations = await getSpaces({ sessionId });
 
-  return sortOrganizations(accountId, organizations);
+  return sortOrganizations(organizations);
 }
 
 /**

--- a/packages/insomnia-data/src/models/organization.ts
+++ b/packages/insomnia-data/src/models/organization.ts
@@ -1,9 +1,7 @@
-import type { Organization, PersonalPlanType } from 'insomnia-api';
+import type { PersonalPlanType } from 'insomnia-api';
 
 export const SCRATCHPAD_ORGANIZATION_ID = 'org_scratchpad';
 export const isScratchpadOrganizationId = (organizationId: string) => organizationId === SCRATCHPAD_ORGANIZATION_ID;
-export const isOwnerOfOrganization = ({ organization, accountId }: { organization: Organization; accountId: string }) =>
-  organization.metadata.ownerAccountId === accountId;
 
 export const formatCurrentPlanType = (type: PersonalPlanType) => {
   switch (type) {

--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -8,6 +8,7 @@ import { cosmiconfig } from 'cosmiconfig';
 // @ts-expect-error the enquirer types are incomplete https://github.com/enquirer/enquirer/pull/307
 import { Confirm } from 'enquirer';
 import { pick } from 'es-toolkit';
+import { configureV3ClientDefaults } from 'insomnia/src/common/configure-v3-client';
 import { isDevelopment, JSON_ORDER_PREFIX, JSON_ORDER_SEPARATOR } from 'insomnia/src/common/constants';
 import { insomniaFetch } from 'insomnia/src/common/insomnia-fetch';
 import { getSendRequestCallbackMemDb } from 'insomnia/src/network/send-request.node';
@@ -68,6 +69,7 @@ if (!isDevelopment()) {
 }
 
 configureFetch(options => insomniaFetch({ ...options }));
+configureV3ClientDefaults();
 
 export const tryToReadInsoConfigFile = async (configFile?: string, workingDir?: string) => {
   try {

--- a/packages/insomnia-smoke-test/server/insomnia-api.ts
+++ b/packages/insomnia-smoke-test/server/insomnia-api.ts
@@ -91,6 +91,29 @@ const organizations = [
   },
 ];
 
+// Spaces fixture — backs the v3 `/users/me/spaces` endpoint. Mirrors the legacy
+// `organizations` array above: same ids, `display_name` → `name`, and `is_owner`
+// derived against the v3 test account (User A, `v3User.id` below).
+const v3TestAccountId = 'acct_64a477e6b59d43a5a607f84b4f73e3ce';
+const spaces = organizations.map(org => {
+  const isOwner = org.metadata.ownerAccountId === v3TestAccountId;
+  return {
+    id: org.id,
+    name: org.display_name,
+    picture: null,
+    owner_first_name: null,
+    owner_last_name: null,
+    owner_email: null,
+    // Personal workspace is the user's solo space; Magic represents a shared team
+    // org. Keeps the PR2 migration-target heuristic (`is_owner && total_members === 1`)
+    // deterministic for smoke tests.
+    total_members: isOwner ? 1 : 2,
+    total_invites: 0,
+    is_owner: isOwner,
+    can_leave: !isOwner,
+  };
+});
+
 const defaultOrganizationFeatures = {
   gitSync: {
     enabled: true,
@@ -193,19 +216,6 @@ const userPermissions = {
   'update:membership': true,
   'update:organization': true,
   'update:team_project': true,
-};
-
-const orgInfo = {
-  id: 'org_3d314c35-b9ca-4aec-b57d-04cea38da05c',
-  name: 'Sync',
-  display_name: 'Sync',
-  branding: {
-    logo_url: 'https://d2evto68nv31gd.cloudfront.net/org_98e187f8-a753-4abf-b0b2-58cdb852eba6',
-  },
-  metadata: {
-    organizationType: 'team',
-    ownerAccountId: 'acct_e9cf786dc67b4dbc8c002359b3cc3d70',
-  },
 };
 
 const currentRole = {
@@ -468,10 +478,17 @@ export default function setup(app: Application) {
     res.status(200).send(currentPlan);
   });
 
-  // Organizations
-  app.get('/v1/organizations', (_req, res) => {
+  // Spaces (replaces the legacy /v1/organizations list endpoint).
+  app.get('/v3/users/me/spaces', (_req, res) => {
     res.status(200).send({
-      organizations: organizations,
+      data: spaces,
+      meta: {
+        page: {
+          next: null,
+          previous: null,
+          size: spaces.length,
+        },
+      },
     });
   });
 
@@ -573,10 +590,6 @@ export default function setup(app: Application) {
 
   app.get('/v1/organizations/:organizationId/user-permissions', (_req, res) => {
     res.json(userPermissions);
-  });
-
-  app.get('/v1/organizations/:organizationId', (_req, res) => {
-    res.json(orgInfo);
   });
 
   app.get('/v1/organizations/:organizationId/members/:accountId/roles', (_req, res) => {

--- a/packages/insomnia/src/common/configure-v3-client.ts
+++ b/packages/insomnia/src/common/configure-v3-client.ts
@@ -1,0 +1,17 @@
+import { configureV3Client } from 'insomnia-api';
+
+import { getApiBaseURL, getClientString } from './constants';
+import { generateId } from './misc';
+
+/**
+ * Wires the v3 API client with the standard desktop/CLI configuration. The inputs are identical
+ * across every entrypoint (renderer, main, CLI), so this lives in one place to keep the request-id
+ * prefix and base-URL wiring from drifting between them. Unlike `configureFetch`, which injects
+ * entrypoint-specific behaviour (e.g. deep-link handling) and is wired inline per entrypoint.
+ */
+export const configureV3ClientDefaults = () =>
+  configureV3Client({
+    getBaseURL: getApiBaseURL,
+    getClientString,
+    generateRequestId: () => generateId('desk'),
+  });

--- a/packages/insomnia/src/entry.client.tsx
+++ b/packages/insomnia/src/entry.client.tsx
@@ -17,6 +17,7 @@ import { createServicesProxy } from '~/ui/services-proxy';
 import { clearOAuthWindowSessionId } from '~/ui/spawn-oauth-window';
 import { getInitialEntry } from '~/ui/utils/router';
 
+import { configureV3ClientDefaults } from './common/configure-v3-client';
 import { getInsomniaSession, getInsomniaVaultKey, getInsomniaVaultSalt, getSkipOnboarding } from './common/constants';
 import { HtmlElementWrapper } from './ui/components/html-element-wrapper';
 import { showModal } from './ui/components/modals';
@@ -44,6 +45,7 @@ initServices(dataServices);
 initRuntime(rendererRuntime);
 
 configureFetch(options => insomniaFetch({ ...options, onDeepLink: (uri: string) => window.main.openDeepLink(uri) }));
+configureV3ClientDefaults();
 
 await migrateFromLocalStorage();
 registerSyncMergeConflictListener();

--- a/packages/insomnia/src/entry.main.ts
+++ b/packages/insomnia/src/entry.main.ts
@@ -22,6 +22,7 @@ import { initRuntime } from '~/runtimes';
 import { nodeRuntime } from '~/runtimes/runtime.node';
 
 import { userDataFolder } from '../config/config.json';
+import { configureV3ClientDefaults } from './common/configure-v3-client';
 import { getAppVersion, getProductName, isDevelopment } from './common/constants';
 import { AnalyticsEvent, trackAnalyticsEvent } from './main/analytics';
 import { registerInsomniaProtocols } from './main/api.protocol';
@@ -65,6 +66,7 @@ let openDeepLinkUrl = async (url: string) => {
   console.warn('[main] openDeepLinkUrl function not initialized yet, cannot open URL:', url);
 };
 configureFetch(options => insomniaFetch({ ...options, onDeepLink: (uri: string) => openDeepLinkUrl(uri) }));
+configureV3ClientDefaults();
 // net.fetch picks up the proxy + OS certs like the renderer; node fetch does neither.
 // only works post-ready, which is fine — nothing calls this earlier. 'omit' = no cookies, same as before.
 setFetchImplementation((input, init) =>

--- a/packages/insomnia/src/routes/commands.tsx
+++ b/packages/insomnia/src/routes/commands.tsx
@@ -32,7 +32,7 @@ export async function clientLoader(args: Route.ClientLoaderArgs) {
 
   const { accountId } = await services.userSession.get();
 
-  const allOrganizations = JSON.parse(localStorage.getItem(`${accountId}:organizations`) || '[]') as Organization[];
+  const allOrganizations = JSON.parse(localStorage.getItem(`${accountId}:spaces`) || '[]') as Organization[];
 
   const allOrganizationsIds = models.organization.isScratchpadOrganizationId(organizationId)
     ? [organizationId]
@@ -203,7 +203,7 @@ export async function clientLoader(args: Route.ClientLoaderArgs) {
             url: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request/${item._id}`,
             name: item.name,
             item,
-            organizationName: allOrganizations.find(org => org.id === organizationId)?.display_name || '',
+            organizationName: allOrganizations.find(org => org.id === organizationId)?.name || '',
             projectName: allProjects.find(project => project._id === projectId)?.name || '',
             workspaceName: allOrganizationWorkspaces.find(workspace => workspace._id === workspaceId)?.name || '',
             organizationId,
@@ -223,7 +223,7 @@ export async function clientLoader(args: Route.ClientLoaderArgs) {
             ...workspace,
             teamProjectId: parentProject && project.isRemoteProject(parentProject) ? parentProject.remoteId : '',
           },
-          organizationName: allOrganizations.find(org => org.id === organizationId)?.display_name || '',
+          organizationName: allOrganizations.find(org => org.id === organizationId)?.name || '',
           projectName: allProjects.find(project => project._id === projectId)?.name || '',
           organizationId,
           projectId,
@@ -244,7 +244,7 @@ export async function clientLoader(args: Route.ClientLoaderArgs) {
             url: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request/${item._id}`,
             name: item.name,
             item,
-            organizationName: allOrganizations.find(org => org.id === organizationId)?.display_name || '',
+            organizationName: allOrganizations.find(org => org.id === organizationId)?.name || '',
             projectName: allProjects.find(project => project._id === projectId)?.name || '',
             workspaceName: allOrganizationWorkspaces.find(workspace => workspace._id === workspaceId)?.name || '',
             organizationId,
@@ -264,7 +264,7 @@ export async function clientLoader(args: Route.ClientLoaderArgs) {
             ...workspace,
             teamProjectId: parentProject && project.isRemoteProject(parentProject) ? parentProject.remoteId : '',
           },
-          organizationName: allOrganizations.find(org => org.id === organizationId)?.display_name || '',
+          organizationName: allOrganizations.find(org => org.id === organizationId)?.name || '',
           projectName: allProjects.find(project => project._id === projectId)?.name || '',
           organizationId,
           projectId,

--- a/packages/insomnia/src/routes/git.all-connected-repos.tsx
+++ b/packages/insomnia/src/routes/git.all-connected-repos.tsx
@@ -6,7 +6,7 @@ import { createFetcherLoadHook } from '~/ui/utils/router';
 
 export async function clientLoader() {
   const { accountId } = await services.userSession.get();
-  const organizations = JSON.parse(localStorage.getItem(`${accountId}:organizations`) || '[]') as Organization[];
+  const organizations = JSON.parse(localStorage.getItem(`${accountId}:spaces`) || '[]') as Organization[];
   const allProjects = await services.project.listByOrganizationIds(organizations.map(o => o.id));
 
   const organizationMap = Object.fromEntries(organizations.map(o => [o.id, o]));

--- a/packages/insomnia/src/routes/organization.$organizationId.permissions.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.permissions.tsx
@@ -35,7 +35,7 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
     };
   }
 
-  const organizations = JSON.parse(localStorage.getItem(`${accountId}:organizations`) || '[]') as Organization[];
+  const organizations = JSON.parse(localStorage.getItem(`${accountId}:spaces`) || '[]') as Organization[];
   const organization = organizations.find(o => o.id === organizationId);
 
   if (!organization) {

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
@@ -141,10 +141,7 @@ const Component = ({ loaderData }: Route.ComponentProps) => {
   const [isNewProjectModalOpen, setIsNewProjectModalOpen] = useState(false);
   const [isUpdateProjectModalOpen, setIsUpdateProjectModalOpen] = useState(false);
   const organization = organizationData?.organizations.find(o => o.id === organizationId);
-  const isUserOwner =
-    organization &&
-    userSession.accountId &&
-    models.organization.isOwnerOfOrganization({ organization, accountId: userSession.accountId });
+  const isUserOwner = Boolean(organization?.is_owner);
   const greetingName = userSession.firstName || userSession.email.split('@')[0] || 'there';
   const collectionItems = useMemo(
     () =>

--- a/packages/insomnia/src/routes/organization._index.tsx
+++ b/packages/insomnia/src/routes/organization._index.tsx
@@ -4,7 +4,7 @@ import { href, redirect } from 'react-router';
 
 import { invariant } from '~/common/utils/invariant';
 import * as session from '~/ui/account/session';
-import { migrateProjectsUnderOrganization, syncOrganizations } from '~/ui/organization-utils';
+import { findMigrationTargetSpaceId, migrateProjectsUnderOrganization, syncOrganizations } from '~/ui/organization-utils';
 
 import type { Route } from './+types/organization._index';
 
@@ -13,13 +13,11 @@ export async function clientLoader(_args: Route.ClientLoaderArgs) {
   if (sessionId) {
     await syncOrganizations(sessionId, accountId);
 
-    const organizations = JSON.parse(localStorage.getItem(`${accountId}:organizations`) || '[]') as Organization[];
+    const organizations = JSON.parse(localStorage.getItem(`${accountId}:spaces`) || '[]') as Organization[];
     invariant(organizations.length, 'Failed to fetch organizations. Check your network connection and try again.');
 
     const landingOrganizationId = organizations[0].id;
-    // TODO: when migrating to /v3/users/me/spaces, target the owned space with total_members === 1
-    // so legacy orphan local projects land in the user's solo space rather than a shared owned space.
-    await migrateProjectsUnderOrganization(landingOrganizationId, sessionId);
+    await migrateProjectsUnderOrganization(findMigrationTargetSpaceId(organizations), sessionId);
 
     const specificOrgRedirectAfterAuthorize = window.localStorage.getItem('specificOrgRedirectAfterAuthorize');
     if (specificOrgRedirectAfterAuthorize && specificOrgRedirectAfterAuthorize !== '') {

--- a/packages/insomnia/src/routes/organization.sync-organizations-and-projects.tsx
+++ b/packages/insomnia/src/routes/organization.sync-organizations-and-projects.tsx
@@ -3,7 +3,7 @@ import { services } from 'insomnia-data';
 import { href, redirect } from 'react-router';
 
 import { invariant } from '~/common/utils/invariant';
-import { migrateProjectsUnderOrganization, syncOrganizations, syncProjects } from '~/ui/organization-utils';
+import { findMigrationTargetSpaceId, migrateProjectsUnderOrganization, syncOrganizations, syncProjects } from '~/ui/organization-utils';
 import { AsyncTask, createFetcherSubmitHook } from '~/ui/utils/router';
 
 import type { Route } from './+types/organization.sync-organizations-and-projects';
@@ -32,12 +32,10 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
     }
 
     if (asyncTaskList.includes(AsyncTask.MigrateProjects)) {
-      const organizations = JSON.parse(localStorage.getItem(`${accountId}:organizations`) || '[]') as Organization[];
+      const organizations = JSON.parse(localStorage.getItem(`${accountId}:spaces`) || '[]') as Organization[];
       invariant(organizations.length, 'Failed to fetch organizations.');
       invariant(sessionId, 'sessionId is required');
-      // TODO: when migrating to /v3/users/me/spaces, target the owned space with total_members === 1
-      // so legacy orphan local projects land in the user's solo space rather than a shared owned space.
-      taskPromiseList.push(migrateProjectsUnderOrganization(organizations[0].id, sessionId));
+      taskPromiseList.push(migrateProjectsUnderOrganization(findMigrationTargetSpaceId(organizations), sessionId));
     }
 
     if (asyncTaskList.includes(AsyncTask.SyncProjects)) {

--- a/packages/insomnia/src/routes/organization.tsx
+++ b/packages/insomnia/src/routes/organization.tsx
@@ -42,7 +42,7 @@ export interface OrganizationLoaderData {
 export async function clientLoader(_args: Route.ClientLoaderArgs) {
   const { id, accountId } = await services.userSession.get();
   if (id) {
-    const organizations = JSON.parse(localStorage.getItem(`${accountId}:organizations`) || '[]') as Organization[];
+    const organizations = JSON.parse(localStorage.getItem(`${accountId}:spaces`) || '[]') as Organization[];
     const user = JSON.parse(localStorage.getItem(`${accountId}:user`) || '{}') as User;
     const currentPlan = JSON.parse(localStorage.getItem(`${accountId}:currentPlan`) || '{}') as CurrentPlan;
     return {

--- a/packages/insomnia/src/routes/remote-files.tsx
+++ b/packages/insomnia/src/routes/remote-files.tsx
@@ -33,7 +33,7 @@ export async function clientLoader(_args: Route.ClientLoaderArgs) {
   try {
     const remoteFiles = await getUserFiles({ sessionId });
 
-    const allOrganizations = JSON.parse(localStorage.getItem(`${accountId}:organizations`) || '[]') as Organization[];
+    const allOrganizations = JSON.parse(localStorage.getItem(`${accountId}:spaces`) || '[]') as Organization[];
 
     const allRemoteFilesOrganizationIds = remoteFiles.map(file => file.organizationId);
     const allRemoteFilesProjectIds = remoteFiles.map(file => file.teamProjectId);
@@ -58,7 +58,7 @@ export async function clientLoader(_args: Route.ClientLoaderArgs) {
           : '',
         name: file.name,
         item: { ...file, teamProjectLocalId: parentProject?._id || '', scope: 'unsynced' as const },
-        organizationName: organizations.find(org => org.id === file.organizationId)?.display_name || '',
+        organizationName: organizations.find(org => org.id === file.organizationId)?.name || '',
         projectName: parentProject?.name || '',
       };
     });

--- a/packages/insomnia/src/routes/untracked-projects.tsx
+++ b/packages/insomnia/src/routes/untracked-projects.tsx
@@ -13,7 +13,7 @@ export interface UntrackedProjectsLoaderData {
 
 export async function clientLoader(_args: Route.ClientLoaderArgs) {
   const { accountId } = await services.userSession.get();
-  const organizations = JSON.parse(localStorage.getItem(`${accountId}:organizations`) || '[]') as Organization[];
+  const organizations = JSON.parse(localStorage.getItem(`${accountId}:spaces`) || '[]') as Organization[];
   const listOfOrganizationIds = [...organizations.map(o => o.id), models.organization.SCRATCHPAD_ORGANIZATION_ID];
 
   const projects = await services.project.list({

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-projects-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-projects-modal.tsx
@@ -505,7 +505,7 @@ export const ImportProjectsModal = ({ organizationId, onHide }: { organizationId
 
   const organizationData = useOrganizationLoaderData();
   const organizationName =
-    organizationData?.organizations.find(org => org.id === organizationId)?.display_name || 'Organization';
+    organizationData?.organizations.find(org => org.id === organizationId)?.name || 'Organization';
 
   const [projectItems, setProjectItems] = useState<ProjectImportItem[]>([]);
   const [processingUIStatus, setProcessingUiStatus] = useState<'loading' | 'importing' | 'error' | 'complete'>(

--- a/packages/insomnia/src/ui/components/modals/invite-modal/invite-form.tsx
+++ b/packages/insomnia/src/ui/components/modals/invite-modal/invite-form.tsx
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import { checkSeats, type CheckSeatsResponse, needsToIncreaseSeats, needsToUpgrade, type Role } from 'insomnia-api';
-import { models } from 'insomnia-data';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Button,
@@ -125,10 +124,7 @@ export const InviteForm = ({
   const { userSession } = useRootLoaderData()!;
   const organizationData = useOrganizationLoaderData();
   const organization = organizationData?.organizations.find(o => o.id === organizationId);
-  const isUserOwner =
-    organization &&
-    userSession.accountId &&
-    models.organization.isOwnerOfOrganization({ organization, accountId: userSession.accountId });
+  const isUserOwner = Boolean(organization?.is_owner);
   const sessionId = userSession.id;
 
   const [loading, setLoading] = useState(false);

--- a/packages/insomnia/src/ui/components/modals/invite-modal/invite-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/invite-modal/invite-modal.tsx
@@ -3,12 +3,10 @@ import {
   type Collaborator,
   deleteOrganizationMember,
   type FeatureList,
-  getOrganizationDetail,
   getOrganizationFeatures,
   getOrganizationMemberRoles,
   getOrganizationRoles,
   getOrgUserPermissions,
-  type Organization,
   type Permission,
   revokeInvitation,
   type Role,
@@ -32,6 +30,7 @@ import { useParams, useSearchParams } from 'react-router';
 import { getAppWebsiteBaseURL } from '~/common/constants';
 import { debounce } from '~/common/misc';
 import { invariant } from '~/common/utils/invariant';
+import { useOrganizationLoaderData } from '~/routes/organization';
 import { useCollaboratorsFetcher } from '~/routes/organization.$organizationId.collaborators';
 import { useInviteFetcher } from '~/routes/organization.$organizationId.collaborators.invites.$invitationId';
 import { useReinviteFetcher } from '~/routes/organization.$organizationId.collaborators.invites.$invitationId.reinvite';
@@ -598,14 +597,15 @@ export const InviteModalContainer: FC<{
 }> = ({ isOpen, setIsOpen }) => {
   const [loadingOrgInfo, setLoadingOrgInfo] = useState(true);
   const { organizationId } = useParams();
+  const organizationData = useOrganizationLoaderData();
+  const currentOrg = organizationData?.organizations.find(o => o.id === organizationId);
   const [allRoles, setAllRoles] = useState<Role[]>([]);
   const [currentUserRoleInOrg, setCurrentUserRoleInOrg] = useState<Role | null>(null);
   const [orgFeatures, setOrgFeatures] = useState<FeatureList | null>(null);
   const permissionRef = useRef<Record<Permission, boolean>>();
   const [currentUserAccountId, setCurrentUserAccountId] = useState('');
-  const [currentOrgInfo, setCurrentOrgInfo] = useState<Organization | null>(null);
 
-  const isCurrentUserOrganizationOwner = currentUserAccountId === currentOrgInfo?.metadata?.ownerAccountId;
+  const isCurrentUserOrganizationOwner = Boolean(currentOrg?.is_owner);
 
   async function getBaseInfo(organizationId: string) {
     const sessionId = await getCurrentSessionId();
@@ -622,10 +622,6 @@ export const InviteModalContainer: FC<{
         permissionRef.current = permissions;
       }),
       getAccountId().then(setCurrentUserAccountId),
-      getOrganizationDetail({
-        organizationId,
-        sessionId,
-      }).then(setCurrentOrgInfo),
     ]);
   }
 
@@ -708,11 +704,6 @@ export async function getCurrentUserRoleInOrg(organizationId: string): Promise<R
   }).catch(() => {
     throw new Error('Failed to fetch member roles');
   });
-}
-
-export interface OrganizationBranding {
-  logo_url: string;
-  colors: string[];
 }
 
 async function unlinkTeam(organizationId: string, collaboratorId: string) {

--- a/packages/insomnia/src/ui/components/modals/workspace-duplicate-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-duplicate-modal.tsx
@@ -115,9 +115,9 @@ export const WorkspaceDuplicateModal: FC<WorkspaceDuplicateModalProps> = ({ work
               <label>
                 Organization:
                 <select name="orgId" value={selectedOrgId} onChange={e => setSelectedOrgId(e.target.value)}>
-                  {organizationData?.organizations.map(({ id, display_name }) => (
+                  {organizationData?.organizations.map(({ id, name }) => (
                     <option key={id} value={id}>
-                      {display_name}
+                      {name}
                     </option>
                   ))}
                 </select>

--- a/packages/insomnia/src/ui/components/project/organization-select.tsx
+++ b/packages/insomnia/src/ui/components/project/organization-select.tsx
@@ -34,7 +34,7 @@ export const OrganizationSelect = ({
   }, [isOpen]);
 
   const filteredOrgs = organizations.filter(org =>
-    org.display_name.toLowerCase().includes(filterText.toLowerCase()),
+    org.name.toLowerCase().includes(filterText.toLowerCase()),
   );
 
   return (
@@ -51,7 +51,7 @@ export const OrganizationSelect = ({
         <Button className="flex flex-1 items-center justify-center gap-2 rounded-xs px-4 py-1 text-sm font-bold text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)">
           <SelectValue<Organization> className="flex items-center justify-center gap-2 truncate">
             {({ selectedItems }) => {
-              return selectedItems?.[0]?.display_name || 'Select an organization';
+              return selectedItems?.[0]?.name || 'Select an organization';
             }}
           </SelectValue>
           <Icon icon="caret-down" />
@@ -93,13 +93,13 @@ export const OrganizationSelect = ({
                 id={item.id}
                 key={item.id}
                 className="flex h-(--line-height-xs) w-full items-center gap-2 bg-transparent px-(--padding-md) whitespace-nowrap text-(--color-font) transition-colors hover:bg-(--hl-sm) focus:bg-(--hl-xs) focus:outline-hidden disabled:cursor-not-allowed aria-selected:font-bold"
-                aria-label={item.display_name}
-                textValue={item.display_name}
+                aria-label={item.name}
+                textValue={item.name}
                 value={item}
               >
                 {({ isSelected }) => (
                   <Fragment>
-                    <span>{item.display_name}</span>
+                    <span>{item.name}</span>
                     {isSelected && <Icon icon="check" className="justify-self-end text-(--color-success)" />}
                   </Fragment>
                 )}

--- a/packages/insomnia/src/ui/components/project/project-type-warning.tsx
+++ b/packages/insomnia/src/ui/components/project/project-type-warning.tsx
@@ -7,7 +7,6 @@ import { Button } from '~/basic-components/button';
 import { LearnMoreLink } from '~/basic-components/link';
 import { getAppWebsiteBaseURL } from '~/common/constants';
 import { docsPricingLearnMoreLink } from '~/common/documentation';
-import { useRootLoaderData } from '~/root';
 import { useOrganizationLoaderData } from '~/routes/organization';
 import type { ProjectType } from '~/ui/components/project/utils';
 import { useIsLightTheme } from '~/ui/hooks/theme';
@@ -22,14 +21,10 @@ export const ProjectTypeWarning = ({ isGitSyncEnabled, storageType, storageRules
   const showStorageRestrictionMessage =
     !storageRules.enableCloudSync || !storageRules.enableLocalVault || !storageRules.enableGitSync;
   const organizationData = useOrganizationLoaderData();
-  const { userSession } = useRootLoaderData()!;
   const { organizationId } = useParams() as { organizationId: string };
   const organization = organizationData?.organizations.find(o => o.id === organizationId);
   // TODO: extract to a hook later
-  const isUserOwner =
-    organization &&
-    userSession.accountId &&
-    models.organization.isOwnerOfOrganization({ organization, accountId: userSession.accountId });
+  const isUserOwner = Boolean(organization?.is_owner);
   return (
     <>
       {storageType === 'git' &&

--- a/packages/insomnia/src/ui/components/settings/import-export.tsx
+++ b/packages/insomnia/src/ui/components/settings/import-export.tsx
@@ -492,7 +492,7 @@ const UntrackedProject = ({
                   );
                 }
 
-                return <Fragment>{selectedItem.display_name}</Fragment>;
+                return <Fragment>{selectedItem.name}</Fragment>;
               }}
             </SelectValue>
             <Icon icon="caret-down" />
@@ -513,7 +513,7 @@ const UntrackedProject = ({
                 >
                   {({ isSelected }) => (
                     <Fragment>
-                      {item.display_name}
+                      {item.name}
                       {isSelected && <Icon icon="check" className="justify-self-end text-(--color-success)" />}
                     </Fragment>
                   )}
@@ -681,7 +681,7 @@ export const ImportExport: FC<Props> = ({ hideSettingsModal, onModalChange }) =>
   const projectName = activeProject?.name ?? getProductName();
   const projects = projectLoaderData?.projects || [];
   const organizationName =
-    organizationData?.organizations.find(org => org.id === organizationId)?.display_name || 'Organization';
+    organizationData?.organizations.find(org => org.id === organizationId)?.name || 'Organization';
 
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
   const [isImportProjectsModalOpen, setIsImportProjectsModalOpen] = useState(false);

--- a/packages/insomnia/src/ui/context/app/insomnia-event-stream-context.tsx
+++ b/packages/insomnia/src/ui/context/app/insomnia-event-stream-context.tsx
@@ -206,7 +206,7 @@ export const InsomniaEventStreamProvider: FC<PropsWithChildren> = ({ children })
             } else if (event.type === 'VaultKeyChanged') {
               const accountId = userSession.accountId;
               const organizations = JSON.parse(
-                localStorage.getItem(`${accountId}:organizations`) || '[]',
+                localStorage.getItem(`${accountId}:spaces`) || '[]',
               ) as Organization[];
               clearVaultKeySubmit({
                 organizations: organizations?.map(org => org.id) || [],

--- a/packages/insomnia/src/ui/hooks/use-plan.tsx
+++ b/packages/insomnia/src/ui/hooks/use-plan.tsx
@@ -23,12 +23,8 @@ export const usePlanData = () => {
     organizationData.organizations.length > 0
   ) {
     const currentOrg = organizationData.organizations.find(organization => organization.id === organizationId);
-    const accountId = userSession.accountId;
-    if (currentOrg && accountId) {
-      isOwner = models.organization.isOwnerOfOrganization({
-        organization: currentOrg,
-        accountId: userSession.accountId,
-      });
+    if (currentOrg && userSession.accountId) {
+      isOwner = Boolean(currentOrg.is_owner);
     }
     planType = organizationData.currentPlan?.type || planType;
     isFreePlan = planType.includes('free');

--- a/packages/insomnia/src/ui/organization-utils.ts
+++ b/packages/insomnia/src/ui/organization-utils.ts
@@ -1,4 +1,11 @@
-import { createTeamProject, fetchTeamProjects, getCurrentPlan, getUserProfile, isApiError } from 'insomnia-api';
+import {
+  createTeamProject,
+  fetchTeamProjects,
+  getCurrentPlan,
+  getUserProfile,
+  isApiError,
+  type Organization,
+} from 'insomnia-api';
 import type { Project } from 'insomnia-data';
 import { models, services } from 'insomnia-data';
 
@@ -39,7 +46,7 @@ export async function syncOrganizations(sessionId: string, accountId: string) {
 
     invariant(accountId, 'Account ID is not defined');
 
-    localStorage.setItem(`${accountId}:organizations`, JSON.stringify(organizations));
+    localStorage.setItem(`${accountId}:spaces`, JSON.stringify(organizations));
     localStorage.setItem(`${accountId}:user`, JSON.stringify(user));
     localStorage.setItem(`${accountId}:currentPlan`, JSON.stringify(currentPlan));
   } catch (error) {
@@ -109,6 +116,17 @@ export async function updateLocalProjectToRemote({
   return {
     error: null,
   };
+}
+
+/**
+ * Picks the space that orphaned legacy local projects (no parentId / no remoteId) should be
+ * re-parented into: the user's solo space — an owned space with no other members. If none
+ * qualifies (every owned space has collaborators), falls back to the first cached space so the
+ * migration still runs.
+ */
+export function findMigrationTargetSpaceId(organizations: Organization[]): string {
+  const soloSpace = organizations.find(o => o.is_owner && o.total_members === 1);
+  return soloSpace?.id ?? organizations[0].id;
 }
 
 export async function migrateProjectsUnderOrganization(personalOrganizationId: string, sessionId: string) {

--- a/packages/insomnia/src/ui/utils/router.ts
+++ b/packages/insomnia/src/ui/utils/router.ts
@@ -121,7 +121,7 @@ export const getInitialEntry = async () => {
     const user = await services.userSession.get();
     if (user.id) {
       const organizations = JSON.parse(
-        localStorage.getItem(`${user.accountId}:organizations`) || '[]',
+        localStorage.getItem(`${user.accountId}:spaces`) || '[]',
       ) as Organization[];
       // If no organizations are in local storage, go fetch from org index loader
       if (organizations.length === 0) {


### PR DESCRIPTION
Replaces the GET /v1/organizations call with GET /v3/users/me/spaces via the newly-installed @getinsomnia/insomnia-v3-fetch SDK. Concludes the unified-space migration started in #10033 (PR1).

What changes:

- New getSpaces() in insomnia-api wraps the SDK with cursor pagination, our standard request headers (X-Insomnia-Client, X-Origin, insomnia-request-id), and an error shim that converts the SDK's ResponseError into the existing ResponseFailError so UI error handling is unchanged.
- Organization is now a type alias for the SDK's Space. Consumers read is_owner (replacing metadata.ownerAccountId === accountId), name (replacing display_name), and picture (replacing branding.logo_url).
- Closes the two // TODO: target the owned space with total_members === 1 follow-ups Copilot flagged in PR1: legacy orphan local projects now migrate into the user's solo space (or fall back to the first cached space) via the new findMigrationTargetSpaceId helper.
- Smoke-test mock serves the new /v3/users/me/spaces route alongside the v1 endpoints that stay.
14 other /v1/organizations/{id}/... endpoints (features, storage-rule, members, invites, team-projects, etc.) stay on v1 -> not in the v3 OpenAPI yet, out of scope.