### PR TITLE
feat: add Export to the project context menu [INS-2552]

### DIFF
--- a/packages/insomnia-smoke-test/playwright/pages/project/index.ts
+++ b/packages/insomnia-smoke-test/playwright/pages/project/index.ts
@@ -1,7 +1,7 @@
 import type { ElectronApplication, Page } from '@playwright/test';
 
 import { loadFixture } from '../../paths';
-import { mockSaveDialogForFile } from '../../utils';
+import { mockOpenDialogForDirectory, mockSaveDialogForFile } from '../../utils';
 import { BasePage } from '../base-page';
 import { NavigationSidebar } from '../components/navigation-sidebar';
 import { WorkspaceListComponent } from './workspace-list';
@@ -247,6 +247,28 @@ export class ProjectPage extends BasePage {
     await this.page.getByRole('dialog').getByRole('button', { name: 'Export' }).click();
 
     // Select export format
+    await this.exportModal.selectExportFormat(format);
+  }
+
+  /**
+   * Exports all workspaces in a project via the sidebar project actions dropdown.
+   * Mirrors the Preferences > Data tab export, but triggered from the project context menu.
+   * Note: After calling this method, use waitForExportFiles() utility to ensure files are written.
+   * @param projectName - The name of the project to export
+   * @param exportPath - The directory (yaml) or file (har) path used to mock the save dialog
+   * @param format - The export format ('yaml' or 'har')
+   */
+  async exportProjectFromSidebar(
+    projectName: string,
+    exportPath: string,
+    format: 'yaml' | 'har' = 'yaml',
+  ): Promise<void> {
+    await this.sidebar.selectProjectDropdownOption({ actionName: 'Export', projectName });
+    if (format === 'yaml') {
+      await mockOpenDialogForDirectory(this.app, exportPath);
+    } else if (format === 'har') {
+      await mockSaveDialogForFile(this.app, exportPath);
+    }
     await this.exportModal.selectExportFormat(format);
   }
 }

--- a/packages/insomnia-smoke-test/tests/smoke/export.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/export.test.ts
@@ -143,6 +143,46 @@ test.describe('Export', () => {
     }
   });
 
+  test('Can export project files from the sidebar project dropdown in YAML format', async ({ insomnia, page }) => {
+    const projectName = 'Export Sidebar Project Test';
+    await insomnia.projectPage.createProject(projectName, 'local');
+    await insomnia.projectPage.importMultipleFixtures(FIXTURE_FILES);
+    await expect.soft(insomnia.projectPage.workspaceList.workspaceLocator('Collection A')).toBeVisible();
+    await expect.soft(insomnia.projectPage.workspaceList.workspaceLocator('Collection B')).toBeVisible();
+    const tempDir = createTempExportDir();
+
+    try {
+      await insomnia.projectPage.exportProjectFromSidebar(projectName, tempDir, 'yaml');
+      await waitForExportFiles(tempDir, 2);
+      const exportedFiles = getExportedFiles(tempDir);
+      expect.soft(exportedFiles).toHaveLength(2);
+      const fixtureMap: Record<string, string> = {
+        'Collection-A': FIXTURE_FILES[0],
+        'Collection-B': FIXTURE_FILES[1],
+      };
+
+      for (const exportedFile of exportedFiles) {
+        const exportedContent = readExportedFile(exportedFile);
+        const fileName = path.basename(exportedFile);
+
+        // Find the matching fixture file by collection name
+        const collectionNameMatch = fileName.match(/^(Collection-[AB])/);
+        expect.soft(collectionNameMatch, `File ${fileName} should match collection name pattern`).not.toBeNull();
+
+        const collectionName = String(collectionNameMatch?.[1]);
+        const fixtureFile = String(fixtureMap[collectionName]);
+        expect.soft(fixtureFile, `Should find fixture for ${collectionName}`).toBeTruthy();
+
+        // Compare with fixture
+        const comparison = compareWithFixture(exportedContent, fixtureFile);
+
+        expect.soft(comparison.matches, `Exported file ${fileName} should match fixture ${fixtureFile}`).toBe(true);
+      }
+    } finally {
+      cleanupExportDir(tempDir);
+    }
+  });
+
   test('Can export single workspace from workspace card dropdown', async ({ insomnia, page }) => {
     const projectName = 'Export Single Workspace Test';
     const fixtureFile = FIXTURE_FILES[0];

--- a/packages/insomnia/src/ui/components/dropdowns/sidebar-project-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/sidebar-project-dropdown.tsx
@@ -1,7 +1,7 @@
 import type { IconName, IconProp } from '@fortawesome/fontawesome-svg-core';
 import type { StorageRules } from 'insomnia-api';
 import type { GitRepository, Project, WorkspaceScope } from 'insomnia-data';
-import { models } from 'insomnia-data';
+import { models, services } from 'insomnia-data';
 import React, { type FC, Fragment, useEffect, useState } from 'react';
 import {
   Button,
@@ -26,6 +26,7 @@ import { useProjectDeleteActionFetcher } from '~/routes/organization.$organizati
 import { AnalyticsEvent } from '~/ui/analytics';
 import { ImportModal } from '~/ui/components/modals/import-modal/import-modal';
 import { NewWorkspaceModal } from '~/ui/components/modals/new-workspace-modal';
+import { exportProjectToFile } from '~/ui/components/settings/import-export';
 
 import { Icon } from '../icon';
 import { showModal } from '../modals';
@@ -119,6 +120,21 @@ export const ProjectDropdown: FC<Props> = ({
           },
         });
         setImportModalType('file');
+      },
+    },
+    {
+      id: 'export',
+      name: 'Export',
+      icon: 'file-export',
+      action: async (projectId: string, projectName: string) => {
+        window.main.trackAnalyticsEvent({
+          event: AnalyticsEvent.exportStarted,
+          properties: {
+            source: 'project',
+          },
+        });
+        const workspacesForProject = await services.workspace.findByParentId(projectId);
+        exportProjectToFile(projectName, workspacesForProject);
       },
     },
     {


### PR DESCRIPTION
## Summary

Adds an **Export** option to the project context menu (sidebar "..." dropdown),
placed directly below **Import**. Previously you could export a Collection or
Environment by right-clicking it, but there was no way to export a whole Project
from the sidebar — you had to go to Preferences → Data. This restores that parity.

Export from the project menu reuses the exact same handler as Preferences → Data
(`exportProjectToFile`), so it behaves identically: format selection (YAML/HAR),
private-environment prompt, and save dialog.

## Changes

- `sidebar-project-dropdown.tsx`: new **Export** action in the ACTIONS section,
  below **Import**. It gathers the project's workspaces via
  `services.workspace.findByParentId` and calls the shared `exportProjectToFile`,
  tracking the `exportStarted` analytics event with `source: 'project'`.
- `insomnia-smoke-test`: added an E2E test covering the new menu path, plus an
  `exportProjectFromSidebar` page-object helper mirroring the existing
  `exportProjectData`.

## Testing

- `npm run lint` / `npm run type-check` — clean
- New smoke test passes: `npm run test:smoke:dev -- -g "sidebar project dropdown"`

## Screenshots

_Before:_ project menu had Import, Settings, Sort, Delete — no Export.
<img width="445" height="475" alt="image" src="https://github.com/user-attachments/assets/de093a11-a7de-408a-bcaa-3878a0c46517" />

_After:_ Export appears directly below Import.
<img width="366" height="514" alt="image" src="https://github.com/user-attachments/assets/5200d0bd-d47e-452c-8ba4-fedaeef57f58" />
