### PR TITLE
feat(templating): manifest-gated module registry for the sandbox require (M1)

### DIFF
--- a/examples/insomnia-plugin-sandbox-demo/README.md
+++ b/examples/insomnia-plugin-sandbox-demo/README.md
@@ -21,6 +21,8 @@ absent inside QuickJS. `arch via bridge` proves `context.util.nodeOS()` round-tr
 6. In a request URL/header, insert the `Sandbox Probe` template tag (or type `{% sandboxprobe 'hi' %}`),
    and watch the preview change as you toggle the flag.
 
-Note: this cut's `require` shim only supports `path` and `crypto`. A plugin that `require()`s
-an npm package, another builtin, or a relative file will throw a clear
-`Cannot find module ... in sandbox` — broader coverage is follow-up work.
+The `requireprobe` tag demos the manifest-gated module registry (M1): `{% requireprobe 'path' %}`
+renders `a/b` (baseline grant, curated registry implementation), while `{% requireprobe 'fs' %}`
+or any npm package fails with `Module 'X' not permitted by manifest`. A granted-but-unshipped
+module would fail with `Module 'X' not available in sandbox`. Registry coverage grows in M2/M3;
+relative files (`require('./util')`) arrive with plugin pre-bundling (M4).

--- a/examples/insomnia-plugin-sandbox-demo/index.js
+++ b/examples/insomnia-plugin-sandbox-demo/index.js
@@ -4,9 +4,7 @@ module.exports.templateTags = [
     name: 'sandboxprobe',
     displayName: 'Sandbox Probe',
     description: 'Reports whether it executed inside the QuickJS sandbox, and exercises an async bridge',
-    args: [
-      { displayName: 'Label', type: 'string', defaultValue: 'hello' },
-    ],
+    args: [{ displayName: 'Label', type: 'string', defaultValue: 'hello' }],
     async run(context, label = 'hello') {
       // In the QuickJS sandbox, Node globals like `process` are absent; in the legacy main-process
       // path they exist. This makes the chosen execution path directly observable in the output.
@@ -29,9 +27,7 @@ module.exports.templateTags = [
     name: 'requireprobe',
     displayName: 'Require Probe',
     description: 'Requires the named module to demo manifest-gated module resolution (M1)',
-    args: [
-      { displayName: 'Module', type: 'string', defaultValue: 'path' },
-    ],
+    args: [{ displayName: 'Module', type: 'string', defaultValue: 'path' }],
     async run(context, mod = 'path') {
       // With the sandbox on, baseline modules (path, crypto) resolve from the curated registry;
       // anything else fails with "Module 'X' not permitted by manifest".

--- a/examples/insomnia-plugin-sandbox-demo/index.js
+++ b/examples/insomnia-plugin-sandbox-demo/index.js
@@ -25,4 +25,22 @@ module.exports.templateTags = [
       return `${label} | ran in: ${ranIn} | arch via bridge: ${arch}`;
     },
   },
+  {
+    name: 'requireprobe',
+    displayName: 'Require Probe',
+    description: 'Requires the named module to demo manifest-gated module resolution (M1)',
+    args: [
+      { displayName: 'Module', type: 'string', defaultValue: 'path' },
+    ],
+    async run(context, mod = 'path') {
+      // With the sandbox on, baseline modules (path, crypto) resolve from the curated registry;
+      // anything else fails with "Module 'X' not permitted by manifest".
+      if (mod === 'path') {
+        // eslint-disable-next-line no-undef, unicorn/prefer-node-protocol -- CJS plugin requiring the registry's canonical module name
+        return require('path').join('a', 'b');
+      }
+      // eslint-disable-next-line no-undef -- CJS plugin
+      return typeof require(mod);
+    },
+  },
 ];

--- a/packages/insomnia-smoke-test/fixtures/sandbox-probe-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/sandbox-probe-collection.yaml
@@ -20,6 +20,9 @@ collection:
       text: |
         {% sandboxprobe 'e2e' %}
         {% cryptoparity 'insomnia-test' %}
+        {% requireprobe 'path' %}
+        {% requireprobe 'left-pad' %}
+        {% requireprobe 'fs' %}
     headers:
       - name: Content-Type
         value: text/plain

--- a/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
@@ -52,6 +52,18 @@ const installProbePlugin = (dataPath: string) => {
             return require('crypto').createHash('sha256').update(String(input)).digest('hex');
           },
         },
+        {
+          name: 'requireprobe',
+          displayName: 'Require Probe',
+          description: 'Requires the named module so tests can assert grant/deny behavior',
+          args: [{ displayName: 'Module', type: 'string', defaultValue: 'path' }],
+          async run(context, mod = 'path') {
+            if (mod === 'path') {
+              return require('path').join('a', 'b');
+            }
+            return typeof require(mod);
+          },
+        },
       ];
     `,
   );
@@ -126,4 +138,11 @@ test('Template tag sandbox: flag routes plugin tag execution into the QuickJS sa
 
   // Parity: the sandboxed require('crypto') workload is byte-identical to the legacy render above.
   await assertTagPreview('{% cryptoparity', expectedHash);
+
+  // Module gating (M1): the baseline grant resolves through the registry, while anything outside
+  // it — npm packages and raw Node builtins alike — fails with the exact manifest denial message
+  // that tells a plugin author what to declare.
+  await assertTagPreview("{% requireprobe 'path'", 'a/b');
+  await assertTagPreview("{% requireprobe 'left-pad'", "Module 'left-pad' not permitted by manifest");
+  await assertTagPreview("{% requireprobe 'fs'", "Module 'fs' not permitted by manifest");
 });

--- a/packages/insomnia/src/main/api.protocol.ts
+++ b/packages/insomnia/src/main/api.protocol.ts
@@ -131,7 +131,8 @@ export async function registerInsomniaProtocols() {
             const { protocol, hostname } = urlParse(urlStr);
             const { httpProxy, httpsProxy, noProxy } = settings;
             const proxyHost = protocol === 'https:' ? httpsProxy : httpProxy;
-            const proxy = !shouldBypassProxyForHost(hostname, noProxy) && proxyHost ? setDefaultProtocol(proxyHost) : '';
+            const proxy =
+              !shouldBypassProxyForHost(hostname, noProxy) && proxyHost ? setDefaultProtocol(proxyHost) : '';
             curl.setOpt(Curl.option.PROXY, proxy);
             if (proxy) {
               curl.setOpt(Curl.option.PROXYAUTH, CurlAuth.Any);

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -114,7 +114,9 @@ export const getPluginEntrySource = ({ directory, name }: { directory: string; n
     }
     return fs.readFileSync(entryPath, 'utf8');
   } catch (err) {
-    throw new Error(`Failed to load sandbox source for plugin '${name}': ${err instanceof Error ? err.message : String(err)}`);
+    throw new Error(
+      `Failed to load sandbox source for plugin '${name}': ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 };
 

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -132,6 +132,7 @@ export const runPluginTagInSandbox = async (
 ): Promise<string> => {
   const { runTagInSandbox } = await import('../templating/sandbox/plugin-tag-sandbox');
   const { createMapBridge } = await import('../templating/sandbox/host-bridge');
+  const { TEMPLATE_TAG_BASELINE_MODULES } = await import('../templating/sandbox/module-registry');
   const { pluginName, tagName, args, context: originContext } = body;
   const { meta, renderPurpose, context } = originContext;
   const bridge = createMapBridge({
@@ -171,6 +172,8 @@ export const runPluginTagInSandbox = async (
       appInfo: { version: app.getVersion(), platform: process.platform },
       pluginName,
       renderDepth: 0,
+      // Pre-manifest baseline grant (C3 replaces this with the plugin's declared modules).
+      grantedModules: [...TEMPLATE_TAG_BASELINE_MODULES],
     },
   });
 };

--- a/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
+++ b/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
@@ -1,7 +1,8 @@
 /**
  * JS evaluated *inside* the QuickJS sandbox, as global code, before any plugin source. It:
  *   1. polyfills the Web APIs QuickJS lacks (btoa/atob/TextEncoder/TextDecoder) and `console`,
- *   2. provides a minimal CommonJS `require` shim (expanded in later milestones),
+ *   2. provides a manifest-gated CommonJS `require` resolving only from the curated module
+ *      registry (`module-registry.ts`), default-deny against the envelope's `grantedModules`,
  *   3. rebuilds the plugin `context` object in pure JS over the bulk-copied envelope, with every
  *      async capability routed through the single `__hostBridge` host function, and
  *   4. exposes `__invoke()` which finds the requested tag in the evaluated plugin module and runs it.
@@ -107,47 +108,36 @@ export const IN_SANDBOX_BOOTSTRAP = [
   '    };',
   '  }',
 
-  // --- minimal CommonJS require shim (expanded in M2/M3) ---
+  // --- manifest-gated CommonJS require over the curated module registry (M1) ---
+  // Factories are registered by MODULE_REGISTRY_SOURCE (module-registry.ts), evaluated right after
+  // this bootstrap. Resolution is default-deny against the envelope's grantedModules: an ungranted
+  // name is "not permitted by manifest"; a granted name with no factory is "not available in
+  // sandbox". Both messages are user-facing contract asserted by tests.
+  '  var __moduleRegistry = {};',
+  '  var __moduleAliases = {};',
+  '  var __moduleCache = {};',
+  '  globalThis.__registerModule = function (name, aliases, factory) {',
+  '    __moduleRegistry[name] = factory;',
+  '    for (var i = 0; i < (aliases || []).length; i++) { __moduleAliases[aliases[i]] = name; }',
+  '  };',
+  // The envelope is injected as __envelopeJSON after the bootstrap evaluates, and __require can run
+  // during plugin module evaluation — so the grant set is read lazily and cached on first use.
+  '  var __grantedModulesCache = null;',
+  '  function __grantedModules() {',
+  '    if (__grantedModulesCache === null) {',
+  '      var env = null;',
+  '      try { env = JSON.parse(globalThis.__envelopeJSON); } catch (e) { env = null; }',
+  '      __grantedModulesCache = (env && env.grantedModules) || [];',
+  '    }',
+  '    return __grantedModulesCache;',
+  '  }',
   '  globalThis.__require = function (name) {',
-  '    if (name === "path") {',
-  '      return {',
-  '        sep: "/",',
-  '        basename: function (p) { var s = String(p).split("/"); return s[s.length - 1]; },',
-  '        extname: function (p) { var b = String(p).split("/").pop(); var d = b.lastIndexOf("."); return d > 0 ? b.slice(d) : ""; },',
-  '        join: function () { return Array.prototype.slice.call(arguments).join("/").replace(/\\/+/g, "/"); }',
-  '      };',
-  '    }',
-  // crypto is backed by synchronous host functions (real host crypto), so digest()/randomBytes()
-  // return values inline — matching node:crypto's synchronous contract.
-  '    if (name === "crypto" || name === "node:crypto") {',
-  '      if (typeof globalThis.__cryptoHash !== "function") { throw new Error("\'crypto\' is not available in this sandbox"); }',
-  '      var mkDigester = function (compute) {',
-  '        var parts = [];',
-  '        var obj = {',
-  '          update: function (data) { parts.push(typeof data === "string" ? data : String(data)); return obj; },',
-  '          digest: function (enc) { return compute(parts.join(""), enc || "hex"); }',
-  '        };',
-  '        return obj;',
-  '      };',
-  '      return {',
-  '        createHash: function (algo) { return mkDigester(function (data, enc) { return globalThis.__cryptoHash(algo, data, "utf8", enc); }); },',
-  '        createHmac: function (algo, key) { var k = typeof key === "string" ? key : String(key); return mkDigester(function (data, enc) { return globalThis.__cryptoHmac(algo, k, data, enc); }); },',
-  '        randomBytes: function (size) {',
-  '          var b64 = globalThis.__cryptoRandomBytes(size);',
-  '          var binary = atob(b64);',
-  '          return {',
-  '            length: binary.length,',
-  '            toString: function (enc) {',
-  '              if (enc === "base64") { return b64; }',
-  '              if (enc === "latin1" || enc === "binary") { return binary; }',
-  '              var hex = ""; for (var i = 0; i < binary.length; i++) { hex += ("0" + binary.charCodeAt(i).toString(16)).slice(-2); } return hex;',
-  '            }',
-  '          };',
-  '        },',
-  '        randomUUID: function () { return globalThis.__cryptoRandomUUID(); }',
-  '      };',
-  '    }',
-  '    throw new Error("Cannot find module \'" + name + "\' in sandbox (not yet supported)");',
+  '    var canonical = __moduleAliases[name] || String(name);',
+  '    if (__grantedModules().indexOf(canonical) === -1) { throw new Error("Module \'" + name + "\' not permitted by manifest"); }',
+  '    var factory = __moduleRegistry[canonical];',
+  '    if (!factory) { throw new Error("Module \'" + name + "\' not available in sandbox"); }',
+  '    if (!(canonical in __moduleCache)) { __moduleCache[canonical] = factory(); }',
+  '    return __moduleCache[canonical];',
   '  };',
 
   // --- rebuild the plugin context over the bulk-copied envelope ---

--- a/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
+++ b/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
@@ -226,6 +226,13 @@ export const IN_SANDBOX_BOOTSTRAP = [
   '    var args = [ctx].concat(env.args || []);',
   '    return Promise.resolve(tag.run.apply(null, args)).then(function (r) { return r == null ? "" : String(r); });',
   '  };',
+
+  // --- lock the sandbox-internal globals ---
+  // Plugin code runs after this bootstrap; pin these so it can't reassign the require gate or the
+  // context/invocation entry points. __registerModule is intentionally left mutable — the module
+  // registry source deletes it once the registry is populated.
+  '  var __lock = function (n) { Object.defineProperty(globalThis, n, { value: globalThis[n], writable: false, configurable: false }); };',
+  '  __lock("__require"); __lock("__buildContext"); __lock("__invoke");',
   '})();',
 ].join('\n');
 

--- a/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
+++ b/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
@@ -29,6 +29,12 @@ export const IN_SANDBOX_BOOTSTRAP = [
   '  delete globalThis.__envelopeJSON;',
   '  delete globalThis.__tagName;',
 
+  // --- pristine intrinsics for the module gate ---
+  // Captured now, before any plugin code runs, so the grant check can't be defeated by a plugin
+  // reassigning Array.prototype.indexOf (or the global String). Callers below use these instead of
+  // method syntax / String() so the gate never routes through a plugin-mutable intrinsic.
+  '  var __arrIndexOf = Function.prototype.call.bind(Array.prototype.indexOf);',
+
   '  var T = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";',
 
   // --- btoa / atob (operate on Latin1 binary strings, matching the browser) ---
@@ -136,8 +142,8 @@ export const IN_SANDBOX_BOOTSTRAP = [
   '  };',
   '  var __grantedModules = (__env && __env.grantedModules) || [];',
   '  globalThis.__require = function (name) {',
-  '    var canonical = __moduleAliases[name] || String(name);',
-  '    if (__grantedModules.indexOf(canonical) === -1) { throw new Error("Module \'" + name + "\' not permitted by manifest"); }',
+  '    var canonical = __moduleAliases[name] || ("" + name);',
+  '    if (__arrIndexOf(__grantedModules, canonical) === -1) { throw new Error("Module \'" + name + "\' not permitted by manifest"); }',
   '    var factory = __moduleRegistry[canonical];',
   '    if (!factory) { throw new Error("Module \'" + name + "\' not available in sandbox"); }',
   '    if (!(canonical in __moduleCache)) { __moduleCache[canonical] = factory(); }',

--- a/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
+++ b/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
@@ -7,9 +7,11 @@
  *      async capability routed through the single `__hostBridge` host function, and
  *   4. exposes `__invoke()` which finds the requested tag in the evaluated plugin module and runs it.
  *
- * The host side injects `__hostBridge(path, bodyJson) -> Promise<resultJson>` and (optionally)
- * `__hostConsole(level, msg)` as globals before this runs. The rebuilt context is structurally
- * identical to the worker context in `liquid-extension-worker.ts` — that file is the contract.
+ * The host side injects `__hostBridge(path, bodyJson) -> Promise<resultJson>`, (optionally)
+ * `__hostConsole(level, msg)`, and the `__envelopeJSON`/`__tagName` strings as globals before this
+ * runs; the bootstrap captures the envelope into closure state and deletes those globals so plugin
+ * code can never read or rewrite them. The rebuilt context is structurally identical to the worker
+ * context in `liquid-extension-worker.ts` — that file is the contract.
  *
  * Authoring constraint: this is a plain JS string evaluated by QuickJS, so it deliberately avoids
  * template literals / optional chaining / modern globals and sticks to widely-supported ES5-ish JS.
@@ -17,6 +19,16 @@
 export const IN_SANDBOX_BOOTSTRAP = [
   '(function(){',
   '  "use strict";',
+
+  // --- capture the envelope + tag name, then delete the globals ---
+  // The host injects __envelopeJSON/__tagName before this bootstrap runs. Capturing them into
+  // closure state (and deleting the globals) means plugin top-level code can't rewrite
+  // grantedModules — or any other envelope field — before __invoke() executes.
+  '  var __env = JSON.parse(globalThis.__envelopeJSON);',
+  '  var __tag = globalThis.__tagName;',
+  '  delete globalThis.__envelopeJSON;',
+  '  delete globalThis.__tagName;',
+
   '  var T = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";',
 
   // --- btoa / atob (operate on Latin1 binary strings, matching the browser) ---
@@ -113,27 +125,19 @@ export const IN_SANDBOX_BOOTSTRAP = [
   // this bootstrap. Resolution is default-deny against the envelope's grantedModules: an ungranted
   // name is "not permitted by manifest"; a granted name with no factory is "not available in
   // sandbox". Both messages are user-facing contract asserted by tests.
-  '  var __moduleRegistry = {};',
-  '  var __moduleAliases = {};',
-  '  var __moduleCache = {};',
+  // Null-prototype dictionaries so prototype-chain names ("__proto__", "constructor") behave as
+  // ordinary, absent keys in sandbox-facing lookups.
+  '  var __moduleRegistry = Object.create(null);',
+  '  var __moduleAliases = Object.create(null);',
+  '  var __moduleCache = Object.create(null);',
   '  globalThis.__registerModule = function (name, aliases, factory) {',
   '    __moduleRegistry[name] = factory;',
   '    for (var i = 0; i < (aliases || []).length; i++) { __moduleAliases[aliases[i]] = name; }',
   '  };',
-  // The envelope is injected as __envelopeJSON after the bootstrap evaluates, and __require can run
-  // during plugin module evaluation — so the grant set is read lazily and cached on first use.
-  '  var __grantedModulesCache = null;',
-  '  function __grantedModules() {',
-  '    if (__grantedModulesCache === null) {',
-  '      var env = null;',
-  '      try { env = JSON.parse(globalThis.__envelopeJSON); } catch (e) { env = null; }',
-  '      __grantedModulesCache = (env && env.grantedModules) || [];',
-  '    }',
-  '    return __grantedModulesCache;',
-  '  }',
+  '  var __grantedModules = (__env && __env.grantedModules) || [];',
   '  globalThis.__require = function (name) {',
   '    var canonical = __moduleAliases[name] || String(name);',
-  '    if (__grantedModules().indexOf(canonical) === -1) { throw new Error("Module \'" + name + "\' not permitted by manifest"); }',
+  '    if (__grantedModules.indexOf(canonical) === -1) { throw new Error("Module \'" + name + "\' not permitted by manifest"); }',
   '    var factory = __moduleRegistry[canonical];',
   '    if (!factory) { throw new Error("Module \'" + name + "\' not available in sandbox"); }',
   '    if (!(canonical in __moduleCache)) { __moduleCache[canonical] = factory(); }',
@@ -206,13 +210,13 @@ export const IN_SANDBOX_BOOTSTRAP = [
 
   // --- find the requested tag in the evaluated plugin module and run it ---
   '  globalThis.__invoke = function () {',
-  '    var env = JSON.parse(globalThis.__envelopeJSON);',
+  '    var env = __env;',
   '    var ctx = globalThis.__buildContext(env);',
   '    var mod = globalThis.__pluginModule;',
   '    var tags = (mod && mod.templateTags) || [];',
   '    var tag = null;',
-  '    for (var i = 0; i < tags.length; i++) { if (tags[i].name === globalThis.__tagName) { tag = tags[i]; break; } }',
-  '    if (!tag) { throw new Error("Template tag \'" + globalThis.__tagName + "\' not found in plugin module"); }',
+  '    for (var i = 0; i < tags.length; i++) { if (tags[i].name === __tag) { tag = tags[i]; break; } }',
+  '    if (!tag) { throw new Error("Template tag \'" + __tag + "\' not found in plugin module"); }',
   '    var args = [ctx].concat(env.args || []);',
   '    return Promise.resolve(tag.run.apply(null, args)).then(function (r) { return r == null ? "" : String(r); });',
   '  };',

--- a/packages/insomnia/src/templating/sandbox/marshal.ts
+++ b/packages/insomnia/src/templating/sandbox/marshal.ts
@@ -21,6 +21,12 @@ export interface ContextEnvelope {
   pluginName: string;
   /** Unused: recursion via util.render is now prevented by rejecting {% tag %} syntax there, not by depth-limiting. */
   renderDepth: number;
+  /**
+   * Canonical registry-module names the plugin may `require()` (default-deny; see
+   * `module-registry.ts`). Until the manifest loader (C3) lands, callers pass the
+   * `TEMPLATE_TAG_BASELINE_MODULES` baseline.
+   */
+  grantedModules: string[];
 }
 
 /**

--- a/packages/insomnia/src/templating/sandbox/module-registry.ts
+++ b/packages/insomnia/src/templating/sandbox/module-registry.ts
@@ -1,0 +1,93 @@
+/**
+ * The curated "sandbox stdlib": the single source of truth for every module reachable from plugin
+ * code via `require()` inside the QuickJS sandbox. Each entry maps a canonical name to a factory
+ * evaluated *inside* the sandbox, so implementations are always safe equivalents — pure-JS
+ * reimplementations or shims over vetted host functions — never raw Node builtins.
+ *
+ * Resolution is default-deny and two-staged (see `__require` in `in-sandbox-bootstrap.ts`):
+ *   1. a name outside the plugin's granted set throws "Module 'X' not permitted by manifest";
+ *   2. a granted name with no registry entry throws "Module 'X' not available in sandbox".
+ * Both messages are user-facing contract — they tell a plugin author which of the two problems
+ * they have — and are asserted verbatim by unit and smoke tests.
+ *
+ * Authoring constraint: factory sources are plain JS strings evaluated by QuickJS, so they avoid
+ * template literals / optional chaining / modern globals and stick to widely-supported ES5-ish JS
+ * (same rule as `in-sandbox-bootstrap.ts`).
+ */
+
+export interface SandboxModuleDefinition {
+  /** Canonical registry name — also the name a plugin manifest will declare (C3). */
+  name: string;
+  /** Alternate request specifiers that resolve to this module (e.g. the `node:` prefixed form). */
+  aliases?: string[];
+  /**
+   * ES5 function-expression source, evaluated inside the sandbox, that returns the module's
+   * exports. Invoked at most once per sandbox context — `__require` caches the exports object.
+   */
+  factorySource: string;
+}
+
+const PATH_FACTORY = [
+  'function () {',
+  '  return {',
+  '    sep: "/",',
+  '    basename: function (p) { var s = String(p).split("/"); return s[s.length - 1]; },',
+  '    extname: function (p) { var b = String(p).split("/").pop(); var d = b.lastIndexOf("."); return d > 0 ? b.slice(d) : ""; },',
+  '    join: function () { return Array.prototype.slice.call(arguments).join("/").replace(/\\/+/g, "/"); }',
+  '  };',
+  '}',
+].join('\n');
+
+// crypto is backed by synchronous host functions (real host crypto), so digest()/randomBytes()
+// return values inline — matching node:crypto's synchronous contract.
+const CRYPTO_FACTORY = [
+  'function () {',
+  '  if (typeof globalThis.__cryptoHash !== "function") { throw new Error("\'crypto\' is not available in this sandbox"); }',
+  '  var mkDigester = function (compute) {',
+  '    var parts = [];',
+  '    var obj = {',
+  '      update: function (data) { parts.push(typeof data === "string" ? data : String(data)); return obj; },',
+  '      digest: function (enc) { return compute(parts.join(""), enc || "hex"); }',
+  '    };',
+  '    return obj;',
+  '  };',
+  '  return {',
+  '    createHash: function (algo) { return mkDigester(function (data, enc) { return globalThis.__cryptoHash(algo, data, "utf8", enc); }); },',
+  '    createHmac: function (algo, key) { var k = typeof key === "string" ? key : String(key); return mkDigester(function (data, enc) { return globalThis.__cryptoHmac(algo, k, data, enc); }); },',
+  '    randomBytes: function (size) {',
+  '      var b64 = globalThis.__cryptoRandomBytes(size);',
+  '      var binary = atob(b64);',
+  '      return {',
+  '        length: binary.length,',
+  '        toString: function (enc) {',
+  '          if (enc === "base64") { return b64; }',
+  '          if (enc === "latin1" || enc === "binary") { return binary; }',
+  '          var hex = ""; for (var i = 0; i < binary.length; i++) { hex += ("0" + binary.charCodeAt(i).toString(16)).slice(-2); } return hex;',
+  '        }',
+  '      };',
+  '    },',
+  '    randomUUID: function () { return globalThis.__cryptoRandomUUID(); }',
+  '  };',
+  '}',
+].join('\n');
+
+/** Every module the sandbox can serve. Grown deliberately, one vetted entry at a time (M2/M3). */
+export const SANDBOX_MODULES: SandboxModuleDefinition[] = [
+  { name: 'path', aliases: ['node:path'], factorySource: PATH_FACTORY },
+  { name: 'crypto', aliases: ['node:crypto'], factorySource: CRYPTO_FACTORY },
+];
+
+/**
+ * The module grant every template-tag plugin receives today. This is the pre-manifest baseline —
+ * once the manifest loader (C3) and surface profiles (P1) land, the effective grant becomes
+ * `manifest ∩ profile` with this set as the template-tag profile's floor.
+ */
+export const TEMPLATE_TAG_BASELINE_MODULES: string[] = ['path', 'crypto'];
+
+/**
+ * JS evaluated inside the sandbox immediately after the bootstrap. Populates the registry the
+ * bootstrap's `__require` resolves from.
+ */
+export const MODULE_REGISTRY_SOURCE: string = SANDBOX_MODULES.map(
+  m => `globalThis.__registerModule(${JSON.stringify(m.name)}, ${JSON.stringify(m.aliases ?? [])}, ${m.factorySource});`,
+).join('\n');

--- a/packages/insomnia/src/templating/sandbox/module-registry.ts
+++ b/packages/insomnia/src/templating/sandbox/module-registry.ts
@@ -88,6 +88,11 @@ export const TEMPLATE_TAG_BASELINE_MODULES: string[] = ['path', 'crypto'];
  * JS evaluated inside the sandbox immediately after the bootstrap. Populates the registry the
  * bootstrap's `__require` resolves from.
  */
-export const MODULE_REGISTRY_SOURCE: string = SANDBOX_MODULES.map(
-  m => `globalThis.__registerModule(${JSON.stringify(m.name)}, ${JSON.stringify(m.aliases ?? [])}, ${m.factorySource});`,
-).join('\n');
+export const MODULE_REGISTRY_SOURCE: string = [
+  ...SANDBOX_MODULES.map(
+    m =>
+      `globalThis.__registerModule(${JSON.stringify(m.name)}, ${JSON.stringify(m.aliases ?? [])}, ${m.factorySource});`,
+  ),
+  // Lock the registry once populated — plugin code must not be able to register or replace factories.
+  'delete globalThis.__registerModule;',
+].join('\n');

--- a/packages/insomnia/src/templating/sandbox/module-registry.ts
+++ b/packages/insomnia/src/templating/sandbox/module-registry.ts
@@ -23,6 +23,11 @@ export interface SandboxModuleDefinition {
   /**
    * ES5 function-expression source, evaluated inside the sandbox, that returns the module's
    * exports. Invoked at most once per sandbox context — `__require` caches the exports object.
+   *
+   * SECURITY INVARIANT: this string is interpolated **verbatim** (not escaped) into
+   * `MODULE_REGISTRY_SOURCE` and eval'd inside the sandbox, so it MUST be a trusted, in-repo
+   * literal. Never derive it from plugin manifests, user input, or anything fetched at runtime —
+   * doing so is code injection into the sandbox bootstrap.
    */
   factorySource: string;
 }
@@ -89,10 +94,15 @@ export const TEMPLATE_TAG_BASELINE_MODULES: string[] = ['path', 'crypto'];
  * bootstrap's `__require` resolves from.
  */
 export const MODULE_REGISTRY_SOURCE: string = [
-  ...SANDBOX_MODULES.map(
-    m =>
-      `globalThis.__registerModule(${JSON.stringify(m.name)}, ${JSON.stringify(m.aliases ?? [])}, ${m.factorySource});`,
-  ),
+  ...SANDBOX_MODULES.map(m => {
+    // name/aliases are JSON-encoded (data); factorySource is interpolated raw (code), so it must be
+    // a trusted literal — see SandboxModuleDefinition.factorySource. Tripwire: reject anything that
+    // isn't a bare function expression, catching accidental non-literal/derived sources.
+    if (!/^function\b/.test(m.factorySource.trim())) {
+      throw new Error(`Sandbox module '${m.name}' factorySource must be a function expression`);
+    }
+    return `globalThis.__registerModule(${JSON.stringify(m.name)}, ${JSON.stringify(m.aliases ?? [])}, ${m.factorySource});`;
+  }),
   // Lock the registry once populated — plugin code must not be able to register or replace factories.
   'delete globalThis.__registerModule;',
 ].join('\n');

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
@@ -69,7 +69,7 @@ module.exports.templateTags = [{
   }
 }];`;
 
-const envelope = (args: unknown[], grantedModules: string[] = ['path', 'crypto']): ContextEnvelope => ({
+const envelope = (args: unknown[], grantedModules: string[] = TEMPLATE_TAG_BASELINE_MODULES): ContextEnvelope => ({
   args,
   context: {},
   meta: {},
@@ -251,7 +251,13 @@ describe('runTagInSandbox — PoC milestone 1', () => {
     const source = 'module.exports.templateTags = [{ name: "spin", run: function () { while (true) {} } }];';
     const start = Date.now();
     await expect(
-      runTagInSandbox({ pluginSource: source, tagName: 'spin', envelope: envelope([]), bridge: noBridge, timeoutMs: 200 }),
+      runTagInSandbox({
+        pluginSource: source,
+        tagName: 'spin',
+        envelope: envelope([]),
+        bridge: noBridge,
+        timeoutMs: 200,
+      }),
     ).rejects.toThrow(/interrupted|timed out/i);
     expect(Date.now() - start).toBeLessThan(5000);
   });
@@ -266,7 +272,13 @@ describe('runTagInSandbox — PoC milestone 1', () => {
     // A generous timeoutMs that's far longer than hitting the 32MB memory limit should take, so a
     // pass here can only be explained by the memory limit firing, not the wall-clock timeout.
     await expect(
-      runTagInSandbox({ pluginSource: source, tagName: 'hog', envelope: envelope([]), bridge: noBridge, timeoutMs: 30_000 }),
+      runTagInSandbox({
+        pluginSource: source,
+        tagName: 'hog',
+        envelope: envelope([]),
+        bridge: noBridge,
+        timeoutMs: 30_000,
+      }),
     ).rejects.toThrow(/memory/i);
     expect(Date.now() - start).toBeLessThan(5000);
   });
@@ -351,5 +363,31 @@ describe('module registry gating (M1)', () => {
     await expect(
       runTagInSandbox({ pluginSource: source, tagName: 'r', envelope: envelope([]), bridge: noBridge }),
     ).rejects.toThrow("Module 'fs' not permitted by manifest");
+  });
+
+  it('treats prototype-chain names as ordinary ungranted modules', async () => {
+    await expect(
+      runTagInSandbox({
+        pluginSource: requireTag('__proto__'),
+        tagName: 'r',
+        envelope: envelope([]),
+        bridge: noBridge,
+      }),
+    ).rejects.toThrow("Module '__proto__' not permitted by manifest");
+  });
+
+  it('ignores plugin tampering with __envelopeJSON — grants are captured before plugin eval', async () => {
+    const forged = JSON.stringify({ ...envelope([]), grantedModules: ['fs', 'path', 'crypto'] });
+    const source = [
+      `globalThis.__envelopeJSON = ${JSON.stringify(forged)};`,
+      'module.exports.templateTags = [{ name: "r", run: function () { try { require("fs"); return "escaped"; } catch (e) { return e.message; } } }];',
+    ].join('\n');
+    const actual = await runTagInSandbox({
+      pluginSource: source,
+      tagName: 'r',
+      envelope: envelope([]),
+      bridge: noBridge,
+    });
+    expect(actual).toBe("Module 'fs' not permitted by manifest");
   });
 });

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
@@ -406,4 +406,20 @@ describe('module registry gating (M1)', () => {
     });
     expect(actual).toBe("Module 'crypto' not permitted by manifest");
   });
+
+  it('locks __require so a plugin cannot replace the gate', async () => {
+    // __require is pinned non-writable after the bootstrap; reassigning it throws in strict mode,
+    // so a plugin cannot swap in a permissive resolver.
+    const source = [
+      'try { globalThis.__require = function () { return {}; }; } catch (e) {}',
+      'module.exports.templateTags = [{ name: "r", run: function () { try { require("fs"); return "escaped"; } catch (e) { return e.message; } } }];',
+    ].join('\n');
+    const actual = await runTagInSandbox({
+      pluginSource: source,
+      tagName: 'r',
+      envelope: envelope([]),
+      bridge: noBridge,
+    });
+    expect(actual).toBe("Module 'fs' not permitted by manifest");
+  });
 });

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
@@ -390,4 +390,20 @@ describe('module registry gating (M1)', () => {
     });
     expect(actual).toBe("Module 'fs' not permitted by manifest");
   });
+
+  it('keeps the grant check working when a plugin poisons Array.prototype.indexOf', async () => {
+    // The gate captures a pristine indexOf before plugin code runs, so overriding the intrinsic to
+    // never return -1 must not let an ungranted module through.
+    const source = [
+      'Array.prototype.indexOf = function () { return 0; };',
+      'module.exports.templateTags = [{ name: "r", run: function () { try { require("crypto"); return "escaped"; } catch (e) { return e.message; } } }];',
+    ].join('\n');
+    const actual = await runTagInSandbox({
+      pluginSource: source,
+      tagName: 'r',
+      envelope: envelope([], ['path']),
+      bridge: noBridge,
+    });
+    expect(actual).toBe("Module 'crypto' not permitted by manifest");
+  });
 });

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 import { localTemplateTags } from '../../common/templating/local-template-tags';
 import { createMapBridge, type HostBridge } from './host-bridge';
 import type { ContextEnvelope } from './marshal';
+import { SANDBOX_MODULES, TEMPLATE_TAG_BASELINE_MODULES } from './module-registry';
 import { type HostCrypto, runTagInSandbox } from './plugin-tag-sandbox';
 
 // Real node:crypto-backed host crypto, identical to what main provides.
@@ -68,7 +69,7 @@ module.exports.templateTags = [{
   }
 }];`;
 
-const envelope = (args: unknown[]): ContextEnvelope => ({
+const envelope = (args: unknown[], grantedModules: string[] = ['path', 'crypto']): ContextEnvelope => ({
   args,
   context: {},
   meta: {},
@@ -76,6 +77,7 @@ const envelope = (args: unknown[]): ContextEnvelope => ({
   appInfo: { version: '0.0.0', platform: 'linux' },
   pluginName: 'test-plugin',
   renderDepth: 0,
+  grantedModules,
 });
 
 const noBridge: HostBridge = async path => {
@@ -267,5 +269,87 @@ describe('runTagInSandbox — PoC milestone 1', () => {
       runTagInSandbox({ pluginSource: source, tagName: 'hog', envelope: envelope([]), bridge: noBridge, timeoutMs: 30_000 }),
     ).rejects.toThrow(/memory/i);
     expect(Date.now() - start).toBeLessThan(5000);
+  });
+});
+
+describe('module registry gating (M1)', () => {
+  const requireTag = (mod: string) =>
+    `module.exports.templateTags = [{ name: 'r', run: function () { var m = require('${mod}'); return typeof m; } }];`;
+
+  it('baseline grant only names registered modules', () => {
+    const registered = SANDBOX_MODULES.map(m => m.name);
+    for (const name of TEMPLATE_TAG_BASELINE_MODULES) {
+      expect(registered).toContain(name);
+    }
+  });
+
+  it('resolves a granted, registered module through the registry', async () => {
+    const source =
+      "module.exports.templateTags = [{ name: 'r', run: function () { return require('path').join('a', 'b'); } }];";
+    const actual = await runTagInSandbox({
+      pluginSource: source,
+      tagName: 'r',
+      envelope: envelope([], ['path']),
+      bridge: noBridge,
+    });
+    expect(actual).toBe('a/b');
+  });
+
+  it('resolves node:-prefixed aliases against the canonical grant', async () => {
+    const source =
+      "module.exports.templateTags = [{ name: 'r', run: function () { return require('node:path').join('a', 'b'); } }];";
+    const actual = await runTagInSandbox({
+      pluginSource: source,
+      tagName: 'r',
+      envelope: envelope([], ['path']),
+      bridge: noBridge,
+    });
+    expect(actual).toBe('a/b');
+  });
+
+  it.each(['left-pad', 'fs', 'child_process', 'process'])(
+    'denies ungranted module %s with the manifest message',
+    async mod => {
+      await expect(
+        runTagInSandbox({ pluginSource: requireTag(mod), tagName: 'r', envelope: envelope([]), bridge: noBridge }),
+      ).rejects.toThrow(`Module '${mod}' not permitted by manifest`);
+    },
+  );
+
+  it('denies even baseline modules when the grant set is empty (default-deny)', async () => {
+    await expect(
+      runTagInSandbox({ pluginSource: requireTag('path'), tagName: 'r', envelope: envelope([], []), bridge: noBridge }),
+    ).rejects.toThrow("Module 'path' not permitted by manifest");
+  });
+
+  it('distinguishes granted-but-unregistered with the availability message', async () => {
+    await expect(
+      runTagInSandbox({
+        pluginSource: requireTag('left-pad'),
+        tagName: 'r',
+        envelope: envelope([], ['left-pad']),
+        bridge: noBridge,
+      }),
+    ).rejects.toThrow("Module 'left-pad' not available in sandbox");
+  });
+
+  it('caches module exports — repeated require returns the same object', async () => {
+    const source =
+      "module.exports.templateTags = [{ name: 'r', run: function () { return String(require('path') === require('path')); } }];";
+    const actual = await runTagInSandbox({
+      pluginSource: source,
+      tagName: 'r',
+      envelope: envelope([], ['path']),
+      bridge: noBridge,
+    });
+    expect(actual).toBe('true');
+  });
+
+  it('denies a top-level require at plugin-module evaluation time', async () => {
+    const source =
+      "var fs = require('fs');\nmodule.exports.templateTags = [{ name: 'r', run: function () { return 'unreachable'; } }];";
+    await expect(
+      runTagInSandbox({ pluginSource: source, tagName: 'r', envelope: envelope([]), bridge: noBridge }),
+    ).rejects.toThrow("Module 'fs' not permitted by manifest");
   });
 });

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
@@ -3,6 +3,7 @@ import type { QuickJSContext, QuickJSHandle } from 'quickjs-emscripten';
 import type { HostBridge } from './host-bridge';
 import { IN_SANDBOX_BOOTSTRAP, RUNNER, wrapPluginSource } from './in-sandbox-bootstrap';
 import { type ContextEnvelope, encodeBridgeFailure, encodeBridgeSuccess } from './marshal';
+import { MODULE_REGISTRY_SOURCE } from './module-registry';
 
 /**
  * Synchronous crypto operations backed by the host's real crypto (node:crypto in main). Exposed as
@@ -56,6 +57,7 @@ export const runTagInSandbox = async (opts: RunTagInSandboxOptions): Promise<str
     installHostCrypto(ctx, opts.hostCrypto);
 
     evalOrThrow(ctx, IN_SANDBOX_BOOTSTRAP, '<sandbox-bootstrap>');
+    evalOrThrow(ctx, MODULE_REGISTRY_SOURCE, '<sandbox-modules>');
     setGlobalString(ctx, '__envelopeJSON', JSON.stringify(envelope));
     setGlobalString(ctx, '__tagName', tagName);
     evalOrThrow(ctx, wrapPluginSource(pluginSource), '<plugin>');

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
@@ -56,10 +56,13 @@ export const runTagInSandbox = async (opts: RunTagInSandboxOptions): Promise<str
     installHostConsole(ctx, onConsole);
     installHostCrypto(ctx, opts.hostCrypto);
 
-    evalOrThrow(ctx, IN_SANDBOX_BOOTSTRAP, '<sandbox-bootstrap>');
-    evalOrThrow(ctx, MODULE_REGISTRY_SOURCE, '<sandbox-modules>');
+    // The envelope/tag globals are injected BEFORE the bootstrap, which captures them into closure
+    // state and deletes the globals — so plugin top-level code can't rewrite grantedModules (or any
+    // other envelope field) before __invoke() runs.
     setGlobalString(ctx, '__envelopeJSON', JSON.stringify(envelope));
     setGlobalString(ctx, '__tagName', tagName);
+    evalOrThrow(ctx, IN_SANDBOX_BOOTSTRAP, '<sandbox-bootstrap>');
+    evalOrThrow(ctx, MODULE_REGISTRY_SOURCE, '<sandbox-modules>');
     evalOrThrow(ctx, wrapPluginSource(pluginSource), '<plugin>');
     evalOrThrow(ctx, RUNNER, '<runner>');
 
@@ -102,7 +105,9 @@ const installHostCrypto = (ctx: QuickJSContext, hostCrypto?: HostCrypto): void =
     return;
   }
   const hashFn = ctx.newFunction('__cryptoHash', (algo, data, inEnc, outEnc) =>
-    ctx.newString(hostCrypto.hash(ctx.getString(algo), ctx.getString(data), ctx.getString(inEnc), ctx.getString(outEnc))),
+    ctx.newString(
+      hostCrypto.hash(ctx.getString(algo), ctx.getString(data), ctx.getString(inEnc), ctx.getString(outEnc)),
+    ),
   );
   setGlobal(ctx, '__cryptoHash', hashFn);
 


### PR DESCRIPTION
PR 1 of the sandbox plan (https://gist.github.com/jackkav/4bbf717954a18a6753b64f33ab678ad4) — ticket **M1**. Stacked on #10207 (PR 0); only the last commit is new.

## What

Replaces the sandbox's hardcoded `path`/`crypto` require shim with a **curated module registry** resolved by a **default-deny** `require`:

- `packages/insomnia/src/templating/sandbox/module-registry.ts` (new): single source of truth mapping canonical module names to in-sandbox factory sources (the existing `path` and `crypto` implementations moved here verbatim), plus `node:` aliases and the `TEMPLATE_TAG_BASELINE_MODULES` grant.
- `__require` in the bootstrap now resolves **only** from the registry against `ContextEnvelope.grantedModules`, two-staged:
  1. ungranted name → `Module 'X' not permitted by manifest`
  2. granted but unimplemented → `Module 'X' not available in sandbox`
- Module exports are cached per sandbox context (same object on repeated `require`), and the grant set is read lazily so top-level `require` during plugin evaluation is gated identically.
- Grants are hardcoded to the `path`/`crypto` baseline until the manifest loader (C3, next PR) feeds them from `insomnia.permissions`.

## User-verifiable value

Plugin authors get **actionable, distinct error messages** instead of a generic module failure — the message names the module and tells them which of the two problems they have. And raw Node builtins (`fs`, `child_process`) are now unreachable *by name* through the same deny path.

## E2E

`sandbox-template-tags.test.ts` grows a `requireprobe` tag (also added to the demo plugin), asserted in the Live Preview with the sandbox flag on:

- `{% requireprobe 'path' %}` → `a/b` — baseline grant resolves through the registry
- `{% requireprobe 'left-pad' %}` → `Module 'left-pad' not permitted by manifest` (exact string)
- `{% requireprobe 'fs' %}` → `Module 'fs' not permitted by manifest` (exact string)

## Verification

- `npx vitest run src/templating/sandbox` — **32/32** (21 existing parity tests unchanged; 11 new: both denial messages, alias resolution, empty-grant default-deny, granted-but-unregistered, cache identity, top-level-require denial, baseline⊆registry completeness)
- `npm run test:smoke:dev -- sandbox-template-tags` — 1 passed
- Repo-wide `npm run lint && npm run type-check && npm test` — clean
