### PR TITLE
feat(templating): plugin manifest permissions loader + Plugins-UI display (C3)

### DIFF
--- a/examples/insomnia-plugin-sandbox-demo/README.md
+++ b/examples/insomnia-plugin-sandbox-demo/README.md
@@ -26,3 +26,8 @@ renders `a/b` (baseline grant, curated registry implementation), while `{% requi
 or any npm package fails with `Module 'X' not permitted by manifest`. A granted-but-unshipped
 module would fail with `Module 'X' not available in sandbox`. Registry coverage grows in M2/M3;
 relative files (`require('./util')`) arrive with plugin pre-bundling (M4).
+
+The `eventsprobe` tag demos a **manifest-declared grant** (C3): this plugin's `package.json`
+declares `insomnia.permissions.modules: ["events"]`, so `{% eventsprobe %}` renders `events-ok`.
+A plugin that did not declare `events` would get `Module 'events' not permitted by manifest`.
+Preferences → Plugins shows each plugin's declared permissions (this one lists `modules: events`).

--- a/examples/insomnia-plugin-sandbox-demo/index.js
+++ b/examples/insomnia-plugin-sandbox-demo/index.js
@@ -39,4 +39,24 @@ module.exports.templateTags = [
       return typeof require(mod);
     },
   },
+  {
+    name: 'eventsprobe',
+    displayName: 'Events Probe',
+    description: "Demos a manifest-granted module: this plugin declares insomnia.permissions.modules ['events']",
+    args: [],
+    async run() {
+      // Works because package.json declares the `events` grant; a plugin without it would get
+      // "Module 'events' not permitted by manifest".
+      // eslint-disable-next-line no-undef, unicorn/prefer-node-protocol -- CJS plugin requiring the registry's canonical module name
+      const EventEmitter = require('events').EventEmitter;
+      // eslint-disable-next-line unicorn/prefer-event-target -- demoing the sandbox 'events' module, not browser EventTarget
+      const emitter = new EventEmitter();
+      let out = '';
+      emitter.on('ping', value => {
+        out = value;
+      });
+      emitter.emit('ping', 'events-ok');
+      return out;
+    },
+  },
 ];

--- a/examples/insomnia-plugin-sandbox-demo/package.json
+++ b/examples/insomnia-plugin-sandbox-demo/package.json
@@ -5,6 +5,10 @@
   "main": "index.js",
   "insomnia": {
     "name": "sandbox-demo",
-    "description": "Demo plugin to manually verify the QuickJS template-tag sandbox path"
+    "description": "Demo plugin to manually verify the QuickJS template-tag sandbox path",
+    "permissions": {
+      "modules": ["events"],
+      "capabilities": []
+    }
   }
 }

--- a/packages/insomnia-smoke-test/fixtures/sandbox-manifest-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/sandbox-manifest-collection.yaml
@@ -1,0 +1,25 @@
+type: collection.insomnia.rest/5.0
+schema_version: "5.1"
+name: Sandbox Manifest Collection
+meta:
+  id: wrk_5a4db0c5000000000000000000000010
+  created: 1751800000010
+  modified: 1751800000010
+collection:
+  - url: http://127.0.0.1:4010/echo
+    name: Manifest Probe
+    meta:
+      id: req_5a4db0c5000000000000000000000011
+      created: 1751800000011
+      modified: 1751800000011
+      isPrivate: false
+      sortKey: -1751800000011
+    method: GET
+    body:
+      mimeType: text/plain
+      text: |
+        {% eventsgranted %}
+        {% eventsbaseline %}
+    headers:
+      - name: Content-Type
+        value: text/plain

--- a/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
@@ -2,7 +2,7 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { expect } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 
 import { loadFixture } from '../../playwright/paths';
 import { test } from '../../playwright/test';
@@ -67,6 +67,42 @@ const installProbePlugin = (dataPath: string) => {
       ];
     `,
   );
+};
+
+// Write an arbitrary inline plugin (package.json + index.js) into the data-path plugins directory.
+const writePlugin = (dataPath: string, name: string, insomnia: unknown, indexJs: string) => {
+  const pluginDir = path.join(dataPath, 'plugins', name);
+  fs.mkdirSync(pluginDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pluginDir, 'package.json'),
+    JSON.stringify({ name, version: '1.0.0', main: 'index.js', insomnia }),
+  );
+  fs.writeFileSync(path.join(pluginDir, 'index.js'), indexJs);
+};
+
+// Seed the once-only guard for the persistent "Plugin system updated" toast (it intercepts pointer
+// events over the page) and dismiss any toast already in flight, before driving the UI.
+const clearPluginToast = async (page: Page) => {
+  await page.getByLabel('Import').waitFor();
+  await page.evaluate(() => localStorage.setItem('plugin-system-changes-toast-shown', 'true'));
+  const dismissButtons = page.getByRole('button', { name: 'Dismiss' });
+  await dismissButtons
+    .first()
+    .waitFor({ timeout: 3000 })
+    .catch(() => {});
+  while ((await dismissButtons.count()) > 0) {
+    await dismissButtons.first().click();
+  }
+};
+
+// Enable the sandbox via Preferences → Scripting, then close the modal.
+const enableSandbox = async (page: Page) => {
+  await page.getByTestId('settings-button').click();
+  await page.getByRole('tab', { name: 'Scripting' }).click();
+  const sandboxToggle = page.getByTestId('toggle-template-tag-sandbox');
+  await sandboxToggle.click();
+  await expect.soft(sandboxToggle.getByRole('switch')).toBeChecked();
+  await page.locator('.app').press('Escape');
 };
 
 test('Template tag sandbox: flag routes plugin tag execution into the QuickJS sandbox', async ({
@@ -145,4 +181,90 @@ test('Template tag sandbox: flag routes plugin tag execution into the QuickJS sa
   await assertTagPreview("{% requireprobe 'path'", 'a/b');
   await assertTagPreview("{% requireprobe 'left-pad'", "Module 'left-pad' not permitted by manifest");
   await assertTagPreview("{% requireprobe 'fs'", "Module 'fs' not permitted by manifest");
+});
+
+// The tag body used by both manifest plugins: require('events') and prove EventEmitter works, or
+// report the failure. Its outcome depends solely on whether the owning plugin declared the grant.
+const eventsTagBody = (tagName: string) => `
+  module.exports.templateTags = [{
+    name: '${tagName}',
+    displayName: '${tagName}',
+    args: [],
+    async run() {
+      try {
+        var E = require('events').EventEmitter;
+        var e = new E();
+        var out = '';
+        e.on('x', function (v) { out = v; });
+        e.emit('x', 'events-ok');
+        return out;
+      } catch (err) {
+        return err.message;
+      }
+    }
+  }];`;
+
+test('Template tag sandbox: manifest grants a non-baseline module and is shown in the Plugins pane', async ({
+  page,
+  app,
+  dataPath,
+  insomnia,
+}) => {
+  // Plugin A declares `events`; plugin B declares nothing; plugin C's permissions block is malformed.
+  writePlugin(
+    dataPath,
+    'insomnia-plugin-events-granted',
+    { permissions: { modules: ['events'] } },
+    eventsTagBody('eventsgranted'),
+  );
+  writePlugin(dataPath, 'insomnia-plugin-events-baseline', {}, eventsTagBody('eventsbaseline'));
+  writePlugin(
+    dataPath,
+    'insomnia-plugin-events-malformed',
+    { permissions: { modules: 'events' } },
+    eventsTagBody('eventsmalformed'),
+  );
+
+  await clearPluginToast(page);
+  await page.evaluate(() => (window as any).main.plugins.reloadPlugins());
+
+  const fixture = await loadFixture('sandbox-manifest-collection.yaml');
+  await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), fixture);
+  await page.getByLabel('Import').click();
+  await page.locator('[data-test-id="import-from-clipboard"]').click();
+  await page.getByRole('button', { name: 'Scan' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+
+  await enableSandbox(page);
+
+  await insomnia.navigationSidebar.clickRequestOrFolder('Manifest Probe');
+  await page.getByText('Body', { exact: true }).click();
+
+  const assertTagPreview = async (tagPrefix: string, expected: string) => {
+    await page.locator(`[data-template^="${tagPrefix}"]`).click();
+    const modal = page.getByRole('dialog');
+    await expect.soft(modal.getByLabel('Live Preview')).toContainText(expected);
+    await modal.getByRole('button', { name: 'Done' }).click();
+  };
+
+  // A plugin that declared `events` can construct an EventEmitter; an undeclared one is denied with
+  // the exact manifest message. (The grant working at all also proves the sandbox flag applied.)
+  await assertTagPreview('{% eventsgranted', 'events-ok');
+  await assertTagPreview('{% eventsbaseline', "Module 'events' not permitted by manifest");
+
+  // Preferences → Plugins surfaces each plugin's declared permissions, and flags the malformed one.
+  await page.getByTestId('settings-button').click();
+  await page.locator('div[role="tab"]:has-text("Plugins")').click();
+
+  await expect
+    .soft(page.getByTestId('plugin-permissions-insomnia-plugin-events-granted'))
+    .toContainText('modules: events');
+  await expect
+    .soft(page.getByTestId('plugin-permissions-insomnia-plugin-events-baseline'))
+    .toContainText('baseline access');
+  // Malformed manifest degrades to baseline AND surfaces a validation warning — never crashes the loader.
+  await expect
+    .soft(page.getByTestId('plugin-permissions-insomnia-plugin-events-malformed'))
+    .toContainText('baseline access');
+  await expect.soft(page.getByTestId('plugin-permission-warning-insomnia-plugin-events-malformed')).toBeVisible();
 });

--- a/packages/insomnia/src/common/plugins/bridge-types.ts
+++ b/packages/insomnia/src/common/plugins/bridge-types.ts
@@ -77,6 +77,12 @@ export interface SerializablePlugin {
   version: string;
   directory: string;
   config: { disabled: boolean };
+  /** Parsed `insomnia.permissions` manifest (sandbox plan C3), surfaced in Preferences → Plugins. */
+  permissions: { modules: string[]; capabilities: string[] };
+  /** Validation warnings from parsing `permissions`; shown on the plugin card. Empty when clean. */
+  permissionWarnings: string[];
+  /** True when the plugin declared a valid `permissions` object (even if empty); false = baseline access (no/malformed manifest). */
+  permissionsDeclared: boolean;
 }
 
 export interface SerializableTheme {

--- a/packages/insomnia/src/common/plugins/permissions.test.ts
+++ b/packages/insomnia/src/common/plugins/permissions.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import { parsePluginPermissions } from './permissions';
+
+describe('parsePluginPermissions', () => {
+  it('treats a missing permissions block as baseline (not declared, no warnings)', () => {
+    const result = parsePluginPermissions({ description: 'x' });
+    expect(result).toEqual({ permissions: { modules: [], capabilities: [] }, warnings: [], declared: false });
+  });
+
+  it('parses a valid permissions block', () => {
+    const result = parsePluginPermissions({ permissions: { modules: ['events', 'crypto'], capabilities: ['storage'] } });
+    expect(result.permissions).toEqual({ modules: ['events', 'crypto'], capabilities: ['storage'] });
+    expect(result.warnings).toEqual([]);
+    expect(result.declared).toBe(true);
+  });
+
+  it('accepts a declared-but-empty permissions block', () => {
+    const result = parsePluginPermissions({ permissions: {} });
+    expect(result.permissions).toEqual({ modules: [], capabilities: [] });
+    expect(result.declared).toBe(true);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('de-duplicates repeated module names', () => {
+    const result = parsePluginPermissions({ permissions: { modules: ['events', 'events', 'path'] } });
+    expect(result.permissions.modules).toEqual(['events', 'path']);
+  });
+
+  it('keeps unknown module names (grant vs. availability are separate concerns)', () => {
+    // Unknown names are not rejected at parse — they fail later at require() with "not available".
+    const result = parsePluginPermissions({ permissions: { modules: ['left-pad'] } });
+    expect(result.permissions.modules).toEqual(['left-pad']);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('degrades a non-array modules axis to empty with a warning (never throws)', () => {
+    const result = parsePluginPermissions({ permissions: { modules: 'events' } });
+    expect(result.permissions.modules).toEqual([]);
+    expect(result.declared).toBe(true);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/modules must be an array/);
+  });
+
+  it('drops non-string array entries with a warning', () => {
+    const result = parsePluginPermissions({ permissions: { modules: ['events', 42, '', null] } });
+    expect(result.permissions.modules).toEqual(['events']);
+    expect(result.warnings).toHaveLength(3);
+  });
+
+  it('degrades a non-object permissions field with a warning', () => {
+    const result = parsePluginPermissions({ permissions: ['events'] });
+    expect(result.permissions).toEqual({ modules: [], capabilities: [] });
+    expect(result.declared).toBe(false);
+    expect(result.warnings[0]).toMatch(/permissions must be an object/);
+  });
+
+  it('handles a non-object insomnia field', () => {
+    expect(parsePluginPermissions(null)).toEqual({
+      permissions: { modules: [], capabilities: [] },
+      warnings: [],
+      declared: false,
+    });
+    expect(parsePluginPermissions('nope')).toEqual({
+      permissions: { modules: [], capabilities: [] },
+      warnings: [],
+      declared: false,
+    });
+  });
+});

--- a/packages/insomnia/src/common/plugins/permissions.ts
+++ b/packages/insomnia/src/common/plugins/permissions.ts
@@ -1,0 +1,87 @@
+/**
+ * Parsing + validation for a plugin's declared `insomnia.permissions` manifest (sandbox plan C3).
+ *
+ * Two independent, default-deny grant axes:
+ *   - `modules`      — registry names the plugin may `require()` inside the sandbox (axis 1, M1).
+ *   - `capabilities` — host-bridge groups the plugin may call out to (axis 2; gating lands in C1).
+ *
+ * Both are parsed here so the loader can attach them to the `Plugin` and the Preferences → Plugins
+ * pane can display them. A malformed manifest never throws: it degrades to no declared permissions
+ * (baseline access) and surfaces a human-readable warning on the plugin's card.
+ */
+
+export interface PluginPermissions {
+  /** Registry-module names the plugin declares it needs (axis 1). */
+  modules: string[];
+  /** Host-capability groups the plugin declares it needs (axis 2; consumed by C1). */
+  capabilities: string[];
+}
+
+export interface ParsedPluginPermissions {
+  permissions: PluginPermissions;
+  /** Validation warnings, shown on the plugin card and logged. Empty when the manifest is clean. */
+  warnings: string[];
+  /**
+   * True when the plugin declared a valid `permissions` object (even if empty); false when it was
+   * absent or malformed. Distinguishes "declared-but-empty" from "baseline access (no manifest)".
+   */
+  declared: boolean;
+}
+
+const emptyPermissions = (): PluginPermissions => ({ modules: [], capabilities: [] });
+
+// Validate one string[] axis. Non-arrays yield a warning and an empty axis; within an array, only
+// non-empty strings are kept (other entries are dropped with a warning). De-duplicates.
+const parseStringArrayAxis = (value: unknown, axis: string, warnings: string[]): string[] => {
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    warnings.push(`insomnia.permissions.${axis} must be an array of strings; ignoring it (baseline access).`);
+    return [];
+  }
+  const valid: string[] = [];
+  for (const entry of value) {
+    if (typeof entry === 'string' && entry.length > 0) {
+      if (!valid.includes(entry)) {
+        valid.push(entry);
+      }
+    } else {
+      warnings.push(
+        `insomnia.permissions.${axis} entries must be non-empty strings; ignoring ${JSON.stringify(entry)}.`,
+      );
+    }
+  }
+  return valid;
+};
+
+/**
+ * Parse the `insomnia` field of a plugin's package.json into validated permissions. `insomniaField`
+ * is `pluginJson.insomnia` (already known to exist — the loader skips packages without it).
+ */
+export const parsePluginPermissions = (insomniaField: unknown): ParsedPluginPermissions => {
+  const warnings: string[] = [];
+
+  if (insomniaField === null || typeof insomniaField !== 'object') {
+    return { permissions: emptyPermissions(), warnings, declared: false };
+  }
+
+  const permissionsField = (insomniaField as { permissions?: unknown }).permissions;
+  if (permissionsField === undefined) {
+    return { permissions: emptyPermissions(), warnings, declared: false };
+  }
+  if (permissionsField === null || typeof permissionsField !== 'object' || Array.isArray(permissionsField)) {
+    warnings.push('insomnia.permissions must be an object; ignoring it (baseline access).');
+    return { permissions: emptyPermissions(), warnings, declared: false };
+  }
+
+  const { modules, capabilities } = permissionsField as { modules?: unknown; capabilities?: unknown };
+  return {
+    permissions: {
+      modules: parseStringArrayAxis(modules, 'modules', warnings),
+      capabilities: parseStringArrayAxis(capabilities, 'capabilities', warnings),
+    },
+    warnings,
+    declared: true,
+  };
+};

--- a/packages/insomnia/src/common/plugins/types.ts
+++ b/packages/insomnia/src/common/plugins/types.ts
@@ -2,6 +2,7 @@ import type { GrpcRequest, Request, RequestGroup, SocketIORequest, WebSocketRequ
 
 import type { ParsedApiSpec } from '~/common/api-specs';
 import type { PluginTheme } from '~/common/plugins/bridge-types';
+import type { PluginPermissions } from '~/common/plugins/permissions';
 import type { PluginTemplateTag } from '~/common/templating/types';
 
 // shared types for private plugins
@@ -73,6 +74,12 @@ export interface Plugin {
   version: string;
   directory: string;
   config: { disabled: boolean };
+  /** Parsed, validated `insomnia.permissions` manifest (sandbox plan C3). */
+  permissions: PluginPermissions;
+  /** Validation warnings from parsing `permissions`; shown on the plugin card. Empty when clean. */
+  permissionWarnings: string[];
+  /** True when the plugin declared a valid `permissions` object (even if empty); false = baseline access (no/malformed manifest). */
+  permissionsDeclared: boolean;
   module: {
     templateTags?: PluginTemplateTag[];
     requestHooks?: ((requestContext: any) => void)[];

--- a/packages/insomnia/src/common/templating/local-template-tags.ts
+++ b/packages/insomnia/src/common/templating/local-template-tags.ts
@@ -1012,6 +1012,9 @@ export const localTemplateTags: TemplateTag[] = localTemplatePlugins.map(t => ({
     config: {
       disabled: false,
     },
+    permissions: { modules: [], capabilities: [] },
+    permissionWarnings: [],
+    permissionsDeclared: false,
     module: {},
   },
   templateTag: t.templateTag,

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -131,6 +131,9 @@ export const runPluginTagInSandbox = async (
     tagName: string;
     context: Pick<PluginTemplateTagContext, 'meta' | 'renderPurpose' | 'context'>;
   },
+  // Registry-module names the plugin may require(). Defaults to the baseline floor; callers pass the
+  // plugin's manifest-resolved grant (baseline ∪ insomnia.permissions.modules).
+  grantedModules?: string[],
 ): Promise<string> => {
   const { runTagInSandbox } = await import('../templating/sandbox/plugin-tag-sandbox');
   const { createMapBridge } = await import('../templating/sandbox/host-bridge');
@@ -174,8 +177,7 @@ export const runPluginTagInSandbox = async (
       appInfo: { version: app.getVersion(), platform: process.platform },
       pluginName,
       renderDepth: 0,
-      // Pre-manifest baseline grant (C3 replaces this with the plugin's declared modules).
-      grantedModules: [...TEMPLATE_TAG_BASELINE_MODULES],
+      grantedModules: grantedModules ?? [...TEMPLATE_TAG_BASELINE_MODULES],
     },
   });
 };
@@ -375,6 +377,9 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
           config: {
             disabled: false,
           },
+          permissions: { modules: [], capabilities: [] },
+          permissionWarnings: [],
+          permissionsDeclared: false,
           module,
         },
         templateTag: tt,
@@ -438,9 +443,11 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
     if (targetTag) {
       const settings = await services.settings.get();
       if (settings.templateTagSandboxEnabled) {
+        const { resolveTemplateTagModules } = await import('../templating/sandbox/module-registry');
         return runPluginTagInSandbox(
           getPluginEntrySource({ directory: targetTag.plugin.directory, name: pluginName }),
           body,
+          resolveTemplateTagModules(targetTag.plugin.permissions?.modules),
         );
       }
       return runPluginTag(targetTag.templateTag.run, body);

--- a/packages/insomnia/src/plugins/__tests__/invoke-method.test.ts
+++ b/packages/insomnia/src/plugins/__tests__/invoke-method.test.ts
@@ -31,6 +31,9 @@ const makePlugin = (overrides: Partial<Plugin> = {}): Plugin => ({
   version: '1.0.0',
   directory: '/plugins/test-plugin',
   config: { disabled: false },
+  permissions: { modules: [], capabilities: [] },
+  permissionWarnings: [],
+  permissionsDeclared: false,
   module: {},
   ...overrides,
 });

--- a/packages/insomnia/src/plugins/__tests__/themes.test.ts
+++ b/packages/insomnia/src/plugins/__tests__/themes.test.ts
@@ -11,6 +11,9 @@ const makePlugin = (overrides: Partial<Plugin> = {}): Plugin => ({
   version: '1.0.0',
   directory: '/plugins/test-plugin',
   config: { disabled: false },
+  permissions: { modules: [], capabilities: [] },
+  permissionWarnings: [],
+  permissionsDeclared: false,
   module: {},
   ...overrides,
 });

--- a/packages/insomnia/src/plugins/index.ts
+++ b/packages/insomnia/src/plugins/index.ts
@@ -6,6 +6,7 @@ import type { Request, RequestGroup, Workspace } from 'insomnia-data';
 import { database as db, models, services } from 'insomnia-data';
 import type { PluginConfigMap } from 'insomnia-data/common';
 
+import { parsePluginPermissions } from '~/common/plugins/permissions';
 import type {
   DocumentAction,
   Plugin,
@@ -109,12 +110,21 @@ async function traversePluginPath(pluginMap: Record<string, Plugin>, allPaths: s
         // Delete require cache entry and re-require
         const module = nodeRequire(modulePath);
 
+        const parsedPermissions = parsePluginPermissions(pluginJson.insomnia);
+        if (parsedPermissions.warnings.length > 0) {
+          // Constant format string; interpolated values passed as args so a plugin name can't forge log output.
+          console.warn('[plugin] %s has invalid insomnia.permissions: %o', pluginJson.name, parsedPermissions.warnings);
+        }
+
         pluginMap[pluginJson.name] = {
           name: pluginJson.name,
           description: pluginJson.description || pluginJson.insomnia.description || '',
           version: pluginJson.version || 'unknown',
           directory: modulePath || '',
           config: pluginJson.name in allConfigs ? allConfigs[pluginJson.name] : { disabled: false },
+          permissions: parsedPermissions.permissions,
+          permissionWarnings: parsedPermissions.warnings,
+          permissionsDeclared: parsedPermissions.declared,
           module: module,
         };
       } catch (err) {
@@ -188,6 +198,10 @@ function getBundlePluginMap() {
         version: 'unknown',
         directory: '',
         config: { disabled: false },
+        // Bundle plugins are first-party; they declare no manifest and run on the baseline grant.
+        permissions: { modules: [], capabilities: [] },
+        permissionWarnings: [],
+        permissionsDeclared: false,
         module: module,
       };
     } catch (err) {

--- a/packages/insomnia/src/plugins/invoke-method.ts
+++ b/packages/insomnia/src/plugins/invoke-method.ts
@@ -56,6 +56,9 @@ function serializePlugin(p: Plugin) {
     version: p.version,
     directory: p.directory,
     config: p.config,
+    permissions: p.permissions,
+    permissionWarnings: p.permissionWarnings,
+    permissionsDeclared: p.permissionsDeclared,
   };
 }
 

--- a/packages/insomnia/src/templating/sandbox/module-registry.ts
+++ b/packages/insomnia/src/templating/sandbox/module-registry.ts
@@ -129,11 +129,17 @@ export const TEMPLATE_TAG_BASELINE_MODULES: string[] = ['path', 'crypto'];
  * they simply fail at require time with "not available in sandbox" (parse and grant are separate
  * concerns). Profile-ceiling intersection is added in P1.
  */
+// alias -> canonical (e.g. "node:events" -> "events"); a Map so keys like "__proto__" stay literal.
+const canonicalModuleName = new Map<string, string>(
+  SANDBOX_MODULES.flatMap(m => [[m.name, m.name], ...(m.aliases ?? []).map(a => [a, m.name] as [string, string])]),
+);
+
 export const resolveTemplateTagModules = (declaredModules: string[] = []): string[] => {
   const resolved = [...TEMPLATE_TAG_BASELINE_MODULES];
   for (const name of declaredModules) {
-    if (!resolved.includes(name)) {
-      resolved.push(name);
+    const canonical = canonicalModuleName.get(name) ?? name;
+    if (!resolved.includes(canonical)) {
+      resolved.push(canonical);
     }
   }
   return resolved;

--- a/packages/insomnia/src/templating/sandbox/module-registry.ts
+++ b/packages/insomnia/src/templating/sandbox/module-registry.ts
@@ -76,18 +76,68 @@ const CRYPTO_FACTORY = [
   '}',
 ].join('\n');
 
+// A minimal, pure-JS EventEmitter — the first non-baseline registry module, so a manifest that
+// declares `"modules": ["events"]` grants something a baseline plugin cannot reach (C3). Covers the
+// common surface (on/once/emit/removeListener); the full Node API is out of scope until a plugin
+// needs more. Registered here but NOT in the template-tag baseline — it requires an explicit grant.
+const EVENTS_FACTORY = [
+  'function () {',
+  '  function EventEmitter() { this._events = Object.create(null); }',
+  '  EventEmitter.prototype.on = function (type, fn) {',
+  '    (this._events[type] = this._events[type] || []).push(fn); return this;',
+  '  };',
+  '  EventEmitter.prototype.addListener = EventEmitter.prototype.on;',
+  '  EventEmitter.prototype.once = function (type, fn) {',
+  '    var self = this; function g() { self.removeListener(type, g); fn.apply(this, arguments); }',
+  '    g.listener = fn; return this.on(type, g);',
+  '  };',
+  '  EventEmitter.prototype.removeListener = function (type, fn) {',
+  '    var list = this._events[type]; if (!list) { return this; }',
+  '    for (var i = list.length - 1; i >= 0; i--) { if (list[i] === fn || list[i].listener === fn) { list.splice(i, 1); } }',
+  '    return this;',
+  '  };',
+  '  EventEmitter.prototype.removeAllListeners = function (type) {',
+  '    if (type === undefined) { this._events = Object.create(null); } else { delete this._events[type]; } return this;',
+  '  };',
+  '  EventEmitter.prototype.listeners = function (type) { return (this._events[type] || []).slice(); };',
+  '  EventEmitter.prototype.emit = function (type) {',
+  '    var list = this._events[type]; if (!list || !list.length) { return false; }',
+  '    var args = Array.prototype.slice.call(arguments, 1);',
+  '    var copy = list.slice(); for (var i = 0; i < copy.length; i++) { copy[i].apply(this, args); } return true;',
+  '  };',
+  '  return { EventEmitter: EventEmitter };',
+  '}',
+].join('\n');
+
 /** Every module the sandbox can serve. Grown deliberately, one vetted entry at a time (M2/M3). */
 export const SANDBOX_MODULES: SandboxModuleDefinition[] = [
   { name: 'path', aliases: ['node:path'], factorySource: PATH_FACTORY },
   { name: 'crypto', aliases: ['node:crypto'], factorySource: CRYPTO_FACTORY },
+  { name: 'events', aliases: ['node:events'], factorySource: EVENTS_FACTORY },
 ];
 
 /**
- * The module grant every template-tag plugin receives today. This is the pre-manifest baseline —
- * once the manifest loader (C3) and surface profiles (P1) land, the effective grant becomes
- * `manifest ∩ profile` with this set as the template-tag profile's floor.
+ * The floor of module access every template-tag plugin receives, even with no manifest. Surface
+ * profiles (P1) will intersect the resolved grant with a ceiling; for now the effective grant is
+ * simply `baseline ∪ manifest.modules` (see `resolveTemplateTagModules`).
  */
 export const TEMPLATE_TAG_BASELINE_MODULES: string[] = ['path', 'crypto'];
+
+/**
+ * Resolve the module set a template-tag plugin may `require()`: the baseline floor plus whatever the
+ * plugin declared in `insomnia.permissions.modules`. Unknown declared names are harmless here —
+ * they simply fail at require time with "not available in sandbox" (parse and grant are separate
+ * concerns). Profile-ceiling intersection is added in P1.
+ */
+export const resolveTemplateTagModules = (declaredModules: string[] = []): string[] => {
+  const resolved = [...TEMPLATE_TAG_BASELINE_MODULES];
+  for (const name of declaredModules) {
+    if (!resolved.includes(name)) {
+      resolved.push(name);
+    }
+  }
+  return resolved;
+};
 
 /**
  * JS evaluated inside the sandbox immediately after the bootstrap. Populates the registry the

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
@@ -435,6 +435,22 @@ describe('manifest-declared module grants (C3)', () => {
     expect(resolveTemplateTagModules(['path'])).toEqual(TEMPLATE_TAG_BASELINE_MODULES);
   });
 
+  it('canonicalizes declared aliases so the node:-prefixed form grants the module', () => {
+    expect(resolveTemplateTagModules(['node:events'])).toEqual([...TEMPLATE_TAG_BASELINE_MODULES, 'events']);
+    // node:crypto resolves to the already-baseline crypto without duplicating it.
+    expect(resolveTemplateTagModules(['node:crypto'])).toEqual(TEMPLATE_TAG_BASELINE_MODULES);
+  });
+
+  it('a plugin declaring the node:events alias can use EventEmitter', async () => {
+    const actual = await runTagInSandbox({
+      pluginSource: eventsTag,
+      tagName: 'r',
+      envelope: envelope([], resolveTemplateTagModules(['node:events'])),
+      bridge: noBridge,
+    });
+    expect(actual).toBe('fired');
+  });
+
   it('a plugin granted "events" can use EventEmitter', async () => {
     const actual = await runTagInSandbox({
       pluginSource: eventsTag,

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest';
 import { localTemplateTags } from '../../common/templating/local-template-tags';
 import { createMapBridge, type HostBridge } from './host-bridge';
 import type { ContextEnvelope } from './marshal';
-import { SANDBOX_MODULES, TEMPLATE_TAG_BASELINE_MODULES } from './module-registry';
+import { resolveTemplateTagModules, SANDBOX_MODULES, TEMPLATE_TAG_BASELINE_MODULES } from './module-registry';
 import { type HostCrypto, runTagInSandbox } from './plugin-tag-sandbox';
 
 // Real node:crypto-backed host crypto, identical to what main provides.
@@ -421,5 +421,38 @@ describe('module registry gating (M1)', () => {
       bridge: noBridge,
     });
     expect(actual).toBe("Module 'fs' not permitted by manifest");
+  });
+});
+
+describe('manifest-declared module grants (C3)', () => {
+  const eventsTag =
+    "module.exports.templateTags = [{ name: 'r', run: function () { var E = require('events').EventEmitter; var e = new E(); var out = ''; e.on('x', function (v) { out = v; }); e.emit('x', 'fired'); return out; } }];";
+
+  it('resolveTemplateTagModules unions the baseline with declared modules', () => {
+    expect(resolveTemplateTagModules(['events'])).toEqual([...TEMPLATE_TAG_BASELINE_MODULES, 'events']);
+    expect(resolveTemplateTagModules()).toEqual(TEMPLATE_TAG_BASELINE_MODULES);
+    // Declaring a baseline module doesn't duplicate it.
+    expect(resolveTemplateTagModules(['path'])).toEqual(TEMPLATE_TAG_BASELINE_MODULES);
+  });
+
+  it('a plugin granted "events" can use EventEmitter', async () => {
+    const actual = await runTagInSandbox({
+      pluginSource: eventsTag,
+      tagName: 'r',
+      envelope: envelope([], resolveTemplateTagModules(['events'])),
+      bridge: noBridge,
+    });
+    expect(actual).toBe('fired');
+  });
+
+  it('a plugin without the grant is denied "events" with the manifest message', async () => {
+    await expect(
+      runTagInSandbox({
+        pluginSource: eventsTag,
+        tagName: 'r',
+        envelope: envelope([], resolveTemplateTagModules()),
+        bridge: noBridge,
+      }),
+    ).rejects.toThrow("Module 'events' not permitted by manifest");
   });
 });

--- a/packages/insomnia/src/ui/components/settings/plugins.tsx
+++ b/packages/insomnia/src/ui/components/settings/plugins.tsx
@@ -179,7 +179,7 @@ export const Plugins: FC = () => {
                   />
                 </TextField>
                 <Button
-                  className="flex h-full shrink-0 min-w-[13ch] items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-center text-sm font-semibold whitespace-nowrap text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--color-surprise)/80"
+                  className="flex h-full min-w-[13ch] shrink-0 items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-center text-sm font-semibold whitespace-nowrap text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--color-surprise)/80"
                   isDisabled={isInstallingFromNpm}
                   type="submit"
                   onPress={async () => {
@@ -481,6 +481,23 @@ export const Plugins: FC = () => {
                   ? PLUGIN_HUB_BASE
                   : NPM_PACKAGE_BASE + '/' + plugin.name;
 
+                // Summarize the plugin's declared sandbox permissions (C3). No declaration means it
+                // runs on the baseline grant; a declared block lists its requested modules/capabilities.
+                const { modules, capabilities } = plugin.permissions ?? { modules: [], capabilities: [] };
+                const permissionParts: string[] = [];
+                if (modules.length > 0) {
+                  permissionParts.push(`modules: ${modules.join(', ')}`);
+                }
+                if (capabilities.length > 0) {
+                  permissionParts.push(`capabilities: ${capabilities.join(', ')}`);
+                }
+                const permissionLabel =
+                  permissionParts.length > 0
+                    ? permissionParts.join(' · ')
+                    : plugin.permissionsDeclared
+                      ? 'Declared empty permissions (baseline access)'
+                      : 'No permissions declared (baseline access)';
+
                 return (
                   <GridListItem
                     textValue={plugin.name}
@@ -515,6 +532,23 @@ export const Plugins: FC = () => {
                           <HelpTooltip info className="space-left">
                             {plugin.description}
                           </HelpTooltip>
+                        )}
+                        <span
+                          data-testid={`plugin-permissions-${plugin.name}`}
+                          className="truncate text-xs text-(--hl)"
+                          title={permissionLabel}
+                        >
+                          {permissionLabel}
+                        </span>
+                        {plugin.permissionWarnings && plugin.permissionWarnings.length > 0 && (
+                          <span
+                            data-testid={`plugin-permission-warning-${plugin.name}`}
+                            className="text-(--color-warning)"
+                          >
+                            <HelpTooltip info={false} className="space-left text-(--color-warning)">
+                              {plugin.permissionWarnings.join(' ')}
+                            </HelpTooltip>
+                          </span>
                         )}
                       </div>
                     </div>

--- a/packages/insomnia/src/ui/templating/__tests__/worker.test.ts
+++ b/packages/insomnia/src/ui/templating/__tests__/worker.test.ts
@@ -21,6 +21,9 @@ const userPluginTag: TemplateTag = {
     // user-installed plugins are loaded from disk and have a non-empty directory
     directory: '/Users/me/Library/Application Support/Insomnia/plugins/insomnia-plugin-request-body-hmac',
     config: { disabled: false },
+    permissions: { modules: [], capabilities: [] },
+    permissionWarnings: [],
+    permissionsDeclared: false,
     module: {},
   },
   templateTag: {


### PR DESCRIPTION
PR 2 of the sandbox plan (https://gist.github.com/jackkav/4bbf717954a18a6753b64f33ab678ad4) — ticket **C3**. Stacked on #10208 (PR 1); only the last commit is new.

## What

Adds the plugin **manifest permissions** system and makes a declared grant do something observable.

- **`common/plugins/permissions.ts`** (new): parses + validates `insomnia.permissions.{modules,capabilities}`. Default-deny; a malformed manifest degrades to baseline with a human-readable warning and **never crashes the loader**. (`capabilities` is parsed now but not consumed until C1.)
- **Loader + types**: `Plugin` and `SerializablePlugin` gain `permissions` / `permissionWarnings` / `permissionsDeclared`; the loader parses on load. The main-process execute handler threads `resolveTemplateTagModules(baseline ∪ manifest.modules)` into the sandbox envelope, replacing PR 1's hardcoded baseline for user plugins.
- **Registry**: seeded `events` (a pure-JS `EventEmitter`) as the first **non-baseline** module, so a declared grant reaches something a baseline plugin cannot.
- **Preferences → Plugins**: each plugin card now shows its declared permissions (`modules: events`) or `baseline access`, with a warning badge when the manifest is malformed.

## User-verifiable value

Two things a user can see: (a) a plugin declaring `"modules": ["events"]` can use `EventEmitter` where an undeclared plugin cannot; (b) the Plugins pane shows what every installed plugin has asked for — the transparency half of a permissions system.

## E2E (second test in `sandbox-template-tags.test.ts`)

Installs three plugins — one declaring `events`, one with no manifest, one with a malformed `permissions` block — then with the sandbox flag on:

- declared plugin → `{% eventsgranted %}` renders `events-ok` (EventEmitter works; also proves the flag applied)
- undeclared plugin → `{% eventsbaseline %}` renders `Module 'events' not permitted by manifest` (exact string)
- Preferences → Plugins shows `modules: events` for the declared plugin and `baseline access` for the other
- malformed plugin loads, degrades to baseline, and shows a validation-warning badge (never crashes)

## Verification

- `npx vitest run src/templating/sandbox src/common/plugins/permissions.test.ts` — sandbox suite + 9 new permissions-parser tests, all green
- `npm run test:smoke:dev -- sandbox-template-tags` — 2 passed
- Repo-wide `npm run lint && npm run type-check && npm test` — clean

## Notes

- Bundle (first-party) plugins declare no manifest and stay on the baseline grant.
- Grant resolution here is `baseline ∪ manifest.modules`; the profile **ceiling** intersection lands in P1.
