### PR TITLE
feat: do not redirect to active request

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/cloud-sync.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/cloud-sync.test.ts
@@ -70,7 +70,7 @@ test.describe('Cloud Sync', () => {
     // Ensure body is restored
     await page.getByRole('tab', { name: 'Body' }).click();
     await page.getByRole('button', { name: 'Send' }).click();
-    await expect.soft(page.getByTestId('response-pane').getByText('foo=bar')).toBeHidden();
+    await expect.soft(page.getByTestId('request-pane').getByText('foo=bar')).toBeHidden();
 
     // select unsynced MCP project to check branch actions
     await insomnia.navigationSidebar.fetchUnsyncedWorkspace('MCP Project');

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
@@ -134,7 +134,7 @@ const INITIAL_GRPC_REQUEST_STATE = {
   methods: [],
 };
 
-export async function clientLoader({ params, request }: Route.ClientLoaderArgs) {
+export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (!params.requestId && !params.requestGroupId) {
     const { projectId, workspaceId, organizationId } = params;
 
@@ -148,20 +148,6 @@ export async function clientLoader({ params, request }: Route.ClientLoaderArgs) 
     if (!activeWorkspace) {
       showResourceNotFoundToast(`Workspace not found: ${workspaceId}`);
       throw redirect(href('/organization/:organizationId/project/:projectId', { organizationId, projectId }));
-    }
-
-    const activeWorkspaceMeta = await services.workspaceMeta.getOrCreateByParentId(workspaceId);
-    const activeRequestId = activeWorkspaceMeta.activeRequestId;
-    const activeRequest = activeRequestId ? await services.request.getById(activeRequestId) : null;
-    // TODO(george): we should remove this after enabling the sidebar for the runner
-    const startOfQuery = request.url.indexOf('?');
-    const urlWithoutQuery = startOfQuery > 0 ? request.url.slice(0, startOfQuery) : request.url;
-    const isDisplayingRunner = urlWithoutQuery.includes('/runner');
-    const doNotSkipToActiveRequest = request.url.includes('doNotSkipToActiveRequest=true');
-    if (activeRequest && !isDisplayingRunner && !doNotSkipToActiveRequest) {
-      return redirect(
-        `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request/${activeRequestId}`,
-      );
     }
   }
   return null;

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.restore.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.restore.tsx
@@ -31,13 +31,7 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   const workspace = await services.workspace.getById(workspaceId);
   invariant(workspace, 'Workspace not found');
 
-  return redirect(
-    `${href('/organization/:organizationId/project/:projectId/workspace/:workspaceId', {
-      organizationId,
-      projectId,
-      workspaceId,
-    })}/${models.workspace.scopeToActivity(workspace?.scope)}`,
-  );
+  return null;
 }
 
 export const useInsomniaSyncRestoreActionFetcher = createFetcherSubmitHook(

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.restore.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.restore.tsx
@@ -1,5 +1,5 @@
-import { models, services } from 'insomnia-data';
-import { href, redirect } from 'react-router';
+import { services } from 'insomnia-data';
+import { href } from 'react-router';
 
 import type { Operation } from '~/common/database';
 import { database } from '~/common/database';
@@ -10,7 +10,7 @@ import { createFetcherSubmitHook } from '~/ui/utils/router';
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.restore';
 
 export async function clientAction({ request, params }: Route.ClientActionArgs) {
-  const { organizationId, projectId, workspaceId } = params;
+  const { projectId, workspaceId } = params;
 
   const formData = await request.formData();
   const id = formData.get('id');

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.rollback.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.rollback.tsx
@@ -1,5 +1,5 @@
-import { models, services } from 'insomnia-data';
-import { href, redirect } from 'react-router';
+import { services } from 'insomnia-data';
+import { href } from 'react-router';
 
 import type { Operation } from '~/common/database';
 import { database } from '~/common/database';
@@ -10,7 +10,7 @@ import { createFetcherSubmitHook } from '~/ui/utils/router';
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.rollback';
 
 export async function clientAction({ params }: Route.ClientActionArgs) {
-  const { organizationId, projectId, workspaceId } = params;
+  const { projectId, workspaceId } = params;
 
   try {
     const { syncItems } = await getSyncItems({ workspaceId });
@@ -28,13 +28,7 @@ export async function clientAction({ params }: Route.ClientActionArgs) {
   const workspace = await services.workspace.getById(workspaceId);
   invariant(workspace, 'Workspace not found');
 
-  return redirect(
-    `${href('/organization/:organizationId/project/:projectId/workspace/:workspaceId', {
-      organizationId,
-      projectId,
-      workspaceId,
-    })}/${models.workspace.scopeToActivity(workspace?.scope)}`,
-  );
+  return null;
 }
 
 export const useInsomniaSyncRollbackActionFetcher = createFetcherSubmitHook(

--- a/packages/insomnia/src/ui/hooks/use-insomnia-tab.ts
+++ b/packages/insomnia/src/ui/hooks/use-insomnia-tab.ts
@@ -119,14 +119,12 @@ const buildTabUrlFromResource = ({
   projectId,
   workspaceId,
   searchParams,
-  withTab,
 }: {
   resource: TabResource;
   organizationId: string;
   projectId: string;
   workspaceId: string;
   searchParams?: URLSearchParams;
-  withTab?: boolean;
 }) => {
   const type = inferTabType(resource);
   if (!type) {
@@ -134,9 +132,6 @@ const buildTabUrlFromResource = ({
   }
 
   const nextSearchParams = new URLSearchParams(searchParams);
-  if (type === 'collection' && withTab) {
-    nextSearchParams.set('doNotSkipToActiveRequest', 'true');
-  }
 
   return buildResourceUrl({
     organizationId,
@@ -147,7 +142,7 @@ const buildTabUrlFromResource = ({
   });
 };
 
-const buildTabFromResource = async (params: AddTabParams, withTab?: boolean): Promise<BaseTab | null> => {
+const buildTabFromResource = async (params: AddTabParams): Promise<BaseTab | null> => {
   const { resource, organizationId, projectId, workspaceId, projectName, workspaceName, searchParams } = params;
   const effectiveWorkspaceId = workspaceId ?? resource._id;
   const type = inferTabType(resource);
@@ -160,7 +155,6 @@ const buildTabFromResource = async (params: AddTabParams, withTab?: boolean): Pr
     projectId,
     workspaceId: effectiveWorkspaceId,
     searchParams,
-    withTab,
   });
 
   const baseTab: BaseTab = {
@@ -292,18 +286,15 @@ export const useTabNavigate = () => {
             folderId: item.type === 'RequestGroup' ? item._id : undefined,
             searchParams,
           })
-        : await buildTabFromResource(
-            {
-              resource: item,
-              organizationId,
-              projectId: project._id,
-              workspaceId: workspace._id,
-              projectName: project.name,
-              workspaceName: workspace.name,
-              searchParams,
-            },
-            withTab,
-          );
+        : await buildTabFromResource({
+            resource: item,
+            organizationId,
+            projectId: project._id,
+            workspaceId: workspace._id,
+            projectName: project.name,
+            workspaceName: workspace.name,
+            searchParams,
+          });
 
       // Skip if this navigation is outdated by a newer one
       if (navigationId !== navigationCounterRef.current) return;


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
INS-2844

### Changes

- Remove the logic that redirects to the last time active request in the debug page.
- Fix cloud sync smoke test: remove redirect to workspace route logic in the cloud sync restore&rollback action. 
    - We don't need to redirect back to the workspace page after restore&rollback. If the workspace is deleted after restore & rollback, we already have logic to fall back to the previous-level route in the workspace loader.
