### PR TITLE
Add F2 keyboard shortcut to inline-rename sidebar items [INS-2553]

### DIFF
--- a/packages/insomnia-data/common-src/hotkeys.ts
+++ b/packages/insomnia-data/common-src/hotkeys.ts
@@ -25,6 +25,7 @@ export const keyboardShortcutDescriptions: Record<KeyboardShortcut, string> = {
   request_showGenerateCodeEditor: 'Generate Code',
   sidebar_focusFilter: 'Filter Sidebar',
   sidebar_toggle: 'Toggle Sidebar',
+  sidebar_renameSelectedItem: 'Rename Selected Item',
   response_focus: 'Focus Response',
   showCookiesEditor: 'Edit Cookies',
   request_createHTTP: 'Create HTTP Request',
@@ -121,6 +122,10 @@ const defaultRegistry: HotKeyRegistry = {
   sidebar_toggle: {
     macKeys: [{ meta: true, keyCode: keyboardKeys.backslash.keyCode }],
     winLinuxKeys: [{ ctrl: true, keyCode: keyboardKeys.backslash.keyCode }],
+  },
+  sidebar_renameSelectedItem: {
+    macKeys: [{ keyCode: keyboardKeys.f2.keyCode }],
+    winLinuxKeys: [{ keyCode: keyboardKeys.f2.keyCode }],
   },
   response_focus: {
     macKeys: [{ meta: true, keyCode: keyboardKeys.singlequote.keyCode }],

--- a/packages/insomnia-data/common-src/hotkeys.ts
+++ b/packages/insomnia-data/common-src/hotkeys.ts
@@ -25,7 +25,7 @@ export const keyboardShortcutDescriptions: Record<KeyboardShortcut, string> = {
   request_showGenerateCodeEditor: 'Generate Code',
   sidebar_focusFilter: 'Filter Sidebar',
   sidebar_toggle: 'Toggle Sidebar',
-  sidebar_renameSelectedItem: 'Rename Selected Item',
+  sidebar_renameFocusedItem: 'Rename Focused Item',
   response_focus: 'Focus Response',
   showCookiesEditor: 'Edit Cookies',
   request_createHTTP: 'Create HTTP Request',
@@ -123,7 +123,7 @@ const defaultRegistry: HotKeyRegistry = {
     macKeys: [{ meta: true, keyCode: keyboardKeys.backslash.keyCode }],
     winLinuxKeys: [{ ctrl: true, keyCode: keyboardKeys.backslash.keyCode }],
   },
-  sidebar_renameSelectedItem: {
+  sidebar_renameFocusedItem: {
     macKeys: [{ keyCode: keyboardKeys.f2.keyCode }],
     winLinuxKeys: [{ keyCode: keyboardKeys.f2.keyCode }],
   },

--- a/packages/insomnia-data/common-src/settings.ts
+++ b/packages/insomnia-data/common-src/settings.ts
@@ -46,6 +46,7 @@ export type KeyboardShortcut =
   | 'request_showGenerateCodeEditor'
   | 'sidebar_focusFilter'
   | 'sidebar_toggle'
+  | 'sidebar_renameSelectedItem'
   | 'response_focus'
   | 'showCookiesEditor'
   | 'request_createHTTP'

--- a/packages/insomnia-data/common-src/settings.ts
+++ b/packages/insomnia-data/common-src/settings.ts
@@ -46,7 +46,7 @@ export type KeyboardShortcut =
   | 'request_showGenerateCodeEditor'
   | 'sidebar_focusFilter'
   | 'sidebar_toggle'
-  | 'sidebar_renameSelectedItem'
+  | 'sidebar_renameFocusedItem'
   | 'response_focus'
   | 'showCookiesEditor'
   | 'request_createHTTP'

--- a/packages/insomnia-smoke-test/tests/smoke/sidebar-rename-shortcut.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/sidebar-rename-shortcut.test.ts
@@ -1,0 +1,89 @@
+import type { Locator, Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+import { loadFixture } from '../../playwright/paths';
+import { test } from '../../playwright/test';
+
+// Coverage for the F2 rename shortcut (sidebar_renameFocusedItem): pressing F2 while a sidebar row
+// holds keyboard focus switches that row into inline-edit mode. There is one test per supported
+// item type — requests, folders, collections, documents, mock servers, environments and MCP clients.
+
+// The sidebar rows are React Aria GridList rows; the node's data-testid lives inside the focusable
+// [role="row"] element that carries the data-key the shortcut reads.
+const focusableRow = (page: Page, nodeTestId: string): Locator =>
+  page.locator(`[role="row"]:has([data-testid="${nodeTestId}"])`);
+
+// Focus the row, press F2, then type the new name into the inline editor that appears.
+const renameFocusedRow = async (page: Page, nodeTestId: string, newName: string): Promise<void> => {
+  const row = focusableRow(page, nodeTestId);
+  await row.waitFor({ state: 'visible' });
+  await row.press('F2');
+  const input = row.getByRole('textbox');
+  await input.fill(newName);
+  await input.press('Enter');
+};
+
+// Return to the project dashboard and create a workspace of the given type via the "Create in
+// project" menu. The New Workspace modal pre-fills a default name we can predict per type.
+const createWorkspaceViaMenu = async (page: Page, menuItemName: string): Promise<void> => {
+  await page.getByTestId('workspace-breadcrumb-level-0').click();
+  await page.getByLabel('Create in project').click();
+  await page.getByRole('menuitemradio', { name: menuItemName }).click();
+  await page.getByRole('button', { name: 'Create', exact: true }).click();
+};
+
+test.describe('F2 renames the focused sidebar item', () => {
+  test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
+
+  // Import a collection so the sidebar already contains a request ("example http"), a folder
+  // ("test folder") and a collection ("simple"), and the project dashboard shows the create toolbar.
+  test.beforeEach(async ({ app, page }) => {
+    const text = await loadFixture('simple.yaml');
+    await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
+    await page.getByLabel('Import').click();
+    await page.locator('[data-test-id="import-from-clipboard"]').click();
+    await page.getByRole('button', { name: 'Scan' }).click();
+    await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+    await page.getByRole('dialog').waitFor({ state: 'hidden' });
+    await page.getByTestId('request-node-example http').waitFor({ state: 'visible' });
+  });
+
+  test('renames a request', async ({ page, insomnia }) => {
+    await renameFocusedRow(page, 'request-node-example http', 'renamed request');
+    await expect.soft(insomnia.navigationSidebar.requestRow('renamed request')).toBeVisible();
+  });
+
+  test('renames a folder', async ({ page, insomnia }) => {
+    await renameFocusedRow(page, 'request-node-test folder', 'renamed folder');
+    await expect.soft(insomnia.navigationSidebar.requestRow('renamed folder')).toBeVisible();
+  });
+
+  test('renames a collection', async ({ page, insomnia }) => {
+    await renameFocusedRow(page, 'workspace-node-simple', 'renamed collection');
+    await expect.soft(insomnia.navigationSidebar.workspaceRow('renamed collection')).toBeVisible();
+  });
+
+  test('renames a document', async ({ page, insomnia }) => {
+    await createWorkspaceViaMenu(page, 'Document');
+    await renameFocusedRow(page, 'workspace-node-My Design Document', 'renamed document');
+    await expect.soft(insomnia.navigationSidebar.workspaceRow('renamed document')).toBeVisible();
+  });
+
+  test('renames a mock server', async ({ page, insomnia }) => {
+    await createWorkspaceViaMenu(page, 'Mock Server');
+    await renameFocusedRow(page, 'workspace-node-My Mock Server', 'renamed mock');
+    await expect.soft(insomnia.navigationSidebar.workspaceRow('renamed mock')).toBeVisible();
+  });
+
+  test('renames an environment', async ({ page, insomnia }) => {
+    await createWorkspaceViaMenu(page, 'Environment');
+    await renameFocusedRow(page, 'workspace-node-My Environment', 'renamed environment');
+    await expect.soft(insomnia.navigationSidebar.workspaceRow('renamed environment')).toBeVisible();
+  });
+
+  test('renames an MCP client', async ({ page, insomnia }) => {
+    await createWorkspaceViaMenu(page, 'MCP Client');
+    await renameFocusedRow(page, 'workspace-node-My MCP Client', 'renamed mcp');
+    await expect.soft(insomnia.navigationSidebar.workspaceRow('renamed mcp')).toBeVisible();
+  });
+});

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
@@ -39,6 +39,7 @@ import { useRootLoaderData } from '~/root';
 import { useProjectLoaderData } from '~/routes/organization.$organizationId.project.$projectId';
 import { AnalyticsEvent } from '~/ui/analytics';
 import type { WorkspaceSortOrder } from '~/ui/components/dropdowns/sidebar-project-dropdown';
+import { useDocBodyKeyboardShortcuts } from '~/ui/components/keydown-binder';
 import { KongLogo } from '~/ui/components/kong-logo';
 import { showModal } from '~/ui/components/modals';
 import { AskModal } from '~/ui/components/modals/ask-modal';
@@ -999,6 +1000,20 @@ const ProjectNavigationSidebarInner = (
       ? [selectedItemId]
       : [];
 
+  // Id of the request/folder that should switch into inline rename mode via the rename shortcut.
+  const [renamingItemId, setRenamingItemId] = useState<string | null>(null);
+  useDocBodyKeyboardShortcuts({
+    sidebar_renameSelectedItem: () => {
+      // Only requests and folders (collection children) support inline rename in the sidebar.
+      const selectedItem =
+        selectedItemId &&
+        visibleFlatItems.find(item => item.doc._id === selectedItemId && item.kind === 'collectionChild');
+      if (selectedItem) {
+        setRenamingItemId(selectedItemId);
+      }
+    },
+  });
+
   const { hasKonnectPat } = settings;
   const showKonnectSyncIntro = konnectSyncEnabled && !isProjectTabActive && !hasKonnectPat;
   const [showKonnectConfigModal, setShowKonnectConfigModal] = useState(false);
@@ -1258,7 +1273,12 @@ const ProjectNavigationSidebarInner = (
                     {item.kind === 'pinnedHeader' && <PinnedHeaderNode />}
 
                     {item.kind === 'collectionChild' && (
-                      <RequestNode item={item} onToggleFolder={toggleRequestGroups} />
+                      <RequestNode
+                        item={item}
+                        onToggleFolder={toggleRequestGroups}
+                        isRenaming={renamingItemId === item.doc._id}
+                        onRenameHandled={() => setRenamingItemId(null)}
+                      />
                     )}
 
                     {item.kind === 'pinnedRequest' && <RequestNode item={item} onToggleFolder={toggleRequestGroups} />}

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
@@ -1000,14 +1000,18 @@ const ProjectNavigationSidebarInner = (
       ? [selectedItemId]
       : [];
 
-  // Id of the request/folder that should switch into inline rename mode via the rename shortcut.
+  // Id of the sidebar item that should switch into inline rename mode via the rename shortcut.
   const [renamingItemId, setRenamingItemId] = useState<string | null>(null);
   useDocBodyKeyboardShortcuts({
     sidebar_renameSelectedItem: () => {
-      // Only requests and folders (collection children) support inline rename in the sidebar.
+      // Requests, folders (collection children) and workspaces (collections, docs, mocks,
+      // environments, MCP clients) support inline rename in the sidebar.
       const selectedItem =
         selectedItemId &&
-        visibleFlatItems.find(item => item.doc._id === selectedItemId && item.kind === 'collectionChild');
+        visibleFlatItems.find(
+          item =>
+            item.doc._id === selectedItemId && (item.kind === 'collectionChild' || item.kind === 'workspace'),
+        );
       if (selectedItem) {
         setRenamingItemId(selectedItemId);
       }
@@ -1267,6 +1271,8 @@ const ProjectNavigationSidebarInner = (
                         }}
                         highlighted={item.doc._id === onboardingEnvWorkspaceId}
                         nodeRef={item.doc._id === onboardingEnvWorkspaceId ? setEnvOnboardingNode : undefined}
+                        isRenaming={renamingItemId === item.doc._id}
+                        onRenameHandled={() => setRenamingItemId(null)}
                       />
                     )}
 

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
@@ -1003,17 +1003,28 @@ const ProjectNavigationSidebarInner = (
   // Id of the sidebar item that should switch into inline rename mode via the rename shortcut.
   const [renamingItemId, setRenamingItemId] = useState<string | null>(null);
   useDocBodyKeyboardShortcuts({
-    sidebar_renameSelectedItem: () => {
-      // Requests, folders (collection children) and workspaces (collections, docs, mocks,
-      // environments, MCP clients) support inline rename in the sidebar.
-      const selectedItem =
-        selectedItemId &&
+    sidebar_renameFocusedItem: () => {
+      // Rename the row that currently holds keyboard focus within the sidebar tree. Only requests,
+      // folders (collection children) and workspaces (collections, docs, mocks, environments, MCP
+      // clients) support inline rename.
+      const treeEl = parentRef.current;
+      const activeEl = document.activeElement;
+      if (!treeEl || !(activeEl instanceof HTMLElement) || !treeEl.contains(activeEl)) {
+        return;
+      }
+      const rowEl = activeEl.closest('[data-key]');
+      if (!(rowEl instanceof HTMLElement)) {
+        return;
+      }
+      // Pinned rows prefix their key; strip it to resolve the underlying doc id.
+      const docId = (rowEl.dataset.key || '').replace(/^pinned-request-/, '');
+      const focusedItem =
+        docId &&
         visibleFlatItems.find(
-          item =>
-            item.doc._id === selectedItemId && (item.kind === 'collectionChild' || item.kind === 'workspace'),
+          item => item.doc._id === docId && (item.kind === 'collectionChild' || item.kind === 'workspace'),
         );
-      if (selectedItem) {
-        setRenamingItemId(selectedItemId);
+      if (focusedItem) {
+        setRenamingItemId(docId);
       }
     },
   });

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/request-node.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/request-node.tsx
@@ -8,7 +8,7 @@ import type {
   Workspace,
 } from 'insomnia-data';
 import { models } from 'insomnia-data';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button, Tooltip, TooltipTrigger } from 'react-aria-components';
 import { useParams } from 'react-router';
 
@@ -132,9 +132,13 @@ interface RequestNodeProps {
   item: CollectionChildFlatItem | PinnedRequestFlatItem;
   onToggleFolder: (requestGroupIds: string[], workspace: Workspace) => void;
   className?: string;
+  // Whether an external trigger (e.g. the rename keyboard shortcut) has requested to rename this item.
+  isRenaming?: boolean;
+  // Called once the rename edit has been entered so the parent can clear its request.
+  onRenameHandled?: () => void;
 }
 
-export const RequestNode = ({ item, onToggleFolder, className }: RequestNodeProps) => {
+export const RequestNode = ({ item, onToggleFolder, className, isRenaming, onRenameHandled }: RequestNodeProps) => {
   const { doc, level: requestLevel, workspace, project, collapsed, pinned, kind } = item;
   const isPinnedRequest = kind === 'pinnedRequest';
   const isLastPinned = item.kind === 'pinnedRequest' && item.isLastPinned;
@@ -150,6 +154,15 @@ export const RequestNode = ({ item, onToggleFolder, className }: RequestNodeProp
   const level = isPinnedRequest ? 0 : requestLevel;
   const params = useParams() as { requestId?: string; requestGroupId?: string };
   const isSelected = item.doc._id === params.requestId || item.doc._id === params.requestGroupId;
+  // Pinned requests are a duplicate rendering of a request already shown in the tree,
+  // so only the in-tree node reacts to an external rename request to avoid two editors.
+  const shouldRename = Boolean(isRenaming) && !isPinnedRequest;
+
+  useEffect(() => {
+    if (shouldRename) {
+      setIsEditable(true);
+    }
+  }, [shouldRename]);
 
   const content = (
     <>
@@ -169,8 +182,14 @@ export const RequestNode = ({ item, onToggleFolder, className }: RequestNodeProp
           value={getRequestNameOrFallback(doc)}
           name="request name"
           ariaLabel={getRequestNameOrFallback(doc)}
+          editable={shouldRename}
           className="flex-1 text-base hover:bg-transparent!"
-          onEditableChange={editable => setIsEditable(editable)}
+          onEditableChange={editable => {
+            setIsEditable(editable);
+            if (!editable) {
+              onRenameHandled?.();
+            }
+          }}
           onSubmit={newName => {
             if (models.requestGroup.isRequestGroup(doc)) {
               patchGroup(doc._id, { name: newName });

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/workspace-node.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/workspace-node.tsx
@@ -1,9 +1,12 @@
-import { type Ref, useState } from 'react';
+import { models } from 'insomnia-data';
+import { type Ref, useEffect, useState } from 'react';
 import { Button } from 'react-aria-components';
 
 import type { SortOrder } from '~/common/constants';
 import { scopeToBgColorMap, scopeToIconMap, scopeToTextColorMap } from '~/common/get-workspace-label';
+import { useWorkspaceUpdateActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.update';
 import { SidebarWorkspaceDropdown } from '~/ui/components/dropdowns/sidebar-workspace-dropdown';
+import { EditableInput } from '~/ui/components/editable-input';
 
 import { Icon } from '../../icon';
 import {
@@ -23,6 +26,10 @@ interface WorkspaceNodeProps {
   onSortOrderChange: (newSortOrder: SortOrder) => void;
   highlighted?: boolean;
   nodeRef?: Ref<HTMLDivElement> | ((node: HTMLDivElement | null) => void);
+  // Whether an external trigger (e.g. the rename keyboard shortcut) has requested to rename this workspace.
+  isRenaming?: boolean;
+  // Called once the rename edit has been entered so the parent can clear its request.
+  onRenameHandled?: () => void;
 }
 
 export const WorkspaceNode = ({
@@ -32,11 +39,24 @@ export const WorkspaceNode = ({
   onSortOrderChange,
   highlighted,
   nodeRef,
+  isRenaming,
+  onRenameHandled,
 }: WorkspaceNodeProps) => {
   const { doc, collapsed, project, organizationId, hasUncommittedChanges, hasUnpushedChanges } = item;
   const { name: workspaceName, _id: workspaceId, scope: workspaceScope } = doc;
   const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
+  const [isEditable, setIsEditable] = useState(false);
   const isCollection = workspaceScope === 'collection';
+  // The Scratch Pad is a fixed workspace that cannot be renamed (its actions menu omits Rename too).
+  const canRename = !models.workspace.isScratchpad(doc);
+  const shouldRename = Boolean(isRenaming) && canRename;
+  const updateWorkspaceFetcher = useWorkspaceUpdateActionFetcher();
+
+  useEffect(() => {
+    if (shouldRename) {
+      setIsEditable(true);
+    }
+  }, [shouldRename]);
 
   return (
     <div
@@ -67,24 +87,49 @@ export const WorkspaceNode = ({
           <Icon icon={scopeToIconMap[workspaceScope]} className={ICON_CLASS} />
         </div>
 
-        <span className="min-w-0 flex-1 truncate text-base">{workspaceName}</span>
+        {canRename ? (
+          <EditableInput
+            value={workspaceName}
+            name="workspace name"
+            ariaLabel={workspaceName}
+            editable={shouldRename}
+            className="min-w-0 flex-1 text-base hover:bg-transparent!"
+            onEditableChange={editable => {
+              setIsEditable(editable);
+              if (!editable) {
+                onRenameHandled?.();
+              }
+            }}
+            onSubmit={newName =>
+              updateWorkspaceFetcher.submit({
+                organizationId,
+                projectId: project._id,
+                patch: { name: newName, workspaceId },
+              })
+            }
+          />
+        ) : (
+          <span className="min-w-0 flex-1 truncate text-base">{workspaceName}</span>
+        )}
       </div>
       {(hasUncommittedChanges || hasUnpushedChanges) && (
         <div className="flex aspect-square h-6 shrink-0 items-center justify-center">
           <Icon icon="circle" className="h-2 w-2" color="var(--color-warning)" />
         </div>
       )}
-      <div className="shrink-0">
-        <SidebarWorkspaceDropdown
-          workspace={doc}
-          project={project}
-          sortOrder={sortOrder}
-          organizationId={organizationId}
-          onSortOrderChange={onSortOrderChange}
-          isOpen={isContextMenuOpen}
-          onOpenChange={setIsContextMenuOpen}
-        />
-      </div>
+      {!isEditable && (
+        <div className="shrink-0">
+          <SidebarWorkspaceDropdown
+            workspace={doc}
+            project={project}
+            sortOrder={sortOrder}
+            organizationId={organizationId}
+            onSortOrderChange={onSortOrderChange}
+            isOpen={isContextMenuOpen}
+            onOpenChange={setIsContextMenuOpen}
+          />
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Renaming an item in the sidebar required opening a context menu and a prompt modal. There was also no consistent inline-rename affordance across item types (only requests/folders supported it; collections, docs, mocks, environments, and MCP clients did not).

<img width="807" height="294" alt="image" src="https://github.com/user-attachments/assets/6bfb99fe-7019-4d7a-8e66-f1d7e5b49922" />

This PR adds a new customizable hotkey (sidebar_renameFocusedItem, default F2) that puts the sidebar row currently holding keyboard focus into inline-edit mode, reusing the existing EditableInput component. This PR also replaces the modal-based rename pattern with an inline one for other sidebar items (collections, documents, mock servers, environments, MCP clients) by routing their submissions through the existing workspace-update action, which already handles each scope's persistence correctly.

E2E smoke tests have been added (sidebar-rename-shortcut.test.ts) with one focused test per supported item type, each exercising the real focus → F2 → inline-edit → persist path. Changes were also manually tested in the local dev build.

The flow for renaming items successively isn't very smooth even with this PR in place because the sidebar as a whole seems to lose focus if inline editing is exited using the Esc key. I've left that out of the scope of this PR.