### PR TITLE
feat: Add analytic events to track shortcut for show sidebar create dropdown and create http request

### DIFF
--- a/packages/insomnia-analytics/src/events.ts
+++ b/packages/insomnia-analytics/src/events.ts
@@ -87,6 +87,7 @@ export enum AnalyticsEvent {
   aiFeatureDisabled = 'AI Feature Disabled',
   installPlugin = 'Plugin Installed',
   AppMenuPreferencesClicked = 'App Menu Preferences Clicked',
+  keyboardShortcutUsed = 'Keyboard Shortcut Used',
 
   homepageFiltered = 'homepage-filtered',
   quickSearchOpenedByKeyboard = 'quick-search-opened-by-keyboard',

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
@@ -407,6 +407,14 @@ const Debug = () => {
         : requestGroupId && isRequestGroupId(requestGroupId)
           ? requestGroupId
           : activeWorkspace._id;
+
+      window.main.trackAnalyticsEvent({
+        event: AnalyticsEvent.keyboardShortcutUsed,
+        properties: {
+          source: parentId === activeWorkspace._id ? 'empty-collection-page' : 'collection-page-request-list',
+          action: 'createHttpRequest',
+        },
+      });
       createRequestFetcher.submit({
         organizationId,
         projectId,

--- a/packages/insomnia/src/ui/components/first-request-creation.tsx
+++ b/packages/insomnia/src/ui/components/first-request-creation.tsx
@@ -153,6 +153,13 @@ export const FirstRequestCreation = ({
   };
 
   const handleRequestCreateShortcut = (_event: KeyboardEvent) => {
+    window.main.trackAnalyticsEvent({
+      event: AnalyticsEvent.keyboardShortcutUsed,
+      properties: {
+        source: 'first-request-creation-pane',
+        action: 'createHttpRequest',
+      },
+    });
     if (!selectedCollectionId) {
       createWorkspaceFetcher.submit({
         organizationId,

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
@@ -1063,6 +1063,13 @@ const ProjectNavigationSidebarInner = (
       }
 
       event.preventDefault();
+      window.main.trackAnalyticsEvent({
+        event: AnalyticsEvent.keyboardShortcutUsed,
+        properties: {
+          source: 'navigation-sidebar',
+          action: 'showCreateDropdown',
+        },
+      });
 
       const targetId = targetItem.doc._id;
       const targetIndex = visibleFlatItems.findIndex(item => item.doc._id === targetId);


### PR DESCRIPTION
Add analytic event to track:
- Press shortcut to show create dropdown in sidebar
- Press shortcut to create HTTP request in first creation pane/collection page

[INS-2937](https://konghq.atlassian.net/browse/INS-2937)

[INS-2937]: https://konghq.atlassian.net/browse/INS-2937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ