### PR TITLE
fix: show side bar active project after start up

### DIFF
--- a/packages/insomnia-smoke-test/playwright/pages/components/navigation-sidebar.ts
+++ b/packages/insomnia-smoke-test/playwright/pages/components/navigation-sidebar.ts
@@ -90,6 +90,15 @@ export class NavigationSidebar {
     return this.root.getByTestId(`workspace-node-${workspaceName}`);
   }
 
+  workspaceGridListItem(workspaceName: string): Locator {
+    return this.navigationTree.getByRole('row', { name: workspaceName });
+  }
+
+  async expectWorkspaceActive(workspaceName: string): Promise<void> {
+    await expect.soft(this.workspaceRow(workspaceName)).toBeVisible();
+    await expect.soft(this.workspaceGridListItem(workspaceName)).toHaveAttribute('aria-selected', 'true');
+  }
+
   async selectWorkspace(workspaceName: string): Promise<void> {
     await this.workspaceRow(workspaceName).click();
   }
@@ -268,9 +277,9 @@ export class NavigationSidebar {
   async fetchUnsyncedWorkspace(name: string): Promise<void> {
     const unsyncedWorkspaceButton = this.unsyncedWorkspaceButton(name);
     await unsyncedWorkspaceButton.click();
-    await this.unsyncedWorkspaceRow(name)
-      .waitFor({ state: 'hidden', timeout: 5000 })
-      .catch(() => {});
+    await expect.soft(this.unsyncedWorkspaceRow(name)).toBeHidden({ timeout: 5000 });
+    await expect.soft(this.workspaceRow(name)).toBeVisible();
+    await this.expectWorkspaceActive(name);
   }
 
   // ===========================================================================

--- a/packages/insomnia-smoke-test/server/cloud-sync-api.ts
+++ b/packages/insomnia-smoke-test/server/cloud-sync-api.ts
@@ -64,21 +64,21 @@ const encryptedSymmetricKey =
 const cloudSyncProject = [
   {
     id: 'proj_5145140e072d4007a30bfa6630ddae70',
-    name: 'Collection Project',
+    name: 'My Collection R1',
     rootDocumentId: 'wrk_a7132f924ba7451594ba64ec411c9e13',
     teamProjectId: 'proj_org_7ef19d06-5a24-47ca-bc81-3dea011edec2',
     teams,
   },
   {
     id: 'proj_5145140e072d4007a30bfa6630ddae71',
-    name: 'Environment Project',
+    name: 'My Environment',
     rootDocumentId: 'wrk_2068a8dfd6914c369073686bb92737ae',
     teamProjectId: 'proj_org_7ef19d06-5a24-47ca-bc81-3dea011edec2',
     teams,
   },
   {
     id: 'proj_5145140e072d4007a30bfa6630ddae72',
-    name: 'MCP Project',
+    name: 'My MCP Client',
     rootDocumentId: 'wrk_efab8e758b97459bab2659d8fdcf8627',
     teamProjectId: 'proj_org_7ef19d06-5a24-47ca-bc81-3dea011edec2',
     teams,

--- a/packages/insomnia-smoke-test/tests/smoke/cloud-sync.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/cloud-sync.test.ts
@@ -24,8 +24,8 @@ test.describe('Cloud Sync', () => {
   });
 
   test('Discard, branch and commit actions', async ({ page, insomnia }) => {
-    // Sync collection project
-    await insomnia.navigationSidebar.fetchUnsyncedWorkspace('Collection Project');
+    // Sync My Collection R1
+    await insomnia.navigationSidebar.fetchUnsyncedWorkspace('My Collection R1');
     await insomnia.navigationSidebar.clickRequestOrFolder('New Request');
     // Send request and check body
     await page.getByRole('button', { name: 'Send' }).click();
@@ -73,7 +73,7 @@ test.describe('Cloud Sync', () => {
     await expect.soft(page.getByTestId('request-pane').getByText('foo=bar')).toBeHidden();
 
     // select unsynced MCP project to check branch actions
-    await insomnia.navigationSidebar.fetchUnsyncedWorkspace('MCP Project');
+    await insomnia.navigationSidebar.fetchUnsyncedWorkspace('My MCP Client');
     await page.getByLabel('Git Sync').click();
     await page.getByText('Branches').click();
 
@@ -103,7 +103,7 @@ test.describe('Cloud Sync', () => {
   test('Push actions', async ({ page, app, insomnia }) => {
     test.slow();
 
-    await insomnia.navigationSidebar.fetchUnsyncedWorkspace('Environment Project');
+    await insomnia.navigationSidebar.fetchUnsyncedWorkspace('My Environment');
     // Wait for sync-dropdown to be mounted
     await page.getByLabel('Git Sync').waitFor({ state: 'visible' });
     await fetch(`${devServerUrl}/__test-config/cloud-sync/new-commit`, {
@@ -135,8 +135,8 @@ test.describe('Cloud Sync', () => {
   });
 
   test('Check delete workspace locally and remotely', async ({ page, insomnia }) => {
-    //Sync collection project
-    await page.getByTestId('workspace-grid').getByLabel('Collection Project').click();
+    //Sync My Collection R1
+    await insomnia.navigationSidebar.fetchUnsyncedWorkspace('My Collection R1');
     // go back
     await page.getByTestId('workspace-breadcrumb-level-0').click();
 
@@ -147,10 +147,10 @@ test.describe('Cloud Sync', () => {
     await page.getByRole('button', { name: 'Delete Workspace' }).click();
     // check workspace is deleted locally
 
-    await expect.soft(page.getByTestId('workspace-grid').getByLabel('Collection Project')).toBeVisible();
-    await expect.soft(page.getByTestId('workspace-grid').getByLabel('My Collection R1')).toBeHidden();
-    // Sync collection project again
-    await page.getByTestId('workspace-grid').getByLabel('Collection Project').click();
+    await expect.soft(insomnia.navigationSidebar.unsyncedWorkspaceRow('My Collection R1')).toBeVisible();
+    await expect.soft(insomnia.navigationSidebar.workspaceRow('My Collection R1')).toBeHidden();
+    // Sync My Collection R1 again
+    await page.getByTestId('workspace-grid').getByLabel('My Collection R1').click();
     // go back
     await page.getByTestId('workspace-breadcrumb-level-0').click();
 
@@ -159,6 +159,7 @@ test.describe('Cloud Sync', () => {
     await page.getByRole('button', { name: 'Delete' }).click();
     await page.getByRole('button', { name: 'Delete Workspace' }).click();
     // check workspace is deleted remotely
-    await expect.soft(page.getByTestId('workspace-grid').getByLabel('Collection Project')).toBeHidden();
+    await expect.soft(insomnia.navigationSidebar.unsyncedWorkspaceRow('My Collection R1')).toBeHidden();
+    await expect.soft(insomnia.navigationSidebar.workspaceRow('My Collection R1')).toBeHidden();
   });
 });

--- a/packages/insomnia-smoke-test/tests/smoke/cloud-sync.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/cloud-sync.test.ts
@@ -25,7 +25,7 @@ test.describe('Cloud Sync', () => {
 
   test('Discard, branch and commit actions', async ({ page, insomnia }) => {
     // Sync collection project
-    await page.getByLabel('Collection Project').click();
+    await insomnia.navigationSidebar.fetchUnsyncedWorkspace('Collection Project');
     await insomnia.navigationSidebar.clickRequestOrFolder('New Request');
     // Send request and check body
     await page.getByRole('button', { name: 'Send' }).click();
@@ -100,10 +100,10 @@ test.describe('Cloud Sync', () => {
     await page.getByRole('dialog').locator('[data-icon="x"]').click();
   });
 
-  test('Push actions', async ({ page, app }) => {
+  test('Push actions', async ({ page, app, insomnia }) => {
     test.slow();
 
-    await page.getByLabel('Environment Project').click();
+    await insomnia.navigationSidebar.fetchUnsyncedWorkspace('Environment Project');
     // Wait for sync-dropdown to be mounted
     await page.getByLabel('Git Sync').waitFor({ state: 'visible' });
     await fetch(`${devServerUrl}/__test-config/cloud-sync/new-commit`, {

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
@@ -521,6 +521,8 @@ const ProjectNavigationSidebarInner = (
       return cachedCollectionChildrenAndMetaRef.current;
     };
 
+    let cancelled = false;
+
     const buildWorkspaceAndCollectionData = async () => {
       const items: FlatItem[] = [];
       // Array of project and collection workspace ids that should get data from db
@@ -759,9 +761,19 @@ const ProjectNavigationSidebarInner = (
         });
       }
 
+      // Bail out if a newer effect run has superseded this one to avoid
+      // a stale async build overwriting fresh data (race condition).
+      if (cancelled) {
+        return;
+      }
+
       setFlatItems(items);
     };
     buildWorkspaceAndCollectionData();
+
+    return () => {
+      cancelled = true;
+    };
   }, [
     activeFilter,
     collectionSortOrders,

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/use-project-navigation-sidebar-navigation.ts
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/use-project-navigation-sidebar-navigation.ts
@@ -40,24 +40,22 @@ export const useProjectNavigationSidebarNavigation = ({
   const { scrollToIndex } = virtualizer;
   const { routeInfo, getNavigationResources } = useInsomniaNavigation();
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
-  const navigationKey = routeInfo ? `${routeInfo.routeId}:${routeInfo.resourceId}` : 'unknown-route';
-  const lastHandledNavigationKeyRef = useRef<string | null>(null);
   const lastHandledScrollKeyRef = useRef<string | null>(null);
+
+  const setActiveTabRef = useRef(setActiveTab);
+  const toggleRequestGroupsRef = useRef(toggleRequestGroups);
+  const expandProjectOrWorkspacesRef = useRef(expandProjectOrWorkspaces);
+  setActiveTabRef.current = setActiveTab;
+  toggleRequestGroupsRef.current = toggleRequestGroups;
+  expandProjectOrWorkspacesRef.current = expandProjectOrWorkspaces;
 
   useEffect(() => {
     let cancelled = false;
 
     if (!routeInfo) {
-      lastHandledNavigationKeyRef.current = null;
       setSelectedItemId(null);
       return;
     }
-
-    if (lastHandledNavigationKeyRef.current === navigationKey) {
-      return;
-    }
-
-    lastHandledNavigationKeyRef.current = navigationKey;
 
     getNavigationResources().then(async resources => {
       if (cancelled) {
@@ -72,7 +70,7 @@ export const useProjectNavigationSidebarNavigation = ({
       }
 
       // update active tab
-      setActiveTab(resources.project.konnectControlPlaneId != null ? 'konnect' : 'projects');
+      setActiveTabRef.current(resources.project.konnectControlPlaneId != null ? 'konnect' : 'projects');
 
       const idsToExpand = [resources.project._id];
       if (resources.workspace && models.workspace.isCollection(resources.workspace)) {
@@ -97,17 +95,17 @@ export const useProjectNavigationSidebarNavigation = ({
         idsToExpand.push(...requestGroupIds);
 
         if (requestGroupIds.length > 0) {
-          await toggleRequestGroups(requestGroupIds, resources.workspace, false);
+          await toggleRequestGroupsRef.current(requestGroupIds, resources.workspace, false);
         }
       }
 
-      expandProjectOrWorkspaces([...idsToExpand]);
+      expandProjectOrWorkspacesRef.current([...idsToExpand]);
     });
 
     return () => {
       cancelled = true;
     };
-  }, [expandProjectOrWorkspaces, getNavigationResources, navigationKey, routeInfo, setActiveTab, toggleRequestGroups]);
+  }, [getNavigationResources, routeInfo]);
 
   useEffect(() => {
     if (!selectedItemId) {


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
INS-2911

### Changes
- Fix 2 minor bugs for the sidebar:
    - Show an active border for the active project after startup
    - Expand active project after startup
- Fix `cloud-sync` smoke test
    - Use sidebar page object to open unsynced workspace