### PR TITLE
fix: surface invalid spectral ruleset issues to renderer in git sync projects

### DIFF
--- a/packages/insomnia/src/common/spectral-ruleset-validator.ts
+++ b/packages/insomnia/src/common/spectral-ruleset-validator.ts
@@ -147,7 +147,7 @@ export function validateSpectralRuleset(content: string): SpectralRulesetValidat
   try {
     parsed = YAML.parse(content);
   } catch {
-    return fail(`Ruleset is not valid YAML or JSON`);
+    return fail('Ruleset is not valid YAML or JSON.');
   }
 
   if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
@@ -162,7 +162,7 @@ export function validateSpectralRuleset(content: string): SpectralRulesetValidat
 
   const disallowed = keys.filter(key => !ALLOWED_TOP_LEVEL_PROPERTIES.includes(key));
   if (disallowed.length > 0) {
-    return fail(`Ruleset contains unsupported top-level keys. Only "rules" and "extends" are allowed.`);
+    return fail('Ruleset contains unsupported top-level keys. Only "rules" and "extends" are allowed.');
   }
 
   if ('extends' in ruleset) {

--- a/packages/insomnia/src/entry.preload.ts
+++ b/packages/insomnia/src/entry.preload.ts
@@ -204,6 +204,7 @@ const git: GitServiceAPI = {
   getGitBranches: options => invokeWithNormalizedError('git.getGitBranches', options),
   fetchGitRemoteBranches: options => invokeWithNormalizedError('git.fetchGitRemoteBranches', options),
   getProjectGitFileIssues: options => invokeWithNormalizedError('git.getProjectGitFileIssues', options),
+  getProjectRulesetImportIssue: options => invokeWithNormalizedError('git.getProjectRulesetImportIssue', options),
   validateGitRepositoryCredentials: options =>
     invokeWithNormalizedError('git.validateGitRepositoryCredentials', options),
   validateGitCredentialById: options => invokeWithNormalizedError('git.validateGitCredentialById', options),

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -324,6 +324,35 @@ export async function getProjectGitFileIssues({
   });
 }
 
+/**
+ * Return the current import problem message for the project's Spectral
+ * ruleset (`.spectral.yaml`), or null if the ruleset is valid/absent. Used by
+ * the spec page to passively surface a git-imported ruleset that was rejected
+ * as invalid.
+ */
+export async function getProjectRulesetImportIssue({
+  projectId,
+  gitRepositoryId,
+}: {
+  projectId: string;
+  gitRepositoryId: string;
+}): Promise<string | null> {
+  const project = await services.project.getById(projectId);
+  if (!project || !models.project.isConnectedGitProject(project)) {
+    return null;
+  }
+
+  const effectiveRepoId = models.project.getEffectiveRepoId(project);
+  if (effectiveRepoId !== gitRepositoryId) {
+    return null;
+  }
+
+  const issue = repoFileWatcherRegistry
+    .getProblems(effectiveRepoId)
+    .find(problem => problem.relPath === '.spectral.yaml');
+  return issue?.message ?? null;
+}
+
 export interface BranchRemoteInfo {
   trackingRemote: string | null;
   isOrigin: boolean;
@@ -3043,6 +3072,7 @@ export interface GitServiceAPI {
   validateGitRepositoryCredentials: typeof validateGitRepositoryCredentials;
   validateGitCredentialById: typeof validateGitCredentialById;
   getProjectGitFileIssues: typeof getProjectGitFileIssues;
+  getProjectRulesetImportIssue: typeof getProjectRulesetImportIssue;
 
   initSignInToGitProvider: typeof initSignInToGitProvider;
   completeSignInToGitProvider: typeof completeSignInToGitProvider;
@@ -3072,6 +3102,9 @@ export const registerGitServiceAPI = () => {
   );
   ipcMainHandle('git.getProjectGitFileIssues', (_, options: Parameters<typeof getProjectGitFileIssues>[0]) =>
     getProjectGitFileIssues(options),
+  );
+  ipcMainHandle('git.getProjectRulesetImportIssue', (_, options: Parameters<typeof getProjectRulesetImportIssue>[0]) =>
+    getProjectRulesetImportIssue(options),
   );
   ipcMainHandle('git.gitFetchAction', (_, options: Parameters<typeof gitFetchAction>[0]) => gitFetchAction(options));
   ipcMainHandle('git.gitLogLoader', (_, options: Parameters<typeof gitLogLoader>[0]) => gitLogLoader(options));

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -64,6 +64,7 @@ export type HandleChannels =
   | 'git.discardChanges'
   | 'git.fetchGitRemoteBranches'
   | 'git.getProjectGitFileIssues'
+  | 'git.getProjectRulesetImportIssue'
   | 'git.validateGitRepositoryCredentials'
   | 'git.validateGitCredentialById'
   | 'git.getGitBranches'

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx
@@ -112,6 +112,15 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   const rulesetContent = projectLintRuleset?.rulesetContent || '';
   const rulesetLastCompiledAt = projectLintRuleset?.modified ?? null;
 
+  // For git projects, surface a committed .spectral.yaml that was rejected as
+  // invalid on import (so the user learns it wasn't applied and why, instead of
+  // silently falling back to the default ruleset). Refreshed automatically via
+  // the git.db-synced → revalidate flow in root.tsx.
+  const rulesetImportIssue =
+    isConnectedGitProject && gitRepositoryId
+      ? await window.main.git.getProjectRulesetImportIssue({ projectId, gitRepositoryId })
+      : null;
+
   let parsedSpec: OpenAPIV3.Document | undefined;
 
   try {
@@ -125,6 +134,7 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
     parsedSpec,
     rulesetContent,
     rulesetLastCompiledAt,
+    rulesetImportIssue,
   };
 }
 
@@ -212,8 +222,15 @@ const Component = ({ params }: Route.ComponentProps) => {
 
   const { isGenerateMockServersWithAIEnabled } = useAIFeatureStatus();
 
-  const { apiSpec, gitSyncRulesetPath, isConnectedGitProject, parsedSpec, rulesetContent, rulesetLastCompiledAt } =
-    useLoaderData<typeof clientLoader>();
+  const {
+    apiSpec,
+    gitSyncRulesetPath,
+    isConnectedGitProject,
+    parsedSpec,
+    rulesetContent,
+    rulesetLastCompiledAt,
+    rulesetImportIssue,
+  } = useLoaderData<typeof clientLoader>();
 
   const [lintMessages, setLintMessages] = useState<LintMessage[]>([]);
   const [expandedLintMessageCodes, setExpandedLintMessageCodes] = useState<string[]>([]);
@@ -772,13 +789,54 @@ const Component = ({ params }: Route.ComponentProps) => {
     </div>
   ) : null;
 
+  const isRulesetInvalid = !!rulesetImportIssue && !rulesetContent;
+
   const lintToolbar = (
     <div
       className={`flex h-(--line-height-sm) items-center gap-2 overflow-hidden border-solid border-(--hl-md) px-(--padding-sm) ${isLintPaneOpen ? 'border-b' : ''}`}
     >
       <div className="inline-flex items-center gap-2">
-        <Icon icon={selectedRulesetPath ? 'file-circle-check' : 'file-circle-xmark'} />
-        {selectedRulesetPath ? (
+        <Icon icon={selectedRulesetPath && !isRulesetInvalid ? 'file-circle-check' : 'file-circle-xmark'} />
+        {isRulesetInvalid && (
+          <>
+            <span>Invalid Custom Ruleset</span>
+            <TooltipTrigger delay={0}>
+              <Button
+                aria-label="Invalid ruleset details"
+                className="flex aspect-square h-6 shrink-0 items-center justify-center rounded-xs text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
+              >
+                <Icon icon="circle-info" />
+              </Button>
+              <Tooltip
+                placement="top end"
+                offset={8}
+                className="max-h-[85vh] max-w-xs overflow-y-auto rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) px-4 py-2 text-sm text-(--color-font) shadow-lg select-none focus:outline-hidden"
+              >
+                <p className="mb-2">
+                  The custom ruleset in this project contains invalid content: {rulesetImportIssue}
+                </p>
+                <p>Fix the syntax in your connected git repository. The default OAS ruleset is used until then.</p>
+              </Tooltip>
+            </TooltipTrigger>
+            <TooltipTrigger delay={0}>
+              <Button
+                aria-label="Upload custom ruleset"
+                onPress={handleSelectSpectralFile}
+                className="flex aspect-square h-6 shrink-0 items-center justify-center rounded-xs text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
+              >
+                <Icon icon="upload" />
+              </Button>
+              <Tooltip
+                placement="top end"
+                offset={8}
+                className="max-h-[85vh] max-w-xs overflow-y-auto rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) px-4 py-2 text-sm text-(--color-font) shadow-lg select-none focus:outline-hidden"
+              >
+                <p>Upload a valid custom Spectral ruleset to replace the invalid one.</p>
+              </Tooltip>
+            </TooltipTrigger>
+          </>
+        )}
+        {!isRulesetInvalid && selectedRulesetPath && (
           <>
             <TooltipTrigger delay={0}>
               <Button
@@ -836,7 +894,8 @@ const Component = ({ params }: Route.ComponentProps) => {
               </Tooltip>
             </TooltipTrigger>
           </>
-        ) : (
+        )}
+        {!isRulesetInvalid && !selectedRulesetPath && (
           <>
             <span>Default OAS Ruleset</span>
             <TooltipTrigger delay={0}>

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx
@@ -797,45 +797,6 @@ const Component = ({ params }: Route.ComponentProps) => {
     >
       <div className="inline-flex items-center gap-2">
         <Icon icon={selectedRulesetPath && !isRulesetInvalid ? 'file-circle-check' : 'file-circle-xmark'} />
-        {isRulesetInvalid && (
-          <>
-            <span>Invalid Custom Ruleset</span>
-            <TooltipTrigger delay={0}>
-              <Button
-                aria-label="Invalid ruleset details"
-                className="flex aspect-square h-6 shrink-0 items-center justify-center rounded-xs text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
-              >
-                <Icon icon="circle-info" />
-              </Button>
-              <Tooltip
-                placement="top end"
-                offset={8}
-                className="max-h-[85vh] max-w-xs overflow-y-auto rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) px-4 py-2 text-sm text-(--color-font) shadow-lg select-none focus:outline-hidden"
-              >
-                <p className="mb-2">
-                  The custom ruleset in this project contains invalid content: {rulesetImportIssue}
-                </p>
-                <p>Fix the syntax in your connected git repository. The default OAS ruleset is used until then.</p>
-              </Tooltip>
-            </TooltipTrigger>
-            <TooltipTrigger delay={0}>
-              <Button
-                aria-label="Upload custom ruleset"
-                onPress={handleSelectSpectralFile}
-                className="flex aspect-square h-6 shrink-0 items-center justify-center rounded-xs text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
-              >
-                <Icon icon="upload" />
-              </Button>
-              <Tooltip
-                placement="top end"
-                offset={8}
-                className="max-h-[85vh] max-w-xs overflow-y-auto rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) px-4 py-2 text-sm text-(--color-font) shadow-lg select-none focus:outline-hidden"
-              >
-                <p>Upload a valid custom Spectral ruleset to replace the invalid one.</p>
-              </Tooltip>
-            </TooltipTrigger>
-          </>
-        )}
         {!isRulesetInvalid && selectedRulesetPath && (
           <>
             <TooltipTrigger delay={0}>
@@ -895,9 +856,29 @@ const Component = ({ params }: Route.ComponentProps) => {
             </TooltipTrigger>
           </>
         )}
-        {!isRulesetInvalid && !selectedRulesetPath && (
+        {!selectedRulesetPath && (
           <>
             <span>Default OAS Ruleset</span>
+            {isRulesetInvalid && (
+              <TooltipTrigger delay={0}>
+                <Button
+                  aria-label="Invalid ruleset details"
+                  className="flex aspect-square h-6 shrink-0 items-center justify-center rounded-xs text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
+                >
+                  <Icon icon="triangle-exclamation" className="text-(--color-warning)" />
+                </Button>
+                <Tooltip
+                  placement="top end"
+                  offset={8}
+                  className="max-h-[85vh] max-w-xs overflow-y-auto rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) px-4 py-2 text-sm text-(--color-font) shadow-lg select-none focus:outline-hidden"
+                >
+                  <p className="mb-2">
+                    The custom ruleset in this project contains invalid content: {rulesetImportIssue}
+                  </p>
+                  <p>Fix the syntax in your connected git repository. The default OAS ruleset is used until then.</p>
+                </Tooltip>
+              </TooltipTrigger>
+            )}
             <TooltipTrigger delay={0}>
               <Button
                 aria-label="Upload custom ruleset"

--- a/packages/insomnia/src/sync/git/__tests__/repo-file-watcher.test.ts
+++ b/packages/insomnia/src/sync/git/__tests__/repo-file-watcher.test.ts
@@ -149,4 +149,34 @@ describe('RepoFileWatcher ruleset import problems', () => {
 
     expect(getRulesetImportIssue(REPO_ID)).toBeNull();
   });
+
+  // Regression: cloning a repo whose committed .spectral.yaml is invalid must
+  // never delete the file. Previously, an invalid ruleset was silently
+  // ignored (not recognized as a ruleset at all) instead of being rejected,
+  // so nothing prevented the file from later being deleted as a stale
+  // tracked file — which git staged as a deletion that Discard could never
+  // resolve, since re-importing the same invalid content each time was also
+  // a silent no-op.
+  it('keeps an invalid cloned ruleset on disk and out of the DB, surviving repeated re-imports', async () => {
+    const absPath = path.join(repoDir, RULESET_PATH);
+    await fs.promises.writeFile(absPath, INVALID_RULESET, 'utf8');
+
+    // Simulate the initial clone import.
+    await registry.startWatcher(REPO_ID, repoDir, PROJECT_ID);
+
+    const exists = () => fs.promises.access(absPath).then(() => true).catch(() => false);
+    expect(await exists()).toBe(true);
+    expect(await services.projectLintRuleset.getByParentId(PROJECT_ID)).toBeFalsy();
+    expect(getRulesetImportIssue(REPO_ID)).not.toBeNull();
+
+    // Simulate a Discard, which re-writes the same invalid content (as if
+    // restored from git HEAD), followed by the resulting re-import.
+    await fs.promises.writeFile(absPath, INVALID_RULESET, 'utf8');
+    await registry.importAllFiles(REPO_ID);
+    await registry.flushNow(REPO_ID);
+
+    expect(await exists()).toBe(true);
+    expect(await services.projectLintRuleset.getByParentId(PROJECT_ID)).toBeFalsy();
+    expect(getRulesetImportIssue(REPO_ID)).not.toBeNull();
+  });
 });

--- a/packages/insomnia/src/sync/git/__tests__/repo-file-watcher.test.ts
+++ b/packages/insomnia/src/sync/git/__tests__/repo-file-watcher.test.ts
@@ -87,3 +87,66 @@ describe('RepoFileWatcher orphan reconciliation', () => {
     expect(stillThere).not.toBeNull();
   });
 });
+
+describe('RepoFileWatcher ruleset import problems', () => {
+  let repoDir: string;
+  let registry: RepoFileWatcherRegistry;
+  const RULESET_PATH = '.spectral.yaml';
+  const VALID_RULESET = 'extends:\n  - "spectral:oas"\nrules: {}\n';
+  const INVALID_RULESET = 'rules:\n  - [unclosed';
+
+  const getRulesetImportIssue = (repoId: string) =>
+    registry.getProblems(repoId).find(problem => problem.relPath === RULESET_PATH) ?? null;
+
+  beforeEach(async () => {
+    await db.init({ inMemoryOnly: true }, true);
+    repoDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'insomnia-repo-watcher-ruleset-'));
+    registry = makeRegistry();
+  });
+
+  afterEach(async () => {
+    registry.stopAll();
+    await fs.promises.rm(repoDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it('surfaces the .spectral.yaml problem when invalid and clears it once fixed', async () => {
+    const absPath = path.join(repoDir, RULESET_PATH);
+
+    // Invalid → issue surfaced.
+    await fs.promises.writeFile(absPath, INVALID_RULESET, 'utf8');
+    await registry.startWatcher(REPO_ID, repoDir, PROJECT_ID);
+    expect(getRulesetImportIssue(REPO_ID)).toMatchObject({ kind: 'parse-error', relPath: RULESET_PATH });
+
+    // Fixed → issue cleared.
+    await fs.promises.writeFile(absPath, VALID_RULESET, 'utf8');
+    await registry.importAllFiles(REPO_ID);
+    expect(getRulesetImportIssue(REPO_ID)).toBeNull();
+  });
+
+  it('returns null when the ruleset is valid', async () => {
+    await fs.promises.writeFile(path.join(repoDir, RULESET_PATH), VALID_RULESET, 'utf8');
+    await registry.startWatcher(REPO_ID, repoDir, PROJECT_ID);
+    expect(getRulesetImportIssue(REPO_ID)).toBeNull();
+  });
+
+  it('returns null when the watcher is not running', () => {
+    expect(getRulesetImportIssue('nonexistent_repo')).toBeNull();
+  });
+
+  // Regression: uploading a valid ruleset over a previously-invalid committed
+  // file must clear the stale problem, so the spec page stops showing
+  // "Invalid ruleset — using default".
+  it('clears a stale ruleset problem after a valid ruleset is stored via upload', async () => {
+    const absPath = path.join(repoDir, RULESET_PATH);
+    await fs.promises.writeFile(absPath, INVALID_RULESET, 'utf8');
+    await registry.startWatcher(REPO_ID, repoDir, PROJECT_ID);
+    expect(getRulesetImportIssue(REPO_ID)).not.toBeNull();
+
+    // Simulate a UI upload: valid ruleset upserted to the DB, then flushed to disk.
+    await services.projectLintRuleset.upsert(PROJECT_ID, { rulesetContent: VALID_RULESET });
+    await registry.flushNow(REPO_ID);
+
+    expect(getRulesetImportIssue(REPO_ID)).toBeNull();
+  });
+});

--- a/packages/insomnia/src/sync/git/repo-file-watcher.ts
+++ b/packages/insomnia/src/sync/git/repo-file-watcher.ts
@@ -43,13 +43,13 @@ import path from 'node:path';
 
 import type { BaseModel, Workspace, WorkspaceMeta } from 'insomnia-data';
 import { models, services } from 'insomnia-data';
-import YAML from 'yaml';
 
 import type { WorkspaceFileIssue } from '~/main/git-service';
 
 import { database as db } from '../../common/database';
 import { InsomniaFileTypeValues } from '../../common/import-v5-parser';
 import { getInsomniaV5DataExport, tryImportV5Data } from '../../common/insomnia-v5';
+import { validateSpectralRuleset } from '../../common/spectral-ruleset-validator';
 import { SyncQueue } from './sync-queue';
 
 const POLL_INTERVAL_MS = 10_000;
@@ -534,6 +534,10 @@ class RepoFileWatcher {
 
     try {
       if (!ruleset) {
+        if (this.hasProblem(absPath)) {
+          return;
+        }
+
         // Ruleset removed from the DB — remove the file if we were tracking it.
         if (this.lastWrittenHash.has(absPath) || this.lastSyncMtime.has(absPath)) {
           await fs.promises.rm(absPath, { force: true });
@@ -654,20 +658,6 @@ class RepoFileWatcher {
     );
   }
 
-  private isSpectralRulesetFile(normalisedPath: string, content: string): boolean {
-    if (!this.isSpectralRulesetPath(normalisedPath)) {
-      return false;
-    }
-    try {
-      const parsedContent = YAML.parse(content);
-      return (
-        !!parsedContent && typeof parsedContent === 'object' && ('extends' in parsedContent || 'rules' in parsedContent)
-      );
-    } catch {
-      return false;
-    }
-  }
-
   /**
    * Read a YAML file from disk and import its documents into the DB.
    *
@@ -691,7 +681,21 @@ class RepoFileWatcher {
     this.lastWrittenHash.set(normalised, result.hash);
     this.lastSyncMtime.set(normalised, result.mtimeMs);
 
-    if (this.isSpectralRulesetFile(normalised, result.content)) {
+    if (this.isSpectralRulesetPath(normalised)) {
+      const validation = validateSpectralRuleset(result.content);
+      if (!validation.isValid) {
+        await services.projectLintRuleset.remove(this.projectId);
+        this.addProblem(normalised, {
+          filePath: absPath,
+          relPath: this.toPosixRelPath(absPath),
+          kind: 'parse-error',
+          message: validation.error,
+        });
+        this.notifyRenderer();
+        return;
+      }
+
+      this.clearProblem(normalised);
       await services.projectLintRuleset.upsert(this.projectId, { rulesetContent: result.content });
       this.notifyRenderer();
       return;

--- a/packages/insomnia/src/sync/git/repo-file-watcher.ts
+++ b/packages/insomnia/src/sync/git/repo-file-watcher.ts
@@ -547,6 +547,16 @@ class RepoFileWatcher {
         return;
       }
 
+      // A DB ruleset only exists when it was validated (UI upload or a valid
+      // git import), so any problem still recorded for this path is stale —
+      // e.g. a previously-invalid committed file that the user has now replaced
+      // via upload. Clear it here, because the fs.watch echo of the write below
+      // is dedup-skipped and never reaches importFile's clearProblem path.
+      if (this.hasProblem(absPath)) {
+        this.clearProblem(absPath);
+        this.notifyRenderer();
+      }
+
       const hash = contentHash(ruleset.rulesetContent);
       if (this.lastWrittenHash.get(absPath) === hash) {
         return;


### PR DESCRIPTION
This PR fixes the issue identified in [INS-2888](https://konghq.atlassian.net/browse/INS-2888). 

Previously, when creating git sync projects, an invalid (e.g. improper yaml syntax) `.spectral.yaml` file would get imported by Insomnia and silently swalloed - the app fell back to the default OAS ruleset with no indication to the user that their committed ruleset was rejected or why. This also caused issues when committing changes (the `.spectral.yaml` would be staged as a deleted file). 

This behaviour is fixed by not allowing an invalid `.spectral.yaml` to end up in the database. It stays on disk from isomorphic-git when cloning, and we display UI to the user that the ruleset has invalid syntax that needs fixing and until that happens the default OAS ruleset will be used. 

[INS-2888]: https://konghq.atlassian.net/browse/INS-2888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ