### PR TITLE
fix: use fixed colors for Konnect Configure button [INS-2913]

### DIFF
--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/konnect-sync-intro/konnect-sync-intro.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/konnect-sync-intro/konnect-sync-intro.tsx
@@ -20,7 +20,7 @@ export const KonnectSyncIntro = ({ onConfigure }: KonnectSyncIntroProps) => {
         </div>
         <Button
           onPress={onConfigure}
-          className="flex h-full items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) px-4 py-2 text-sm text-(--color-font) transition-colors hover:bg-(--hl-xs) aria-pressed:bg-(--hl-xs)"
+          className="flex h-full items-center justify-center gap-2 rounded-md border border-solid border-white/40 px-4 py-2 text-sm text-white transition-colors hover:bg-white/10 aria-pressed:bg-white/10"
         >
           Configure
         </Button>


### PR DESCRIPTION
## Summary

Fix the Konnect "Configure" button appearing greyed out on light mode.

The button sits on an always-black card background but was using theme-dependent CSS variables (`--hl-md`, `--color-font`, `--hl-xs`) for its border/text/hover colors. In light mode these variables resolve to dark/muted values, making the button nearly invisible.

## Changes

Replace theme-dependent CSS variables with fixed white-based colors:
- `border-(--hl-md)` → `border-white/40`
- `text-(--color-font)` → `text-white`
- `hover:bg-(--hl-xs)` → `hover:bg-white/10`
- `aria-pressed:bg-(--hl-xs)` → `aria-pressed:bg-white/10`

Fixes [INS-2913](https://konghq.atlassian.net/browse/INS-2913)

[INS-2913]: https://konghq.atlassian.net/browse/INS-2913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ