### PR TITLE
fix: fix invite/cookies modal backdrop rendering wrong theme color

### DIFF
--- a/packages/insomnia/src/ui/components/modals/cookies-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/cookies-modal.tsx
@@ -432,7 +432,7 @@ const CookieModifyModal = ({ cookie, isOpen, setIsOpen, onUpdateCookie }: Cookie
       isDismissable={true}
       isOpen={isOpen}
       onOpenChange={setIsOpen}
-      className="theme--transparent-overlay fixed top-0 left-0 z-10 flex h-(--visual-viewport-height) w-full justify-center bg-(--color-bg) py-[100px]"
+      className="fixed top-0 left-0 z-10 flex h-(--visual-viewport-height) w-full justify-center bg-black/30 py-[100px]"
     >
       <Modal className="theme--dialog h-fit max-h-full w-full max-w-[900px] overflow-y-auto rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) p-[32px] text-(--color-font)">
         <Dialog className="relative outline-hidden">

--- a/packages/insomnia/src/ui/components/modals/invite-modal/invite-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/invite-modal/invite-modal.tsx
@@ -154,7 +154,7 @@ const InviteModal: FC<{
       isDismissable={false}
       isOpen={true}
       onOpenChange={setIsOpen}
-      className="theme--transparent-overlay fixed top-0 left-0 z-10 flex h-(--visual-viewport-height) w-full items-start justify-center bg-(--color-bg) pt-[70px]"
+      className="fixed top-0 left-0 z-10 flex h-(--visual-viewport-height) w-full items-start justify-center bg-black/30 pt-[70px]"
     >
       <Modal className="theme--dialog flex max-h-[calc(var(--visual-viewport-height)-140px)] w-full max-w-[900px] flex-col rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) p-[32px] text-(--color-font)">
         <Dialog className="relative flex h-full flex-1 flex-col overflow-hidden outline-hidden">


### PR DESCRIPTION
Fixes the `Invite Collaborators` and `Manage Cookies` modals rendering with the wrong background color regardless of the user's selected theme — e.g. a solid dark backdrop and panel showing even when a light theme is active.

Before:
<img width="1238" height="597" alt="Screenshot 2026-07-06 at 4 18 19 PM" src="https://github.com/user-attachments/assets/c4eefd4b-60fc-4390-883d-8ef399625110" />
<img width="1124" height="590" alt="Screenshot 2026-07-06 at 4 18 50 PM" src="https://github.com/user-attachments/assets/43cac7df-0e1b-43e0-9619-199fe484e7db" />


After: 
<img width="1253" height="490" alt="Screenshot 2026-07-06 at 4 19 31 PM" src="https://github.com/user-attachments/assets/5a5e2070-eb3b-491a-874b-98b5d17ceb0a" />
<img width="1114" height="603" alt="Screenshot 2026-07-06 at 4 19 42 PM" src="https://github.com/user-attachments/assets/336ec635-08dc-423a-a9f6-bba155d0eff9" />


