### PR TITLE
sec(templating): QuickJS template-tag sandbox additions 

### DIFF
--- a/packages/insomnia/src/main/__tests__/templating-worker-database.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database.test.ts
@@ -1,0 +1,53 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({ app: {}, clipboard: {}, dialog: {}, shell: {} }));
+vi.mock('insomnia-data', () => ({ services: {} }));
+vi.mock('~/plugins', () => ({ getPluginCommonContext: vi.fn(), getTemplateTags: vi.fn() }));
+vi.mock('~/common/cookies', () => ({ jarFromCookies: vi.fn() }));
+vi.mock('../common/database', () => ({ database: {} }));
+vi.mock('../network/network', () => ({ fetchRequestData: vi.fn(), sendCurlAndWriteTimeline: vi.fn(), tryToInterpolateRequest: vi.fn() }));
+vi.mock('../network/libcurl-promise', () => ({ curlRequest: vi.fn() }));
+vi.mock('../prompt-bridge', () => ({ requestPromptFromRenderer: vi.fn() }));
+vi.mock('../secure-read-file', () => ({ secureReadFile: vi.fn() }));
+
+import { getPluginEntrySource } from '../templating-worker-database';
+
+describe('getPluginEntrySource', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'insomnia-plugin-entry-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('reads the entry file declared in package.json', () => {
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ main: 'index.js' }));
+    fs.writeFileSync(path.join(dir, 'index.js'), 'module.exports = {};');
+    expect(getPluginEntrySource({ directory: dir, name: 'p' })).toBe('module.exports = {};');
+  });
+
+  it('rejects a "main" that traverses outside the plugin directory', () => {
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ main: '../../../../etc/passwd' }));
+    expect(() => getPluginEntrySource({ directory: dir, name: 'p' })).toThrow(/escapes plugin directory/);
+  });
+
+  it('rejects a symlinked entry file whose real target is outside the plugin directory', () => {
+    const secret = fs.mkdtempSync(path.join(os.tmpdir(), 'insomnia-plugin-secret-'));
+    const secretFile = path.join(secret, 'secret.js');
+    fs.writeFileSync(secretFile, 'module.exports.templateTags = [{ name: "steal", run: () => "leaked" }];');
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ main: 'index.js' }));
+    fs.symlinkSync(secretFile, path.join(dir, 'index.js'));
+    try {
+      expect(() => getPluginEntrySource({ directory: dir, name: 'p' })).toThrow(/escapes plugin directory/);
+    } finally {
+      fs.rmSync(secret, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/insomnia/src/main/__tests__/templating-worker-database.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database.test.ts
@@ -4,9 +4,21 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('electron', () => ({ app: {}, clipboard: {}, dialog: {}, shell: {} }));
-vi.mock('insomnia-data', () => ({ services: {} }));
-vi.mock('~/plugins', () => ({ getPluginCommonContext: vi.fn(), getTemplateTags: vi.fn() }));
+vi.mock('electron', () => ({ app: { getVersion: () => '1.0.0' }, clipboard: {}, dialog: {}, shell: {} }));
+vi.mock('insomnia-data', () => ({
+  services: {
+    request: { getById: vi.fn() },
+    cloudCredential: { getById: vi.fn(), update: vi.fn() },
+    workspace: { getById: vi.fn() },
+    oAuth2Token: { getByParentId: vi.fn() },
+    cookieJar: { getOrCreateForParentId: vi.fn() },
+    response: { getLatestForRequestId: vi.fn() },
+    helpers: { getResponseBodyBuffer: vi.fn() },
+    settings: { get: vi.fn() },
+  },
+  models: {},
+}));
+vi.mock('~/plugins', () => ({ getPluginCommonContext: vi.fn(), getTemplateTags: vi.fn().mockResolvedValue([]) }));
 vi.mock('~/common/cookies', () => ({ jarFromCookies: vi.fn() }));
 vi.mock('../common/database', () => ({ database: {} }));
 vi.mock('../network/network', () => ({ fetchRequestData: vi.fn(), sendCurlAndWriteTimeline: vi.fn(), tryToInterpolateRequest: vi.fn() }));
@@ -14,7 +26,7 @@ vi.mock('../network/libcurl-promise', () => ({ curlRequest: vi.fn() }));
 vi.mock('../prompt-bridge', () => ({ requestPromptFromRenderer: vi.fn() }));
 vi.mock('../secure-read-file', () => ({ secureReadFile: vi.fn() }));
 
-import { getPluginEntrySource } from '../templating-worker-database';
+import { getPluginEntrySource, runPluginTagInSandbox } from '../templating-worker-database';
 
 describe('getPluginEntrySource', () => {
   let dir: string;
@@ -49,5 +61,33 @@ describe('getPluginEntrySource', () => {
     } finally {
       fs.rmSync(secret, { recursive: true, force: true });
     }
+  });
+});
+
+describe('runPluginTagInSandbox — util.render escape', () => {
+  const body = {
+    args: [],
+    pluginName: 'p',
+    tagName: 'escape',
+    context: { meta: {}, renderPurpose: 'send' as const, context: {} as any },
+  };
+
+  it('does not let a sandboxed tag invoke another tag through util.render', async () => {
+    const source = `module.exports.templateTags = [{ name: "escape", run: async function (context) {
+      return await context.util.render("{% hash 'md5', 'hex', 'x' %}");
+    } }];`;
+    await expect(runPluginTagInSandbox(source, body)).rejects.toThrow();
+  });
+
+  it('still resolves plain variable interpolation through util.render', async () => {
+    const source = `module.exports.templateTags = [{ name: "escape", run: async function (context) {
+      return await context.util.render("hello {{ name }}");
+    } }];`;
+    await expect(
+      runPluginTagInSandbox(source, {
+        ...body,
+        context: { meta: {}, renderPurpose: 'send' as const, context: { name: 'kyle' } as any },
+      }),
+    ).resolves.toBe('hello kyle');
   });
 });

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -121,7 +121,7 @@ export const getPluginEntrySource = ({ directory, name }: { directory: string; n
 // Execute a plugin template tag inside the QuickJS-WASM sandbox instead of directly in the main
 // process. The host bridge reuses the existing pluginToMainAPI handlers verbatim, plus a util.render
 // handler that recurses through main templating. Gated behind the templateTagSandboxEnabled setting.
-const runPluginTagInSandbox = async (
+export const runPluginTagInSandbox = async (
   pluginSource: string,
   body: {
     args: any[];
@@ -136,9 +136,11 @@ const runPluginTagInSandbox = async (
   const { meta, renderPurpose, context } = originContext;
   const bridge = createMapBridge({
     ...(pluginToMainAPI as Record<string, (b: any) => Promise<any>>),
+    // allowTags: false so a sandboxed plugin can't invoke another tag's real, unsandboxed run()
+    // (including its own) by handing util.render a string containing "{% tagName %}".
     'util.render': async (b: { str: string; context: Record<string, any> }) => {
       const { render } = await import('../templating');
-      return render(b.str, { context: b.context });
+      return render(b.str, { context: b.context, allowTags: false });
     },
   });
   return runTagInSandbox({

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -87,7 +87,7 @@ const runPluginTag = (
 // because the bundled main process shims it via createRequire(import.meta.url) where import.meta.url
 // is undefined, which throws "filename ... Received undefined". Bundle plugins (no directory) fall
 // back to require.resolve by name.
-const getPluginEntrySource = ({ directory, name }: { directory: string; name: string }): string => {
+export const getPluginEntrySource = ({ directory, name }: { directory: string; name: string }): string => {
   try {
     let entryPath: string;
     if (directory) {
@@ -98,6 +98,11 @@ const getPluginEntrySource = ({ directory, name }: { directory: string; name: st
       entryPath = path.resolve(base, pkg.main || 'index.js');
       const relative = path.relative(base, entryPath);
       if (relative.startsWith('..') || path.isAbsolute(relative)) {
+        throw new Error(`plugin entry point escapes plugin directory: ${pkg.main}`);
+      }
+      // Re-check after resolving symlinks, since a symlinked entry can point outside `base`.
+      const realRelative = path.relative(fs.realpathSync(base), fs.realpathSync(entryPath));
+      if (realRelative.startsWith('..') || path.isAbsolute(realRelative)) {
         throw new Error(`plugin entry point escapes plugin directory: ${pkg.main}`);
       }
     } else {

--- a/packages/insomnia/src/templating/__tests__/liquid-compat.test.ts
+++ b/packages/insomnia/src/templating/__tests__/liquid-compat.test.ts
@@ -655,3 +655,18 @@ describe('unicode and special byte inputs', () => {
     expect(await render('{{ v }}', { context: { v: '🔥💧' } })).toBe('🔥💧');
   });
 });
+
+describe('allowTags: false', () => {
+  it('still resolves {{ variable }} interpolation', async () => {
+    expect(await render('Bearer {{ token }}', { context: { token: 'abc123' }, allowTags: false })).toBe('Bearer abc123');
+  });
+
+  it('rejects {% tag %} syntax instead of running the tag', async () => {
+    await expect(render("{% hash 'md5', 'hex', 'x' %}", { allowTags: false })).rejects.toThrow();
+  });
+
+  it('a tag still runs when allowTags is unset (default behavior unchanged)', async () => {
+    const md5OfVaporeon = 'ec38601e9ebd2fc22c7c476e14c7890d';
+    expect(await render("{% hash 'md5', 'hex', 'vaporeon' %}")).toBe(md5OfVaporeon);
+  });
+});

--- a/packages/insomnia/src/templating/index.ts
+++ b/packages/insomnia/src/templating/index.ts
@@ -11,6 +11,8 @@ export { LIQUID_TEMPLATE_GLOBAL_PROPERTY_NAME, NUNJUCKS_TEMPLATE_GLOBAL_PROPERTY
 // Cached engine instances
 let liquidAll: Liquid | null = null;
 let liquidAllTagMetadata: Map<string, any> | null = null;
+// No local/plugin tags registered, so unlike liquidAll this never needs to be invalidated on reload().
+let liquidNoTags: Liquid | null = null;
 
 /**
  * Render text based on stuff
@@ -18,6 +20,7 @@ let liquidAllTagMetadata: Map<string, any> | null = null;
  * @param {Object} [config] - Config options for rendering
  * @param {Object} [config.context] - Context to render with
  * @param {Object} [config.path] - Path to include in the error message
+ * @param {boolean} [config.allowTags] - Set to false to reject `{% tag %}` syntax (still allows `{{ variable }}` interpolation). Used by the sandboxed util.render bridge so a plugin can't invoke another tag's real, unsandboxed run() through it.
  */
 export function render(
   text: string,
@@ -25,6 +28,7 @@ export function render(
     context?: Record<string, any>;
     path?: string;
     ignoreUndefinedEnvVariable?: boolean;
+    allowTags?: boolean;
   } = {},
 ) {
   const hasTemplateInterpolationSymbols = text.includes('{{') && text.includes('}}');
@@ -44,7 +48,7 @@ export function render(
     // NOTE: this is added as a breadcrumb because rendering sometimes hangs
     const id = setTimeout(() => console.log('[templating] Warning: liquid failed to respond within 5 seconds'), 5000);
     try {
-      const { engine } = await getLiquid(config.ignoreUndefinedEnvVariable);
+      const { engine } = config.allowTags === false ? await getLiquidNoTags() : await getLiquid(config.ignoreUndefinedEnvVariable);
       const preprocessed = stripLiquidComments(text);
       const result = await engine.parseAndRender(preprocessed, templatingContext);
       clearTimeout(id);
@@ -123,4 +127,20 @@ async function getLiquid(
   }
 
   return { engine, tagMetadata };
+}
+
+// A Liquid engine with no local/plugin tags registered — only native Liquid control flow and
+// {{ variable }} interpolation work; any {% tag %} fails to parse instead of dispatching to that
+// tag's real run().
+async function getLiquidNoTags(): Promise<{ engine: Liquid }> {
+  if (!liquidNoTags) {
+    const { engine } = buildLiquidEngine({
+      tagFactory: () => {
+        throw new Error('unreachable: no tags are registered on this engine');
+      },
+      tags: [],
+    });
+    liquidNoTags = engine;
+  }
+  return { engine: liquidNoTags };
 }

--- a/packages/insomnia/src/templating/sandbox/marshal.ts
+++ b/packages/insomnia/src/templating/sandbox/marshal.ts
@@ -19,7 +19,7 @@ export interface ContextEnvelope {
   appInfo: { version: string; platform: string };
   /** Owning plugin name — needed to scope `store.*` (pluginData) bridge calls. */
   pluginName: string;
-  /** Guards `util.render` recursion across the boundary against the existing renderLimit. */
+  /** Unused: recursion via util.render is now prevented by rejecting {% tag %} syntax there, not by depth-limiting. */
   renderDepth: number;
 }
 

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
@@ -253,4 +253,19 @@ describe('runTagInSandbox — PoC milestone 1', () => {
     ).rejects.toThrow(/interrupted|timed out/i);
     expect(Date.now() - start).toBeLessThan(5_000);
   });
+
+  it('rejects unbounded allocation instead of exhausting host memory', async () => {
+    const source = `module.exports.templateTags = [{ name: "hog", run: function () {
+      var chunks = [];
+      var big = new Array(1 << 20).join("x");
+      while (true) { chunks.push(big); }
+    } }];`;
+    const start = Date.now();
+    // A generous timeoutMs that's far longer than hitting the 32MB memory limit should take, so a
+    // pass here can only be explained by the memory limit firing, not the wall-clock timeout.
+    await expect(
+      runTagInSandbox({ pluginSource: source, tagName: 'hog', envelope: envelope([]), bridge: noBridge, timeoutMs: 30_000 }),
+    ).rejects.toThrow(/memory/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
 });

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
@@ -214,7 +214,7 @@ describe('runTagInSandbox — PoC milestone 1', () => {
         bridge: noBridge,
         hostCrypto: nodeHostCrypto,
       });
-      expect(Number(actual)).toBeLessThanOrEqual(65536 * 2);
+      expect(Number(actual)).toBeLessThanOrEqual(65_536 * 2);
     });
 
     it('throws a clear error when crypto is not provided', async () => {
@@ -251,7 +251,7 @@ describe('runTagInSandbox — PoC milestone 1', () => {
     await expect(
       runTagInSandbox({ pluginSource: source, tagName: 'spin', envelope: envelope([]), bridge: noBridge, timeoutMs: 200 }),
     ).rejects.toThrow(/interrupted|timed out/i);
-    expect(Date.now() - start).toBeLessThan(5_000);
+    expect(Date.now() - start).toBeLessThan(5000);
   });
 
   it('rejects unbounded allocation instead of exhausting host memory', async () => {
@@ -266,6 +266,6 @@ describe('runTagInSandbox — PoC milestone 1', () => {
     await expect(
       runTagInSandbox({ pluginSource: source, tagName: 'hog', envelope: envelope([]), bridge: noBridge, timeoutMs: 30_000 }),
     ).rejects.toThrow(/memory/i);
-    expect(Date.now() - start).toBeLessThan(5_000);
+    expect(Date.now() - start).toBeLessThan(5000);
   });
 });

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
@@ -232,4 +232,13 @@ describe('runTagInSandbox — PoC milestone 1', () => {
       runTagInSandbox({ pluginSource: source, tagName: 'needsOs', envelope: envelope([]), bridge: failing }),
     ).rejects.toThrow('bridge exploded');
   });
+
+  it('times out a synchronous infinite loop instead of hanging', async () => {
+    const source = 'module.exports.templateTags = [{ name: "spin", run: function () { while (true) {} } }];';
+    const start = Date.now();
+    await expect(
+      runTagInSandbox({ pluginSource: source, tagName: 'spin', envelope: envelope([]), bridge: noBridge, timeoutMs: 200 }),
+    ).rejects.toThrow(/interrupted|timed out/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
 });

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
@@ -205,6 +205,18 @@ describe('runTagInSandbox — PoC milestone 1', () => {
       expect(actual).toMatch(/^[0-9a-f]{32}$/);
     });
 
+    it('clamps an oversized randomBytes request instead of allocating it', async () => {
+      const source = cryptoTag("return crypto.randomBytes(2147483648).toString('hex').length;");
+      const actual = await runTagInSandbox({
+        pluginSource: source,
+        tagName: 'c',
+        envelope: envelope([]),
+        bridge: noBridge,
+        hostCrypto: nodeHostCrypto,
+      });
+      expect(Number(actual)).toBeLessThanOrEqual(65536 * 2);
+    });
+
     it('throws a clear error when crypto is not provided', async () => {
       const source = cryptoTag("return crypto.createHash('sha256').update(input).digest('hex');");
       await expect(

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
@@ -107,9 +107,11 @@ const installHostCrypto = (ctx: QuickJSContext, hostCrypto?: HostCrypto): void =
   );
   setGlobal(ctx, '__cryptoHmac', hmacFn);
 
-  const randomBytesFn = ctx.newFunction('__cryptoRandomBytes', size =>
-    ctx.newString(hostCrypto.randomBytes(ctx.getNumber(size))),
-  );
+  const randomBytesFn = ctx.newFunction('__cryptoRandomBytes', size => {
+    // Clamp so a plugin can't force a multi-GB allocation (e.g. crypto.randomBytes(2 ** 31)).
+    const clamped = Math.max(0, Math.min(Math.floor(ctx.getNumber(size)) || 0, 65536));
+    return ctx.newString(hostCrypto.randomBytes(clamped));
+  });
   setGlobal(ctx, '__cryptoRandomBytes', randomBytesFn);
 
   const randomUUIDFn = ctx.newFunction('__cryptoRandomUUID', () => ctx.newString(hostCrypto.randomUUID()));

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
@@ -49,6 +49,8 @@ export const runTagInSandbox = async (opts: RunTagInSandboxOptions): Promise<str
   try {
     // Polled during synchronous execution so a tight sync loop in plugin code can't bypass the timeout.
     ctx.runtime.setInterruptHandler(() => Date.now() > deadline);
+    // Caps the WASM heap so a plugin can't OOM the host by allocating without bound.
+    ctx.runtime.setMemoryLimit(32 * 1024 * 1024);
     installHostBridge(ctx, bridge);
     installHostConsole(ctx, onConsole);
     installHostCrypto(ctx, opts.hostCrypto);

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
@@ -111,7 +111,7 @@ const installHostCrypto = (ctx: QuickJSContext, hostCrypto?: HostCrypto): void =
 
   const randomBytesFn = ctx.newFunction('__cryptoRandomBytes', size => {
     // Clamp so a plugin can't force a multi-GB allocation (e.g. crypto.randomBytes(2 ** 31)).
-    const clamped = Math.max(0, Math.min(Math.floor(ctx.getNumber(size)) || 0, 65536));
+    const clamped = Math.max(0, Math.min(Math.floor(ctx.getNumber(size)) || 0, 65_536));
     return ctx.newString(hostCrypto.randomBytes(clamped));
   });
   setGlobal(ctx, '__cryptoRandomBytes', randomBytesFn);

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
@@ -44,8 +44,11 @@ export const runTagInSandbox = async (opts: RunTagInSandboxOptions): Promise<str
   const { getQuickJSModule } = await import('./quickjs-runtime');
   const QuickJS = await getQuickJSModule();
   const ctx = QuickJS.newContext();
+  const deadline = Date.now() + timeoutMs;
 
   try {
+    // Polled during synchronous execution so a tight sync loop in plugin code can't bypass the timeout.
+    ctx.runtime.setInterruptHandler(() => Date.now() > deadline);
     installHostBridge(ctx, bridge);
     installHostConsole(ctx, onConsole);
     installHostCrypto(ctx, opts.hostCrypto);


### PR DESCRIPTION
## What this PR does 
* Enforce the sandbox timeout during synchronous plugin code ( previously hung the main process indefinitely).
* Clamp crypto.randomBytes(size) to prevent a multi-GB allocation/crash.
* Cap the QuickJS heap so unbounded allocation can't exhaust host memory.
* Resolve symlinks before validating a plugin's entry-point path, closing a traversal bypass.
* context.util.render() invoked any template tag (including the calling plugin's own tag) through the normal, unsandboxed Liquid pipeline. It's now restricted to plain {{ variable }} interpolation the only real existing use (@jackkav, can you confirm this?). It  rejects {% tag %} syntax instead of executing it outside the sandbox. Verified this technique worked within the base PR.  