### PR TITLE
Fix/grpc empty data

### DIFF
--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -52,7 +52,7 @@
     "@fortawesome/react-fontawesome": "^3.0.2",
     "@getinsomnia/node-libcurl": "3.2.2",
     "@getinsomnia/srp-js": "1.0.0-alpha.1",
-    "@grpc/grpc-js": "^1.14.4",
+    "@grpc/grpc-js": "1.14.4",
     "@grpc/proto-loader": "^0.7.13",
     "@react-router/fs-routes": "7.15.0",
     "@react-router/node": "7.15.0",

--- a/packages/insomnia/src/main/ipc/__tests__/grpc.test.ts
+++ b/packages/insomnia/src/main/ipc/__tests__/grpc.test.ts
@@ -2,6 +2,8 @@
 import type { AnyMessage, MethodInfo, PartialMessage, ServiceType } from '@bufbuild/protobuf';
 import type { UnaryResponse } from '@connectrpc/connect';
 import { createConnectTransport } from '@connectrpc/connect-node';
+import { Metadata } from '@grpc/grpc-js';
+import { CompressionFilter } from '@grpc/grpc-js/build/src/compression-filter';
 import * as grpcReflection from 'grpc-reflection-js';
 import { services } from 'insomnia-data';
 import protobuf from 'protobufjs';
@@ -15,6 +17,28 @@ vi.mock('../../../network/grpc/write-proto-file.node');
 vi.mock('@grpc/proto-loader', async importOriginal => {
   const actual = await importOriginal();
   return { ...actual, load: vi.fn().mockResolvedValue({}) };
+});
+
+// Regression test for https://github.com/Kong/insomnia/issues/8659
+// A gRPC response with an empty repeated field serializes to a zero-length
+// message. Some servers still set the compressed flag on that frame, and
+// grpc-js used to feed the empty payload to zlib, which throws "unexpected end
+// of file" and surfaced as an error/hang in the UI. The patched readMessage
+// short-circuits zero-length payloads. (see patches/@grpc+grpc-js+1.14.4.patch)
+describe('grpc empty compressed message handling', () => {
+  it('treats a zero-length gzip-flagged frame as an empty message instead of throwing', async () => {
+    const filter = new CompressionFilter({}, {});
+    const metadata = new Metadata();
+    metadata.set('grpc-encoding', 'gzip');
+    filter.receiveMetadata(metadata);
+
+    // 5-byte gRPC frame: compressed flag = 1, message length = 0, no payload.
+    const frame = Buffer.alloc(5);
+    frame.writeUInt8(1, 0);
+    frame.writeUInt32BE(0, 1);
+
+    await expect(filter.receiveMessage(Promise.resolve(frame))).resolves.toEqual(Buffer.alloc(0));
+  });
 });
 
 describe('writeProtoFileById', () => {

--- a/patches/@grpc+grpc-js+1.14.4.patch
+++ b/patches/@grpc+grpc-js+1.14.4.patch
@@ -1,0 +1,17 @@
+diff --git a/node_modules/@grpc/grpc-js/build/src/compression-filter.js b/node_modules/@grpc/grpc-js/build/src/compression-filter.js
+index a3d422a..0ac9c54 100644
+--- a/node_modules/@grpc/grpc-js/build/src/compression-filter.js
++++ b/node_modules/@grpc/grpc-js/build/src/compression-filter.js
+@@ -49,7 +49,11 @@ class CompressionHandler {
+     async readMessage(data) {
+         const compressed = data.readUInt8(0) === 1;
+         let messageBuffer = data.slice(5);
+-        if (compressed) {
++        // A zero-length payload is unambiguously an empty message regardless of
++        // the compressed flag. Feeding it to zlib would throw ("unexpected end of
++        // file") because an empty buffer is not a valid gzip/deflate stream, which
++        // some servers nonetheless emit for empty messages when compression is on.
++        if (compressed && messageBuffer.length > 0) {
+             messageBuffer = await this.decompressMessage(messageBuffer);
+         }
+         return messageBuffer;


### PR DESCRIPTION
## What & Why

Fixes #8659. A gRPC response with all-default fields (e.g. an empty `repeated` field) serializes to a **0-byte** message. Some servers still flag that frame as compressed and send `grpc-encoding: gzip`, so the client receives `[compressed=1][length=0]`. `@grpc/grpc-js` then feeds the empty payload to zlib, which throws `unexpected end of file` and surfaces in the UI as:

```
13 INTERNAL: Failed to decompress gzip-encoded message
```

## Fix

Patch `@grpc/grpc-js` so `CompressionHandler.readMessage` short-circuits a zero-length payload (which unambiguously decodes to an empty message) instead of attempting decompression:

```js
if (compressed && messageBuffer.length > 0) {
    messageBuffer = await this.decompressMessage(messageBuffer);
}
```

Single dispatch point → covers gzip/deflate; semantically correct since decompressing 0 bytes yields 0 bytes.

## Changes

- `patches/@grpc+grpc-js+1.14.4.patch` — the fix (applied via `patch-package` on `postinstall`)
- `grpc.test.ts` — regression test feeding a gzip-flagged zero-length frame through `CompressionFilter`

## Verification

Against a test server that emits `[compressed=1][length=0]` + `grpc-encoding: gzip` for empty messages:

| Client | Result |
|--------|--------|
| Unpatched grpc-js 1.14.4 | `ERROR: 13 Failed to decompress...` (reproduces #8659) |
| Patched | `SUCCESS {"article_ids":[]}` |

Plus unit tests + lint passing.

> Note: this is a client-side robustness fix for a non-conformant server frame. Worth reporting upstream to grpc-node so the patch can eventually be dropped.
