### PR TITLE
feat: improve collection runner feedback [INS-2627]

### DIFF
--- a/packages/insomnia-data/src/models/runner-test-result.ts
+++ b/packages/insomnia-data/src/models/runner-test-result.ts
@@ -26,6 +26,10 @@ export interface RunnerResultPerRequest {
   requestName: string;
   requestUrl: string;
   responseCode: number;
+  responseMessage?: string;
+  responseTime?: number;
+  responseSize?: number;
+  skipped?: boolean;
 }
 
 export interface ResponseInfo {

--- a/packages/insomnia-smoke-test/fixtures/runner-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/runner-collection.yaml
@@ -392,6 +392,28 @@ collection:
         send: true
         store: true
       rebuildPath: true
+  - url: "{{ _.base_url }}/delay/seconds/10"
+    name: delaySkip
+    meta:
+      id: req_aa11bb22cc33dd44ee55ff6600000002
+      sortKey: 201
+    method: GET
+    scripts:
+      afterResponse: |-
+        insomnia.test('delaySkip-post-check', () => {
+          insomnia.expect(200).to.eql(200);
+        });
+  - url: http://127.0.0.1:4010/echo
+    name: fastAfterSkip
+    meta:
+      id: req_aa11bb22cc33dd44ee55ff6600000003
+      sortKey: 202
+    method: POST
+    scripts:
+      afterResponse: |-
+        insomnia.test('fastAfterSkip-post-check', () => {
+          insomnia.expect(200).to.eql(200);
+        });
 cookieJar:
   name: Default Jar
   meta:
@@ -408,6 +430,7 @@ environments:
   data:
     scope: collection_base
     value: collection_base
+    base_url: http://127.0.0.1:4010
   subEnvironments:
     - name: Sub Env
       meta:

--- a/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
@@ -50,6 +50,12 @@ test.describe('runner features tests', () => {
     expect.soft(passedResultCount + failedResultCount + skippedResultCount).toEqual(expectedTotal);
   };
 
+  const selectRunnerRequest = async (page: Page, name: string) => {
+    const row = page.locator(`.runner-request-list-${name}`);
+    await row.waitFor({ state: 'visible' });
+    await row.locator('label[slot="selection"]').click();
+  };
+
   test('run collection runner', async ({ page, insomnia }) => {
     await insomnia.navigationSidebar.selectWorkspaceDropdownOption({
       actionName: 'Run Collection',
@@ -93,6 +99,49 @@ test.describe('runner features tests', () => {
     ];
 
     await verifyResultRows(page, 6, 1, 8, expectedTestOrder);
+  });
+
+  test('shows live progress and cancels an in-progress run', async ({ page, insomnia }) => {
+    await insomnia.navigationSidebar.selectWorkspaceDropdownOption({
+      actionName: 'Run Collection',
+      workspaceName: 'Runner',
+    });
+
+    await selectRunnerRequest(page, 'delaySkip');
+    await selectRunnerRequest(page, 'fastAfterSkip');
+
+    await page.getByRole('button', { name: 'Run', exact: true }).click();
+
+    await expect.soft(page.getByRole('button', { name: 'Cancel all' })).toBeVisible();
+    await expect.soft(page.getByTestId('runner-live-item-delaySkip')).toContainText('RUNNING');
+    await expect.soft(page.getByTestId('runner-live-item-fastAfterSkip')).toContainText('PENDING');
+
+    // the templated URL is resolved (like the request view's preview) while the request runs
+    await expect.soft(page.getByTestId('runner-live-item-delaySkip')).toContainText('127.0.0.1:4010/delay/seconds/10');
+    await expect.soft(page.getByTestId('runner-live-item-delaySkip')).not.toContainText('{{');
+
+    await page.getByRole('button', { name: 'Cancel all' }).click();
+    await expect.soft(page.getByTestId('runner-live-item-delaySkip')).toContainText('CANCELED', { timeout: 8000 });
+  });
+
+  test('skips the in-flight request and continues to the next', async ({ page, insomnia }) => {
+    await insomnia.navigationSidebar.selectWorkspaceDropdownOption({
+      actionName: 'Run Collection',
+      workspaceName: 'Runner',
+    });
+
+    await selectRunnerRequest(page, 'delaySkip');
+    await selectRunnerRequest(page, 'fastAfterSkip');
+
+    await page.getByRole('button', { name: 'Run', exact: true }).click();
+
+    const delayCard = page.getByTestId('runner-live-item-delaySkip');
+    await expect.soft(delayCard).toContainText('RUNNING');
+    await delayCard.getByRole('button', { name: 'Skip' }).click();
+
+    // the fast request lands well under the 10s delay, proving the slow one was actually aborted
+    await expect.soft(page.getByText('fastAfterSkip-post-check')).toBeVisible({ timeout: 8000 });
+    await expect.soft(page.getByText('delaySkip-post-check')).toBeHidden();
   });
 
   test('run collection runner with data upload', async ({ page, insomnia }) => {

--- a/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
@@ -176,8 +176,8 @@ test.describe('runner features tests', () => {
       const iterationTestResultElement = page.getByTestId(testId);
       await iterationTestResultElement.click();
       await expect.soft(iterationTestResultElement).toBeVisible();
-      // req2 should be skipped from pre-request script
-      await expect.soft(iterationTestResultElement).not.toContainText('req2');
+      await expect.soft(iterationTestResultElement.getByTestId('request-test-result-1')).toContainText('SKIPPED');
+      await expect.soft(iterationTestResultElement.getByTestId('request-test-result-2')).toContainText('SKIPPED');
     }
 
     await verifyResultRows(page, 4, 1, 6, [
@@ -258,6 +258,7 @@ test.describe('runner features tests', () => {
 
     // check result
     await page.getByText('1 / 2').first().click();
+    await expect.soft(page.getByTestId('request-test-result-1')).toContainText('SKIPPED');
 
     const expectedTestOrder = [
       'req0-post-check',

--- a/packages/insomnia/src/common/__tests__/runner-feedback.test.ts
+++ b/packages/insomnia/src/common/__tests__/runner-feedback.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatResponseStats, formatStatusLabel, getRunnerStatusTag } from '../runner-feedback';
+
+describe('formatStatusLabel()', () => {
+  it('combines code and message, falling back to the standard reason then the bare message', () => {
+    expect(formatStatusLabel({ statusCode: 200, statusMessage: 'OK' })).toBe('200 OK');
+    expect(formatStatusLabel({ statusCode: 404 })).toBe('404 Not Found');
+    expect(formatStatusLabel({ statusMessage: 'Canceled' })).toBe('Canceled');
+  });
+});
+
+describe('formatResponseStats()', () => {
+  it('rounds the time and scales the size unit', () => {
+    expect(formatResponseStats({ responseTime: 36.6, responseSize: 212 })).toBe('37ms - 212 bytes');
+    expect(formatResponseStats({ responseTime: 1, responseSize: 4096 })).toBe('1ms - 4 kilobytes');
+  });
+});
+
+describe('getRunnerStatusTag()', () => {
+  it('colors a completed status code green/yellow/red, and falls back to ERROR with no code', () => {
+    expect(getRunnerStatusTag({ status: 'completed', statusCode: 200, statusMessage: 'OK' })).toEqual({
+      label: '200 OK',
+      className: 'bg-lime-600',
+    });
+    expect(getRunnerStatusTag({ status: 'completed', statusCode: 302 }).className).toBe('bg-yellow-600');
+    expect(getRunnerStatusTag({ status: 'completed', statusCode: 500 }).className).toBe('bg-red-600');
+    expect(getRunnerStatusTag({ status: 'failed' })).toEqual({ label: 'ERROR', className: 'bg-red-600' });
+  });
+});

--- a/packages/insomnia/src/common/runner-feedback.ts
+++ b/packages/insomnia/src/common/runner-feedback.ts
@@ -1,0 +1,65 @@
+import type { RequestTestResult } from 'insomnia-data';
+
+import { RESPONSE_CODE_REASONS } from './constants';
+import { describeByteSize } from './misc';
+
+export type RunnerItemStatus = 'pending' | 'running' | 'completed' | 'failed' | 'canceled' | 'skipped';
+
+export interface RunnerLiveItem {
+  key: string;
+  iteration: number;
+  requestId: string;
+  requestName: string;
+  requestUrl: string;
+  status: RunnerItemStatus;
+  statusCode?: number;
+  statusMessage?: string;
+  responseTime?: number;
+  responseSize?: number;
+  errorMessage?: string;
+  results?: RequestTestResult[];
+}
+
+export const buildRunnerItemKey = (iteration: number, index: number, requestId: string) =>
+  `${iteration}-${index}-${requestId}`;
+
+export const formatStatusLabel = (item: { statusCode?: number; statusMessage?: string }) => {
+  if (item.statusCode && item.statusCode > 0) {
+    const reason = item.statusMessage || RESPONSE_CODE_REASONS[item.statusCode] || '';
+    return reason ? `${item.statusCode} ${reason}` : `${item.statusCode}`;
+  }
+  return item.statusMessage || '';
+};
+
+export const formatResponseStats = ({ responseTime, responseSize }: { responseTime?: number; responseSize?: number }) =>
+  [
+    typeof responseTime === 'number' && responseTime >= 0 ? `${Math.round(responseTime)}ms` : null,
+    typeof responseSize === 'number' && responseSize >= 0 ? describeByteSize(responseSize, true) : null,
+  ]
+    .filter(Boolean)
+    .join(' - ');
+
+const STATUS_TAGS: Partial<Record<RunnerItemStatus, { label: string; className: string }>> = {
+  pending: { label: 'PENDING', className: 'bg-slate-600' },
+  running: { label: 'RUNNING', className: 'bg-sky-600' },
+  canceled: { label: 'CANCELED', className: 'bg-slate-600' },
+  skipped: { label: 'SKIPPED', className: 'bg-slate-600' },
+};
+
+export const getRunnerStatusTag = (item: { status: RunnerItemStatus; statusCode?: number; statusMessage?: string }) => {
+  const fixed = STATUS_TAGS[item.status];
+  if (fixed) {
+    return fixed;
+  }
+  const label = formatStatusLabel(item);
+  if (!label) {
+    return { label: 'ERROR', className: 'bg-red-600' };
+  }
+  const code = item.statusCode ?? 0;
+  const className =
+    code >= 200 && code < 300 ? 'bg-lime-600' : code >= 300 && code < 400 ? 'bg-yellow-600' : 'bg-red-600';
+  return { label, className };
+};
+
+export const isFinished = (status: RunnerItemStatus) =>
+  status === 'completed' || status === 'failed' || status === 'canceled' || status === 'skipped';

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -98,7 +98,7 @@ export interface ResponsePatch {
 
 // NOTE: this is a dictionary of functions to close open listeners
 const cancelCurlRequestHandlers: Record<string, () => void> = {};
-export const cancelCurlRequest = (id: string) => cancelCurlRequestHandlers[id]();
+export const cancelCurlRequest = (id: string) => cancelCurlRequestHandlers[id]?.();
 export const curlRequest = (options: CurlRequestOptions) =>
   new Promise<CurlRequestOutput>(async resolve => {
     try {
@@ -238,6 +238,7 @@ export const curlRequest = (options: CurlRequestOptions) =>
           url: curl.getInfo(Curl.info.EFFECTIVE_URL) as string,
         };
         curl.isOpen && curl.close();
+        delete cancelCurlRequestHandlers[requestId];
         await waitForStreamToFinish(responseBodyWriteStream);
 
         const headerResults = _parseHeaders(rawHeaders);
@@ -248,6 +249,7 @@ export const curlRequest = (options: CurlRequestOptions) =>
       curl.on('error', async (err, code) => {
         const elapsedTime = (curl.getInfo(Curl.info.TOTAL_TIME) as number) * 1000;
         curl.isOpen && curl.close();
+        delete cancelCurlRequestHandlers[requestId];
         await waitForStreamToFinish(responseBodyWriteStream);
 
         // If libcurl can't decompress the response, retry without decompression

--- a/packages/insomnia/src/network/cancellation.renderer.ts
+++ b/packages/insomnia/src/network/cancellation.renderer.ts
@@ -47,12 +47,13 @@ export const cancellableCurlRequest = async (requestOptions: CurlRequestOptions)
     const result = await cancellablePromise({ signal: controller.signal, fn: window.main.curlRequest(requestOptions) });
     return result;
   } catch (err) {
-    cancelRequestFunctionMap.delete(requestId);
     if (err.name === 'AbortError') {
       return { statusMessage: 'Cancelled', error: 'Request was cancelled' };
     }
     console.log('[network] Error', err);
     return { statusMessage: 'Error', error: err.message || 'Something went wrong trying to create curl request' };
+  } finally {
+    cancelRequestFunctionMap.delete(requestId);
   }
 };
 

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx
@@ -62,6 +62,7 @@ export interface RunnerContextForRequest {
   requestName: string;
   requestUrl: string;
   statusCode: number;
+  statusMessage: string;
   duration: number; // millisecond
   size: number;
   results: RequestTestResult[];
@@ -294,6 +295,10 @@ export const sendActionImplementation = async (options: {
       return acc + (cur.duration || 0);
     }, 0);
     testResultCollector.responseId = response._id;
+    testResultCollector.requestUrl = renderedRequest.url || testResultCollector.requestUrl;
+    testResultCollector.statusCode = baseResponsePatch.statusCode || 0;
+    testResultCollector.statusMessage = baseResponsePatch.statusMessage || '';
+    testResultCollector.size = baseResponsePatch.bytesRead || 0;
   }
   const responsePatch = postMutatedContext
     ? {

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx
@@ -113,7 +113,7 @@ export const sendActionImplementation = async (options: {
   userUploadEnvironment?: UserUploadEnvironment;
   transientVariables?: Environment;
   runtime?: SendActionRuntime;
-}): Promise<{ nextRequestIdOrName: string | undefined } | undefined> => {
+}): Promise<{ nextRequestIdOrName: string | undefined; skipped?: boolean } | undefined> => {
   const {
     requestId,
     userUploadEnvironment,
@@ -184,7 +184,7 @@ export const sendActionImplementation = async (options: {
     );
     await services.requestMeta.updateOrCreateByParentId(requestId, { activeResponseId: createdResponse._id });
     window.main.completeExecutionStep({ requestId });
-    return { nextRequestIdOrName: mutatedContext.execution?.nextRequestIdOrName };
+    return { nextRequestIdOrName: mutatedContext.execution?.nextRequestIdOrName, skipped: true };
   }
 
   window.main.completeExecutionStep({ requestId });

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.runner.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.runner.tsx
@@ -29,9 +29,8 @@ import * as reactUse from 'react-use';
 import { v4 as uuidv4 } from 'uuid';
 
 import { JSON_ORDER_PREFIX, JSON_ORDER_SEPARATOR } from '~/common/constants';
+import { buildRunnerItemKey, type RunnerItemStatus, type RunnerLiveItem } from '~/common/runner-feedback';
 import { invariant } from '~/common/utils/invariant';
-import type { TimingStep } from '~/main/network/request-timing';
-import { cancelRequestById } from '~/network/cancellation.renderer';
 import { defaultSendActionRuntime } from '~/network/network';
 import { useRootLoaderData } from '~/root';
 import { useOrganizationLoaderData } from '~/routes/organization';
@@ -47,9 +46,9 @@ import { AlertModal } from '~/ui/components/modals/alert-modal';
 import { CLIPreviewModal } from '~/ui/components/modals/cli-preview-modal';
 import { UploadDataModal, type UploadDataType } from '~/ui/components/modals/upload-runner-data-modal';
 import { Pane, PaneBody, PaneHeader } from '~/ui/components/panes/pane';
+import { RunnerLiveProgressPane } from '~/ui/components/panes/runner-live-progress-pane';
 import { RunnerResultHistoryPane } from '~/ui/components/panes/runner-result-history-pane';
 import { RunnerTestResultPane } from '~/ui/components/panes/runner-test-result-pane';
-import { ResponseTimer } from '~/ui/components/response-timer';
 import { getTimeAndUnit } from '~/ui/components/tags/time-tag';
 import { Tooltip } from '~/ui/components/tooltip';
 import { ResponseTimelineViewer } from '~/ui/components/viewers/response-timeline-viewer';
@@ -57,6 +56,18 @@ import { useInsomniaTabContext } from '~/ui/context/app/insomnia-tab-context';
 import { useRunnerContext } from '~/ui/context/app/runner-context';
 import { buildRunnerTabId } from '~/ui/hooks/use-insomnia-tab';
 import { useRunnerRequestList } from '~/ui/hooks/use-runner-request-list';
+import {
+  cancelExecution,
+  finishExecution,
+  getExecution,
+  getRunnerLiveItems,
+  isExecutionCanceled,
+  isItemSkipped,
+  skipRunnerItem,
+  startExecution,
+  updateExecution,
+  upsertLiveItem,
+} from '~/ui/runner-execution-store';
 import { moveAfter, moveBefore } from '~/ui/utils';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.runner';
@@ -342,13 +353,13 @@ export const Runner: FC = () => {
     readResults();
   }, [runnerId]);
 
-  const [timingSteps, setTimingSteps] = useState<TimingStep[]>([]);
   const [totalTime, setTotalTime] = useState({
     duration: 0,
     unit: 'ms',
   });
 
   const [executionResult, setExecutionResult] = useState<RunnerTestResult | null>(null);
+  const [liveItems, setLiveItems] = useState<RunnerLiveItem[]>([]);
   const [timelines, setTimelines] = useState<ResponseTimelineEntry[]>([]);
   const gotoExecutionResult = useCallback(
     async (executionId: string) => {
@@ -398,7 +409,6 @@ export const Runner: FC = () => {
     if (isRunning) {
       const duration = Date.now() - latestTimingSteps[latestTimingSteps.length - 1].startedAt;
       const { number: durationNumber, unit: durationUnit } = getTimeAndUnit(duration);
-      setTimingSteps(latestTimingSteps);
       setTotalTime({
         duration: durationNumber,
         unit: durationUnit,
@@ -431,6 +441,19 @@ export const Runner: FC = () => {
     isRunning ? 1000 : null,
   );
 
+  reactUse.useInterval(
+    () => {
+      setLiveItems(getRunnerLiveItems(runnerId));
+    },
+    isRunning ? 250 : null,
+  );
+
+  useEffect(() => {
+    if (isRunning) {
+      setLiveItems(getRunnerLiveItems(runnerId));
+    }
+  }, [isRunning, runnerId]);
+
   useEffect(() => {
     refreshPanes();
   }, [refreshPanes]);
@@ -458,10 +481,9 @@ export const Runner: FC = () => {
     return { passedTestCount, totalTestCount, testResultCountTagColor };
   }, [executionResult, isRunning]);
 
-  const [selectedTab, setSelectedTab] = React.useState<Key>('test-results');
-  const gotoTestResultsTab = useCallback(() => {
-    setSelectedTab('test-results');
-  }, [setSelectedTab]);
+  const [selectedTab, setSelectedTab] = React.useState<Key>('results');
+  const [canceledRun, setCanceledRun] = useState(false);
+  const activeTab = isRunning ? 'results' : selectedTab;
 
   const allKeys = reqList.map(item => item.id);
   const disabledKeys = useMemo(() => {
@@ -695,7 +717,11 @@ export const Runner: FC = () => {
                           <span className={`ml-2 text-xs uppercase http-method-${item.method}`}>{item.method}</span>
                           <span
                             className="ml-2 cursor-pointer text-(--hl) hover:underline"
-                            onClick={() => goToRequest(item.id)}
+                            onPointerDown={e => e.stopPropagation()}
+                            onClick={e => {
+                              e.stopPropagation();
+                              goToRequest(item.id);
+                            }}
                           >
                             {item.name}
                           </span>
@@ -806,7 +832,7 @@ export const Runner: FC = () => {
           </Heading>
         </PaneHeader>
         <Tabs
-          selectedKey={selectedTab}
+          selectedKey={activeTab}
           onSelectionChange={setSelectedTab}
           aria-label="Request group tabs"
           className="flex h-full w-full flex-1 flex-col"
@@ -817,10 +843,10 @@ export const Runner: FC = () => {
           >
             <Tab
               className="flex h-full shrink-0 cursor-pointer items-center justify-between gap-2 px-3 py-1 text-(--hl) outline-hidden transition-colors duration-300 select-none hover:bg-(--hl-sm) hover:text-(--color-font) focus:bg-(--hl-sm) aria-selected:bg-(--hl-xs) aria-selected:text-(--color-font) aria-selected:hover:bg-(--hl-sm) aria-selected:focus:bg-(--hl-sm)"
-              id="test-results"
+              id="results"
             >
               <div>
-                <span>Tests</span>
+                <span>Results</span>
                 <span
                   className={`test-result-count ml-1 rounded-xs px-1 ${testResultCountTagColor}`}
                   style={{ color: 'white' }}
@@ -833,7 +859,7 @@ export const Runner: FC = () => {
               className="flex h-full shrink-0 cursor-pointer items-center justify-between gap-2 px-3 py-1 text-(--hl) outline-hidden transition-colors duration-300 select-none hover:bg-(--hl-sm) hover:text-(--color-font) focus:bg-(--hl-sm) aria-selected:bg-(--hl-xs) aria-selected:text-(--color-font) aria-selected:hover:bg-(--hl-sm) aria-selected:focus:bg-(--hl-sm)"
               id="history"
             >
-              History
+              Test History
             </Tab>
             <Tab
               className="flex h-full shrink-0 cursor-pointer items-center justify-between gap-2 px-3 py-1 text-(--hl) outline-hidden transition-colors duration-300 select-none hover:bg-(--hl-sm) hover:text-(--color-font) focus:bg-(--hl-sm) aria-selected:bg-(--hl-xs) aria-selected:text-(--color-font) aria-selected:hover:bg-(--hl-sm) aria-selected:focus:bg-(--hl-sm)"
@@ -849,25 +875,32 @@ export const Runner: FC = () => {
             <RunnerResultHistoryPane
               history={testHistory.filter(item => !deletedItems.includes(item._id))}
               gotoExecutionResult={gotoExecutionResult}
-              gotoTestResultsTab={gotoTestResultsTab}
+              gotoTestResultsTab={() => {
+                setSelectedTab('results');
+              }}
               deleteHistoryItem={deleteHistoryItem}
             />
           </TabPanel>
-          <TabPanel className="flex w-full flex-1 flex-col overflow-y-auto" id="test-results">
-            {isRunning && (
-              <div className="flex h-full w-full items-center">
-                <ResponseTimer
-                  handleCancel={() => cancelExecution(runnerId)}
-                  activeRequestId={runnerId}
-                  steps={timingSteps}
+          <TabPanel className="flex w-full flex-1 flex-col overflow-y-auto" id="results">
+            <ErrorBoundary showAlert>
+              {isRunning || canceledRun ? (
+                <RunnerLiveProgressPane
+                  items={liveItems}
+                  isRunning={isRunning}
+                  handleCancel={() => {
+                    cancelExecution(runnerId);
+                    setCanceledRun(true);
+                    setLiveItems(getRunnerLiveItems(runnerId));
+                  }}
+                  handleSkip={key => {
+                    skipRunnerItem(runnerId, key);
+                    setLiveItems(getRunnerLiveItems(runnerId));
+                  }}
                 />
-              </div>
-            )}
-            {!isRunning && (
-              <ErrorBoundary showAlert>
+              ) : (
                 <RunnerTestResultPane result={executionResult} />
-              </ErrorBoundary>
-            )}
+              )}
+            </ErrorBoundary>
           </TabPanel>
         </Tabs>
       </Panel>
@@ -877,39 +910,6 @@ export const Runner: FC = () => {
 
 export default Runner;
 
-// This is required for tracking the active request for one runner execution
-// Then in runner cancellation, both the active request and the runner execution will be canceled
-// TODO(george): Potentially it could be merged with maps in request-timing.ts and cancellation.ts
-interface ExecutionInfo {
-  activeRequestId?: string;
-  error?: string;
-}
-const runnerExecutions = new Map<string, ExecutionInfo>();
-function startExecution(workspaceId: string) {
-  runnerExecutions.set(workspaceId, {});
-}
-
-function updateExecution(workspaceId: string, executionInfo: ExecutionInfo) {
-  const info = runnerExecutions.get(workspaceId);
-  runnerExecutions.set(workspaceId, {
-    ...info,
-    ...executionInfo,
-  });
-}
-
-function getExecution(workspaceId: string) {
-  return runnerExecutions.get(workspaceId) || {};
-}
-
-function cancelExecution(workspaceId: string) {
-  const { activeRequestId } = getExecution(workspaceId);
-  if (activeRequestId) {
-    cancelRequestById(activeRequestId);
-    window.main.completeExecutionStep({ requestId: activeRequestId });
-    window.main.updateLatestStepName({ requestId: workspaceId, stepName: 'Done' });
-    window.main.completeExecutionStep({ requestId: workspaceId });
-  }
-}
 const wrapAroundIterationOverIterationData = (
   list?: UserUploadEnvironment[],
   currentIteration?: number,
@@ -974,6 +974,21 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   });
   startExecution(runnerId);
 
+  const initialLiveItems: RunnerLiveItem[] = [];
+  for (let i = 0; i < iterationCount; i++) {
+    requests.forEach((req, index) => {
+      initialLiveItems.push({
+        key: buildRunnerItemKey(i + 1, index, req.id),
+        iteration: i + 1,
+        requestId: req.id,
+        requestName: req.name,
+        requestUrl: req.url,
+        status: 'pending',
+      });
+    });
+  }
+  updateExecution(runnerId, { liveItems: initialLiveItems });
+
   const noLogRuntime = {
     appendTimeline: async (_timelinePath: string, _logs: string[]) => {}, // no op
   };
@@ -989,22 +1004,60 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
 
       let j = 0;
       while (j < requests.length) {
-        // TODO: we might find a better way to do runner cancellation
-        if (getExecution(runnerId) === undefined) {
-          throw new Error('Runner has been stopped');
+        if (isExecutionCanceled(runnerId)) {
+          throw new Error('Runner has been canceled');
         }
 
         const targetRequest = requests[j];
+        const liveItemKey = buildRunnerItemKey(i + 1, j, targetRequest.id);
+        const interruptStatus = (): RunnerItemStatus | null =>
+          isExecutionCanceled(runnerId) ? 'canceled' : isItemSkipped(runnerId, liveItemKey) ? 'skipped' : null;
+
+        if (isItemSkipped(runnerId, liveItemKey)) {
+          upsertLiveItem(runnerId, liveItemKey, { status: 'skipped' });
+          testResultsForOneIteration = [
+            ...testResultsForOneIteration,
+            {
+              requestName: targetRequest.name,
+              requestUrl: targetRequest.url,
+              responseCode: 0,
+              results: [],
+              skipped: true,
+            },
+          ];
+          j++;
+          continue;
+        }
+
         const resultCollector = {
           requestId: targetRequest.id,
           requestName: targetRequest.name,
           requestUrl: targetRequest.url,
           statusCode: 0,
+          statusMessage: '',
           duration: 0,
           size: 0,
           results: [],
           responseId: '',
         };
+        const buildResult = () => ({
+          requestName: targetRequest.name,
+          requestUrl: resultCollector.requestUrl,
+          responseCode: resultCollector.statusCode,
+          responseMessage: resultCollector.statusMessage,
+          responseTime: resultCollector.duration,
+          responseSize: resultCollector.size,
+          results: resultCollector.results,
+        });
+        const buildLivePatch = (status: RunnerLiveItem['status']) => ({
+          status,
+          requestUrl: resultCollector.requestUrl,
+          statusCode: resultCollector.statusCode,
+          statusMessage: resultCollector.statusMessage,
+          responseTime: resultCollector.duration,
+          responseSize: resultCollector.size,
+          results: resultCollector.results,
+        });
 
         const isNextRequest = (targetRequest: RequestRow, nextRequestIdOrName: string) => {
           const matchId = targetRequest.id === nextRequestIdOrName;
@@ -1027,7 +1080,9 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
 
           updateExecution(runnerId, {
             activeRequestId: targetRequest.id,
+            activeRequestKey: liveItemKey,
           });
+          upsertLiveItem(runnerId, liveItemKey, { status: 'running' });
           window.main.updateLatestStepName({
             requestId: runnerId,
             stepName: `Iteration ${i + 1} - Executing ${j + 1} of ${requests.length} requests - "${targetRequest.name}"`,
@@ -1039,6 +1094,12 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
           invariant(activeRequestMeta, 'Request meta not found');
 
           await new Promise(resolve => setTimeout(resolve, delay));
+
+          const beforeSend = interruptStatus();
+          if (beforeSend) {
+            upsertLiveItem(runnerId, liveItemKey, { status: beforeSend });
+            continue;
+          }
 
           const execution = await sendActionImplementation({
             requestId: targetRequest.id,
@@ -1055,14 +1116,14 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
             nextRequestIdOrName = execution.nextRequestIdOrName || '';
           }
 
-          const requestResults: RunnerResultPerRequest = {
-            requestName: targetRequest.name,
-            requestUrl: targetRequest.url,
-            responseCode: resultCollector.statusCode,
-            results: resultCollector.results,
-          };
+          const afterSend = interruptStatus();
+          if (afterSend) {
+            upsertLiveItem(runnerId, liveItemKey, { status: afterSend });
+            continue;
+          }
 
-          testResultsForOneIteration = [...testResultsForOneIteration, requestResults];
+          upsertLiveItem(runnerId, liveItemKey, buildLivePatch('completed'));
+          testResultsForOneIteration = [...testResultsForOneIteration, buildResult()];
           testCtx = {
             ...testCtx,
             duration: testCtx.duration + resultCollector.duration,
@@ -1076,14 +1137,15 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
             ],
           };
         } catch (e) {
-          const requestResults: RunnerResultPerRequest = {
-            requestName: targetRequest.name,
-            requestUrl: targetRequest.url,
-            responseCode: resultCollector.statusCode,
-            results: resultCollector.results,
-          };
-
-          testResultsForOneIteration = [...testResultsForOneIteration, requestResults];
+          const interrupted = interruptStatus();
+          upsertLiveItem(runnerId, liveItemKey, {
+            ...buildLivePatch(interrupted ?? 'failed'),
+            errorMessage: e.message || e.error || String(e),
+          });
+          testResultsForOneIteration = [
+            ...testResultsForOneIteration,
+            { ...buildResult(), skipped: interrupted === 'skipped' },
+          ];
           testCtx = {
             ...testCtx,
             responsesInfo: [
@@ -1124,12 +1186,13 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
     window.main.updateLatestStepName({ requestId: runnerId, stepName: 'Done' });
     window.main.completeExecutionStep({ requestId: runnerId });
   } catch (e) {
-    // the error could be from third party
-    const errMsg = e.message || e.error || e;
-    updateExecution(runnerId, { error: errMsg });
+    if (!isExecutionCanceled(runnerId)) {
+      const errMsg = e.message || e.error || e;
+      updateExecution(runnerId, { error: errMsg });
+    }
     return null;
   } finally {
-    cancelExecution(runnerId);
+    finishExecution(runnerId);
 
     await services.runnerTestResult.create({
       parentId: runnerId,

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.runner.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.runner.tsx
@@ -1074,6 +1074,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
               // reset nextRequestIdOrName when request name or id meets;
               nextRequestIdOrName = '';
             } else {
+              upsertLiveItem(runnerId, liveItemKey, buildLivePatch('skipped'));
+              testResultsForOneIteration = [...testResultsForOneIteration, { ...buildResult(), skipped: true }];
               continue;
             }
           }
@@ -1114,6 +1116,12 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
           });
           if (execution?.nextRequestIdOrName) {
             nextRequestIdOrName = execution.nextRequestIdOrName || '';
+          }
+
+          if (execution?.skipped) {
+            upsertLiveItem(runnerId, liveItemKey, buildLivePatch('skipped'));
+            testResultsForOneIteration = [...testResultsForOneIteration, { ...buildResult(), skipped: true }];
+            continue;
           }
 
           const afterSend = interruptStatus();

--- a/packages/insomnia/src/ui/components/panes/request-result-card.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-result-card.tsx
@@ -1,0 +1,94 @@
+import type { RunnerResultPerRequest } from 'insomnia-data';
+import React, { type FC, useState } from 'react';
+import { Button } from 'react-aria-components';
+
+import { Icon } from '~/ui/components/icon';
+
+import {
+  formatResponseStats,
+  getRunnerStatusTag,
+  type RunnerItemStatus,
+  type RunnerLiveItem,
+} from '../../../common/runner-feedback';
+import { RenderedText } from '../rendered-text';
+import { RequestTestResultRows } from './request-test-result-pane';
+
+interface Props {
+  item: RunnerResultPerRequest | RunnerLiveItem;
+  resultFilter?: string;
+  targetTests?: string;
+  onSkip?: () => void;
+  testId?: string;
+}
+
+export const RequestResultCard: FC<Props> = ({ item, resultFilter = '', targetTests = 'all', onSkip, testId }) => {
+  const [isExpanded, setIsExpanded] = useState(!!targetTests);
+  const status: RunnerItemStatus =
+    'status' in item ? item.status : item.skipped ? 'skipped' : item.responseCode > 0 ? 'completed' : 'failed';
+  const isSkipped = status === 'skipped';
+  const statusCode = 'status' in item ? item.statusCode : item.responseCode;
+  const statusMessage = 'status' in item ? item.statusMessage : item.responseMessage;
+  const errorMessage = 'status' in item ? item.errorMessage : undefined;
+  const tag = getRunnerStatusTag({ status, statusCode, statusMessage });
+  const stats = formatResponseStats(item);
+  const results = item.results ?? [];
+  const passedTests = results.filter(result => result.status === 'passed').length;
+  const showSkip = Boolean(onSkip) && (status === 'pending' || status === 'running');
+  const showError = (status === 'failed' || status === 'canceled') && Boolean(errorMessage);
+  const showExpand = status === 'completed' || status === 'failed';
+  const showTestResults = isExpanded && !isSkipped && results.length > 0;
+  const showInlineStats = isExpanded && !isSkipped && stats;
+
+  const requestId = 'requestId' in item ? item.requestId : undefined;
+
+  return (
+    <div data-testid={testId} className="m-3 rounded-sm border border-solid border-(--hl-md) p-3">
+      <div className="flex items-start gap-2">
+        <div
+          className={`inline-block w-22 shrink-0 rounded-sm px-2 py-[2px] text-center text-xs font-semibold text-white ${tag.className}`}
+        >
+          {tag.label}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div>
+            <span>{item.requestName}</span>
+            <span className="text-sm text-neutral-400">
+              {' - '}
+              {item.requestUrl.includes('{{') ? (
+                <RenderedText requestId={requestId}>{item.requestUrl}</RenderedText>
+              ) : (
+                item.requestUrl
+              )}
+            </span>
+            {!isExpanded && !isSkipped && results.length > 0 && (
+              <span className="ml-2 text-xs whitespace-nowrap text-neutral-400">
+                {`(${passedTests}/${results.length} tests passed)`}
+              </span>
+            )}
+          </div>
+          {showInlineStats && <div className="text-sm text-neutral-400">{stats}</div>}
+          {showError && <div className="text-sm text-red-500">{errorMessage}</div>}
+        </div>
+        {showSkip && (
+          <Button
+            className="shrink-0 rounded-xs border border-solid border-(--hl-md) px-3 py-0.5 text-sm hover:bg-(--hl-xs)"
+            onPress={onSkip}
+          >
+            Skip
+          </Button>
+        )}
+        {showExpand && (
+          <Button
+            onPress={() => setIsExpanded(prev => !prev)}
+            className="shrink-0 rounded-xs px-3 pt-1 pb-0.5 text-sm hover:bg-(--hl-xs)"
+          >
+            {isExpanded ? <Icon icon="chevron-down" /> : <Icon icon="chevron-right" />}
+          </Button>
+        )}
+      </div>
+      {showTestResults && (
+        <RequestTestResultRows requestTestResults={results} resultFilter={resultFilter} targetTests={targetTests} />
+      )}
+    </div>
+  );
+};

--- a/packages/insomnia/src/ui/components/panes/request-test-result-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-test-result-pane.tsx
@@ -24,7 +24,7 @@ export const RequestTestResultRows: FC<RequestTestResultRowsProps> = ({
 }: RequestTestResultRowsProps) => {
   if (requestTestResults.length === 0) {
     return (
-      <div className="my-3 w-full pl-3 text-sm text-neutral-400">
+      <div className="my-2 w-full pl-3 text-sm text-neutral-400">
         No test was detected, add test cases in scripts to see results.
       </div>
     );
@@ -100,13 +100,13 @@ export const RequestTestResultRows: FC<RequestTestResultRowsProps> = ({
         // stable & unique key avoids rendering quirks.
         // Ref: https://react.dev/learn/rendering-lists#keeping-list-items-in-order-with-key
         <div key={index} data-testid="test-result-row">
-          <div className="my-3 flex w-full text-base">
-            <div className="m-auto mx-1 leading-4">
+          <div className="mt-5 flex w-full items-start text-base">
+            <div className="mx-1 leading-4">
               <span className="mr-2 ml-2">{statusTag}</span>
             </div>
             <div className="mr-2 leading-4">
-              <div className="my-1 mr-2 w-auto text-nowrap">{message}</div>
-              <div className="my-1 text-sm text-neutral-400">
+              <div className="mt-1 mr-2 w-auto text-nowrap">{message}</div>
+              <div className="mt-1 text-sm text-neutral-400">
                 {`${testCategory} (`}
                 {executionTime}
                 {' ms)'}

--- a/packages/insomnia/src/ui/components/panes/runner-live-progress-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/runner-live-progress-pane.tsx
@@ -1,0 +1,51 @@
+import React, { type FC } from 'react';
+import { Button } from 'react-aria-components';
+
+import { isFinished, type RunnerLiveItem } from '../../../common/runner-feedback';
+import { RequestResultCard } from './request-result-card';
+
+interface Props {
+  items: RunnerLiveItem[];
+  isRunning: boolean;
+  handleCancel: () => void;
+  handleSkip: (key: string) => void;
+}
+
+export const RunnerLiveProgressPane: FC<Props> = ({ items, isRunning, handleCancel, handleSkip }) => {
+  const total = items.length;
+  const finished = items.filter(item => isFinished(item.status)).length;
+  const skipped = items.filter(item => item.status === 'skipped').length;
+  const canceled = items.filter(item => item.status === 'canceled').length;
+  const iterations = [...new Set(items.map(item => item.iteration))];
+
+  return (
+    <div className="flex h-full w-full flex-col overflow-y-auto">
+      <div className="sticky top-0 z-10 flex shrink-0 items-center justify-between border-b border-solid border-(--hl-md) bg-(--color-bg) px-3 py-2">
+        <span className="text-sm">{`${isRunning ? 'Running' : 'Finished'} ${finished - skipped - canceled} / ${total} requests (${skipped} skipped, ${canceled} canceled)`}</span>
+        {isRunning && (
+          <Button
+            className="rounded-xs border border-solid border-(--hl-md) px-3 py-0.5 text-sm hover:bg-(--hl-xs)"
+            onPress={handleCancel}
+          >
+            Cancel all
+          </Button>
+        )}
+      </div>
+      {iterations.map(iteration => (
+        <div key={`live-iteration-${iteration}`}>
+          <div className="mb-1 pl-3 leading-10 font-bold uppercase">{`Iteration ${iteration}`}</div>
+          {items
+            .filter(item => item.iteration === iteration)
+            .map(item => (
+              <RequestResultCard
+                key={item.key}
+                item={item}
+                testId={`runner-live-item-${item.requestName}`}
+                onSkip={() => handleSkip(item.key)}
+              />
+            ))}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/packages/insomnia/src/ui/components/panes/runner-test-result-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/runner-test-result-pane.tsx
@@ -2,7 +2,7 @@ import type { BaseRunnerTestResult, RunnerResultPerRequest } from 'insomnia-data
 import React, { type FC, useState } from 'react';
 import { Toolbar } from 'react-aria-components';
 
-import { RequestTestResultRows } from './request-test-result-pane';
+import { RequestResultCard } from './request-result-card';
 
 type TargetTestType = 'all' | 'passed' | 'failed' | 'skipped';
 
@@ -38,20 +38,10 @@ export const RunnerTestResultPane: FC<Props> = ({ result }) => {
     const key = `runner-test-result-iteration-${i + 1}`;
 
     if (Array.isArray(iterationResults)) {
-      const resultByRequest = iterationResults.map((requestTestResult: RunnerResultPerRequest, i: number) => {
-        const key = `request-test-result-${i}`;
+      const resultByRequest = iterationResults.map((requestTestResult: RunnerResultPerRequest, reqIndex: number) => {
+        const key = `request-test-result-${reqIndex}`;
         return (
-          <div key={key}>
-            <div className="pl-3">
-              <span>{requestTestResult.requestName}</span>
-              <span className="text-sm text-neutral-400">{` - ${requestTestResult.requestUrl}`}</span>
-            </div>
-            <RequestTestResultRows
-              requestTestResults={requestTestResult.results}
-              resultFilter={resultFilter}
-              targetTests={targetTests}
-            />
-          </div>
+          <RequestResultCard key={key} item={requestTestResult} resultFilter={resultFilter} targetTests={targetTests} />
         );
       });
 

--- a/packages/insomnia/src/ui/components/panes/runner-test-result-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/runner-test-result-pane.tsx
@@ -41,7 +41,13 @@ export const RunnerTestResultPane: FC<Props> = ({ result }) => {
       const resultByRequest = iterationResults.map((requestTestResult: RunnerResultPerRequest, reqIndex: number) => {
         const key = `request-test-result-${reqIndex}`;
         return (
-          <RequestResultCard key={key} item={requestTestResult} resultFilter={resultFilter} targetTests={targetTests} />
+          <RequestResultCard
+            key={key}
+            item={requestTestResult}
+            resultFilter={resultFilter}
+            targetTests={targetTests}
+            testId={key}
+          />
         );
       });
 

--- a/packages/insomnia/src/ui/components/rendered-text.tsx
+++ b/packages/insomnia/src/ui/components/rendered-text.tsx
@@ -7,6 +7,7 @@ import { useNunjucks } from '../context/nunjucks/use-nunjucks';
 interface Props {
   children: string;
   render: HandleRender;
+  requestId?: string;
 }
 interface State {
   renderedText: string;
@@ -70,7 +71,7 @@ class RenderedTextInternal extends PureComponent<Props, State> {
 }
 
 export const RenderedText: FC<Omit<Props, 'render'>> = props => {
-  const { handleRender } = useNunjucks();
+  const { handleRender } = useNunjucks({ requestId: props.requestId });
 
   return <RenderedTextInternal {...props} render={handleRender} />;
 };

--- a/packages/insomnia/src/ui/context/nunjucks/use-nunjucks.ts
+++ b/packages/insomnia/src/ui/context/nunjucks/use-nunjucks.ts
@@ -1,3 +1,4 @@
+import { services } from 'insomnia-data';
 import { useCallback } from 'react';
 
 import { getRenderContext, getRenderContextAncestors, render } from '~/common/render';
@@ -11,7 +12,8 @@ import { useRequestGroupLoaderData } from '~/routes/organization.$organizationId
 let getRenderContextPromiseCache: any = {};
 
 export interface UseNunjucksOptions {
-  renderContext: Pick<Partial<RenderContextOptions>, 'purpose' | 'extraInfo'>;
+  renderContext?: Pick<Partial<RenderContextOptions>, 'purpose' | 'extraInfo'>;
+  requestId?: string;
 }
 export const initializeNunjucksRenderPromiseCache = () => {
   getRenderContextPromiseCache = {};
@@ -30,11 +32,11 @@ export const useNunjucks = (options?: UseNunjucksOptions) => {
   const workspaceData = useWorkspaceLoaderData();
 
   const fetchRenderContext = useCallback(async () => {
-    const ancestors = await getRenderContextAncestors(
-      requestData?.activeRequest || activeRequestGroup || workspaceData?.activeWorkspace,
-    );
+    const overrideRequest = options?.requestId ? await services.request.getById(options.requestId) : null;
+    const base = overrideRequest || requestData?.activeRequest || activeRequestGroup || workspaceData?.activeWorkspace;
+    const ancestors = await getRenderContextAncestors(base);
     return getRenderContext({
-      request: requestData?.activeRequest || undefined,
+      request: overrideRequest || requestData?.activeRequest || undefined,
       environment: workspaceData?.activeEnvironment._id,
       ancestors,
       ...options?.renderContext,
@@ -44,6 +46,7 @@ export const useNunjucks = (options?: UseNunjucksOptions) => {
     workspaceData?.activeWorkspace,
     workspaceData?.activeEnvironment._id,
     options?.renderContext,
+    options?.requestId,
     activeRequestGroup,
   ]);
 

--- a/packages/insomnia/src/ui/runner-execution-store.ts
+++ b/packages/insomnia/src/ui/runner-execution-store.ts
@@ -1,0 +1,99 @@
+import { isFinished, type RunnerLiveItem } from '~/common/runner-feedback';
+import { cancelRequestById } from '~/network/cancellation.renderer';
+
+interface ExecutionInfo {
+  activeRequestId?: string;
+  activeRequestKey?: string;
+  error?: string;
+  canceled?: boolean;
+  skippedKeys?: string[];
+  liveItems?: RunnerLiveItem[];
+}
+
+const runnerExecutions = new Map<string, ExecutionInfo>();
+
+export function startExecution(workspaceId: string) {
+  runnerExecutions.set(workspaceId, { canceled: false, skippedKeys: [], liveItems: [] });
+}
+
+export function updateExecution(workspaceId: string, executionInfo: ExecutionInfo) {
+  const info = runnerExecutions.get(workspaceId);
+  runnerExecutions.set(workspaceId, {
+    ...info,
+    ...executionInfo,
+  });
+}
+
+export function getExecution(workspaceId: string) {
+  return runnerExecutions.get(workspaceId) || {};
+}
+
+export function getRunnerLiveItems(workspaceId: string) {
+  return runnerExecutions.get(workspaceId)?.liveItems || [];
+}
+
+export function upsertLiveItem(workspaceId: string, key: string, patch: Partial<RunnerLiveItem>) {
+  const info = runnerExecutions.get(workspaceId);
+  if (!info) {
+    return;
+  }
+  const items = info.liveItems ? [...info.liveItems] : [];
+  const idx = items.findIndex(item => item.key === key);
+  if (idx === -1) {
+    return;
+  }
+  const current = items[idx];
+  const status = patch.status && !isFinished(current.status) ? patch.status : current.status;
+  items[idx] = { ...current, ...patch, status };
+  updateExecution(workspaceId, { liveItems: items });
+}
+
+export function isExecutionCanceled(workspaceId: string) {
+  return Boolean(runnerExecutions.get(workspaceId)?.canceled);
+}
+
+export function isItemSkipped(workspaceId: string, key: string) {
+  return Boolean(runnerExecutions.get(workspaceId)?.skippedKeys?.includes(key));
+}
+
+export function skipRunnerItem(workspaceId: string, key: string) {
+  const info = runnerExecutions.get(workspaceId);
+  if (!info) {
+    return;
+  }
+  const skippedKeys = info.skippedKeys ? [...info.skippedKeys] : [];
+  if (!skippedKeys.includes(key)) {
+    skippedKeys.push(key);
+  }
+  updateExecution(workspaceId, { skippedKeys });
+  if (info.activeRequestKey === key && info.activeRequestId) {
+    cancelRequestById(info.activeRequestId);
+  }
+  upsertLiveItem(workspaceId, key, { status: 'skipped' });
+}
+
+function endExecution(workspaceId: string, forceComplete: boolean) {
+  const { activeRequestId } = getExecution(workspaceId);
+  if (activeRequestId) {
+    cancelRequestById(activeRequestId);
+    window.main.completeExecutionStep({ requestId: activeRequestId });
+  }
+  if (forceComplete || activeRequestId) {
+    window.main.updateLatestStepName({ requestId: workspaceId, stepName: 'Done' });
+    window.main.completeExecutionStep({ requestId: workspaceId });
+  }
+}
+
+export function cancelExecution(workspaceId: string) {
+  updateExecution(workspaceId, {
+    canceled: true,
+    liveItems: getRunnerLiveItems(workspaceId).map(item =>
+      isFinished(item.status) ? item : { ...item, status: 'canceled' },
+    ),
+  });
+  endExecution(workspaceId, true);
+}
+
+export function finishExecution(workspaceId: string) {
+  endExecution(workspaceId, false);
+}


### PR DESCRIPTION
Improves the Collection Runner in-progress view with per-request statuses and actions:

<img width="704" height="529" alt="Screenshot 2026-06-30 at 13 20 24" src="https://github.com/user-attachments/assets/bc814ad4-4a8d-4556-a22c-f82a94e32a74" />

- Templated URLs will now render before request completes
- Entire run can be canceled
- Run state is moved into its own file