### PR TITLE
feat: surface more errors in console tab

### DIFF
--- a/packages/insomnia-data/node-src/services/helpers/response-operations.ts
+++ b/packages/insomnia-data/node-src/services/helpers/response-operations.ts
@@ -95,8 +95,12 @@ export const readCurlResponse = async (options: { bodyPath?: string; bodyCompres
 export async function getResponseTimeline(response: Response, showBody?: boolean): Promise<ResponseTimelineEntry[]> {
   const { timelinePath, bodyPath } = response;
 
+  const errorEntry: ResponseTimelineEntry[] = response.error
+    ? [{ name: 'Text', timestamp: Date.now(), value: response.error }]
+    : [];
+
   if (!timelinePath) {
-    return [];
+    return errorEntry;
   }
 
   try {
@@ -113,11 +117,11 @@ export async function getResponseTimeline(response: Response, showBody?: boolean
           },
         ]
       : [];
-    const output = [...timeline, ...body];
+    const output = [...timeline, ...body, ...errorEntry];
     return output;
   } catch (err) {
     console.warn('Failed to read response body', err.message);
-    return [];
+    return errorEntry;
   }
 }
 


### PR DESCRIPTION
Replicates error messages that are shown in the Preview tab in the Console tab so users aren't met with this when encountering an error while remaining focused on the Console tab:
<img width="520" height="209" alt="Screenshot 2026-06-29 at 17 10 29" src="https://github.com/user-attachments/assets/140e5a48-1bbd-4e4d-a65b-05ecf26bc0d1" />

And instead are shown the error:
<img width="519" height="241" alt="Screenshot 2026-06-29 at 16 45 53" src="https://github.com/user-attachments/assets/cea96b1b-aac4-4c70-af23-5529429a309b" />

(the message there is shown in the Preview tab, that could use a reword since this is the desktop app)