### PR TITLE
feat(ci): add release_build check option to publish workflow

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -43,8 +43,10 @@ jobs:
       packages: write
     steps:
       - name: Check Release Build Confirmed
+        env:
+          IS_RELEASE_BUILD_TRIGGERED: ${{ github.event.inputs.release_build }}
         run: |
-          if [ "${{ github.event.inputs.release_build }}" != "true" ]; then
+          if [ "$IS_RELEASE_BUILD_TRIGGERED" != "true" ]; then
             echo "::error title=Missing Release Build::You must check 'release_build' to confirm that release-build.yml has been triggered for this version before running this workflow."
             exit 1
           fi

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -4,6 +4,11 @@ run-name: Publish ${{ github.event.inputs.version }} channel by @${{ github.acto
 on:
   workflow_dispatch:
     inputs:
+      release_build:
+        required: true
+        type: boolean
+        default: false
+        description: Confirm that release-build.yml has been triggered for this version
       version:
         required: true
         description: Release version (e.g. 12.5.0)
@@ -37,6 +42,13 @@ jobs:
       contents: write # Required to upload assets. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues
       packages: write
     steps:
+      - name: Check Release Build Confirmed
+        run: |
+          if [ "${{ github.event.inputs.release_build }}" != "true" ]; then
+            echo "::error title=Missing Release Build::You must check 'release_build' to confirm that release-build.yml has been triggered for this version before running this workflow."
+            exit 1
+          fi
+
       - name: Calculate Release Branch
         env:
           VERSION: ${{ github.event.inputs.version }}


### PR DESCRIPTION
Introduces a new `release_build` input option to the publish pipeline. Publishers must verify this checkbox before deploying to guarantee that the prerequisite release build workflow has successfully executed.
<img width="1538" height="211" alt="image" src="https://github.com/user-attachments/assets/e77277e4-ee6a-4fcb-a663-0a99a23498e3" />
