### PR TITLE
fix: no proxy setting with roots [INS-2838]

### DIFF
--- a/packages/insomnia/src/main/__tests__/libcurl-promise.test.ts
+++ b/packages/insomnia/src/main/__tests__/libcurl-promise.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldBypassProxyForHost } from '~/main/network/libcurl-promise';
+
+describe('shouldBypassProxyForHost()', () => {
+  it('returns false when there is no noProxy setting', () => {
+    expect(shouldBypassProxyForHost('rest.rodeo', '')).toBe(false);
+  });
+
+  it('returns false when there is no hostname', () => {
+    expect(shouldBypassProxyForHost(null, '.rest.rodeo')).toBe(false);
+  });
+
+  it('matches an exact hostname without a leading dot', () => {
+    expect(shouldBypassProxyForHost('rest.rodeo', 'rest.rodeo')).toBe(true);
+  });
+
+  it('does not match a subdomain when the entry has no leading dot', () => {
+    expect(shouldBypassProxyForHost('api.rest.rodeo', 'rest.rodeo')).toBe(false);
+  });
+
+  it('matches the bare domain when the entry has a leading dot', () => {
+    expect(shouldBypassProxyForHost('rest.rodeo', '.rest.rodeo')).toBe(true);
+  });
+
+  it('matches any subdomain when the entry has a leading dot', () => {
+    expect(shouldBypassProxyForHost('api.rest.rodeo', '.rest.rodeo')).toBe(true);
+  });
+
+  it('does not match an unrelated domain that shares a suffix', () => {
+    expect(shouldBypassProxyForHost('notrest.rodeo', '.rest.rodeo')).toBe(false);
+  });
+
+  it('honors every entry in a comma-separated list, not just the first', () => {
+    const noProxy = '.rest.rodeo,.konghq.com,localhost';
+    expect(shouldBypassProxyForHost('rest.rodeo', noProxy)).toBe(true);
+    expect(shouldBypassProxyForHost('api.rest.rodeo', noProxy)).toBe(true);
+    expect(shouldBypassProxyForHost('konghq.com', noProxy)).toBe(true);
+    expect(shouldBypassProxyForHost('api.konghq.com', noProxy)).toBe(true);
+  });
+
+  it('trims whitespace around entries', () => {
+    expect(shouldBypassProxyForHost('api.rest.rodeo', ' .rest.rodeo , .konghq.com ')).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(shouldBypassProxyForHost('API.REST.RODEO', '.rest.rodeo')).toBe(true);
+  });
+
+  it('returns false for a host that does not match any entry', () => {
+    expect(shouldBypassProxyForHost('example.com', '.rest.rodeo,.konghq.com')).toBe(false);
+  });
+});

--- a/packages/insomnia/src/main/api.protocol.ts
+++ b/packages/insomnia/src/main/api.protocol.ts
@@ -7,7 +7,7 @@ import { app, net, protocol, session } from 'electron';
 import { services } from 'insomnia-data';
 
 import { getApiBaseURL } from '../common/constants';
-import { setDefaultProtocol } from './network/libcurl-promise';
+import { setDefaultProtocol, shouldBypassProxyForHost } from './network/libcurl-promise';
 import { resolveDbByKey } from './templating-worker-database';
 
 export interface RegisterProtocolOptions {
@@ -128,14 +128,15 @@ export async function registerInsomniaProtocols() {
               }
             }
           } else {
-            const { protocol } = urlParse(urlStr);
+            const { protocol, hostname } = urlParse(urlStr);
             const { httpProxy, httpsProxy, noProxy } = settings;
             const proxyHost = protocol === 'https:' ? httpsProxy : httpProxy;
-            const proxy = proxyHost ? setDefaultProtocol(proxyHost) : null;
+            const proxy = !shouldBypassProxyForHost(hostname, noProxy) && proxyHost ? setDefaultProtocol(proxyHost) : '';
+            curl.setOpt(Curl.option.PROXY, proxy);
             if (proxy) {
-              curl.setOpt(Curl.option.PROXY, proxy);
               curl.setOpt(Curl.option.PROXYAUTH, CurlAuth.Any);
             }
+            // also pass the raw list to curl, which still correctly handles IP/CIDR entries (e.g. "192.168.0.0/16")
             if (noProxy) {
               curl.setOpt(Curl.option.NOPROXY, noProxy);
             }

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -365,15 +365,16 @@ export const createConfiguredCurlInstance = ({
   if (!settings.proxyEnabled) {
     curl.setOpt(Curl.option.PROXY, '');
   } else {
-    const { protocol } = urlParse(req.url);
+    const { protocol, hostname } = urlParse(req.url);
     const { httpProxy, httpsProxy, noProxy } = settings;
     const proxyHost = protocol === 'https:' ? httpsProxy : httpProxy;
-    const proxy = proxyHost ? setDefaultProtocol(proxyHost) : '';
+    const proxy = !shouldBypassProxyForHost(hostname, noProxy) && proxyHost ? setDefaultProtocol(proxyHost) : '';
+    curl.setOpt(Curl.option.PROXY, proxy);
     if (proxy) {
       debugTimeline.push({ value: `Using proxy: ${proxy}`, name: 'Text', timestamp: Date.now() });
-      curl.setOpt(Curl.option.PROXY, proxy);
       curl.setOpt(Curl.option.PROXYAUTH, CurlAuth.Any);
     }
+    // also pass the raw list to curl, which still correctly handles IP/CIDR entries (e.g. "192.168.0.0/16")
     if (noProxy) {
       curl.setOpt(Curl.option.NOPROXY, noProxy);
     }
@@ -579,6 +580,26 @@ export const getHttpVersion = (preferredHttpVersion: string) => {
     }
   }
 };
+
+// workaround for a curl 7.86 bug: https://github.com/curl/curl/issues/10122
+export function shouldBypassProxyForHost(hostname: string | null, noProxy: string): boolean {
+  if (!hostname || !noProxy) {
+    return false;
+  }
+
+  const normalizedHostname = hostname.toLowerCase();
+
+  return noProxy
+    .split(',')
+    .map(entry => entry.trim().toLowerCase())
+    .filter(Boolean)
+    .some(entry => {
+      if (entry.startsWith('.')) {
+        return normalizedHostname === entry.slice(1) || normalizedHostname.endsWith(entry);
+      }
+      return normalizedHostname === entry;
+    });
+}
 
 export const setDefaultProtocol = (url: string, defaultProto?: string) => {
   const trimmedUrl = url.trim();


### PR DESCRIPTION
Elevates the responsibility of `.sld.tld` matching for `No proxy` preferences to the main process instead of passing it on to cURL since the version we utilize has an issue: https://github.com/curl/curl/issues/10122

This is a stopgap until we've bumped `node-libcurl` to use a later version