### PR TITLE
fix: fallback to https protocol when url includes template to avoid error

### DIFF
--- a/packages/insomnia-scripting-environment/src/objects/__tests__/urls.test.ts
+++ b/packages/insomnia-scripting-environment/src/objects/__tests__/urls.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { QueryParam, Url, UrlMatchPattern } from '../urls';
+import { QueryParam, resolveProtocolForProxy, Url, UrlMatchPattern } from '../urls';
 import { Variable } from '../variables';
 
 describe('test Url object', () => {
@@ -339,5 +339,26 @@ describe('test Url Match Pattern', () => {
     expect(matchPattern.testPort('80', 'http')).toBeTruthy();
     expect(matchPattern.testPort('443', 'http')).toBeFalsy();
     expect(matchPattern.testPort('80', 'https')).toBeFalsy();
+  });
+});
+
+describe('test resolveProtocolForProxy', () => {
+  it('uses the parsed protocol when available', () => {
+    expect(resolveProtocolForProxy('https://example.com/')).toEqual('https:');
+    expect(resolveProtocolForProxy('http://example.com/')).toEqual('http:');
+  });
+
+  it('falls back to the scheme in the raw url when parsedProtocol is empty (url has unrendered tags)', () => {
+    // e.g. https://httpbin.io/anything/{% base64 'encode', 'normal', '1' %}
+    expect(resolveProtocolForProxy("https://httpbin.io/anything/{% base64 'encode', 'normal', '1' %}")).toEqual(
+      'https:',
+    );
+    expect(resolveProtocolForProxy('http://example.com/{{ _.var }}')).toEqual('http:');
+  });
+
+  it('falls back to https: when the scheme itself is templated', () => {
+    // e.g. {{ baseUrl }}/path -- scheme unknown until rendering happens
+    expect(resolveProtocolForProxy('{{ _.baseUrl }}/path')).toEqual('https:');
+    expect(resolveProtocolForProxy('http://{{ _.host }}/{{ _.var }}')).toEqual('https:');
   });
 });

--- a/packages/insomnia-scripting-environment/src/objects/insomnia.ts
+++ b/packages/insomnia-scripting-environment/src/objects/insomnia.ts
@@ -16,7 +16,7 @@ import type { Response as ScriptResponse } from './response';
 import { readBodyFromPath, toScriptResponse } from './response';
 import { sendRequest } from './send-request';
 import { skip, test, type TestHandler } from './test';
-import { toUrlObject } from './urls';
+import { resolveProtocolForProxy, toUrlObject } from './urls';
 import { checkIfUrlIncludesTag } from './utils';
 
 export class InsomniaObject {
@@ -231,7 +231,7 @@ export async function initInsomniaObject(rawObj: RequestContext, log: (...args: 
 
   const reqUrl = toUrlObject(rawObj.request.url);
   const proxy = transformToSdkProxyOptions(
-    reqUrl.protocol,
+    resolveProtocolForProxy(rawObj.request.url),
     rawObj.settings.httpProxy,
     rawObj.settings.httpsProxy,
     rawObj.settings.proxyEnabled,

--- a/packages/insomnia-scripting-environment/src/objects/urls.ts
+++ b/packages/insomnia-scripting-environment/src/objects/urls.ts
@@ -625,7 +625,7 @@ export function toUrlObject(url: string | Url): Url {
  * Resolves the protocol to use for proxy selection when the request URL may still
  * contain unrendered template tags (pre-request scripts run before template rendering).
  * Falls back to parsing the scheme off the raw URL string, and to 'https:' when the
- * scheme itself is templated (e.g. "{{ baseUrl }}/path").
+ * scheme or host itself is templated (e.g. "{{ baseUrl }}/path").
  */
 export function resolveProtocolForProxy(rawUrl: string): string {
   try {

--- a/packages/insomnia-scripting-environment/src/objects/urls.ts
+++ b/packages/insomnia-scripting-environment/src/objects/urls.ts
@@ -620,3 +620,17 @@ export function toUrlObject(url: string | Url): Url {
   }
   return typeof url === 'string' ? new Url(url) : url;
 }
+
+/**
+ * Resolves the protocol to use for proxy selection when the request URL may still
+ * contain unrendered template tags (pre-request scripts run before template rendering).
+ * Falls back to parsing the scheme off the raw URL string, and to 'https:' when the
+ * scheme itself is templated (e.g. "{{ baseUrl }}/path").
+ */
+export function resolveProtocolForProxy(rawUrl: string): string {
+  try {
+    return new URL(rawUrl).protocol;
+  } catch {
+    return 'https:';
+  }
+}


### PR DESCRIPTION
[INS-2929](https://konghq.atlassian.net/browse/INS-2929)

## Background

Encounter errors when:
- Proxy enabled
- Templates are included in the request URL
- Scripts are included in the request

## Change

Fallback to `https` protocol when the URL includes template to avoid error.

[INS-2929]: https://konghq.atlassian.net/browse/INS-2929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ