### PR TITLE
feat(INS-2933): first-request experience A/B experiment (13.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3539,9 +3539,9 @@
       }
     },
     "node_modules/@getinsomnia/insomnia-v3-fetch": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@getinsomnia/insomnia-v3-fetch/-/insomnia-v3-fetch-1.0.16.tgz",
-      "integrity": "sha512-ukYo8HJGZJK5rGH6SnzJDQSeFMPvd2N48F1hbNzgJTvzQtUxhckoIPI9VmMT4QRFGw0+NHZ00sRubMl3I130PA==",
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/@getinsomnia/insomnia-v3-fetch/-/insomnia-v3-fetch-1.0.20.tgz",
+      "integrity": "sha512-5hBO9nfd9Dq+Hw1HTGjqkTTUahJB2ZBQOUbS8dz37JYjg8TJpuE4gfUXAGZpK2EDYU1NJZdQVvcz3eTunZEn3A==",
       "license": "Apache-2.0"
     },
     "node_modules/@getinsomnia/node-libcurl": {
@@ -29322,7 +29322,7 @@
       "version": "12.5.1-alpha.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@getinsomnia/insomnia-v3-fetch": "^1.0.16"
+        "@getinsomnia/insomnia-v3-fetch": "^1.0.20"
       }
     },
     "packages/insomnia-data": {

--- a/packages/insomnia-analytics/src/events.ts
+++ b/packages/insomnia-analytics/src/events.ts
@@ -139,7 +139,9 @@ export enum AnalyticsEvent {
   uploadLintRulesetClicked = 'upload-lint-ruleset-clicked',
   firstRequestPaneExampleClicked = 'first-request-pane-example-clicked',
   firstRequestPaneCollectionChanged = 'first-request-pane-collection-changed',
-  firstRequestExperimentExposed = 'first-request-experiment-exposed',
+  // Generic experiment-assignment event (reusable across experiments). Emitted on
+  // each assignment change; feeds the warehouse `experiment_assignments` model.
+  experimentAssigned = 'Experiment Assigned',
 }
 
 export enum InsoEvent {

--- a/packages/insomnia-analytics/src/events.ts
+++ b/packages/insomnia-analytics/src/events.ts
@@ -139,6 +139,7 @@ export enum AnalyticsEvent {
   uploadLintRulesetClicked = 'upload-lint-ruleset-clicked',
   firstRequestPaneExampleClicked = 'first-request-pane-example-clicked',
   firstRequestPaneCollectionChanged = 'first-request-pane-collection-changed',
+  firstRequestExperimentExposed = 'first-request-experiment-exposed',
 }
 
 export enum InsoEvent {

--- a/packages/insomnia-api/package.json
+++ b/packages/insomnia-api/package.json
@@ -26,6 +26,6 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@getinsomnia/insomnia-v3-fetch": "^1.0.16"
+    "@getinsomnia/insomnia-v3-fetch": "^1.0.20"
   }
 }

--- a/packages/insomnia-api/src/__tests__/user.test.ts
+++ b/packages/insomnia-api/src/__tests__/user.test.ts
@@ -144,13 +144,13 @@ describe('latchRequestThresholdReached', () => {
     vi.clearAllMocks();
   });
 
-  it('POSTs the idempotent threshold latch and returns the updated state', async () => {
+  it('PATCHes the idempotent threshold latch and returns the updated state', async () => {
     mockFetch.mockResolvedValue({ has_reached_request_threshold: true });
 
     const result = await latchRequestThresholdReached({ sessionId: 'sess_xyz' });
 
     expect(mockFetch).toHaveBeenCalledWith({
-      method: 'POST',
+      method: 'PATCH',
       path: '/v3/users/me/onboarding',
       sessionId: 'sess_xyz',
       data: { reached_request_threshold: true },

--- a/packages/insomnia-api/src/__tests__/user.test.ts
+++ b/packages/insomnia-api/src/__tests__/user.test.ts
@@ -144,16 +144,15 @@ describe('latchRequestThresholdReached', () => {
     vi.clearAllMocks();
   });
 
-  it('PATCHes the idempotent threshold latch and returns the updated state', async () => {
+  it('PUTs the idempotent threshold-reached latch (no body) and returns the updated state', async () => {
     mockFetch.mockResolvedValue({ reached_request_threshold: true });
 
     const result = await latchRequestThresholdReached({ sessionId: 'sess_xyz' });
 
     expect(mockFetch).toHaveBeenCalledWith({
-      method: 'PATCH',
-      path: '/v3/users/me/onboarding',
+      method: 'PUT',
+      path: '/v3/users/me/onboarding/request-threshold-reached',
       sessionId: 'sess_xyz',
-      data: { reached_request_threshold: true },
     });
     expect(result.reached_request_threshold).toBe(true);
   });

--- a/packages/insomnia-api/src/__tests__/user.test.ts
+++ b/packages/insomnia-api/src/__tests__/user.test.ts
@@ -120,14 +120,14 @@ describe('getOnboardingState', () => {
   });
 
   it('GETs the onboarding endpoint with the sessionId', async () => {
-    mockFetch.mockResolvedValue({ first_request_treatment: 'A', is_new_signup: true, has_reached_request_threshold: false });
+    mockFetch.mockResolvedValue({ first_request_treatment: 'A', is_new_signup: true, reached_request_threshold: false });
 
     const result = await getOnboardingState({ sessionId: 'sess_xyz' });
 
     expect(mockFetch).toHaveBeenCalledWith({ method: 'GET', path: '/v3/users/me/onboarding', sessionId: 'sess_xyz' });
     expect(result.first_request_treatment).toBe('A');
     expect(result.is_new_signup).toBe(true);
-    expect(result.has_reached_request_threshold).toBe(false);
+    expect(result.reached_request_threshold).toBe(false);
   });
 
   it('passes an empty state through as-is', async () => {
@@ -145,7 +145,7 @@ describe('latchRequestThresholdReached', () => {
   });
 
   it('PATCHes the idempotent threshold latch and returns the updated state', async () => {
-    mockFetch.mockResolvedValue({ has_reached_request_threshold: true });
+    mockFetch.mockResolvedValue({ reached_request_threshold: true });
 
     const result = await latchRequestThresholdReached({ sessionId: 'sess_xyz' });
 
@@ -155,6 +155,6 @@ describe('latchRequestThresholdReached', () => {
       sessionId: 'sess_xyz',
       data: { reached_request_threshold: true },
     });
-    expect(result.has_reached_request_threshold).toBe(true);
+    expect(result.reached_request_threshold).toBe(true);
   });
 });

--- a/packages/insomnia-api/src/__tests__/user.test.ts
+++ b/packages/insomnia-api/src/__tests__/user.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { getEncryptionKeys, getUserProfile, reportRequestsCreated } from '../user';
+import { getEncryptionKeys, getOnboardingState, getUserProfile, latchRequestThresholdReached } from '../user';
 
 const { mockFetch } = vi.hoisted(() => ({
   mockFetch: vi.fn(),
@@ -114,42 +114,47 @@ describe('getEncryptionKeys', () => {
   });
 });
 
-describe('reportRequestsCreated', () => {
+describe('getOnboardingState', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('POSTs to the requests-created endpoint with no body by default (server defaults to 1)', async () => {
-    mockFetch.mockResolvedValue({ requests_created: 5 });
+  it('GETs the onboarding endpoint with the sessionId', async () => {
+    mockFetch.mockResolvedValue({ first_request_treatment: 'A', is_new_signup: true, has_reached_request_threshold: false });
 
-    await reportRequestsCreated({ sessionId: 'sess_xyz' });
+    const result = await getOnboardingState({ sessionId: 'sess_xyz' });
+
+    expect(mockFetch).toHaveBeenCalledWith({ method: 'GET', path: '/v3/users/me/onboarding', sessionId: 'sess_xyz' });
+    expect(result.first_request_treatment).toBe('A');
+    expect(result.is_new_signup).toBe(true);
+    expect(result.has_reached_request_threshold).toBe(false);
+  });
+
+  it('passes an empty state through as-is', async () => {
+    mockFetch.mockResolvedValue({});
+
+    const result = await getOnboardingState({ sessionId: 'sess_xyz' });
+
+    expect(result).toEqual({});
+  });
+});
+
+describe('latchRequestThresholdReached', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('POSTs the idempotent threshold latch and returns the updated state', async () => {
+    mockFetch.mockResolvedValue({ has_reached_request_threshold: true });
+
+    const result = await latchRequestThresholdReached({ sessionId: 'sess_xyz' });
 
     expect(mockFetch).toHaveBeenCalledWith({
       method: 'POST',
-      path: '/v3/users/me/requests-created',
+      path: '/v3/users/me/onboarding',
       sessionId: 'sess_xyz',
-      data: undefined,
+      data: { reached_request_threshold: true },
     });
-  });
-
-  it('sends an explicit count when provided', async () => {
-    mockFetch.mockResolvedValue({ requests_created: 7 });
-
-    await reportRequestsCreated({ sessionId: 'sess_xyz', count: 3 });
-
-    expect(mockFetch).toHaveBeenCalledWith({
-      method: 'POST',
-      path: '/v3/users/me/requests-created',
-      sessionId: 'sess_xyz',
-      data: { count: 3 },
-    });
-  });
-
-  it('returns the updated account total from the API response', async () => {
-    mockFetch.mockResolvedValue({ requests_created: 42 });
-
-    const result = await reportRequestsCreated({ sessionId: 'sess_xyz' });
-
-    expect(result.requests_created).toBe(42);
+    expect(result.has_reached_request_threshold).toBe(true);
   });
 });

--- a/packages/insomnia-api/src/__tests__/user.test.ts
+++ b/packages/insomnia-api/src/__tests__/user.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { getEncryptionKeys, getUserProfile } from '../user';
+import { getEncryptionKeys, getUserProfile, reportRequestsCreated } from '../user';
 
 const { mockFetch } = vi.hoisted(() => ({
   mockFetch: vi.fn(),
@@ -111,5 +111,45 @@ describe('getEncryptionKeys', () => {
       path: '/v3/users/me/encryption-keys',
       sessionId: 'sess_xyz',
     });
+  });
+});
+
+describe('reportRequestsCreated', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('POSTs to the requests-created endpoint with no body by default (server defaults to 1)', async () => {
+    mockFetch.mockResolvedValue({ requests_created: 5 });
+
+    await reportRequestsCreated({ sessionId: 'sess_xyz' });
+
+    expect(mockFetch).toHaveBeenCalledWith({
+      method: 'POST',
+      path: '/v3/users/me/requests-created',
+      sessionId: 'sess_xyz',
+      data: undefined,
+    });
+  });
+
+  it('sends an explicit count when provided', async () => {
+    mockFetch.mockResolvedValue({ requests_created: 7 });
+
+    await reportRequestsCreated({ sessionId: 'sess_xyz', count: 3 });
+
+    expect(mockFetch).toHaveBeenCalledWith({
+      method: 'POST',
+      path: '/v3/users/me/requests-created',
+      sessionId: 'sess_xyz',
+      data: { count: 3 },
+    });
+  });
+
+  it('returns the updated account total from the API response', async () => {
+    mockFetch.mockResolvedValue({ requests_created: 42 });
+
+    const result = await reportRequestsCreated({ sessionId: 'sess_xyz' });
+
+    expect(result.requests_created).toBe(42);
   });
 });

--- a/packages/insomnia-api/src/__tests__/user.test.ts
+++ b/packages/insomnia-api/src/__tests__/user.test.ts
@@ -120,20 +120,20 @@ describe('getOnboardingState', () => {
   });
 
   it('GETs the onboarding endpoint with the sessionId', async () => {
-    mockFetch.mockResolvedValue({ first_request_treatment: 'A', is_new_signup: true });
+    mockFetch.mockResolvedValue({ first_request_treatment: 'treatment_a', is_new_signup: true });
 
     const result = await getOnboardingState({ sessionId: 'sess_xyz' });
 
     expect(mockFetch).toHaveBeenCalledWith({ method: 'GET', path: '/v3/users/me/onboarding', sessionId: 'sess_xyz' });
-    expect(result.first_request_treatment).toBe('A');
+    expect(result.first_request_treatment).toBe('treatment_a');
     expect(result.is_new_signup).toBe(true);
   });
 
-  it('passes an empty state through as-is', async () => {
-    mockFetch.mockResolvedValue({});
+  it('passes a null treatment through as-is', async () => {
+    mockFetch.mockResolvedValue({ first_request_treatment: null, is_new_signup: false });
 
     const result = await getOnboardingState({ sessionId: 'sess_xyz' });
 
-    expect(result).toEqual({});
+    expect(result).toEqual({ first_request_treatment: null, is_new_signup: false });
   });
 });

--- a/packages/insomnia-api/src/__tests__/user.test.ts
+++ b/packages/insomnia-api/src/__tests__/user.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { getEncryptionKeys, getOnboardingState, getUserProfile, latchRequestThresholdReached } from '../user';
+import { getEncryptionKeys, getOnboardingState, getUserProfile } from '../user';
 
 const { mockFetch } = vi.hoisted(() => ({
   mockFetch: vi.fn(),
@@ -120,14 +120,13 @@ describe('getOnboardingState', () => {
   });
 
   it('GETs the onboarding endpoint with the sessionId', async () => {
-    mockFetch.mockResolvedValue({ first_request_treatment: 'A', is_new_signup: true, reached_request_threshold: false });
+    mockFetch.mockResolvedValue({ first_request_treatment: 'A', is_new_signup: true });
 
     const result = await getOnboardingState({ sessionId: 'sess_xyz' });
 
     expect(mockFetch).toHaveBeenCalledWith({ method: 'GET', path: '/v3/users/me/onboarding', sessionId: 'sess_xyz' });
     expect(result.first_request_treatment).toBe('A');
     expect(result.is_new_signup).toBe(true);
-    expect(result.reached_request_threshold).toBe(false);
   });
 
   it('passes an empty state through as-is', async () => {
@@ -136,24 +135,5 @@ describe('getOnboardingState', () => {
     const result = await getOnboardingState({ sessionId: 'sess_xyz' });
 
     expect(result).toEqual({});
-  });
-});
-
-describe('latchRequestThresholdReached', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('PUTs the idempotent threshold-reached latch (no body) and returns the updated state', async () => {
-    mockFetch.mockResolvedValue({ reached_request_threshold: true });
-
-    const result = await latchRequestThresholdReached({ sessionId: 'sess_xyz' });
-
-    expect(mockFetch).toHaveBeenCalledWith({
-      method: 'PUT',
-      path: '/v3/users/me/onboarding/request-threshold-reached',
-      sessionId: 'sess_xyz',
-    });
-    expect(result.reached_request_threshold).toBe(true);
   });
 });

--- a/packages/insomnia-api/src/user.ts
+++ b/packages/insomnia-api/src/user.ts
@@ -27,15 +27,15 @@ export const getEncryptionKeys = async ({ sessionId }: { sessionId: string }): P
 // off the permanent users/me contract) that holds transient onboarding/experiment
 // state with its own lifecycle. All fields are optional/backward-compatible.
 export interface UserOnboardingState {
-  // Server-computed first-request experiment treatment. Present only when the
-  // server is steering assignment; absent → the client computes it locally.
+  // Server-computed first-request experiment treatment (the server is authoritative);
+  // absent → the client falls back to the cached value / safe default.
   first_request_treatment?: 'A' | 'B';
   // Whether the account is a genuine new sign-up (an experiment participant).
   is_new_signup?: boolean;
-  // Sticky, irreversible latch: the account has ever created at least the minimum
-  // number of requests to graduate the first-request experiment (account-wide,
+  // Sticky, irreversible latch: the account has created at least the minimum number
+  // of requests to graduate the first-request experiment (account-wide,
   // device-independent). Once true it never reverts.
-  has_reached_request_threshold?: boolean;
+  reached_request_threshold?: boolean;
 }
 
 // GET /v3/users/me/onboarding

--- a/packages/insomnia-api/src/user.ts
+++ b/packages/insomnia-api/src/user.ts
@@ -43,17 +43,16 @@ export const getOnboardingState = async ({ sessionId }: { sessionId: string }): 
   return fetch<UserOnboardingState>({ method: 'GET', path: '/v3/users/me/onboarding', sessionId });
 };
 
-// PATCH /v3/users/me/onboarding
-// Idempotent latch: tells the server the account has reached the first-request
-// graduation threshold. Safe to call repeatedly — the server stores a sticky bit
-// that never reverts, so dropped calls simply self-heal on the next attempt.
-// Returns the updated onboarding state.
+// PUT /v3/users/me/onboarding/request-threshold-reached
+// Idempotent latch: PUTting this sub-resource marks that the account has reached the
+// first-request graduation threshold. Idempotent by definition, so it's safe to call
+// repeatedly — the server stores a sticky bit that never reverts and dropped calls
+// self-heal on the next attempt. Returns the updated onboarding state.
 export const latchRequestThresholdReached = async ({ sessionId }: { sessionId: string }): Promise<UserOnboardingState> => {
   return fetch<UserOnboardingState>({
-    method: 'PATCH',
-    path: '/v3/users/me/onboarding',
+    method: 'PUT',
+    path: '/v3/users/me/onboarding/request-threshold-reached',
     sessionId,
-    data: { reached_request_threshold: true },
   });
 };
 

--- a/packages/insomnia-api/src/user.ts
+++ b/packages/insomnia-api/src/user.ts
@@ -32,10 +32,6 @@ export interface UserOnboardingState {
   first_request_treatment?: 'A' | 'B';
   // Whether the account is a genuine new sign-up (an experiment participant).
   is_new_signup?: boolean;
-  // Sticky, irreversible latch: the account has created at least the minimum number
-  // of requests to graduate the first-request experiment (account-wide,
-  // device-independent). Once true it never reverts.
-  reached_request_threshold?: boolean;
 }
 
 // GET /v3/users/me/onboarding
@@ -48,7 +44,11 @@ export const getOnboardingState = async ({ sessionId }: { sessionId: string }): 
 // first-request graduation threshold. Idempotent by definition, so it's safe to call
 // repeatedly — the server stores a sticky bit that never reverts and dropped calls
 // self-heal on the next attempt. Returns the updated onboarding state.
-export const latchRequestThresholdReached = async ({ sessionId }: { sessionId: string }): Promise<UserOnboardingState> => {
+export const latchRequestThresholdReached = async ({
+  sessionId,
+}: {
+  sessionId: string;
+}): Promise<UserOnboardingState> => {
   return fetch<UserOnboardingState>({
     method: 'PUT',
     path: '/v3/users/me/onboarding/request-threshold-reached',

--- a/packages/insomnia-api/src/user.ts
+++ b/packages/insomnia-api/src/user.ts
@@ -1,8 +1,10 @@
-import type { User, UserEncryptionKeys } from '@getinsomnia/insomnia-v3-fetch';
+import type { User, UserEncryptionKeys, UserOnboarding } from '@getinsomnia/insomnia-v3-fetch';
+import { UserOnboardingFirstRequestTreatmentEnum } from '@getinsomnia/insomnia-v3-fetch';
 
 import { fetch } from './fetch';
 
-export type { User, UserEncryptionKeys };
+export type { User, UserEncryptionKeys, UserOnboarding };
+export { UserOnboardingFirstRequestTreatmentEnum };
 
 // POST /auth/logout
 export const logout = ({ sessionId }: { sessionId: string }) => {
@@ -23,35 +25,20 @@ export const getEncryptionKeys = async ({ sessionId }: { sessionId: string }): P
   return fetch<UserEncryptionKeys>({ method: 'GET', path: '/v3/users/me/encryption-keys', sessionId });
 };
 
-// Onboarding state for the current user. A standalone, removable resource (kept
-// off the permanent users/me contract) that holds transient onboarding/experiment
-// state with its own lifecycle. All fields are optional/backward-compatible.
-export interface UserOnboardingState {
-  // Server-computed first-request experiment treatment (the server is authoritative);
-  // absent → the client falls back to the cached value / safe default.
-  first_request_treatment?: 'A' | 'B';
-  // Whether the account is a genuine new sign-up (an experiment participant).
-  is_new_signup?: boolean;
-}
-
 // GET /v3/users/me/onboarding
-export const getOnboardingState = async ({ sessionId }: { sessionId: string }): Promise<UserOnboardingState> => {
-  return fetch<UserOnboardingState>({ method: 'GET', path: '/v3/users/me/onboarding', sessionId });
+export const getOnboardingState = async ({ sessionId }: { sessionId: string }): Promise<UserOnboarding> => {
+  return fetch<UserOnboarding>({ method: 'GET', path: '/v3/users/me/onboarding', sessionId });
 };
 
-// PUT /v3/users/me/onboarding/request-threshold-reached
-// Idempotent latch: PUTting this sub-resource marks that the account has reached the
+// POST /v3/users/me/onboarding/request-threshold
+// Idempotent latch: POSTing this sub-resource marks that the account has reached the
 // first-request graduation threshold. Idempotent by definition, so it's safe to call
 // repeatedly — the server stores a sticky bit that never reverts and dropped calls
-// self-heal on the next attempt. Returns the updated onboarding state.
-export const latchRequestThresholdReached = async ({
-  sessionId,
-}: {
-  sessionId: string;
-}): Promise<UserOnboardingState> => {
-  return fetch<UserOnboardingState>({
-    method: 'PUT',
-    path: '/v3/users/me/onboarding/request-threshold-reached',
+// self-heal on the next attempt. Responds 204 with no body.
+export const latchRequestThresholdReached = async ({ sessionId }: { sessionId: string }): Promise<void> => {
+  return fetch<void>({
+    method: 'POST',
+    path: '/v3/users/me/onboarding/request-threshold',
     sessionId,
   });
 };

--- a/packages/insomnia-api/src/user.ts
+++ b/packages/insomnia-api/src/user.ts
@@ -23,6 +23,25 @@ export const getEncryptionKeys = async ({ sessionId }: { sessionId: string }): P
   return fetch<UserEncryptionKeys>({ method: 'GET', path: '/v3/users/me/encryption-keys', sessionId });
 };
 
+// POST /v3/users/me/requests-created
+// Reports request creation to the backend, which keeps the account-level,
+// device-independent count that powers first-request experiment graduation.
+// The body is optional; the server defaults to a count of 1 and caps per call.
+export const reportRequestsCreated = async ({
+  sessionId,
+  count,
+}: {
+  sessionId: string;
+  count?: number;
+}): Promise<{ requests_created: number }> => {
+  return fetch<{ requests_created: number }>({
+    method: 'POST',
+    path: '/v3/users/me/requests-created',
+    sessionId,
+    data: count === undefined ? undefined : { count },
+  });
+};
+
 // GET /v1/billing/current-plan
 export type PersonalPlanType = 'free' | 'individual' | 'team' | 'enterprise' | 'enterprise-member';
 type PaymentSchedules = 'month' | 'year';

--- a/packages/insomnia-api/src/user.ts
+++ b/packages/insomnia-api/src/user.ts
@@ -23,22 +23,37 @@ export const getEncryptionKeys = async ({ sessionId }: { sessionId: string }): P
   return fetch<UserEncryptionKeys>({ method: 'GET', path: '/v3/users/me/encryption-keys', sessionId });
 };
 
-// POST /v3/users/me/requests-created
-// Reports request creation to the backend, which keeps the account-level,
-// device-independent count that powers first-request experiment graduation.
-// The body is optional; the server defaults to a count of 1 and caps per call.
-export const reportRequestsCreated = async ({
-  sessionId,
-  count,
-}: {
-  sessionId: string;
-  count?: number;
-}): Promise<{ requests_created: number }> => {
-  return fetch<{ requests_created: number }>({
+// Onboarding state for the current user. A standalone, removable resource (kept
+// off the permanent users/me contract) that holds transient onboarding/experiment
+// state with its own lifecycle. All fields are optional/backward-compatible.
+export interface UserOnboardingState {
+  // Server-computed first-request experiment treatment. Present only when the
+  // server is steering assignment; absent → the client computes it locally.
+  first_request_treatment?: 'A' | 'B';
+  // Whether the account is a genuine new sign-up (an experiment participant).
+  is_new_signup?: boolean;
+  // Sticky, irreversible latch: the account has ever created at least the minimum
+  // number of requests to graduate the first-request experiment (account-wide,
+  // device-independent). Once true it never reverts.
+  has_reached_request_threshold?: boolean;
+}
+
+// GET /v3/users/me/onboarding
+export const getOnboardingState = async ({ sessionId }: { sessionId: string }): Promise<UserOnboardingState> => {
+  return fetch<UserOnboardingState>({ method: 'GET', path: '/v3/users/me/onboarding', sessionId });
+};
+
+// POST /v3/users/me/onboarding
+// Idempotent latch: tells the server the account has reached the first-request
+// graduation threshold. Safe to call repeatedly — the server stores a sticky bit
+// that never reverts, so dropped calls simply self-heal on the next attempt.
+// Returns the updated onboarding state.
+export const latchRequestThresholdReached = async ({ sessionId }: { sessionId: string }): Promise<UserOnboardingState> => {
+  return fetch<UserOnboardingState>({
     method: 'POST',
-    path: '/v3/users/me/requests-created',
+    path: '/v3/users/me/onboarding',
     sessionId,
-    data: count === undefined ? undefined : { count },
+    data: { reached_request_threshold: true },
   });
 };
 

--- a/packages/insomnia-api/src/user.ts
+++ b/packages/insomnia-api/src/user.ts
@@ -43,14 +43,14 @@ export const getOnboardingState = async ({ sessionId }: { sessionId: string }): 
   return fetch<UserOnboardingState>({ method: 'GET', path: '/v3/users/me/onboarding', sessionId });
 };
 
-// POST /v3/users/me/onboarding
+// PATCH /v3/users/me/onboarding
 // Idempotent latch: tells the server the account has reached the first-request
 // graduation threshold. Safe to call repeatedly — the server stores a sticky bit
 // that never reverts, so dropped calls simply self-heal on the next attempt.
 // Returns the updated onboarding state.
 export const latchRequestThresholdReached = async ({ sessionId }: { sessionId: string }): Promise<UserOnboardingState> => {
   return fetch<UserOnboardingState>({
-    method: 'POST',
+    method: 'PATCH',
     path: '/v3/users/me/onboarding',
     sessionId,
     data: { reached_request_threshold: true },

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
@@ -141,11 +141,7 @@ const Component = ({ loaderData }: Route.ComponentProps) => {
   const [isNewProjectModalOpen, setIsNewProjectModalOpen] = useState(false);
   const [isUpdateProjectModalOpen, setIsUpdateProjectModalOpen] = useState(false);
   const organization = organizationData?.organizations.find(o => o.id === organizationId);
-  const greetingName = userSession.firstName || userSession.email.split('@')[0] || 'there';
-  const isUserOwner =
-    organization &&
-    userSession.accountId &&
-    models.organization.isOwnerOfOrganization({ organization, accountId: userSession.accountId });
+  const isUserOwner = organization && userSession.accountId && Boolean(organization.is_owner);
   const collectionItems = useMemo(
     () =>
       localFiles

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
@@ -141,8 +141,11 @@ const Component = ({ loaderData }: Route.ComponentProps) => {
   const [isNewProjectModalOpen, setIsNewProjectModalOpen] = useState(false);
   const [isUpdateProjectModalOpen, setIsUpdateProjectModalOpen] = useState(false);
   const organization = organizationData?.organizations.find(o => o.id === organizationId);
-  const isUserOwner = Boolean(organization?.is_owner);
   const greetingName = userSession.firstName || userSession.email.split('@')[0] || 'there';
+  const isUserOwner =
+    organization &&
+    userSession.accountId &&
+    models.organization.isOwnerOfOrganization({ organization, accountId: userSession.accountId });
   const collectionItems = useMemo(
     () =>
       localFiles
@@ -368,11 +371,9 @@ const Component = ({ loaderData }: Route.ComponentProps) => {
         <div className="px-4 pt-4">
           {activeSidebarTab === 'projects' && (
             <FirstRequestCreation
-              greetingName={greetingName}
               collectionItems={collectionItems}
               selectedCollectionId={selectedCollectionId}
               onSelectedCollectionChange={setSelectedCollectionId}
-              onCreateDesignDocument={() => createNewDocument('first-request-pane')}
               onCreateCollection={() => {
                 setNewWorkspaceModalState({
                   scope: 'collection',

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new.tsx
@@ -1,7 +1,9 @@
+import { reportRequestsCreated } from 'insomnia-api';
 import type { Request, RequestBody, RequestParameter } from 'insomnia-data';
 import { services } from 'insomnia-data';
 import { href, redirect } from 'react-router';
 
+import { getCurrentSessionId } from '~/common/account/session';
 import {
   CONTENT_TYPE_EVENT_STREAM,
   CONTENT_TYPE_GRAPHQL,
@@ -21,6 +23,21 @@ import { createFetcherSubmitHook } from '~/ui/utils/router';
 const URL_BAR_REQUEST_TYPES: CreateRequestType[] = ['HTTP', 'GraphQL', 'Event Stream', 'From Curl'];
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new';
+
+// Fire-and-forget report to the backend that a request was created, so it can keep
+// the account-level, device-independent count powering first-request experiment
+// graduation. Never blocks or fails request creation; no-op when logged out.
+async function reportRequestCreated() {
+  try {
+    const sessionId = await getCurrentSessionId();
+    if (!sessionId) {
+      return;
+    }
+    await reportRequestsCreated({ sessionId });
+  } catch (error) {
+    console.error('Failed to report created request to backend', error);
+  }
+}
 
 export async function clientAction({ params, request }: Route.ClientActionArgs) {
   const { organizationId, projectId, workspaceId } = params;
@@ -121,6 +138,7 @@ export async function clientAction({ params, request }: Route.ClientActionArgs) 
   }
   invariant(typeof activeRequestId === 'string', 'Request ID is required');
   services.stats.incrementCreatedRequests();
+  reportRequestCreated();
 
   const certificates = await services.clientCertificate.findByParentId(workspaceId);
 

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new.tsx
@@ -1,9 +1,7 @@
-import { reportRequestsCreated } from 'insomnia-api';
 import type { Request, RequestBody, RequestParameter } from 'insomnia-data';
 import { services } from 'insomnia-data';
 import { href, redirect } from 'react-router';
 
-import { getCurrentSessionId } from '~/common/account/session';
 import {
   CONTENT_TYPE_EVENT_STREAM,
   CONTENT_TYPE_GRAPHQL,
@@ -17,27 +15,13 @@ import { AnalyticsEvent } from '~/ui/analytics';
 import { focusUrlBarOnNextRequest } from '~/ui/components/request-url-bar-focus';
 import { trackCioEvent } from '~/ui/hooks/use-cio';
 import type { CreateRequestType } from '~/ui/hooks/use-request';
+import { maybeLatchRequestThreshold } from '~/ui/utils/first-request-latch';
 import { createFetcherSubmitHook } from '~/ui/utils/router';
 
 // Request types that are edited in the RequestPane / RequestUrlBar and should focus the URL on create.
 const URL_BAR_REQUEST_TYPES: CreateRequestType[] = ['HTTP', 'GraphQL', 'Event Stream', 'From Curl'];
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new';
-
-// Fire-and-forget report to the backend that a request was created, so it can keep
-// the account-level, device-independent count powering first-request experiment
-// graduation. Never blocks or fails request creation; no-op when logged out.
-async function reportRequestCreated() {
-  try {
-    const sessionId = await getCurrentSessionId();
-    if (!sessionId) {
-      return;
-    }
-    await reportRequestsCreated({ sessionId });
-  } catch (error) {
-    console.error('Failed to report created request to backend', error);
-  }
-}
 
 export async function clientAction({ params, request }: Route.ClientActionArgs) {
   const { organizationId, projectId, workspaceId } = params;
@@ -138,7 +122,9 @@ export async function clientAction({ params, request }: Route.ClientActionArgs) 
   }
   invariant(typeof activeRequestId === 'string', 'Request ID is required');
   services.stats.incrementCreatedRequests();
-  reportRequestCreated();
+  // Once this install has created enough requests, latch the sticky graduation
+  // bit on the server (fire-and-forget, idempotent — see maybeLatchRequestThreshold).
+  services.stats.get().then(stats => maybeLatchRequestThreshold(stats.createdRequests));
 
   const certificates = await services.clientCertificate.findByParentId(workspaceId);
 

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new.tsx
@@ -37,7 +37,7 @@ export async function clientAction({ params, request }: Route.ClientActionArgs) 
     activeRequestId = (
       await services.request.create({
         parentId: parentId || workspaceId,
-        method: METHOD_GET,
+        method: req?.method || METHOD_GET,
         name: req?.name || 'New Request',
         url: req?.url || '',
         headers: [],

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
@@ -11,6 +11,7 @@ import { safeToUseInsomniaFileNameWithExt } from '~/sync/git/insomnia-filename';
 import { AnalyticsEvent } from '~/ui/analytics';
 import { showToast } from '~/ui/components/toast-notification';
 import { trackCioEvent } from '~/ui/hooks/use-cio';
+import { maybeLatchRequestThreshold } from '~/ui/utils/first-request-latch';
 import { createFetcherSubmitHook } from '~/ui/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.new';
@@ -199,6 +200,11 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
           headers: [],
         })
       )._id;
+
+      services.stats.incrementCreatedRequests();
+      // Keep graduation in sync with requests created via this path too (fire-and-forget,
+      // idempotent — see maybeLatchRequestThreshold).
+      services.stats.get().then(stats => maybeLatchRequestThreshold(stats.createdRequests));
 
       const requestCreatedProperties = {
         requestType: 'HTTP',

--- a/packages/insomnia/src/ui/components/dropdowns/method-selector.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/method-selector.tsx
@@ -1,0 +1,119 @@
+import React, { forwardRef, useCallback, useState } from 'react';
+import { Button } from 'react-aria-components';
+
+import { HTTP_METHODS } from '../../../common/constants';
+import { getMethodPillClasses, getMethodTextClasses } from '../../utils/method-colors';
+import { Dropdown, type DropdownHandle, DropdownItem, DropdownSection, ItemContent } from '../base/dropdown';
+import { showModal } from '../modals/index';
+import { PromptModal } from '../modals/prompt-modal';
+
+const LOCALSTORAGE_KEY = 'insomnia.httpMethods';
+
+interface Props {
+  method: string;
+  onChange: (method: string) => void;
+  /** Extra classes for the trigger button (e.g. sizing/layout in a given context). */
+  className?: string;
+}
+
+/**
+ * Reusable HTTP method selector.
+ *
+ * Renders the current method as a filled, theme-coloured pill with a chevron and
+ * opens a dropdown to pick another method (plus a custom-method option). Self
+ * contained so it can be dropped into any surface that needs method selection.
+ */
+export const MethodSelector = forwardRef<DropdownHandle, Props>(({ method, onChange, className }, ref) => {
+  const localStorageHttpMethods = window.localStorage.getItem(LOCALSTORAGE_KEY);
+  const parsedLocalStorageHttpMethods = localStorageHttpMethods
+    ? (JSON.parse(localStorageHttpMethods) as string[])
+    : [];
+  const [recent, setRecent] = useState(parsedLocalStorageHttpMethods);
+
+  const handleSetCustomMethod = useCallback(() => {
+    showModal(PromptModal, {
+      defaultValue: method,
+      title: 'HTTP Method',
+      submitName: 'Done',
+      upperCase: true,
+      selectText: true,
+      hint: 'Common examples are LINK, UNLINK, FIND, PURGE',
+      label: 'Name',
+      placeholder: 'CUSTOM',
+      hints: recent,
+      onDeleteHint: methodToDelete => {
+        // Note: We need to read and remove the method from localStorage and not rely on react state
+        // It solves the case where you try to delete more than one method at a time, because recent is updated only once
+        const localStorageHttpMethods = window.localStorage.getItem(LOCALSTORAGE_KEY);
+        const currentRecent = localStorageHttpMethods ? (JSON.parse(localStorageHttpMethods) as string[]) : [];
+        const newRecent = currentRecent.filter(m => m !== methodToDelete);
+        setRecent(newRecent);
+        window.localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(newRecent));
+      },
+      onComplete: methodToAdd => {
+        // Don't add empty methods
+        if (!methodToAdd) {
+          return;
+        }
+        // Don't add base methods
+        if (HTTP_METHODS.includes(methodToAdd)) {
+          return;
+        }
+
+        // Note: We need to read and remove the method from localStorage and not rely on react state
+        // It solves the case where you try to add a new method after you deleted some others
+        const localStorageHttpMethods = window.localStorage.getItem(LOCALSTORAGE_KEY);
+        const currentRecent = localStorageHttpMethods ? (JSON.parse(localStorageHttpMethods) as string[]) : [];
+        // Save method as recent
+        if (!currentRecent.includes(methodToAdd)) {
+          const newRecent = [...currentRecent, methodToAdd];
+          setRecent(newRecent);
+          window.localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(newRecent));
+        }
+        onChange(methodToAdd);
+      },
+    });
+  }, [method, onChange, recent]);
+
+  return (
+    <Dropdown
+      ref={ref}
+      aria-label="Request Method"
+      triggerButton={
+        <Button
+          aria-label="Request Method"
+          className={`flex items-center gap-1 rounded-sm px-2 py-1 text-xs font-semibold uppercase ${getMethodPillClasses(method)} ${className || ''}`}
+        >
+          <span>{method}</span>
+          <i className="fa fa-caret-down" />
+        </Button>
+      }
+    >
+      <DropdownSection>
+        {HTTP_METHODS.map(m => (
+          <DropdownItem key={m}>
+            <ItemContent
+              className={getMethodTextClasses(m)}
+              label={m}
+              isSelected={m === method}
+              onClick={() => onChange(m)}
+            />
+          </DropdownItem>
+        ))}
+      </DropdownSection>
+
+      <DropdownSection>
+        <DropdownItem>
+          <ItemContent
+            className={getMethodTextClasses('')}
+            label="Custom Method"
+            isSelected={!HTTP_METHODS.includes(method)}
+            onClick={handleSetCustomMethod}
+          />
+        </DropdownItem>
+      </DropdownSection>
+    </Dropdown>
+  );
+});
+
+MethodSelector.displayName = 'MethodSelector';

--- a/packages/insomnia/src/ui/components/dropdowns/method-selector.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/method-selector.tsx
@@ -82,7 +82,7 @@ export const MethodSelector = forwardRef<DropdownHandle, Props>(({ method, onCha
       triggerButton={
         <Button
           aria-label="Request Method"
-          className={`flex items-center gap-1 rounded-sm px-2 py-1 text-xs font-semibold uppercase ${getMethodPillClasses(method)} ${className || ''}`}
+          className={`flex items-center gap-1 rounded-sm px-2 py-1 text-center text-[12px]/[100%] font-[590] uppercase ${getMethodPillClasses(method)} ${className || ''}`}
         >
           <span>{method}</span>
           <i className="fa fa-caret-down" />

--- a/packages/insomnia/src/ui/components/dropdowns/method-selector.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/method-selector.tsx
@@ -9,6 +9,31 @@ import { PromptModal } from '../modals/prompt-modal';
 
 const LOCALSTORAGE_KEY = 'insomnia.httpMethods';
 
+// Safely read the recent custom methods from localStorage. A corrupted/non-JSON
+// value or blocked storage returns an empty list instead of throwing.
+const readRecentMethods = (): string[] => {
+  try {
+    const raw = window.localStorage.getItem(LOCALSTORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((m): m is string => typeof m === 'string') : [];
+  } catch {
+    return [];
+  }
+};
+
+// Persist the recent custom methods, ignoring storage failures (e.g. private
+// mode / quota / blocked storage) so callers are never blocked by a failed write.
+const writeRecentMethods = (methods: string[]): void => {
+  try {
+    window.localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(methods));
+  } catch {
+    // Ignore storage failures.
+  }
+};
+
 interface Props {
   method: string;
   onChange: (method: string) => void;
@@ -24,11 +49,7 @@ interface Props {
  * contained so it can be dropped into any surface that needs method selection.
  */
 export const MethodSelector = forwardRef<DropdownHandle, Props>(({ method, onChange, className }, ref) => {
-  const localStorageHttpMethods = window.localStorage.getItem(LOCALSTORAGE_KEY);
-  const parsedLocalStorageHttpMethods = localStorageHttpMethods
-    ? (JSON.parse(localStorageHttpMethods) as string[])
-    : [];
-  const [recent, setRecent] = useState(parsedLocalStorageHttpMethods);
+  const [recent, setRecent] = useState(readRecentMethods);
 
   const handleSetCustomMethod = useCallback(() => {
     showModal(PromptModal, {
@@ -44,11 +65,10 @@ export const MethodSelector = forwardRef<DropdownHandle, Props>(({ method, onCha
       onDeleteHint: methodToDelete => {
         // Note: We need to read and remove the method from localStorage and not rely on react state
         // It solves the case where you try to delete more than one method at a time, because recent is updated only once
-        const localStorageHttpMethods = window.localStorage.getItem(LOCALSTORAGE_KEY);
-        const currentRecent = localStorageHttpMethods ? (JSON.parse(localStorageHttpMethods) as string[]) : [];
+        const currentRecent = readRecentMethods();
         const newRecent = currentRecent.filter(m => m !== methodToDelete);
         setRecent(newRecent);
-        window.localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(newRecent));
+        writeRecentMethods(newRecent);
       },
       onComplete: methodToAdd => {
         // Don't add empty methods
@@ -62,13 +82,12 @@ export const MethodSelector = forwardRef<DropdownHandle, Props>(({ method, onCha
 
         // Note: We need to read and remove the method from localStorage and not rely on react state
         // It solves the case where you try to add a new method after you deleted some others
-        const localStorageHttpMethods = window.localStorage.getItem(LOCALSTORAGE_KEY);
-        const currentRecent = localStorageHttpMethods ? (JSON.parse(localStorageHttpMethods) as string[]) : [];
+        const currentRecent = readRecentMethods();
         // Save method as recent
         if (!currentRecent.includes(methodToAdd)) {
           const newRecent = [...currentRecent, methodToAdd];
           setRecent(newRecent);
-          window.localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(newRecent));
+          writeRecentMethods(newRecent);
         }
         onChange(methodToAdd);
       },

--- a/packages/insomnia/src/ui/components/first-request-creation.tsx
+++ b/packages/insomnia/src/ui/components/first-request-creation.tsx
@@ -301,7 +301,8 @@ export const FirstRequestCreation = ({
   }, [selectedCollectionId]);
 
   // Load the lifetime created-request count, used to decide when to latch the
-  // server-side graduation threshold.
+  // server-side graduation threshold (see maybeLatchRequestThreshold for how the
+  // device-wide count is scoped back down to this account).
   useEffect(() => {
     let isActive = true;
 
@@ -340,8 +341,10 @@ export const FirstRequestCreation = ({
     };
   }, []);
 
-  // Self-heal the graduation latch: if this install has already crossed the
+  // Self-heal the graduation latch: if this account has already crossed the
   // threshold (e.g. the crossing creation's latch call was dropped), retry it.
+  // maybeLatchRequestThreshold scopes the device-wide createdRequests count back
+  // down to this account before deciding whether to latch.
   useEffect(() => {
     if (createdRequests !== null) {
       maybeLatchRequestThreshold(createdRequests);
@@ -534,7 +537,7 @@ export const FirstRequestCreation = ({
       <div className="rounded-sm bg-[radial-gradient(95.72%_95.72%_at_-0.32%_2.6%,var(--hl-md)_0%,var(--hl-xs)_100%),radial-gradient(100%_100.41%_at_100%_99.92%,var(--hl-md)_0%,var(--hl-xs)_100%)] p-px">
         <div className="flex w-full flex-col rounded-sm bg-(--color-bg) bg-[linear-gradient(180deg,rgba(var(--color-surprise-rgb),0.2)_0%,color-mix(in_srgb,var(--color-bg)_0%,transparent)_72.8%)] px-6 pt-5 pb-6">
           <h2 className="text-lg font-semibold">New request</h2>
-          <div className="mt-4 flex h-8.5 items-center gap-2 rounded-md border border-(--hl-md) bg-(--color-bg) px-1">
+          <div className="mt-4 flex h-8.5 items-center gap-1.5 rounded-md border border-(--hl-md) bg-(--color-bg) px-1">
             <MethodSelector method={method} onChange={setMethod} className="h-6.5" />
             <input
               ref={inputRef}

--- a/packages/insomnia/src/ui/components/first-request-creation.tsx
+++ b/packages/insomnia/src/ui/components/first-request-creation.tsx
@@ -20,12 +20,19 @@ import { getBadgeClassName } from '~/ui/components/workspace/resource-icon';
 import {
   FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE,
   type FirstRequestTreatment,
-  getFirstRequestTreatment,
+  getBackendFirstRequestTreatment,
+  readCachedFirstRequestTreatment,
+  resolveFirstRequestTreatment,
+  writeCachedFirstRequestTreatment,
 } from '~/ui/utils/first-request-treatment';
 
 import { useRequestNewActionFetcher } from '../../routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new';
 import { useWorkspaceNewActionFetcher } from '../../routes/organization.$organizationId.project.$projectId.workspace.new';
 import { Icon } from './icon';
+
+// Guards the experiment-exposure analytics event so it fires at most once per
+// (account, treatment) per app session instead of on every mount.
+const exposedTreatments = new Set<string>();
 
 const CURL_COMMAND_PATTERN = /^\s*\$?\s*curl(?:\s|$)/i;
 const NOTION_MCP_SERVER_URL = 'https://mcp.notion.com/mcp';
@@ -121,10 +128,14 @@ export const FirstRequestCreation = ({
   const organizationData = useOrganizationLoaderData();
   // Stable id used to bucket new sign-ups ~50/50 into Treatment A or B.
   const cohortId = userSession.accountId || settings.deviceId || '';
+  // Server-computed treatment, when the backend provides it (authoritative).
+  const backendTreatment = getBackendFirstRequestTreatment(organizationData?.user);
   // Account creation time (epoch ms); pre-GA accounts are treated as existing users.
   const accountCreatedAt = organizationData?.user?.created_at
     ? new Date(organizationData.user.created_at).getTime()
     : undefined;
+  // Last-known treatment for this account, used as an offline fallback.
+  const [cachedTreatment] = useState(() => readCachedFirstRequestTreatment(userSession.accountId || ''));
   const inputRef = useRef<HTMLInputElement>(null);
   const createRequestFetcher = useRequestNewActionFetcher();
   const createWorkspaceFetcher = useWorkspaceNewActionFetcher();
@@ -141,15 +152,14 @@ export const FirstRequestCreation = ({
   const isCreatingRequest = createRequestFetcher.state !== 'idle';
   const selectedCollection = collectionItems.find(collection => collection.id === selectedCollectionId) ?? null;
 
-  const treatment: FirstRequestTreatment | null =
-    createdRequests === null
-      ? null
-      : getFirstRequestTreatment({
-          accountCreatedAt,
-          experimentLaunchedAt: FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE,
-          createdRequests,
-          cohortId,
-        });
+  const treatment: FirstRequestTreatment | null = resolveFirstRequestTreatment({
+    backendTreatment,
+    accountCreatedAt,
+    experimentLaunchedAt: FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE,
+    createdRequests,
+    cohortId,
+    cachedTreatment,
+  });
   const createButtonLabel = treatment === 'B' ? 'Create HTTP Request ⏎' : 'Create ⏎';
 
   const ensureWorkspaceId = async () => {
@@ -287,34 +297,47 @@ export const FirstRequestCreation = ({
     setSelectOpen(false);
   }, [selectedCollectionId]);
 
-  // Determine which experiment treatment to show from the lifetime created-request count,
-  // and record exposure once we know it.
+  // Load the lifetime created-request count, used by the client-side fallback.
   useEffect(() => {
     let isActive = true;
 
     services.stats.get().then(stats => {
-      if (!isActive) {
-        return;
+      if (isActive) {
+        setCreatedRequests(stats.createdRequests);
       }
-
-      setCreatedRequests(stats.createdRequests);
-      window.main.trackAnalyticsEvent({
-        event: AnalyticsEvent.firstRequestExperimentExposed,
-        properties: {
-          treatment: getFirstRequestTreatment({
-            accountCreatedAt,
-            experimentLaunchedAt: FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE,
-            createdRequests: stats.createdRequests,
-            cohortId,
-          }),
-        },
-      });
     });
 
     return () => {
       isActive = false;
     };
-  }, [cohortId, accountCreatedAt]);
+  }, []);
+
+  // Cache the resolved treatment (offline fallback) and record exposure at most
+  // once per (account, treatment) per session.
+  useEffect(() => {
+    if (!treatment) {
+      return;
+    }
+
+    // Only cache confident results (backend or a full client-side computation),
+    // never a value that itself came from the cache/default.
+    const isConfident =
+      backendTreatment !== undefined ||
+      (accountCreatedAt !== undefined &&
+        (accountCreatedAt < FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE || createdRequests !== null));
+    if (isConfident) {
+      writeCachedFirstRequestTreatment(userSession.accountId || '', treatment);
+    }
+
+    const exposureKey = `${userSession.accountId || 'anonymous'}:${treatment}`;
+    if (!exposedTreatments.has(exposureKey)) {
+      exposedTreatments.add(exposureKey);
+      window.main.trackAnalyticsEvent({
+        event: AnalyticsEvent.firstRequestExperimentExposed,
+        properties: { treatment },
+      });
+    }
+  }, [treatment, backendTreatment, accountCreatedAt, createdRequests, userSession.accountId]);
 
   const handleCreateNotionMcpWorkspace = () => {
     createWorkspaceFetcher.submit({

--- a/packages/insomnia/src/ui/components/first-request-creation.tsx
+++ b/packages/insomnia/src/ui/components/first-request-creation.tsx
@@ -1,4 +1,5 @@
 import type { IconProp } from '@fortawesome/fontawesome-svg-core';
+import { getOnboardingState, type UserOnboardingState } from 'insomnia-api';
 import type { Request } from 'insomnia-data';
 import { services } from 'insomnia-data';
 import { type KeyboardEvent as ReactKeyboardEvent, useEffect, useRef, useState } from 'react';
@@ -6,6 +7,7 @@ import { useParams } from 'react-router';
 
 import { Button } from '~/basic-components/button';
 import { SelectPopover } from '~/basic-components/select-popover';
+import { getCurrentSessionId } from '~/common/account/session';
 import { METHOD_GET } from '~/common/constants';
 import { setDefaultProtocol } from '~/common/utils/url/protocol';
 import { useRootLoaderData } from '~/root';
@@ -17,13 +19,15 @@ import { ImportModal } from '~/ui/components/modals/import-modal/import-modal';
 import { SvgIcon } from '~/ui/components/svg-icon';
 import { showToast } from '~/ui/components/toast-notification';
 import { getBadgeClassName } from '~/ui/components/workspace/resource-icon';
+import { maybeLatchRequestThreshold } from '~/ui/utils/first-request-latch';
 import {
   FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE,
   FIRST_REQUEST_EXPERIMENT_NAME,
   type FirstRequestTreatment,
-  getBackendFirstRequestTreatment,
-  getBackendIsNewSignup,
   getFirstRequestTreatmentGroup,
+  getOnboardingIsNewSignup,
+  getOnboardingReachedThreshold,
+  getOnboardingTreatment,
   isFirstRequestExperimentParticipant,
   readCachedFirstRequestTreatment,
   resolveFirstRequestTreatment,
@@ -132,8 +136,12 @@ export const FirstRequestCreation = ({
   const organizationData = useOrganizationLoaderData();
   // Stable id used to bucket new sign-ups ~50/50 into Treatment A or B.
   const cohortId = userSession.accountId || settings.deviceId || '';
-  // Server-computed treatment, when the backend provides it (authoritative).
-  const backendTreatment = getBackendFirstRequestTreatment(organizationData?.user);
+  // Onboarding state from the backend (standalone resource), loaded on mount.
+  const [onboarding, setOnboarding] = useState<UserOnboardingState | null>(null);
+  // Server-computed treatment, when the backend is steering assignment (authoritative).
+  const backendTreatment = getOnboardingTreatment(onboarding);
+  // Sticky server-confirmed graduation latch (account-wide, device-independent).
+  const hasReachedThreshold = getOnboardingReachedThreshold(onboarding);
   // Account creation time (epoch ms); pre-GA accounts are treated as existing users.
   const accountCreatedAt = organizationData?.user?.created_at
     ? new Date(organizationData.user.created_at).getTime()
@@ -141,7 +149,7 @@ export const FirstRequestCreation = ({
   // Whether this user is part of the experiment population (a genuine new sign-up).
   // Only participants emit assignment analytics; existing users still get B in the UI.
   const isParticipant = isFirstRequestExperimentParticipant({
-    isNewSignup: getBackendIsNewSignup(organizationData?.user),
+    isNewSignup: getOnboardingIsNewSignup(onboarding),
     accountCreatedAt,
     experimentLaunchedAt: FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE,
   });
@@ -167,6 +175,7 @@ export const FirstRequestCreation = ({
     backendTreatment,
     accountCreatedAt,
     experimentLaunchedAt: FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE,
+    hasReachedThreshold,
     createdRequests,
     cohortId,
     cachedTreatment,
@@ -323,6 +332,37 @@ export const FirstRequestCreation = ({
     };
   }, []);
 
+  // Load the backend onboarding state (treatment / participant flag / graduation
+  // latch). Best-effort: on failure we fall back to the local computation.
+  useEffect(() => {
+    let isActive = true;
+
+    getCurrentSessionId().then(sessionId => {
+      if (!sessionId) {
+        return;
+      }
+      getOnboardingState({ sessionId })
+        .then(state => {
+          if (isActive) {
+            setOnboarding(state);
+          }
+        })
+        .catch(error => console.error('Failed to load onboarding state', error));
+    });
+
+    return () => {
+      isActive = false;
+    };
+  }, []);
+
+  // Self-heal the graduation latch: if this install has already crossed the
+  // threshold (e.g. the crossing creation's latch call was dropped), retry it.
+  useEffect(() => {
+    if (createdRequests !== null) {
+      maybeLatchRequestThreshold(createdRequests);
+    }
+  }, [createdRequests]);
+
   // On a *confident* treatment result, emit an experiment-assignment analytics event
   // only when the treatment changed vs the last-known (cached) value — i.e. on the
   // initial assignment and on a Treatment A→B transition. The warehouse derives each
@@ -337,7 +377,7 @@ export const FirstRequestCreation = ({
     const isConfident =
       backendTreatment !== undefined ||
       (accountCreatedAt !== undefined &&
-        (accountCreatedAt < FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE || createdRequests !== null));
+        (accountCreatedAt < FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE || hasReachedThreshold || createdRequests !== null));
     if (!isConfident) {
       return;
     }
@@ -365,7 +405,16 @@ export const FirstRequestCreation = ({
         },
       });
     }
-  }, [treatment, isParticipant, backendTreatment, accountCreatedAt, createdRequests, userSession.accountId, cachedTreatment]);
+  }, [
+    treatment,
+    isParticipant,
+    backendTreatment,
+    accountCreatedAt,
+    hasReachedThreshold,
+    createdRequests,
+    userSession.accountId,
+    cachedTreatment,
+  ]);
 
   const handleCreateNotionMcpWorkspace = () => {
     createWorkspaceFetcher.submit({

--- a/packages/insomnia/src/ui/components/first-request-creation.tsx
+++ b/packages/insomnia/src/ui/components/first-request-creation.tsx
@@ -23,7 +23,6 @@ import {
   FIRST_REQUEST_EXPERIMENT_NAME,
   type FirstRequestTreatment,
   getFirstRequestTreatmentGroup,
-  getOnboardingIsNewSignup,
   getOnboardingTreatment,
   readCachedFirstRequestTreatment,
   resolveFirstRequestTreatment,
@@ -139,7 +138,9 @@ export const FirstRequestCreation = ({
   const backendTreatment = getOnboardingTreatment(onboarding);
   // Whether this user is part of the experiment population (a genuine new sign-up),
   // per the server. Only participants emit assignment analytics; everyone else gets B.
-  const isParticipant = getOnboardingIsNewSignup(onboarding) === true;
+  // A missing onboarding resource (not yet loaded / fetch failed) means "not a
+  // confirmed participant".
+  const isParticipant = onboarding?.is_new_signup === true;
   // Last-known treatment for this account, used as an offline fallback.
   const [cachedTreatment] = useState(() => readCachedFirstRequestTreatment(userSession.accountId || ''));
   const inputRef = useRef<HTMLInputElement>(null);

--- a/packages/insomnia/src/ui/components/first-request-creation.tsx
+++ b/packages/insomnia/src/ui/components/first-request-creation.tsx
@@ -11,7 +11,6 @@ import { getCurrentSessionId } from '~/common/account/session';
 import { METHOD_GET } from '~/common/constants';
 import { setDefaultProtocol } from '~/common/utils/url/protocol';
 import { useRootLoaderData } from '~/root';
-import { useOrganizationLoaderData } from '~/routes/organization';
 import { AnalyticsEvent } from '~/ui/analytics';
 import { MethodSelector } from '~/ui/components/dropdowns/method-selector';
 import { createKeybindingsHandler, useKeyboardShortcuts } from '~/ui/components/keydown-binder';
@@ -21,14 +20,11 @@ import { showToast } from '~/ui/components/toast-notification';
 import { getBadgeClassName } from '~/ui/components/workspace/resource-icon';
 import { maybeLatchRequestThreshold } from '~/ui/utils/first-request-latch';
 import {
-  FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE,
   FIRST_REQUEST_EXPERIMENT_NAME,
   type FirstRequestTreatment,
   getFirstRequestTreatmentGroup,
   getOnboardingIsNewSignup,
-  getOnboardingReachedThreshold,
   getOnboardingTreatment,
-  isFirstRequestExperimentParticipant,
   readCachedFirstRequestTreatment,
   resolveFirstRequestTreatment,
   writeCachedFirstRequestTreatment,
@@ -132,27 +128,15 @@ export const FirstRequestCreation = ({
     organizationId: string;
     projectId: string;
   };
-  const { userSession, settings } = useRootLoaderData()!;
-  const organizationData = useOrganizationLoaderData();
-  // Stable id used to bucket new sign-ups ~50/50 into Treatment A or B.
-  const cohortId = userSession.accountId || settings.deviceId || '';
+  const { userSession } = useRootLoaderData()!;
   // Onboarding state from the backend (standalone resource), loaded on mount.
+  // null while the fetch is still in flight; an object (possibly empty) once settled.
   const [onboarding, setOnboarding] = useState<UserOnboardingState | null>(null);
-  // Server-computed treatment, when the backend is steering assignment (authoritative).
+  // Server-computed treatment (the backend is authoritative for assignment).
   const backendTreatment = getOnboardingTreatment(onboarding);
-  // Sticky server-confirmed graduation latch (account-wide, device-independent).
-  const hasReachedThreshold = getOnboardingReachedThreshold(onboarding);
-  // Account creation time (epoch ms); pre-GA accounts are treated as existing users.
-  const accountCreatedAt = organizationData?.user?.created_at
-    ? new Date(organizationData.user.created_at).getTime()
-    : undefined;
-  // Whether this user is part of the experiment population (a genuine new sign-up).
-  // Only participants emit assignment analytics; existing users still get B in the UI.
-  const isParticipant = isFirstRequestExperimentParticipant({
-    isNewSignup: getOnboardingIsNewSignup(onboarding),
-    accountCreatedAt,
-    experimentLaunchedAt: FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE,
-  });
+  // Whether this user is part of the experiment population (a genuine new sign-up),
+  // per the server. Only participants emit assignment analytics; everyone else gets B.
+  const isParticipant = getOnboardingIsNewSignup(onboarding) === true;
   // Last-known treatment for this account, used as an offline fallback.
   const [cachedTreatment] = useState(() => readCachedFirstRequestTreatment(userSession.accountId || ''));
   const inputRef = useRef<HTMLInputElement>(null);
@@ -173,11 +157,7 @@ export const FirstRequestCreation = ({
 
   const treatment: FirstRequestTreatment | null = resolveFirstRequestTreatment({
     backendTreatment,
-    accountCreatedAt,
-    experimentLaunchedAt: FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE,
-    hasReachedThreshold,
-    createdRequests,
-    cohortId,
+    onboardingLoaded: onboarding !== null,
     cachedTreatment,
   });
   const createButtonLabel = treatment === 'B' ? 'Create HTTP Request ⏎' : 'Create ⏎';
@@ -317,7 +297,8 @@ export const FirstRequestCreation = ({
     setSelectOpen(false);
   }, [selectedCollectionId]);
 
-  // Load the lifetime created-request count, used by the client-side fallback.
+  // Load the lifetime created-request count, used to decide when to latch the
+  // server-side graduation threshold.
   useEffect(() => {
     let isActive = true;
 
@@ -332,23 +313,23 @@ export const FirstRequestCreation = ({
     };
   }, []);
 
-  // Load the backend onboarding state (treatment / participant flag / graduation
-  // latch). Best-effort: on failure we fall back to the local computation.
+  // Load the backend onboarding state (authoritative treatment + participant flag).
+  // Settle to an empty object when logged out or on failure so the resolver stops
+  // waiting and falls back to the cached value / safe default.
   useEffect(() => {
     let isActive = true;
 
-    getCurrentSessionId().then(sessionId => {
-      if (!sessionId) {
-        return;
-      }
-      getOnboardingState({ sessionId })
-        .then(state => {
-          if (isActive) {
-            setOnboarding(state);
-          }
-        })
-        .catch(error => console.error('Failed to load onboarding state', error));
-    });
+    getCurrentSessionId()
+      .then(sessionId => (sessionId ? getOnboardingState({ sessionId }) : {}))
+      .catch(error => {
+        console.error('Failed to load onboarding state', error);
+        return {};
+      })
+      .then(state => {
+        if (isActive) {
+          setOnboarding(state);
+        }
+      });
 
     return () => {
       isActive = false;
@@ -372,13 +353,9 @@ export const FirstRequestCreation = ({
       return;
     }
 
-    // Confident = from the backend or a full client-side computation, never a value
-    // that itself came from the cache/default (which would create phantom churn).
-    const isConfident =
-      backendTreatment !== undefined ||
-      (accountCreatedAt !== undefined &&
-        (accountCreatedAt < FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE || hasReachedThreshold || createdRequests !== null));
-    if (!isConfident) {
+    // Confident = the server told us the treatment, never a cached/default value
+    // (which would create phantom churn in the assignment timeline).
+    if (backendTreatment === undefined) {
       return;
     }
 
@@ -405,16 +382,7 @@ export const FirstRequestCreation = ({
         },
       });
     }
-  }, [
-    treatment,
-    isParticipant,
-    backendTreatment,
-    accountCreatedAt,
-    hasReachedThreshold,
-    createdRequests,
-    userSession.accountId,
-    cachedTreatment,
-  ]);
+  }, [treatment, isParticipant, backendTreatment, userSession.accountId, cachedTreatment]);
 
   const handleCreateNotionMcpWorkspace = () => {
     createWorkspaceFetcher.submit({

--- a/packages/insomnia/src/ui/components/first-request-creation.tsx
+++ b/packages/insomnia/src/ui/components/first-request-creation.tsx
@@ -19,8 +19,12 @@ import { showToast } from '~/ui/components/toast-notification';
 import { getBadgeClassName } from '~/ui/components/workspace/resource-icon';
 import {
   FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE,
+  FIRST_REQUEST_EXPERIMENT_NAME,
   type FirstRequestTreatment,
   getBackendFirstRequestTreatment,
+  getBackendIsNewSignup,
+  getFirstRequestTreatmentGroup,
+  isFirstRequestExperimentParticipant,
   readCachedFirstRequestTreatment,
   resolveFirstRequestTreatment,
   writeCachedFirstRequestTreatment,
@@ -30,9 +34,9 @@ import { useRequestNewActionFetcher } from '../../routes/organization.$organizat
 import { useWorkspaceNewActionFetcher } from '../../routes/organization.$organizationId.project.$projectId.workspace.new';
 import { Icon } from './icon';
 
-// Guards the experiment-exposure analytics event so it fires at most once per
-// (account, treatment) per app session instead of on every mount.
-const exposedTreatments = new Set<string>();
+// Guards the experiment-assignment analytics event so a given (account, treatment)
+// isn't emitted twice within an app session (cross-session de-dup uses the cache).
+const emittedAssignments = new Set<string>();
 
 const CURL_COMMAND_PATTERN = /^\s*\$?\s*curl(?:\s|$)/i;
 const NOTION_MCP_SERVER_URL = 'https://mcp.notion.com/mcp';
@@ -134,6 +138,13 @@ export const FirstRequestCreation = ({
   const accountCreatedAt = organizationData?.user?.created_at
     ? new Date(organizationData.user.created_at).getTime()
     : undefined;
+  // Whether this user is part of the experiment population (a genuine new sign-up).
+  // Only participants emit assignment analytics; existing users still get B in the UI.
+  const isParticipant = isFirstRequestExperimentParticipant({
+    isNewSignup: getBackendIsNewSignup(organizationData?.user),
+    accountCreatedAt,
+    experimentLaunchedAt: FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE,
+  });
   // Last-known treatment for this account, used as an offline fallback.
   const [cachedTreatment] = useState(() => readCachedFirstRequestTreatment(userSession.accountId || ''));
   const inputRef = useRef<HTMLInputElement>(null);
@@ -312,32 +323,49 @@ export const FirstRequestCreation = ({
     };
   }, []);
 
-  // Cache the resolved treatment (offline fallback) and record exposure at most
-  // once per (account, treatment) per session.
+  // On a *confident* treatment result, emit an experiment-assignment analytics event
+  // only when the treatment changed vs the last-known (cached) value — i.e. on the
+  // initial assignment and on a Treatment A→B transition. The warehouse derives each
+  // assignment's `experiment_end_at` as the next assignment's timestamp (LEAD).
   useEffect(() => {
     if (!treatment) {
       return;
     }
 
-    // Only cache confident results (backend or a full client-side computation),
-    // never a value that itself came from the cache/default.
+    // Confident = from the backend or a full client-side computation, never a value
+    // that itself came from the cache/default (which would create phantom churn).
     const isConfident =
       backendTreatment !== undefined ||
       (accountCreatedAt !== undefined &&
         (accountCreatedAt < FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE || createdRequests !== null));
-    if (isConfident) {
-      writeCachedFirstRequestTreatment(userSession.accountId || '', treatment);
+    if (!isConfident) {
+      return;
     }
 
-    const exposureKey = `${userSession.accountId || 'anonymous'}:${treatment}`;
-    if (!exposedTreatments.has(exposureKey)) {
-      exposedTreatments.add(exposureKey);
+    const accountId = userSession.accountId || '';
+    // Persist the last-known treatment for offline rendering (all users, incl. existing).
+    writeCachedFirstRequestTreatment(accountId, treatment);
+
+    // Emit assignment analytics only for experiment participants (new sign-ups) — existing
+    // users get B but are not part of the A/B population — and only when the treatment
+    // changed vs the last-known value (initial assignment or A→B transition).
+    if (!isParticipant) {
+      return;
+    }
+    const changed = treatment !== cachedTreatment;
+    const sessionKey = `${accountId || 'anonymous'}:${treatment}`;
+    if (changed && !emittedAssignments.has(sessionKey)) {
+      emittedAssignments.add(sessionKey);
       window.main.trackAnalyticsEvent({
-        event: AnalyticsEvent.firstRequestExperimentExposed,
-        properties: { treatment },
+        event: AnalyticsEvent.experimentAssigned,
+        properties: {
+          experiment_name: FIRST_REQUEST_EXPERIMENT_NAME,
+          treatment_group: getFirstRequestTreatmentGroup(treatment),
+          assigned_at: new Date().toISOString(),
+        },
       });
     }
-  }, [treatment, backendTreatment, accountCreatedAt, createdRequests, userSession.accountId]);
+  }, [treatment, isParticipant, backendTreatment, accountCreatedAt, createdRequests, userSession.accountId, cachedTreatment]);
 
   const handleCreateNotionMcpWorkspace = () => {
     createWorkspaceFetcher.submit({

--- a/packages/insomnia/src/ui/components/first-request-creation.tsx
+++ b/packages/insomnia/src/ui/components/first-request-creation.tsx
@@ -1,5 +1,5 @@
 import type { IconProp } from '@fortawesome/fontawesome-svg-core';
-import { getOnboardingState, type UserOnboardingState } from 'insomnia-api';
+import { getOnboardingState, type UserOnboarding } from 'insomnia-api';
 import type { Request } from 'insomnia-data';
 import { services } from 'insomnia-data';
 import { type KeyboardEvent as ReactKeyboardEvent, useEffect, useRef, useState } from 'react';
@@ -130,8 +130,11 @@ export const FirstRequestCreation = ({
   };
   const { userSession } = useRootLoaderData()!;
   // Onboarding state from the backend (standalone resource), loaded on mount.
-  // null while the fetch is still in flight; an object (possibly empty) once settled.
-  const [onboarding, setOnboarding] = useState<UserOnboardingState | null>(null);
+  // null until a successful fetch resolves it (logged out / failed fetches leave it null).
+  const [onboarding, setOnboarding] = useState<UserOnboarding | null>(null);
+  // Whether the onboarding fetch has settled (resolved or failed), independent of
+  // whether it actually produced a value — used to know when to fall back.
+  const [onboardingLoaded, setOnboardingLoaded] = useState(false);
   // Server-computed treatment (the backend is authoritative for assignment).
   const backendTreatment = getOnboardingTreatment(onboarding);
   // Whether this user is part of the experiment population (a genuine new sign-up),
@@ -157,7 +160,7 @@ export const FirstRequestCreation = ({
 
   const treatment: FirstRequestTreatment | null = resolveFirstRequestTreatment({
     backendTreatment,
-    onboardingLoaded: onboarding !== null,
+    onboardingLoaded,
     cachedTreatment,
   });
   const createButtonLabel = treatment === 'B' ? 'Create HTTP Request ⏎' : 'Create ⏎';
@@ -314,20 +317,21 @@ export const FirstRequestCreation = ({
   }, []);
 
   // Load the backend onboarding state (authoritative treatment + participant flag).
-  // Settle to an empty object when logged out or on failure so the resolver stops
-  // waiting and falls back to the cached value / safe default.
+  // Settle to null when logged out or on failure so the resolver stops waiting and
+  // falls back to the cached value / safe default.
   useEffect(() => {
     let isActive = true;
 
     getCurrentSessionId()
-      .then(sessionId => (sessionId ? getOnboardingState({ sessionId }) : {}))
+      .then(sessionId => (sessionId ? getOnboardingState({ sessionId }) : null))
       .catch(error => {
         console.error('Failed to load onboarding state', error);
-        return {};
+        return null;
       })
       .then(state => {
         if (isActive) {
           setOnboarding(state);
+          setOnboardingLoaded(true);
         }
       });
 

--- a/packages/insomnia/src/ui/components/first-request-creation.tsx
+++ b/packages/insomnia/src/ui/components/first-request-creation.tsx
@@ -351,10 +351,11 @@ export const FirstRequestCreation = ({
     }
   }, [createdRequests]);
 
-  // On a *confident* treatment result, emit an experiment-assignment analytics event
-  // only when the treatment changed vs the last-known (cached) value — i.e. on the
-  // initial assignment and on a Treatment A→B transition. The warehouse derives each
-  // assignment's `experiment_end_at` as the next assignment's timestamp (LEAD).
+  // On a *confident* treatment result, emit the initial assignment analytics event —
+  // only the very first observed assignment for this account (nothing cached yet).
+  // The A→B graduation transition is emitted from maybeLatchRequestThreshold instead,
+  // since that's the one place graduation is guaranteed to be detected (this pane
+  // may never remount once the account has already graduated).
   useEffect(() => {
     if (!treatment) {
       return;
@@ -371,14 +372,14 @@ export const FirstRequestCreation = ({
     writeCachedFirstRequestTreatment(accountId, treatment);
 
     // Emit assignment analytics only for experiment participants (new sign-ups) — existing
-    // users get B but are not part of the A/B population — and only when the treatment
-    // changed vs the last-known value (initial assignment or A→B transition).
+    // users get B but are not part of the A/B population — and only for the first-ever
+    // observed assignment (nothing was cached for this account before this render).
     if (!isParticipant) {
       return;
     }
-    const changed = treatment !== cachedTreatment;
+    const isFirstObservedAssignment = cachedTreatment === null;
     const sessionKey = `${accountId || 'anonymous'}:${treatment}`;
-    if (changed && !emittedAssignments.has(sessionKey)) {
+    if (isFirstObservedAssignment && !emittedAssignments.has(sessionKey)) {
       emittedAssignments.add(sessionKey);
       window.main.trackAnalyticsEvent({
         event: AnalyticsEvent.experimentAssigned,

--- a/packages/insomnia/src/ui/components/first-request-creation.tsx
+++ b/packages/insomnia/src/ui/components/first-request-creation.tsx
@@ -582,7 +582,11 @@ export const FirstRequestCreation = ({
               <span>{createButtonLabel}</span>
             </Button>
           </div>
-          {errorText && <div className="mt-2 text-xs text-[#FF5631]">{errorText}</div>}
+          {errorText && (
+            <div className="mt-2 text-xs text-[#FF5631]" role="alert" aria-live="polite">
+              {errorText}
+            </div>
+          )}
 
           {treatment === 'A' && (
             <div className="mt-6 flex flex-wrap gap-x-10 gap-y-6">

--- a/packages/insomnia/src/ui/components/first-request-creation.tsx
+++ b/packages/insomnia/src/ui/components/first-request-creation.tsx
@@ -1,25 +1,32 @@
 import type { IconProp } from '@fortawesome/fontawesome-svg-core';
 import type { Request } from 'insomnia-data';
-import { constructKeyCombinationDisplay, getPlatformKeyCombinations } from 'insomnia-data/common';
+import { services } from 'insomnia-data';
 import { type KeyboardEvent as ReactKeyboardEvent, useEffect, useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
 
 import { Button } from '~/basic-components/button';
 import { SelectPopover } from '~/basic-components/select-popover';
+import { METHOD_GET } from '~/common/constants';
 import { setDefaultProtocol } from '~/common/utils/url/protocol';
 import { useRootLoaderData } from '~/root';
-import { useRequestNewActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new';
-import { useWorkspaceNewActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.new';
+import { useOrganizationLoaderData } from '~/routes/organization';
 import { AnalyticsEvent } from '~/ui/analytics';
+import { MethodSelector } from '~/ui/components/dropdowns/method-selector';
 import { createKeybindingsHandler, useKeyboardShortcuts } from '~/ui/components/keydown-binder';
 import { ImportModal } from '~/ui/components/modals/import-modal/import-modal';
 import { SvgIcon } from '~/ui/components/svg-icon';
 import { showToast } from '~/ui/components/toast-notification';
-import { Tooltip } from '~/ui/components/tooltip';
-import { getBadgeClassName, ResourceIcon } from '~/ui/components/workspace/resource-icon';
-import { getProjectRecentRequests, type RecentProjectRequest } from '~/ui/utils/recent-project-requests';
+import { getBadgeClassName } from '~/ui/components/workspace/resource-icon';
+import {
+  FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE,
+  type FirstRequestTreatment,
+  getFirstRequestTreatment,
+} from '~/ui/utils/first-request-treatment';
 
+import { useRequestNewActionFetcher } from '../../routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new';
+import { useWorkspaceNewActionFetcher } from '../../routes/organization.$organizationId.project.$projectId.workspace.new';
 import { Icon } from './icon';
+
 const CURL_COMMAND_PATTERN = /^\s*\$?\s*curl(?:\s|$)/i;
 const NOTION_MCP_SERVER_URL = 'https://mcp.notion.com/mcp';
 
@@ -56,6 +63,28 @@ const normalizeRequestUrl = (value: string) => {
   }
 };
 
+// Collapse a multi-line cURL (backslash line-continuations and/or bare newlines,
+// with their trailing indentation) into a single line, preserving intra-line spacing.
+const flattenCurlCommand = (value: string) =>
+  value
+    .replace(/\\\r?\n\s*/g, ' ')
+    .replace(/\r?\n\s*/g, ' ')
+    .trim();
+
+// Best-effort read of the HTTP method from a cURL string, for keeping the method
+// dropdown in sync while typing/pasting. Explicit -X/--request wins; otherwise a
+// body/form flag implies POST (curl's own default), matching what the importer does.
+const extractCurlMethod = (value: string): string | null => {
+  const explicit = value.match(/(?:-X|--request)\s+['"]?([A-Za-z]+)/);
+  if (explicit) {
+    return explicit[1].toUpperCase();
+  }
+  if (/(?:^|\s)(?:-d|--data(?:-raw|-binary|-urlencode)?|-F|--form)\b/.test(value)) {
+    return 'POST';
+  }
+  return null;
+};
+
 interface CollectionItem {
   id: string;
   label: string;
@@ -69,51 +98,59 @@ interface QuickStartItem {
   onClick: () => void | Promise<void>;
 }
 
-interface RecentRequestsState {
-  projectId: string;
-  requests: RecentProjectRequest[];
-}
-
 interface FirstRequestCreationProps {
-  greetingName: string;
   collectionItems: CollectionItem[];
   selectedCollectionId: string | null;
   onSelectedCollectionChange: (collectionId: string | null) => void;
   onCreateCollection: () => void;
-  onCreateDesignDocument: () => void;
   onImportFrom: () => void;
 }
 
 export const FirstRequestCreation = ({
-  greetingName,
   collectionItems,
   selectedCollectionId,
   onSelectedCollectionChange,
   onCreateCollection,
-  onCreateDesignDocument,
   onImportFrom,
 }: FirstRequestCreationProps) => {
-  const navigate = useNavigate();
   const { organizationId, projectId } = useParams() as {
     organizationId: string;
     projectId: string;
   };
-  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const { userSession, settings } = useRootLoaderData()!;
+  const organizationData = useOrganizationLoaderData();
+  // Stable id used to bucket new sign-ups ~50/50 into Treatment A or B.
+  const cohortId = userSession.accountId || settings.deviceId || '';
+  // Account creation time (epoch ms); pre-GA accounts are treated as existing users.
+  const accountCreatedAt = organizationData?.user?.created_at
+    ? new Date(organizationData.user.created_at).getTime()
+    : undefined;
+  const inputRef = useRef<HTMLInputElement>(null);
   const createRequestFetcher = useRequestNewActionFetcher();
   const createWorkspaceFetcher = useWorkspaceNewActionFetcher();
   const createWorkspaceFetcherRef = useRef(createWorkspaceFetcher);
   createWorkspaceFetcherRef.current = createWorkspaceFetcher;
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
   const [requestInput, setRequestInput] = useState('');
-  const [recentRequests, setRecentRequests] = useState<RecentRequestsState>({ projectId, requests: [] });
-  const [isRequestInputFocused, setIsRequestInputFocused] = useState(false);
-  const [curlParseError, setCurlParseError] = useState(false);
+  const [method, setMethod] = useState(METHOD_GET);
+  const [errorText, setErrorText] = useState<string | null>(null);
   const [selectOpen, setSelectOpen] = useState(false);
+  // null while stats are loading; treatment is derived once we know the created-request count.
+  const [createdRequests, setCreatedRequests] = useState<number | null>(null);
   const trimmedInput = requestInput.trim();
   const isCreatingRequest = createRequestFetcher.state !== 'idle';
   const selectedCollection = collectionItems.find(collection => collection.id === selectedCollectionId) ?? null;
-  const currentProjectRecentRequests = recentRequests.projectId === projectId ? recentRequests.requests : [];
-  const shouldShowJumpBackIn = currentProjectRecentRequests.length >= 3;
+
+  const treatment: FirstRequestTreatment | null =
+    createdRequests === null
+      ? null
+      : getFirstRequestTreatment({
+          accountCreatedAt,
+          experimentLaunchedAt: FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE,
+          createdRequests,
+          cohortId,
+        });
+  const createButtonLabel = treatment === 'B' ? 'Create HTTP Request ⏎' : 'Create ⏎';
 
   const ensureWorkspaceId = async () => {
     if (selectedCollectionId) {
@@ -147,19 +184,25 @@ export const FirstRequestCreation = ({
     return createdWorkspace.workspaceId;
   };
 
-  const handleInputEnter = (event: ReactKeyboardEvent<HTMLTextAreaElement> | KeyboardEvent) => {
+  const handleInputEnter = (event: ReactKeyboardEvent<HTMLInputElement> | KeyboardEvent) => {
     event.preventDefault();
     handleCreateRequest();
   };
 
-  const handleRequestCreateShortcut = (_event: KeyboardEvent) => {
-    window.main.trackAnalyticsEvent({
-      event: AnalyticsEvent.keyboardShortcutUsed,
-      properties: {
-        source: 'first-request-creation-pane',
-        action: 'createHttpRequest',
-      },
-    });
+  // Update the input value, clear any stale error, and keep the method dropdown in
+  // sync when the value is a cURL command.
+  const applyRequestInput = (value: string) => {
+    setRequestInput(value);
+    setErrorText(null);
+    if (CURL_COMMAND_PATTERN.test(value.trim())) {
+      const curlMethod = extractCurlMethod(value);
+      if (curlMethod) {
+        setMethod(curlMethod);
+      }
+    }
+  };
+
+  const handleCreateBlankRequest = () => {
     if (!selectedCollectionId) {
       createWorkspaceFetcher.submit({
         organizationId,
@@ -183,8 +226,8 @@ export const FirstRequestCreation = ({
     });
   };
 
-  useKeyboardShortcuts(() => inputRef.current as HTMLTextAreaElement, {
-    request_createHTTP: handleRequestCreateShortcut,
+  useKeyboardShortcuts(() => inputRef.current as HTMLInputElement, {
+    request_createHTTP: handleCreateBlankRequest,
   });
 
   const handleCreateRequest = async () => {
@@ -202,7 +245,7 @@ export const FirstRequestCreation = ({
         try {
           req = await parseCurlRequest(trimmedInput);
         } catch {
-          setCurlParseError(true);
+          setErrorText('Invalid cURL. Verify your input and try again.');
           return;
         }
 
@@ -229,17 +272,14 @@ export const FirstRequestCreation = ({
         requestType: 'HTTP',
         req: {
           url: normalizeRequestUrl(trimmedInput),
+          method,
         },
         metrics: {
           source: 'first-request-pane',
         },
       });
     } catch (error) {
-      showToast({
-        icon: 'circle-exclamation',
-        title: error instanceof Error ? error.message : 'Unable to create request',
-        status: 'error',
-      });
+      setErrorText(error instanceof Error ? error.message : 'Unable to create request');
     }
   };
 
@@ -247,25 +287,34 @@ export const FirstRequestCreation = ({
     setSelectOpen(false);
   }, [selectedCollectionId]);
 
+  // Determine which experiment treatment to show from the lifetime created-request count,
+  // and record exposure once we know it.
   useEffect(() => {
     let isActive = true;
 
-    const loadRecentRequests = async () => {
-      const nextRecentRequests = await getProjectRecentRequests(projectId);
-
+    services.stats.get().then(stats => {
       if (!isActive) {
         return;
       }
 
-      setRecentRequests({ projectId, requests: nextRecentRequests });
-    };
-
-    loadRecentRequests();
+      setCreatedRequests(stats.createdRequests);
+      window.main.trackAnalyticsEvent({
+        event: AnalyticsEvent.firstRequestExperimentExposed,
+        properties: {
+          treatment: getFirstRequestTreatment({
+            accountCreatedAt,
+            experimentLaunchedAt: FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE,
+            createdRequests: stats.createdRequests,
+            cohortId,
+          }),
+        },
+      });
+    });
 
     return () => {
       isActive = false;
     };
-  }, [projectId]);
+  }, [cohortId, accountCreatedAt]);
 
   const handleCreateNotionMcpWorkspace = () => {
     createWorkspaceFetcher.submit({
@@ -342,31 +391,12 @@ export const FirstRequestCreation = ({
     }
   };
 
-  const quickStartItems: QuickStartItem[] = [
+  const quickActions: QuickStartItem[] = [
     {
-      id: 'mcp-server',
-      label: 'Notion MCP Server',
-      icon: <Icon icon={['fac', 'mcp'] as unknown as IconProp} />,
-      onClick: handleCreateNotionMcpWorkspace,
-    },
-    {
-      id: 'pokemon',
-      label: 'List pokemon',
-      icon: <span className={getBadgeClassName('GET')}>GET</span>,
-      badge: 'GET',
-      onClick: handleCreatePokemonRequest,
-    },
-    {
-      id: 'github-lookup',
-      label: 'Lookup GitHub repository',
-      icon: <SvgIcon icon="graphql" />,
-      onClick: handleCreateGithubLookupRequest,
-    },
-    {
-      id: 'create-openapi-spec',
-      label: 'Create OpenAPI spec',
-      icon: <Icon icon="file" className="text-(--font-size-xl)" />,
-      onClick: onCreateDesignDocument,
+      id: 'new-http-request',
+      label: 'New HTTP request',
+      icon: <Icon icon="plus" className="text-(--font-size-xl)" />,
+      onClick: handleCreateBlankRequest,
     },
     {
       id: 'import-files',
@@ -384,166 +414,137 @@ export const FirstRequestCreation = ({
     },
   ];
 
-  const { settings } = useRootLoaderData()!;
-  const keyComb = getPlatformKeyCombinations(settings.hotKeyRegistry.request_createHTTP)[0];
-  const shortcutDisplay = constructKeyCombinationDisplay(keyComb, false);
+  const exampleItems: QuickStartItem[] = [
+    {
+      id: 'mcp-server',
+      label: 'Connect to Notion MCP',
+      icon: <Icon icon={['fac', 'mcp'] as unknown as IconProp} />,
+      onClick: handleCreateNotionMcpWorkspace,
+    },
+    {
+      id: 'pokemon',
+      label: 'List a pokemon',
+      icon: <span className={getBadgeClassName('GET')}>GET</span>,
+      badge: 'GET',
+      onClick: handleCreatePokemonRequest,
+    },
+    {
+      id: 'github-lookup',
+      label: 'Lookup GitHub repository',
+      icon: <SvgIcon icon="graphql" />,
+      onClick: handleCreateGithubLookupRequest,
+    },
+  ];
+
+  const renderQuickStartButton = (item: QuickStartItem) => (
+    <Button
+      key={item.id}
+      variant="outlined"
+      size="md"
+      className="h-6.5 px-2"
+      onPress={() => {
+        window.main.trackAnalyticsEvent({
+          event: AnalyticsEvent.firstRequestPaneExampleClicked,
+          properties: {
+            name: item.label,
+          },
+        });
+        item.onClick();
+      }}
+    >
+      {item.icon}
+      <span>{item.label}</span>
+    </Button>
+  );
+
   return (
     <>
       <div className="rounded-sm bg-[radial-gradient(95.72%_95.72%_at_-0.32%_2.6%,var(--hl-md)_0%,var(--hl-xs)_100%),radial-gradient(100%_100.41%_at_100%_99.92%,var(--hl-md)_0%,var(--hl-xs)_100%)] p-px">
-        <div className="flex w-full flex-col items-center rounded-sm bg-(--color-bg) bg-[linear-gradient(180deg,rgba(var(--color-surprise-rgb),0.2)_0%,color-mix(in_srgb,var(--color-bg)_0%,transparent)_72.8%)] px-6 pt-8 pb-5">
-          <h2 className="text-center text-2xl leading-none font-semibold">
-            {shouldShowJumpBackIn ? `Welcome back, ${greetingName}!` : `Welcome, ${greetingName}!`}
-          </h2>
-          <p className="mt-2.5 text-center text-sm">
-            {shouldShowJumpBackIn
-              ? `Today is a new day, we’re rooting for you!`
-              : `We have a sneaking suspicion that you came here to send a request, so let’s get started!`}
-          </p>
-          <div className="mt-8 w-[50%] min-w-135">
-            <div
-              className={`flex aspect-540/127 min-h-31.75 flex-col overflow-hidden rounded-lg border border-(--hl-md) bg-(--color-bg) ${isRequestInputFocused ? 'shadow-[0_0_0_4px_#0044F433]' : ''}`}
-            >
-              <div className="min-h-0 flex-1 px-4 pt-3 pb-2">
-                <textarea
-                  ref={inputRef}
-                  autoFocus
-                  aria-label="Request endpoint or cURL input"
-                  className="text-md h-full w-full flex-1 resize-none font-mono"
-                  placeholder={`Enter an endpoint URL or paste cURL, or ${shortcutDisplay} for a new blank request`}
-                  value={requestInput}
-                  onFocus={() => setIsRequestInputFocused(true)}
-                  onBlur={() => setIsRequestInputFocused(false)}
-                  onChange={event => {
-                    setCurlParseError(false);
-                    setRequestInput(event.target.value);
-                  }}
-                  onKeyDown={createKeybindingsHandler({
-                    Enter: event => handleInputEnter(event),
-                  })}
-                />
-              </div>
-              <div className="flex h-12 shrink-0 items-center justify-between gap-2 p-2">
-                <Tooltip message="Upload Postman, OpenAPI, etc.">
-                  <Button
-                    aria-label="Attach content"
-                    className="w-10 rounded-md px-0"
-                    size="md"
-                    variant="text"
-                    icon={<Icon className="text-lg" icon="paperclip" />}
-                    onPress={() => {
-                      window.main.trackAnalyticsEvent({
-                        event: AnalyticsEvent.importStarted,
-                        properties: {
-                          source: 'first-request-pane',
-                        },
-                      });
-                      setIsImportModalOpen(true);
-                    }}
-                  />
-                </Tooltip>
+        <div className="flex w-full flex-col rounded-sm bg-(--color-bg) bg-[linear-gradient(180deg,rgba(var(--color-surprise-rgb),0.2)_0%,color-mix(in_srgb,var(--color-bg)_0%,transparent)_72.8%)] px-6 pt-5 pb-6">
+          <h2 className="text-lg font-semibold">New request</h2>
+          <div className="mt-4 flex h-8.5 items-center gap-2 rounded-md border border-(--hl-md) bg-(--color-bg) px-1">
+            <MethodSelector method={method} onChange={setMethod} className="h-6.5" />
+            <input
+              ref={inputRef}
+              autoFocus
+              aria-label="Request endpoint or cURL input"
+              className="h-6.5 min-w-0 flex-1 bg-transparent text-[12px]/[18px] font-normal"
+              placeholder="Enter a URL or paste cURL"
+              value={requestInput}
+              onChange={event => applyRequestInput(event.target.value)}
+              onPaste={event => {
+                const pasted = event.clipboardData.getData('text');
+                // Flatten a pasted multi-line cURL into a single line ourselves so it
+                // stays a valid command (the native single-line paste would drop the newlines).
+                if (/\r?\n/.test(pasted) && CURL_COMMAND_PATTERN.test(pasted.trim())) {
+                  event.preventDefault();
+                  applyRequestInput(flattenCurlCommand(pasted));
+                }
+              }}
+              onKeyDown={createKeybindingsHandler({
+                Enter: event => handleInputEnter(event),
+              })}
+            />
+            <SelectPopover
+              isOpen={selectOpen}
+              onOpenChange={isOpen => setSelectOpen(isOpen)}
+              ariaLabel="Select target collection"
+              items={collectionItems}
+              selectedKey={selectedCollectionId}
+              onSelectionChange={key => {
+                onSelectedCollectionChange(key ? String(key) : null);
+                window.main.trackAnalyticsEvent({
+                  event: AnalyticsEvent.firstRequestPaneCollectionChanged,
+                });
+              }}
+              title="Where should we put your request?"
+              emptyState="You have no collections, so a new one will be created for you by default."
+              footer={
+                <Button onPress={onCreateCollection} size="sm">
+                  New Collection
+                </Button>
+              }
+              triggerClassName="h-6.5 rounded-md px-3 text-[12px]/[18px] font-[590] data-[focus-visible=true]:!ring-0"
+              popoverClassName="w-[240px]"
+              dialogClassName="w-[240px]"
+              renderTrigger={selectedItem => (
                 <div className="flex items-center gap-2">
-                  <SelectPopover
-                    isOpen={selectOpen}
-                    onOpenChange={isOpen => setSelectOpen(isOpen)}
-                    ariaLabel="Select target collection"
-                    items={collectionItems}
-                    selectedKey={selectedCollectionId}
-                    onSelectionChange={key => {
-                      onSelectedCollectionChange(key ? String(key) : null);
-                      window.main.trackAnalyticsEvent({
-                        event: AnalyticsEvent.firstRequestPaneCollectionChanged,
-                      });
-                    }}
-                    title="Where should we put your request?"
-                    emptyState="You have no collections, so a new one will be created for you by default."
-                    footer={
-                      <Button onPress={onCreateCollection} size="sm">
-                        New Collection
-                      </Button>
-                    }
-                    triggerClassName="h-8 rounded-md px-3 text-sm data-[focus-visible=true]:!ring-0"
-                    popoverClassName="w-[240px]"
-                    dialogClassName="w-[240px]"
-                    renderTrigger={selectedItem => (
-                      <div className="flex items-center gap-2">
-                        <span className="truncate">{selectedItem?.label ?? 'New collection'}</span>
-                        <Icon icon="chevron-down" className="w-3 shrink-0" />
-                      </div>
-                    )}
-                    renderItem={(item, isSelected) => (
-                      <>
-                        <span className="flex-1 truncate">{item.label}</span>
-                        {isSelected ? <Icon icon="check" className="text-(--color-success)" /> : null}
-                      </>
-                    )}
-                  />
-                  <Button
-                    aria-label="Create request"
-                    primary
-                    size="md"
-                    isDisabled={!trimmedInput || isCreatingRequest}
-                    onPress={() => handleCreateRequest()}
-                  >
-                    <span>Create ⏎</span>
-                  </Button>
+                  <span className="truncate">{selectedItem?.label ?? 'New collection'}</span>
+                  <Icon icon="chevron-down" className="w-3 shrink-0" />
                 </div>
-              </div>
-            </div>
-            {curlParseError && (
-              <div className="mt-2 text-xs text-[#FF5631]">Invalid cURL. Verify your input and try again.</div>
-            )}
-            <div className="my-6 px-4">
-              {shouldShowJumpBackIn ? (
+              )}
+              renderItem={(item, isSelected) => (
                 <>
-                  <p className="text-sm font-semibold text-(--hl)">Jump back in</p>
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    {currentProjectRecentRequests.map(recentRequest => (
-                      <Button
-                        key={recentRequest.request._id}
-                        variant="outlined"
-                        size="md"
-                        className="px-2"
-                        onPress={() => {
-                          navigate(
-                            `/organization/${organizationId}/project/${projectId}/workspace/${recentRequest.workspaceId}/debug/request/${recentRequest.request._id}`,
-                          );
-                        }}
-                      >
-                        <ResourceIcon resource={recentRequest.request} />
-                        <span className="max-w-[18rem] truncate">{recentRequest.request.name}</span>
-                      </Button>
-                    ))}
-                  </div>
-                </>
-              ) : (
-                <>
-                  <p className="text-sm font-semibold text-(--hl)">Not sure where to start?</p>
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    {quickStartItems.map(item => (
-                      <Button
-                        key={item.id}
-                        variant="outlined"
-                        size="md"
-                        className="px-2"
-                        onPress={() => {
-                          window.main.trackAnalyticsEvent({
-                            event: AnalyticsEvent.firstRequestPaneExampleClicked,
-                            properties: {
-                              name: item.label,
-                            },
-                          });
-                          item.onClick();
-                        }}
-                      >
-                        {item.icon}
-                        <span>{item.label}</span>
-                      </Button>
-                    ))}
-                  </div>
+                  <span className="flex-1 truncate">{item.label}</span>
+                  {isSelected ? <Icon icon="check" className="text-(--color-success)" /> : null}
                 </>
               )}
-            </div>
+            />
+            <Button
+              aria-label="Create request"
+              primary
+              size="md"
+              className="h-6.5 rounded-sm px-2 text-[12px]/[18px] font-[590]"
+              isDisabled={!trimmedInput || isCreatingRequest}
+              onPress={() => handleCreateRequest()}
+            >
+              <span>{createButtonLabel}</span>
+            </Button>
           </div>
+          {errorText && <div className="mt-2 text-xs text-[#FF5631]">{errorText}</div>}
+
+          {treatment === 'A' && (
+            <div className="mt-6 flex flex-wrap gap-x-10 gap-y-6">
+              <div>
+                <p className="text-sm font-semibold text-(--hl)">Quick actions</p>
+                <div className="mt-3 flex flex-wrap gap-2">{quickActions.map(renderQuickStartButton)}</div>
+              </div>
+              <div>
+                <p className="text-sm font-semibold text-(--hl)">Start with an example</p>
+                <div className="mt-3 flex flex-wrap gap-2">{exampleItems.map(renderQuickStartButton)}</div>
+              </div>
+            </div>
+          )}
         </div>
       </div>
       {isImportModalOpen && (

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -301,8 +301,9 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(
     const isCancellable = currentInterval || currentTimeout || isEventStreamOpen || isGraphQLSubscriptionOpen;
     return (
       <div className="flex w-full items-stretch justify-between self-stretch">
-        <div className="flex items-center">
+        <div className="flex items-center p-1">
           <MethodSelector
+            className="self-stretch"
             ref={methodDropdownRef}
             onChange={method => patchRequest(requestId, { method })}
             method={method}

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -32,7 +32,7 @@ import { useReadyState } from '../hooks/use-ready-state';
 import { useRequestMetaPatcher, useRequestPatcher } from '../hooks/use-request';
 import { useTimeoutWhen } from '../hooks/use-timeout-when';
 import { Dropdown, type DropdownHandle, DropdownItem, DropdownSection, ItemContent } from './base/dropdown';
-import { MethodDropdown } from './dropdowns/method-dropdown';
+import { MethodSelector } from './dropdowns/method-selector';
 import { createKeybindingsHandler, useDocBodyKeyboardShortcuts } from './keydown-binder';
 import { showModal } from './modals';
 import { AlertModal } from './modals/alert-modal';
@@ -302,7 +302,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(
     return (
       <div className="flex w-full items-stretch justify-between self-stretch">
         <div className="flex items-center">
-          <MethodDropdown
+          <MethodSelector
             ref={methodDropdownRef}
             onChange={method => patchRequest(requestId, { method })}
             method={method}

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -301,7 +301,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(
     const isCancellable = currentInterval || currentTimeout || isEventStreamOpen || isGraphQLSubscriptionOpen;
     return (
       <div className="flex w-full items-stretch justify-between self-stretch">
-        <div className="flex items-center p-1">
+        <div className="flex items-stretch p-1">
           <MethodSelector
             className="self-stretch"
             ref={methodDropdownRef}

--- a/packages/insomnia/src/ui/utils/first-request-latch.ts
+++ b/packages/insomnia/src/ui/utils/first-request-latch.ts
@@ -7,7 +7,6 @@ import {
   FIRST_REQUEST_EXPERIMENT_NAME,
   FIRST_REQUEST_GRADUATION_THRESHOLD,
   getFirstRequestTreatmentGroup,
-  getOnboardingIsNewSignup,
   isRequestThresholdLatched,
   markRequestThresholdLatched,
   readRequestCountBaseline,
@@ -69,7 +68,9 @@ export const maybeLatchRequestThreshold = async (createdRequests: number): Promi
     // the outer try/catch.
     getOnboardingState({ sessionId })
       .then(onboarding => {
-        if (getOnboardingIsNewSignup(onboarding) === true) {
+        // Only participants emit assignment analytics; a missing/failed onboarding
+        // fetch means "not a confirmed participant".
+        if (onboarding?.is_new_signup === true) {
           window.main.trackAnalyticsEvent({
             event: AnalyticsEvent.experimentAssigned,
             properties: {

--- a/packages/insomnia/src/ui/utils/first-request-latch.ts
+++ b/packages/insomnia/src/ui/utils/first-request-latch.ts
@@ -1,9 +1,13 @@
-import { latchRequestThresholdReached } from 'insomnia-api';
+import { getOnboardingState, latchRequestThresholdReached } from 'insomnia-api';
 
 import { getAccountId, getCurrentSessionId } from '~/common/account/session';
+import { AnalyticsEvent } from '~/ui/analytics';
 
 import {
+  FIRST_REQUEST_EXPERIMENT_NAME,
   FIRST_REQUEST_GRADUATION_THRESHOLD,
+  getFirstRequestTreatmentGroup,
+  getOnboardingIsNewSignup,
   isRequestThresholdLatched,
   markRequestThresholdLatched,
   readRequestCountBaseline,
@@ -27,6 +31,12 @@ import {
  * call is safe to repeat: it's guarded by a local flag to avoid needless POSTs,
  * but a dropped call self-heals because the guard is only set after the server
  * confirms, so the next request creation / pane load retries it.
+ *
+ * Also emits the graduation (A→B) assignment analytics event here, not from the
+ * first-request UI — this is the one place graduation is guaranteed to be
+ * detected, since by the time an account has crossed the threshold it usually
+ * won't re-render the first-request empty-state pane that would otherwise need
+ * to observe the transition.
  *
  * Fire-and-forget: never throws, and no-ops when logged out or below threshold.
  */
@@ -53,6 +63,26 @@ export const maybeLatchRequestThreshold = async (createdRequests: number): Promi
 
     await latchRequestThresholdReached({ sessionId });
     markRequestThresholdLatched(accountId);
+
+    // Best-effort, decoupled from the latch itself: a failure here shouldn't
+    // retry the (already-confirmed) latch, so it isn't awaited or folded into
+    // the outer try/catch.
+    getOnboardingState({ sessionId })
+      .then(onboarding => {
+        if (getOnboardingIsNewSignup(onboarding) === true) {
+          window.main.trackAnalyticsEvent({
+            event: AnalyticsEvent.experimentAssigned,
+            properties: {
+              experiment_name: FIRST_REQUEST_EXPERIMENT_NAME,
+              treatment_group: getFirstRequestTreatmentGroup('B'),
+              assigned_at: new Date().toISOString(),
+            },
+          });
+        }
+      })
+      .catch(error => {
+        console.error('Failed to emit first-request graduation analytics event', error);
+      });
   } catch (error) {
     // Leave the local flag unset so the (idempotent) latch is retried next time.
     console.error('Failed to latch first-request graduation threshold', error);

--- a/packages/insomnia/src/ui/utils/first-request-latch.ts
+++ b/packages/insomnia/src/ui/utils/first-request-latch.ts
@@ -1,0 +1,39 @@
+import { latchRequestThresholdReached } from 'insomnia-api';
+
+import { getAccountId, getCurrentSessionId } from '~/common/account/session';
+
+import { FIRST_REQUEST_GRADUATION_THRESHOLD, isRequestThresholdLatched, markRequestThresholdLatched } from './first-request-treatment';
+
+/**
+ * Latch the sticky "reached the first-request graduation threshold" bit on the
+ * server once this install has observed enough created requests.
+ *
+ * Instead of reporting a delta per request (which undercounts when calls drop),
+ * we send one idempotent latch when the local count crosses the threshold. The
+ * call is safe to repeat: it's guarded by a local flag to avoid needless POSTs,
+ * but a dropped call self-heals because the guard is only set after the server
+ * confirms, so the next request creation / pane load retries it.
+ *
+ * Fire-and-forget: never throws, and no-ops when logged out or below threshold.
+ */
+export const maybeLatchRequestThreshold = async (createdRequests: number): Promise<void> => {
+  if (createdRequests < FIRST_REQUEST_GRADUATION_THRESHOLD) {
+    return;
+  }
+
+  try {
+    const sessionId = await getCurrentSessionId();
+    if (!sessionId) {
+      return;
+    }
+    const accountId = (await getAccountId()) || '';
+    if (isRequestThresholdLatched(accountId)) {
+      return;
+    }
+    await latchRequestThresholdReached({ sessionId });
+    markRequestThresholdLatched(accountId);
+  } catch (error) {
+    // Leave the local flag unset so the (idempotent) latch is retried next time.
+    console.error('Failed to latch first-request graduation threshold', error);
+  }
+};

--- a/packages/insomnia/src/ui/utils/first-request-latch.ts
+++ b/packages/insomnia/src/ui/utils/first-request-latch.ts
@@ -2,11 +2,25 @@ import { latchRequestThresholdReached } from 'insomnia-api';
 
 import { getAccountId, getCurrentSessionId } from '~/common/account/session';
 
-import { FIRST_REQUEST_GRADUATION_THRESHOLD, isRequestThresholdLatched, markRequestThresholdLatched } from './first-request-treatment';
+import {
+  FIRST_REQUEST_GRADUATION_THRESHOLD,
+  isRequestThresholdLatched,
+  markRequestThresholdLatched,
+  readRequestCountBaseline,
+  writeRequestCountBaseline,
+} from './first-request-treatment';
 
 /**
  * Latch the sticky "reached the first-request graduation threshold" bit on the
  * server once this install has observed enough created requests.
+ *
+ * `createdRequests` (from `services.stats`) is a device-wide lifetime counter,
+ * not scoped per account — without correction, switching accounts on the same
+ * install would let a brand new account inherit requests created by a previous
+ * account and latch after a single new request. We snapshot a per-account
+ * baseline the first time an account is seen here, and only count requests
+ * created since then. All callers pass the raw device-wide count; this is the
+ * single place that makes the check account-aware.
  *
  * Instead of reporting a delta per request (which undercounts when calls drop),
  * we send one idempotent latch when the local count crosses the threshold. The
@@ -17,10 +31,6 @@ import { FIRST_REQUEST_GRADUATION_THRESHOLD, isRequestThresholdLatched, markRequ
  * Fire-and-forget: never throws, and no-ops when logged out or below threshold.
  */
 export const maybeLatchRequestThreshold = async (createdRequests: number): Promise<void> => {
-  if (createdRequests < FIRST_REQUEST_GRADUATION_THRESHOLD) {
-    return;
-  }
-
   try {
     const sessionId = await getCurrentSessionId();
     if (!sessionId) {
@@ -30,6 +40,17 @@ export const maybeLatchRequestThreshold = async (createdRequests: number): Promi
     if (isRequestThresholdLatched(accountId)) {
       return;
     }
+
+    let baseline = readRequestCountBaseline(accountId);
+    if (baseline === null) {
+      baseline = createdRequests;
+      writeRequestCountBaseline(accountId, baseline);
+    }
+
+    if (createdRequests - baseline < FIRST_REQUEST_GRADUATION_THRESHOLD) {
+      return;
+    }
+
     await latchRequestThresholdReached({ sessionId });
     markRequestThresholdLatched(accountId);
   } catch (error) {

--- a/packages/insomnia/src/ui/utils/first-request-treatment.test.ts
+++ b/packages/insomnia/src/ui/utils/first-request-treatment.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { getFirstRequestCohort, getFirstRequestTreatment } from './first-request-treatment';
+
+const GA = Date.parse('2026-07-06T00:00:00.000Z');
+const BEFORE_GA = GA - 60 * 60 * 1000; // 1h before GA
+const AFTER_GA = GA + 60 * 60 * 1000; // 1h after GA
+
+describe('getFirstRequestCohort', () => {
+  it('is deterministic for the same id', () => {
+    expect(getFirstRequestCohort('acct_123')).toBe(getFirstRequestCohort('acct_123'));
+  });
+
+  it('splits a population of ids across both cohorts (~50/50)', () => {
+    const ids = Array.from({ length: 200 }, (_, i) => `acct_${i}`);
+    const cohorts = ids.map(getFirstRequestCohort);
+    const aCount = cohorts.filter(c => c === 'A').length;
+    expect(cohorts).toContain('A');
+    expect(cohorts).toContain('B');
+    expect(aCount).toBeGreaterThan(ids.length * 0.3);
+    expect(aCount).toBeLessThan(ids.length * 0.7);
+  });
+
+  it('defaults to Treatment B when there is no stable id', () => {
+    expect(getFirstRequestCohort('')).toBe('B');
+  });
+});
+
+describe('getFirstRequestTreatment', () => {
+  it('returns "B" for accounts created before the experiment launched, regardless of request count', () => {
+    expect(
+      getFirstRequestTreatment({
+        accountCreatedAt: BEFORE_GA,
+        experimentLaunchedAt: GA,
+        createdRequests: 0,
+        cohortId: 'acct_123',
+      }),
+    ).toBe('B');
+  });
+
+  it('assigns new sign-ups (created on/after GA, fewer than 3 requests) to their cohort', () => {
+    const cohort = getFirstRequestCohort('acct_123');
+    expect(
+      getFirstRequestTreatment({
+        accountCreatedAt: AFTER_GA,
+        experimentLaunchedAt: GA,
+        createdRequests: 0,
+        cohortId: 'acct_123',
+      }),
+    ).toBe(cohort);
+  });
+
+  it('graduates a new sign-up to "B" once they have created 3 or more requests', () => {
+    expect(
+      getFirstRequestTreatment({
+        accountCreatedAt: AFTER_GA,
+        experimentLaunchedAt: GA,
+        createdRequests: 3,
+        cohortId: 'acct_123',
+      }),
+    ).toBe('B');
+  });
+
+  it('treats an unknown creation date via the new-sign-up path (cohort / graduation)', () => {
+    const cohort = getFirstRequestCohort('acct_123');
+    expect(
+      getFirstRequestTreatment({
+        accountCreatedAt: undefined,
+        experimentLaunchedAt: GA,
+        createdRequests: 0,
+        cohortId: 'acct_123',
+      }),
+    ).toBe(cohort);
+  });
+});

--- a/packages/insomnia/src/ui/utils/first-request-treatment.test.ts
+++ b/packages/insomnia/src/ui/utils/first-request-treatment.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  getBackendFirstRequestTreatment,
-  getBackendIsNewSignup,
   getFirstRequestCohort,
   getFirstRequestTreatment,
   getFirstRequestTreatmentGroup,
+  getOnboardingIsNewSignup,
+  getOnboardingReachedThreshold,
+  getOnboardingTreatment,
   isFirstRequestExperimentParticipant,
   resolveFirstRequestTreatment,
 } from './first-request-treatment';
@@ -37,20 +38,20 @@ describe('getFirstRequestCohort', () => {
 describe('getFirstRequestTreatment (client-side fallback)', () => {
   it('returns "B" for accounts created before the experiment launched', () => {
     expect(
-      getFirstRequestTreatment({ accountCreatedAt: BEFORE_GA, experimentLaunchedAt: GA, createdRequests: 0, cohortId: 'acct_123' }),
+      getFirstRequestTreatment({ accountCreatedAt: BEFORE_GA, experimentLaunchedAt: GA, hasGraduated: false, cohortId: 'acct_123' }),
     ).toBe('B');
   });
 
-  it('assigns new sign-ups (created on/after GA, <3 requests) to their cohort', () => {
+  it('assigns new sign-ups (created on/after GA, not graduated) to their cohort', () => {
     const cohort = getFirstRequestCohort('acct_123');
     expect(
-      getFirstRequestTreatment({ accountCreatedAt: AFTER_GA, experimentLaunchedAt: GA, createdRequests: 0, cohortId: 'acct_123' }),
+      getFirstRequestTreatment({ accountCreatedAt: AFTER_GA, experimentLaunchedAt: GA, hasGraduated: false, cohortId: 'acct_123' }),
     ).toBe(cohort);
   });
 
-  it('graduates a new sign-up to "B" once they have created 3 or more requests', () => {
+  it('graduates a new sign-up to "B" once they have graduated', () => {
     expect(
-      getFirstRequestTreatment({ accountCreatedAt: AFTER_GA, experimentLaunchedAt: GA, createdRequests: 3, cohortId: 'acct_123' }),
+      getFirstRequestTreatment({ accountCreatedAt: AFTER_GA, experimentLaunchedAt: GA, hasGraduated: true, cohortId: 'acct_123' }),
     ).toBe('B');
   });
 });
@@ -62,25 +63,34 @@ describe('getFirstRequestTreatmentGroup', () => {
   });
 });
 
-describe('getBackendFirstRequestTreatment', () => {
-  it('reads a valid treatment from the user profile', () => {
-    expect(getBackendFirstRequestTreatment({ first_request_treatment: 'A' })).toBe('A');
-    expect(getBackendFirstRequestTreatment({ first_request_treatment: 'B' })).toBe('B');
+describe('getOnboardingTreatment', () => {
+  it('reads a valid treatment from the onboarding state', () => {
+    expect(getOnboardingTreatment({ first_request_treatment: 'A' })).toBe('A');
+    expect(getOnboardingTreatment({ first_request_treatment: 'B' })).toBe('B');
   });
 
   it('returns undefined when the field is missing or invalid', () => {
-    expect(getBackendFirstRequestTreatment({})).toBeUndefined();
-    expect(getBackendFirstRequestTreatment(null)).toBeUndefined();
-    expect(getBackendFirstRequestTreatment({ first_request_treatment: 'C' })).toBeUndefined();
+    expect(getOnboardingTreatment({})).toBeUndefined();
+    expect(getOnboardingTreatment(null)).toBeUndefined();
+    expect(getOnboardingTreatment({ first_request_treatment: 'C' as unknown as 'A' })).toBeUndefined();
   });
 });
 
-describe('getBackendIsNewSignup', () => {
-  it('reads a boolean flag from the user profile, else undefined', () => {
-    expect(getBackendIsNewSignup({ is_new_signup: true })).toBe(true);
-    expect(getBackendIsNewSignup({ is_new_signup: false })).toBe(false);
-    expect(getBackendIsNewSignup({})).toBeUndefined();
-    expect(getBackendIsNewSignup(null)).toBeUndefined();
+describe('getOnboardingIsNewSignup', () => {
+  it('reads a boolean flag from the onboarding state, else undefined', () => {
+    expect(getOnboardingIsNewSignup({ is_new_signup: true })).toBe(true);
+    expect(getOnboardingIsNewSignup({ is_new_signup: false })).toBe(false);
+    expect(getOnboardingIsNewSignup({})).toBeUndefined();
+    expect(getOnboardingIsNewSignup(null)).toBeUndefined();
+  });
+});
+
+describe('getOnboardingReachedThreshold', () => {
+  it('is true only when the server confirms the sticky latch', () => {
+    expect(getOnboardingReachedThreshold({ has_reached_request_threshold: true })).toBe(true);
+    expect(getOnboardingReachedThreshold({ has_reached_request_threshold: false })).toBe(false);
+    expect(getOnboardingReachedThreshold({})).toBe(false);
+    expect(getOnboardingReachedThreshold(null)).toBe(false);
   });
 });
 
@@ -103,6 +113,7 @@ describe('isFirstRequestExperimentParticipant', () => {
 describe('resolveFirstRequestTreatment (fallback chain)', () => {
   const base = {
     experimentLaunchedAt: GA,
+    hasReachedThreshold: false,
     createdRequests: 0 as number | null,
     cohortId: 'acct_123',
     cachedTreatment: null,
@@ -110,7 +121,13 @@ describe('resolveFirstRequestTreatment (fallback chain)', () => {
 
   it('1) uses the backend treatment when present, ignoring everything else', () => {
     expect(
-      resolveFirstRequestTreatment({ ...base, backendTreatment: 'A', accountCreatedAt: BEFORE_GA, createdRequests: 99 }),
+      resolveFirstRequestTreatment({
+        ...base,
+        backendTreatment: 'A',
+        accountCreatedAt: BEFORE_GA,
+        hasReachedThreshold: true,
+        createdRequests: 99,
+      }),
     ).toBe('A');
   });
 
@@ -120,6 +137,12 @@ describe('resolveFirstRequestTreatment (fallback chain)', () => {
     expect(resolveFirstRequestTreatment({ ...base, accountCreatedAt: AFTER_GA, createdRequests: 0 })).toBe(
       getFirstRequestCohort('acct_123'),
     );
+  });
+
+  it('2a) the server-confirmed graduation latch decides "B" without needing local stats', () => {
+    expect(
+      resolveFirstRequestTreatment({ ...base, accountCreatedAt: AFTER_GA, hasReachedThreshold: true, createdRequests: null }),
+    ).toBe('B');
   });
 
   it('2b) decides existing users before stats load; waits (or uses cache) for new users', () => {

--- a/packages/insomnia/src/ui/utils/first-request-treatment.test.ts
+++ b/packages/insomnia/src/ui/utils/first-request-treatment.test.ts
@@ -1,60 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  getFirstRequestCohort,
-  getFirstRequestTreatment,
   getFirstRequestTreatmentGroup,
   getOnboardingIsNewSignup,
-  getOnboardingReachedThreshold,
   getOnboardingTreatment,
-  isFirstRequestExperimentParticipant,
   resolveFirstRequestTreatment,
 } from './first-request-treatment';
-
-const GA = Date.parse('2026-07-06T00:00:00.000Z');
-const BEFORE_GA = GA - 60 * 60 * 1000; // 1h before GA
-const AFTER_GA = GA + 60 * 60 * 1000; // 1h after GA
-
-describe('getFirstRequestCohort', () => {
-  it('is deterministic for the same id', () => {
-    expect(getFirstRequestCohort('acct_123')).toBe(getFirstRequestCohort('acct_123'));
-  });
-
-  it('splits a population of ids across both cohorts (~50/50)', () => {
-    const ids = Array.from({ length: 200 }, (_, i) => `acct_${i}`);
-    const cohorts = ids.map(getFirstRequestCohort);
-    const aCount = cohorts.filter(c => c === 'A').length;
-    expect(cohorts).toContain('A');
-    expect(cohorts).toContain('B');
-    expect(aCount).toBeGreaterThan(ids.length * 0.3);
-    expect(aCount).toBeLessThan(ids.length * 0.7);
-  });
-
-  it('defaults to Treatment B when there is no stable id', () => {
-    expect(getFirstRequestCohort('')).toBe('B');
-  });
-});
-
-describe('getFirstRequestTreatment (client-side fallback)', () => {
-  it('returns "B" for accounts created before the experiment launched', () => {
-    expect(
-      getFirstRequestTreatment({ accountCreatedAt: BEFORE_GA, experimentLaunchedAt: GA, hasGraduated: false, cohortId: 'acct_123' }),
-    ).toBe('B');
-  });
-
-  it('assigns new sign-ups (created on/after GA, not graduated) to their cohort', () => {
-    const cohort = getFirstRequestCohort('acct_123');
-    expect(
-      getFirstRequestTreatment({ accountCreatedAt: AFTER_GA, experimentLaunchedAt: GA, hasGraduated: false, cohortId: 'acct_123' }),
-    ).toBe(cohort);
-  });
-
-  it('graduates a new sign-up to "B" once they have graduated', () => {
-    expect(
-      getFirstRequestTreatment({ accountCreatedAt: AFTER_GA, experimentLaunchedAt: GA, hasGraduated: true, cohortId: 'acct_123' }),
-    ).toBe('B');
-  });
-});
 
 describe('getFirstRequestTreatmentGroup', () => {
   it('maps the internal treatment to the analytics treatment_group', () => {
@@ -85,84 +36,25 @@ describe('getOnboardingIsNewSignup', () => {
   });
 });
 
-describe('getOnboardingReachedThreshold', () => {
-  it('is true only when the server confirms the sticky latch', () => {
-    expect(getOnboardingReachedThreshold({ has_reached_request_threshold: true })).toBe(true);
-    expect(getOnboardingReachedThreshold({ has_reached_request_threshold: false })).toBe(false);
-    expect(getOnboardingReachedThreshold({})).toBe(false);
-    expect(getOnboardingReachedThreshold(null)).toBe(false);
-  });
-});
-
-describe('isFirstRequestExperimentParticipant', () => {
-  it('prefers the server is_new_signup flag when provided', () => {
-    expect(isFirstRequestExperimentParticipant({ isNewSignup: true, accountCreatedAt: BEFORE_GA, experimentLaunchedAt: GA })).toBe(true);
-    expect(isFirstRequestExperimentParticipant({ isNewSignup: false, accountCreatedAt: AFTER_GA, experimentLaunchedAt: GA })).toBe(false);
-  });
-
-  it('falls back to created_at >= GA when the flag is absent', () => {
-    expect(isFirstRequestExperimentParticipant({ accountCreatedAt: AFTER_GA, experimentLaunchedAt: GA })).toBe(true);
-    expect(isFirstRequestExperimentParticipant({ accountCreatedAt: BEFORE_GA, experimentLaunchedAt: GA })).toBe(false);
-  });
-
-  it('returns false when neither signal is known', () => {
-    expect(isFirstRequestExperimentParticipant({ experimentLaunchedAt: GA })).toBe(false);
-  });
-});
-
 describe('resolveFirstRequestTreatment (fallback chain)', () => {
   const base = {
-    experimentLaunchedAt: GA,
-    hasReachedThreshold: false,
-    createdRequests: 0 as number | null,
-    cohortId: 'acct_123',
+    onboardingLoaded: true,
     cachedTreatment: null,
   };
 
   it('1) uses the backend treatment when present, ignoring everything else', () => {
-    expect(
-      resolveFirstRequestTreatment({
-        ...base,
-        backendTreatment: 'A',
-        accountCreatedAt: BEFORE_GA,
-        hasReachedThreshold: true,
-        createdRequests: 99,
-      }),
-    ).toBe('A');
+    expect(resolveFirstRequestTreatment({ ...base, backendTreatment: 'A', cachedTreatment: 'B' })).toBe('A');
   });
 
-  it('2) falls back to the client computation when the profile is loaded but no backend field', () => {
-    expect(resolveFirstRequestTreatment({ ...base, accountCreatedAt: BEFORE_GA })).toBe('B');
-    expect(resolveFirstRequestTreatment({ ...base, accountCreatedAt: AFTER_GA, createdRequests: 3 })).toBe('B');
-    expect(resolveFirstRequestTreatment({ ...base, accountCreatedAt: AFTER_GA, createdRequests: 0 })).toBe(
-      getFirstRequestCohort('acct_123'),
-    );
+  it('2) falls back to the cached last-known treatment when the backend has not answered', () => {
+    expect(resolveFirstRequestTreatment({ ...base, cachedTreatment: 'A' })).toBe('A');
   });
 
-  it('2a) the server-confirmed graduation latch decides "B" without needing local stats', () => {
-    expect(
-      resolveFirstRequestTreatment({ ...base, accountCreatedAt: AFTER_GA, hasReachedThreshold: true, createdRequests: null }),
-    ).toBe('B');
+  it('3) returns null while the first response is still pending and nothing is cached', () => {
+    expect(resolveFirstRequestTreatment({ ...base, onboardingLoaded: false, cachedTreatment: null })).toBeNull();
   });
 
-  it('2b) decides existing users before stats load; waits (or uses cache) for new users', () => {
-    // created before GA → B without needing stats
-    expect(resolveFirstRequestTreatment({ ...base, accountCreatedAt: BEFORE_GA, createdRequests: null })).toBe('B');
-    // new user, stats still loading, no cache → null (loading)
-    expect(resolveFirstRequestTreatment({ ...base, accountCreatedAt: AFTER_GA, createdRequests: null })).toBeNull();
-    // new user, stats still loading, but cached → cached value
-    expect(
-      resolveFirstRequestTreatment({ ...base, accountCreatedAt: AFTER_GA, createdRequests: null, cachedTreatment: 'A' }),
-    ).toBe('A');
-  });
-
-  it('3) uses the cached value when the profile is unavailable (offline)', () => {
-    expect(
-      resolveFirstRequestTreatment({ ...base, accountCreatedAt: undefined, createdRequests: null, cachedTreatment: 'A' }),
-    ).toBe('A');
-  });
-
-  it('4) defaults to "B" when the profile is unavailable and nothing is cached', () => {
-    expect(resolveFirstRequestTreatment({ ...base, accountCreatedAt: undefined, createdRequests: null })).toBe('B');
+  it('4) defaults to "B" once loaded with no backend treatment and nothing cached', () => {
+    expect(resolveFirstRequestTreatment({ ...base, onboardingLoaded: true, cachedTreatment: null })).toBe('B');
   });
 });

--- a/packages/insomnia/src/ui/utils/first-request-treatment.test.ts
+++ b/packages/insomnia/src/ui/utils/first-request-treatment.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 
 import {
   getFirstRequestTreatmentGroup,
-  getOnboardingIsNewSignup,
   getOnboardingTreatment,
   resolveFirstRequestTreatment,
 } from './first-request-treatment';
@@ -24,14 +23,6 @@ describe('getOnboardingTreatment', () => {
     expect(getOnboardingTreatment({ first_request_treatment: null, is_new_signup: false })).toBeUndefined();
     expect(getOnboardingTreatment(null)).toBeUndefined();
     expect(getOnboardingTreatment({ first_request_treatment: 'unknown', is_new_signup: false })).toBeUndefined();
-  });
-});
-
-describe('getOnboardingIsNewSignup', () => {
-  it('reads a boolean flag from the onboarding state, else undefined', () => {
-    expect(getOnboardingIsNewSignup({ is_new_signup: true, first_request_treatment: null })).toBe(true);
-    expect(getOnboardingIsNewSignup({ is_new_signup: false, first_request_treatment: null })).toBe(false);
-    expect(getOnboardingIsNewSignup(null)).toBeUndefined();
   });
 });
 

--- a/packages/insomnia/src/ui/utils/first-request-treatment.test.ts
+++ b/packages/insomnia/src/ui/utils/first-request-treatment.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import {
   getBackendFirstRequestTreatment,
+  getBackendIsNewSignup,
   getFirstRequestCohort,
   getFirstRequestTreatment,
+  getFirstRequestTreatmentGroup,
+  isFirstRequestExperimentParticipant,
   resolveFirstRequestTreatment,
 } from './first-request-treatment';
 
@@ -52,6 +55,13 @@ describe('getFirstRequestTreatment (client-side fallback)', () => {
   });
 });
 
+describe('getFirstRequestTreatmentGroup', () => {
+  it('maps the internal treatment to the analytics treatment_group', () => {
+    expect(getFirstRequestTreatmentGroup('A')).toBe('treatment_a');
+    expect(getFirstRequestTreatmentGroup('B')).toBe('treatment_b');
+  });
+});
+
 describe('getBackendFirstRequestTreatment', () => {
   it('reads a valid treatment from the user profile', () => {
     expect(getBackendFirstRequestTreatment({ first_request_treatment: 'A' })).toBe('A');
@@ -62,6 +72,31 @@ describe('getBackendFirstRequestTreatment', () => {
     expect(getBackendFirstRequestTreatment({})).toBeUndefined();
     expect(getBackendFirstRequestTreatment(null)).toBeUndefined();
     expect(getBackendFirstRequestTreatment({ first_request_treatment: 'C' })).toBeUndefined();
+  });
+});
+
+describe('getBackendIsNewSignup', () => {
+  it('reads a boolean flag from the user profile, else undefined', () => {
+    expect(getBackendIsNewSignup({ is_new_signup: true })).toBe(true);
+    expect(getBackendIsNewSignup({ is_new_signup: false })).toBe(false);
+    expect(getBackendIsNewSignup({})).toBeUndefined();
+    expect(getBackendIsNewSignup(null)).toBeUndefined();
+  });
+});
+
+describe('isFirstRequestExperimentParticipant', () => {
+  it('prefers the server is_new_signup flag when provided', () => {
+    expect(isFirstRequestExperimentParticipant({ isNewSignup: true, accountCreatedAt: BEFORE_GA, experimentLaunchedAt: GA })).toBe(true);
+    expect(isFirstRequestExperimentParticipant({ isNewSignup: false, accountCreatedAt: AFTER_GA, experimentLaunchedAt: GA })).toBe(false);
+  });
+
+  it('falls back to created_at >= GA when the flag is absent', () => {
+    expect(isFirstRequestExperimentParticipant({ accountCreatedAt: AFTER_GA, experimentLaunchedAt: GA })).toBe(true);
+    expect(isFirstRequestExperimentParticipant({ accountCreatedAt: BEFORE_GA, experimentLaunchedAt: GA })).toBe(false);
+  });
+
+  it('returns false when neither signal is known', () => {
+    expect(isFirstRequestExperimentParticipant({ experimentLaunchedAt: GA })).toBe(false);
   });
 });
 

--- a/packages/insomnia/src/ui/utils/first-request-treatment.test.ts
+++ b/packages/insomnia/src/ui/utils/first-request-treatment.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { getFirstRequestCohort, getFirstRequestTreatment } from './first-request-treatment';
+import {
+  getBackendFirstRequestTreatment,
+  getFirstRequestCohort,
+  getFirstRequestTreatment,
+  resolveFirstRequestTreatment,
+} from './first-request-treatment';
 
 const GA = Date.parse('2026-07-06T00:00:00.000Z');
 const BEFORE_GA = GA - 60 * 60 * 1000; // 1h before GA
@@ -26,50 +31,80 @@ describe('getFirstRequestCohort', () => {
   });
 });
 
-describe('getFirstRequestTreatment', () => {
-  it('returns "B" for accounts created before the experiment launched, regardless of request count', () => {
+describe('getFirstRequestTreatment (client-side fallback)', () => {
+  it('returns "B" for accounts created before the experiment launched', () => {
     expect(
-      getFirstRequestTreatment({
-        accountCreatedAt: BEFORE_GA,
-        experimentLaunchedAt: GA,
-        createdRequests: 0,
-        cohortId: 'acct_123',
-      }),
+      getFirstRequestTreatment({ accountCreatedAt: BEFORE_GA, experimentLaunchedAt: GA, createdRequests: 0, cohortId: 'acct_123' }),
     ).toBe('B');
   });
 
-  it('assigns new sign-ups (created on/after GA, fewer than 3 requests) to their cohort', () => {
+  it('assigns new sign-ups (created on/after GA, <3 requests) to their cohort', () => {
     const cohort = getFirstRequestCohort('acct_123');
     expect(
-      getFirstRequestTreatment({
-        accountCreatedAt: AFTER_GA,
-        experimentLaunchedAt: GA,
-        createdRequests: 0,
-        cohortId: 'acct_123',
-      }),
+      getFirstRequestTreatment({ accountCreatedAt: AFTER_GA, experimentLaunchedAt: GA, createdRequests: 0, cohortId: 'acct_123' }),
     ).toBe(cohort);
   });
 
   it('graduates a new sign-up to "B" once they have created 3 or more requests', () => {
     expect(
-      getFirstRequestTreatment({
-        accountCreatedAt: AFTER_GA,
-        experimentLaunchedAt: GA,
-        createdRequests: 3,
-        cohortId: 'acct_123',
-      }),
+      getFirstRequestTreatment({ accountCreatedAt: AFTER_GA, experimentLaunchedAt: GA, createdRequests: 3, cohortId: 'acct_123' }),
     ).toBe('B');
   });
+});
 
-  it('treats an unknown creation date via the new-sign-up path (cohort / graduation)', () => {
-    const cohort = getFirstRequestCohort('acct_123');
+describe('getBackendFirstRequestTreatment', () => {
+  it('reads a valid treatment from the user profile', () => {
+    expect(getBackendFirstRequestTreatment({ first_request_treatment: 'A' })).toBe('A');
+    expect(getBackendFirstRequestTreatment({ first_request_treatment: 'B' })).toBe('B');
+  });
+
+  it('returns undefined when the field is missing or invalid', () => {
+    expect(getBackendFirstRequestTreatment({})).toBeUndefined();
+    expect(getBackendFirstRequestTreatment(null)).toBeUndefined();
+    expect(getBackendFirstRequestTreatment({ first_request_treatment: 'C' })).toBeUndefined();
+  });
+});
+
+describe('resolveFirstRequestTreatment (fallback chain)', () => {
+  const base = {
+    experimentLaunchedAt: GA,
+    createdRequests: 0 as number | null,
+    cohortId: 'acct_123',
+    cachedTreatment: null,
+  };
+
+  it('1) uses the backend treatment when present, ignoring everything else', () => {
     expect(
-      getFirstRequestTreatment({
-        accountCreatedAt: undefined,
-        experimentLaunchedAt: GA,
-        createdRequests: 0,
-        cohortId: 'acct_123',
-      }),
-    ).toBe(cohort);
+      resolveFirstRequestTreatment({ ...base, backendTreatment: 'A', accountCreatedAt: BEFORE_GA, createdRequests: 99 }),
+    ).toBe('A');
+  });
+
+  it('2) falls back to the client computation when the profile is loaded but no backend field', () => {
+    expect(resolveFirstRequestTreatment({ ...base, accountCreatedAt: BEFORE_GA })).toBe('B');
+    expect(resolveFirstRequestTreatment({ ...base, accountCreatedAt: AFTER_GA, createdRequests: 3 })).toBe('B');
+    expect(resolveFirstRequestTreatment({ ...base, accountCreatedAt: AFTER_GA, createdRequests: 0 })).toBe(
+      getFirstRequestCohort('acct_123'),
+    );
+  });
+
+  it('2b) decides existing users before stats load; waits (or uses cache) for new users', () => {
+    // created before GA → B without needing stats
+    expect(resolveFirstRequestTreatment({ ...base, accountCreatedAt: BEFORE_GA, createdRequests: null })).toBe('B');
+    // new user, stats still loading, no cache → null (loading)
+    expect(resolveFirstRequestTreatment({ ...base, accountCreatedAt: AFTER_GA, createdRequests: null })).toBeNull();
+    // new user, stats still loading, but cached → cached value
+    expect(
+      resolveFirstRequestTreatment({ ...base, accountCreatedAt: AFTER_GA, createdRequests: null, cachedTreatment: 'A' }),
+    ).toBe('A');
+  });
+
+  it('3) uses the cached value when the profile is unavailable (offline)', () => {
+    expect(
+      resolveFirstRequestTreatment({ ...base, accountCreatedAt: undefined, createdRequests: null, cachedTreatment: 'A' }),
+    ).toBe('A');
+  });
+
+  it('4) defaults to "B" when the profile is unavailable and nothing is cached', () => {
+    expect(resolveFirstRequestTreatment({ ...base, accountCreatedAt: undefined, createdRequests: null })).toBe('B');
   });
 });

--- a/packages/insomnia/src/ui/utils/first-request-treatment.test.ts
+++ b/packages/insomnia/src/ui/utils/first-request-treatment.test.ts
@@ -16,22 +16,21 @@ describe('getFirstRequestTreatmentGroup', () => {
 
 describe('getOnboardingTreatment', () => {
   it('reads a valid treatment from the onboarding state', () => {
-    expect(getOnboardingTreatment({ first_request_treatment: 'A' })).toBe('A');
-    expect(getOnboardingTreatment({ first_request_treatment: 'B' })).toBe('B');
+    expect(getOnboardingTreatment({ first_request_treatment: 'treatment_a', is_new_signup: false })).toBe('A');
+    expect(getOnboardingTreatment({ first_request_treatment: 'treatment_b', is_new_signup: false })).toBe('B');
   });
 
-  it('returns undefined when the field is missing or invalid', () => {
-    expect(getOnboardingTreatment({})).toBeUndefined();
+  it('returns undefined when the field is missing, null, or unknown', () => {
+    expect(getOnboardingTreatment({ first_request_treatment: null, is_new_signup: false })).toBeUndefined();
     expect(getOnboardingTreatment(null)).toBeUndefined();
-    expect(getOnboardingTreatment({ first_request_treatment: 'C' as unknown as 'A' })).toBeUndefined();
+    expect(getOnboardingTreatment({ first_request_treatment: 'unknown', is_new_signup: false })).toBeUndefined();
   });
 });
 
 describe('getOnboardingIsNewSignup', () => {
   it('reads a boolean flag from the onboarding state, else undefined', () => {
-    expect(getOnboardingIsNewSignup({ is_new_signup: true })).toBe(true);
-    expect(getOnboardingIsNewSignup({ is_new_signup: false })).toBe(false);
-    expect(getOnboardingIsNewSignup({})).toBeUndefined();
+    expect(getOnboardingIsNewSignup({ is_new_signup: true, first_request_treatment: null })).toBe(true);
+    expect(getOnboardingIsNewSignup({ is_new_signup: false, first_request_treatment: null })).toBe(false);
     expect(getOnboardingIsNewSignup(null)).toBeUndefined();
   });
 });

--- a/packages/insomnia/src/ui/utils/first-request-treatment.ts
+++ b/packages/insomnia/src/ui/utils/first-request-treatment.ts
@@ -1,0 +1,74 @@
+export type FirstRequestTreatment = 'A' | 'B';
+
+/**
+ * Number of created requests after which a new sign-up graduates from the
+ * first-request experience Treatment A to Treatment B.
+ */
+export const FIRST_REQUEST_GRADUATION_THRESHOLD = 3;
+
+/**
+ * v13.1.0 GA release date (epoch ms). Accounts created before this are considered
+ * pre-existing users and always get Treatment B ("fresh slate" at launch); only
+ * accounts created on/after this date enter the A/B experiment.
+ *
+ * TODO(INS-2933): set to the actual v13.1.0 GA date before release.
+ */
+export const FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE = Date.parse('2026-07-06T00:00:00.000Z');
+
+/**
+ * Deterministic ~50/50 cohort assignment for the first-request experiment.
+ *
+ * There is no A/B framework, so we bucket each user by hashing a stable id
+ * (accountId, falling back to deviceId). This is stable per user across sessions
+ * and devices (when keyed on accountId) and needs no stored state. Over the whole
+ * sign-up population the parity of the hash splits ~50/50 between A and B.
+ */
+export const getFirstRequestCohort = (id: string): FirstRequestTreatment => {
+  if (!id) {
+    return 'B';
+  }
+
+  // Bounded polynomial rolling hash (mod a large prime) so it stays a safe integer
+  // and is deterministic; its parity gives a ~50/50 split across the population.
+  let hash = 0;
+  for (let i = 0; i < id.length; i++) {
+    hash = (hash * 31 + (id.codePointAt(i) ?? 0)) % 2_147_483_647;
+  }
+
+  return hash % 2 === 0 ? 'A' : 'B';
+};
+
+/**
+ * Decides which first-request experience treatment to show.
+ *
+ * - Users whose account was created before the experiment launched are existing
+ *   users and always get Treatment B (regardless of how many requests they've made).
+ * - New sign-ups are split ~50/50 into Treatment A or B by {@link getFirstRequestCohort}.
+ * - A new sign-up in Treatment A graduates to Treatment B once they have created
+ *   {@link FIRST_REQUEST_GRADUATION_THRESHOLD} or more requests.
+ *
+ * `accountCreatedAt` is the account creation time (epoch ms); when undefined (e.g.
+ * the profile hasn't loaded) we can't confirm they're pre-existing, so we treat
+ * them via the new-sign-up path.
+ */
+export const getFirstRequestTreatment = ({
+  accountCreatedAt,
+  experimentLaunchedAt,
+  createdRequests,
+  cohortId,
+}: {
+  accountCreatedAt?: number;
+  experimentLaunchedAt: number;
+  createdRequests: number;
+  cohortId: string;
+}): FirstRequestTreatment => {
+  if (accountCreatedAt !== undefined && accountCreatedAt < experimentLaunchedAt) {
+    return 'B';
+  }
+
+  if (createdRequests >= FIRST_REQUEST_GRADUATION_THRESHOLD) {
+    return 'B';
+  }
+
+  return getFirstRequestCohort(cohortId);
+};

--- a/packages/insomnia/src/ui/utils/first-request-treatment.ts
+++ b/packages/insomnia/src/ui/utils/first-request-treatment.ts
@@ -5,17 +5,12 @@ export type FirstRequestTreatment = 'A' | 'B';
 /**
  * Number of created requests after which a new sign-up graduates from the
  * first-request experience Treatment A to Treatment B.
+ *
+ * The server owns graduation; the client uses this only to decide when its local
+ * created-request count has crossed the threshold and it should latch the sticky
+ * bit on the server (see `maybeLatchRequestThreshold`).
  */
 export const FIRST_REQUEST_GRADUATION_THRESHOLD = 3;
-
-/**
- * v13.1.0 GA release date (epoch ms). Only used by the client-side fallback when
- * the backend does not (yet) return a treatment. Accounts created before this are
- * treated as pre-existing users (Treatment B).
- *
- * TODO(INS-2933): set to the actual v13.1.0 GA date before release.
- */
-export const FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE = Date.parse('2026-07-18T00:00:00.000Z');
 
 const CACHE_KEY_PREFIX = 'insomnia.firstRequestTreatment';
 
@@ -27,63 +22,10 @@ export const getFirstRequestTreatmentGroup = (treatment: FirstRequestTreatment):
   treatment === 'A' ? 'treatment_a' : 'treatment_b';
 
 /**
- * Deterministic ~50/50 cohort assignment for the first-request experiment.
- *
- * Used only by the client-side fallback (the backend is authoritative when it
- * returns a treatment). Buckets a user by hashing a stable id (accountId, falling
- * back to deviceId); stable per user, needs no stored state, splits ~50/50.
- */
-export const getFirstRequestCohort = (id: string): FirstRequestTreatment => {
-  if (!id) {
-    return 'B';
-  }
-
-  // Bounded polynomial rolling hash (mod a large prime) so it stays a safe integer
-  // and is deterministic; its parity gives a ~50/50 split across the population.
-  let hash = 0;
-  for (let i = 0; i < id.length; i++) {
-    hash = (hash * 31 + (id.codePointAt(i) ?? 0)) % 2_147_483_647;
-  }
-
-  return hash % 2 === 0 ? 'A' : 'B';
-};
-
-/**
- * Pure client-side treatment computation (the fallback used when the backend does
- * not return a treatment).
- *
- * - Accounts created before the experiment launched are existing users → B.
- * - New sign-ups are split ~50/50 into A or B by {@link getFirstRequestCohort}.
- * - A new sign-up in Treatment A graduates to B once they have graduated (created
- *   at least {@link FIRST_REQUEST_GRADUATION_THRESHOLD} requests — a sticky fact).
- */
-export const getFirstRequestTreatment = ({
-  accountCreatedAt,
-  experimentLaunchedAt,
-  hasGraduated,
-  cohortId,
-}: {
-  accountCreatedAt?: number;
-  experimentLaunchedAt: number;
-  hasGraduated: boolean;
-  cohortId: string;
-}): FirstRequestTreatment => {
-  if (accountCreatedAt !== undefined && accountCreatedAt < experimentLaunchedAt) {
-    return 'B';
-  }
-
-  if (hasGraduated) {
-    return 'B';
-  }
-
-  return getFirstRequestCohort(cohortId);
-};
-
-/**
- * Reads the server-computed treatment from the onboarding resource, when the
- * backend is steering assignment (field `first_request_treatment`). Returns
- * undefined if absent or invalid, so the caller can fall back to the client-side
- * computation.
+ * Reads the server-computed treatment from the onboarding resource (field
+ * `first_request_treatment`). The server is authoritative for assignment; the
+ * client does not compute treatment itself. Returns undefined if absent or
+ * invalid, so the caller can fall back to the cached value / safe default.
  */
 export const getOnboardingTreatment = (
   onboarding: UserOnboardingState | null | undefined,
@@ -93,47 +35,13 @@ export const getOnboardingTreatment = (
 };
 
 /**
- * Reads the server's `is_new_signup` flag from the onboarding resource, when
- * provided. Used to decide whether the user is an experiment participant.
+ * Reads the server's `is_new_signup` flag from the onboarding resource. This is the
+ * sole signal for experiment participation (whether to emit assignment analytics);
+ * an absent flag means "not a confirmed participant".
  */
 export const getOnboardingIsNewSignup = (onboarding: UserOnboardingState | null | undefined): boolean | undefined => {
   const value = onboarding?.is_new_signup;
   return typeof value === 'boolean' ? value : undefined;
-};
-
-/**
- * Reads the sticky "reached the graduation threshold" latch from the onboarding
- * resource. This is the account-wide, device-independent, irreversible source of
- * truth for graduation; defaults to false when the server hasn't confirmed it.
- */
-export const getOnboardingReachedThreshold = (onboarding: UserOnboardingState | null | undefined): boolean => {
-  return onboarding?.has_reached_request_threshold === true;
-};
-
-/**
- * Whether the user is part of the experiment population (a genuine new sign-up),
- * as opposed to a pre-existing user who is simply defaulted to Treatment B.
- *
- * Prefers the server `is_new_signup` flag; otherwise derives it from the account
- * creation date vs GA. Returns false when neither is known (can't confirm → don't
- * emit assignment analytics).
- */
-export const isFirstRequestExperimentParticipant = ({
-  isNewSignup,
-  accountCreatedAt,
-  experimentLaunchedAt,
-}: {
-  isNewSignup?: boolean;
-  accountCreatedAt?: number;
-  experimentLaunchedAt: number;
-}): boolean => {
-  if (isNewSignup !== undefined) {
-    return isNewSignup;
-  }
-  if (accountCreatedAt !== undefined) {
-    return accountCreatedAt >= experimentLaunchedAt;
-  }
-  return false;
 };
 
 const cacheKey = (accountId: string) => `${CACHE_KEY_PREFIX}:${accountId || 'anonymous'}`;
@@ -181,64 +89,33 @@ export const markRequestThresholdLatched = (accountId: string): void => {
 };
 
 /**
- * Resolves the treatment through a fallback chain so the experience is robust
- * offline and whether or not the backend has shipped its field yet:
+ * Resolves which treatment to render. The server is authoritative for assignment
+ * (treatment, participation and graduation), so the client no longer computes any
+ * of it — it only falls back gracefully when the server hasn't answered:
  *
  *   1. Backend-provided treatment (authoritative).
- *   2. Client-side computation (when the profile is available).
- *   3. Cached last-known treatment (offline / while stats load).
- *   4. Safe default (B) when nothing else is known.
+ *   2. Cached last-known treatment (offline / endpoint not yet reached).
+ *   3. Safe default (B) once we know the server won't tell us.
  *
- * Returns null only while a client-side result is still pending (stats loading),
- * so callers can render a neutral state instead of flickering.
+ * Returns null only while the first onboarding response is still pending and
+ * nothing is cached, so callers can render a neutral state instead of flashing B
+ * and then switching.
  */
 export const resolveFirstRequestTreatment = ({
   backendTreatment,
-  accountCreatedAt,
-  experimentLaunchedAt,
-  hasReachedThreshold,
-  createdRequests,
-  cohortId,
+  onboardingLoaded,
   cachedTreatment,
 }: {
   backendTreatment?: FirstRequestTreatment;
-  accountCreatedAt?: number;
-  experimentLaunchedAt: number;
-  // Sticky server-confirmed graduation latch; decides B on its own when true.
-  hasReachedThreshold: boolean;
-  // Local per-install created-request count (null while still loading).
-  createdRequests: number | null;
-  cohortId: string;
+  // Whether the onboarding fetch has settled (resolved or failed).
+  onboardingLoaded: boolean;
   cachedTreatment: FirstRequestTreatment | null;
 }): FirstRequestTreatment | null => {
-  // 1) Backend is authoritative when present.
   if (backendTreatment) {
     return backendTreatment;
   }
-
-  // 2) Client-side fallback when the profile loaded.
-  if (accountCreatedAt !== undefined) {
-    // Existing users are decided without waiting for local stats.
-    if (accountCreatedAt < experimentLaunchedAt) {
-      return 'B';
-    }
-    // Server-confirmed graduation is definitive and needs no local stats.
-    if (hasReachedThreshold) {
-      return 'B';
-    }
-    // Otherwise fall back to the local created-request count for graduation.
-    if (createdRequests !== null) {
-      return getFirstRequestTreatment({
-        accountCreatedAt,
-        experimentLaunchedAt,
-        hasGraduated: createdRequests >= FIRST_REQUEST_GRADUATION_THRESHOLD,
-        cohortId,
-      });
-    }
-    // Stats still loading: prefer a cached value over showing nothing.
+  if (cachedTreatment) {
     return cachedTreatment;
   }
-
-  // 3) Profile unavailable (offline / failed): last-known, else safe default.
-  return cachedTreatment ?? 'B';
+  return onboardingLoaded ? 'B' : null;
 };

--- a/packages/insomnia/src/ui/utils/first-request-treatment.ts
+++ b/packages/insomnia/src/ui/utils/first-request-treatment.ts
@@ -78,6 +78,37 @@ export const writeCachedFirstRequestTreatment = (accountId: string, treatment: F
   }
 };
 
+const BASELINE_KEY_PREFIX = 'insomnia.firstRequestCountBaseline';
+const baselineKey = (accountId: string) => `${BASELINE_KEY_PREFIX}:${accountId || 'anonymous'}`;
+
+/**
+ * `stats.createdRequests` is a device-wide lifetime counter, not scoped per
+ * account — switching accounts on the same install would otherwise let a brand
+ * new account inherit requests created by a previous account and graduate
+ * prematurely. This snapshots the counter's value the first time an account is
+ * seen on this install, so callers can count only requests created since then.
+ */
+export const readRequestCountBaseline = (accountId: string): number | null => {
+  try {
+    const value = window.localStorage.getItem(baselineKey(accountId));
+    if (value === null) {
+      return null;
+    }
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+export const writeRequestCountBaseline = (accountId: string, count: number): void => {
+  try {
+    window.localStorage.setItem(baselineKey(accountId), String(count));
+  } catch {
+    // Ignore storage failures (e.g. private mode / quota).
+  }
+};
+
 const LATCH_KEY_PREFIX = 'insomnia.firstRequestThresholdLatched';
 const latchKey = (accountId: string) => `${LATCH_KEY_PREFIX}:${accountId || 'anonymous'}`;
 

--- a/packages/insomnia/src/ui/utils/first-request-treatment.ts
+++ b/packages/insomnia/src/ui/utils/first-request-treatment.ts
@@ -1,6 +1,14 @@
-import type { UserOnboardingState } from 'insomnia-api';
+import { type UserOnboarding, UserOnboardingFirstRequestTreatmentEnum } from 'insomnia-api';
 
 export type FirstRequestTreatment = 'A' | 'B';
+
+// The generated SDK type omits `null` for `first_request_treatment` despite the
+// OpenAPI spec marking it nullable — the server sends `null` when the treatment
+// is unknown (see UserOnboarding). Widen it back here so callers can pass the raw
+// server response through without a cast.
+type OnboardingState = Omit<UserOnboarding, 'first_request_treatment'> & {
+  first_request_treatment: UserOnboarding['first_request_treatment'] | null;
+};
 
 /**
  * Number of created requests after which a new sign-up graduates from the
@@ -24,14 +32,20 @@ export const getFirstRequestTreatmentGroup = (treatment: FirstRequestTreatment):
 /**
  * Reads the server-computed treatment from the onboarding resource (field
  * `first_request_treatment`). The server is authoritative for assignment; the
- * client does not compute treatment itself. Returns undefined if absent or
- * invalid, so the caller can fall back to the cached value / safe default.
+ * client does not compute treatment itself. Returns undefined if absent/unknown
+ * or invalid, so the caller can fall back to the cached value / safe default.
  */
 export const getOnboardingTreatment = (
-  onboarding: UserOnboardingState | null | undefined,
+  onboarding: OnboardingState | null | undefined,
 ): FirstRequestTreatment | undefined => {
   const value = onboarding?.first_request_treatment;
-  return value === 'A' || value === 'B' ? value : undefined;
+  if (value === UserOnboardingFirstRequestTreatmentEnum.TreatmentA) {
+    return 'A';
+  }
+  if (value === UserOnboardingFirstRequestTreatmentEnum.TreatmentB) {
+    return 'B';
+  }
+  return undefined;
 };
 
 /**
@@ -39,7 +53,7 @@ export const getOnboardingTreatment = (
  * sole signal for experiment participation (whether to emit assignment analytics);
  * an absent flag means "not a confirmed participant".
  */
-export const getOnboardingIsNewSignup = (onboarding: UserOnboardingState | null | undefined): boolean | undefined => {
+export const getOnboardingIsNewSignup = (onboarding: OnboardingState | null | undefined): boolean | undefined => {
   const value = onboarding?.is_new_signup;
   return typeof value === 'boolean' ? value : undefined;
 };

--- a/packages/insomnia/src/ui/utils/first-request-treatment.ts
+++ b/packages/insomnia/src/ui/utils/first-request-treatment.ts
@@ -17,6 +17,13 @@ export const FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE = Date.parse('2026-07-18T00:00
 
 const CACHE_KEY_PREFIX = 'insomnia.firstRequestTreatment';
 
+/** Experiment name used in analytics (the `experiment_name` column). */
+export const FIRST_REQUEST_EXPERIMENT_NAME = 'new_user_first_request_experience';
+
+/** Maps the internal treatment to the analytics `treatment_group` value. */
+export const getFirstRequestTreatmentGroup = (treatment: FirstRequestTreatment): 'treatment_a' | 'treatment_b' =>
+  treatment === 'A' ? 'treatment_a' : 'treatment_b';
+
 /**
  * Deterministic ~50/50 cohort assignment for the first-request experiment.
  *
@@ -81,6 +88,41 @@ export const getFirstRequestTreatment = ({
 export const getBackendFirstRequestTreatment = (user: unknown): FirstRequestTreatment | undefined => {
   const value = (user as { first_request_treatment?: unknown } | null | undefined)?.first_request_treatment;
   return value === 'A' || value === 'B' ? value : undefined;
+};
+
+/**
+ * Reads the server's `is_new_signup` flag from the user profile, when provided.
+ * Used to decide whether the user is an experiment participant for analytics.
+ */
+export const getBackendIsNewSignup = (user: unknown): boolean | undefined => {
+  const value = (user as { is_new_signup?: unknown } | null | undefined)?.is_new_signup;
+  return typeof value === 'boolean' ? value : undefined;
+};
+
+/**
+ * Whether the user is part of the experiment population (a genuine new sign-up),
+ * as opposed to a pre-existing user who is simply defaulted to Treatment B.
+ *
+ * Prefers the server `is_new_signup` flag; otherwise derives it from the account
+ * creation date vs GA. Returns false when neither is known (can't confirm → don't
+ * emit assignment analytics).
+ */
+export const isFirstRequestExperimentParticipant = ({
+  isNewSignup,
+  accountCreatedAt,
+  experimentLaunchedAt,
+}: {
+  isNewSignup?: boolean;
+  accountCreatedAt?: number;
+  experimentLaunchedAt: number;
+}): boolean => {
+  if (isNewSignup !== undefined) {
+    return isNewSignup;
+  }
+  if (accountCreatedAt !== undefined) {
+    return accountCreatedAt >= experimentLaunchedAt;
+  }
+  return false;
 };
 
 const cacheKey = (accountId: string) => `${CACHE_KEY_PREFIX}:${accountId || 'anonymous'}`;

--- a/packages/insomnia/src/ui/utils/first-request-treatment.ts
+++ b/packages/insomnia/src/ui/utils/first-request-treatment.ts
@@ -7,21 +7,22 @@ export type FirstRequestTreatment = 'A' | 'B';
 export const FIRST_REQUEST_GRADUATION_THRESHOLD = 3;
 
 /**
- * v13.1.0 GA release date (epoch ms). Accounts created before this are considered
- * pre-existing users and always get Treatment B ("fresh slate" at launch); only
- * accounts created on/after this date enter the A/B experiment.
+ * v13.1.0 GA release date (epoch ms). Only used by the client-side fallback when
+ * the backend does not (yet) return a treatment. Accounts created before this are
+ * treated as pre-existing users (Treatment B).
  *
  * TODO(INS-2933): set to the actual v13.1.0 GA date before release.
  */
-export const FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE = Date.parse('2026-07-06T00:00:00.000Z');
+export const FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE = Date.parse('2026-07-18T00:00:00.000Z');
+
+const CACHE_KEY_PREFIX = 'insomnia.firstRequestTreatment';
 
 /**
  * Deterministic ~50/50 cohort assignment for the first-request experiment.
  *
- * There is no A/B framework, so we bucket each user by hashing a stable id
- * (accountId, falling back to deviceId). This is stable per user across sessions
- * and devices (when keyed on accountId) and needs no stored state. Over the whole
- * sign-up population the parity of the hash splits ~50/50 between A and B.
+ * Used only by the client-side fallback (the backend is authoritative when it
+ * returns a treatment). Buckets a user by hashing a stable id (accountId, falling
+ * back to deviceId); stable per user, needs no stored state, splits ~50/50.
  */
 export const getFirstRequestCohort = (id: string): FirstRequestTreatment => {
   if (!id) {
@@ -39,17 +40,13 @@ export const getFirstRequestCohort = (id: string): FirstRequestTreatment => {
 };
 
 /**
- * Decides which first-request experience treatment to show.
+ * Pure client-side treatment computation (the fallback used when the backend does
+ * not return a treatment).
  *
- * - Users whose account was created before the experiment launched are existing
- *   users and always get Treatment B (regardless of how many requests they've made).
- * - New sign-ups are split ~50/50 into Treatment A or B by {@link getFirstRequestCohort}.
- * - A new sign-up in Treatment A graduates to Treatment B once they have created
+ * - Accounts created before the experiment launched are existing users → B.
+ * - New sign-ups are split ~50/50 into A or B by {@link getFirstRequestCohort}.
+ * - A new sign-up in Treatment A graduates to B once they have created
  *   {@link FIRST_REQUEST_GRADUATION_THRESHOLD} or more requests.
- *
- * `accountCreatedAt` is the account creation time (epoch ms); when undefined (e.g.
- * the profile hasn't loaded) we can't confirm they're pre-existing, so we treat
- * them via the new-sign-up path.
  */
 export const getFirstRequestTreatment = ({
   accountCreatedAt,
@@ -71,4 +68,87 @@ export const getFirstRequestTreatment = ({
   }
 
   return getFirstRequestCohort(cohortId);
+};
+
+/**
+ * Reads the server-computed treatment from the user profile, when the backend
+ * provides it (field `first_request_treatment`). Returns undefined if absent or
+ * invalid, so the caller can fall back to the client-side computation.
+ *
+ * Typed as `unknown` because the generated `User` SDK type does not include the
+ * field yet; remove the cast once the SDK is regenerated with it.
+ */
+export const getBackendFirstRequestTreatment = (user: unknown): FirstRequestTreatment | undefined => {
+  const value = (user as { first_request_treatment?: unknown } | null | undefined)?.first_request_treatment;
+  return value === 'A' || value === 'B' ? value : undefined;
+};
+
+const cacheKey = (accountId: string) => `${CACHE_KEY_PREFIX}:${accountId || 'anonymous'}`;
+
+/** Last-known treatment for this account, used as an offline fallback. */
+export const readCachedFirstRequestTreatment = (accountId: string): FirstRequestTreatment | null => {
+  try {
+    const value = window.localStorage.getItem(cacheKey(accountId));
+    return value === 'A' || value === 'B' ? value : null;
+  } catch {
+    return null;
+  }
+};
+
+export const writeCachedFirstRequestTreatment = (accountId: string, treatment: FirstRequestTreatment): void => {
+  try {
+    window.localStorage.setItem(cacheKey(accountId), treatment);
+  } catch {
+    // Ignore storage failures (e.g. private mode / quota).
+  }
+};
+
+/**
+ * Resolves the treatment through a fallback chain so the experience is robust
+ * offline and whether or not the backend has shipped its field yet:
+ *
+ *   1. Backend-provided treatment (authoritative).
+ *   2. Client-side computation (when the profile is available).
+ *   3. Cached last-known treatment (offline / while stats load).
+ *   4. Safe default (B) when nothing else is known.
+ *
+ * Returns null only while a client-side result is still pending (stats loading),
+ * so callers can render a neutral state instead of flickering.
+ */
+export const resolveFirstRequestTreatment = ({
+  backendTreatment,
+  accountCreatedAt,
+  experimentLaunchedAt,
+  createdRequests,
+  cohortId,
+  cachedTreatment,
+}: {
+  backendTreatment?: FirstRequestTreatment;
+  accountCreatedAt?: number;
+  experimentLaunchedAt: number;
+  createdRequests: number | null;
+  cohortId: string;
+  cachedTreatment: FirstRequestTreatment | null;
+}): FirstRequestTreatment | null => {
+  // 1) Backend is authoritative when present.
+  if (backendTreatment) {
+    return backendTreatment;
+  }
+
+  // 2) Client-side fallback when the profile loaded.
+  if (accountCreatedAt !== undefined) {
+    // Existing users are decided without waiting for local stats.
+    if (accountCreatedAt < experimentLaunchedAt) {
+      return 'B';
+    }
+    // New sign-ups need the created-request count to decide graduation.
+    if (createdRequests !== null) {
+      return getFirstRequestTreatment({ accountCreatedAt, experimentLaunchedAt, createdRequests, cohortId });
+    }
+    // Stats still loading: prefer a cached value over showing nothing.
+    return cachedTreatment;
+  }
+
+  // 3) Profile unavailable (offline / failed): last-known, else safe default.
+  return cachedTreatment ?? 'B';
 };

--- a/packages/insomnia/src/ui/utils/first-request-treatment.ts
+++ b/packages/insomnia/src/ui/utils/first-request-treatment.ts
@@ -1,3 +1,5 @@
+import type { UserOnboardingState } from 'insomnia-api';
+
 export type FirstRequestTreatment = 'A' | 'B';
 
 /**
@@ -52,25 +54,25 @@ export const getFirstRequestCohort = (id: string): FirstRequestTreatment => {
  *
  * - Accounts created before the experiment launched are existing users → B.
  * - New sign-ups are split ~50/50 into A or B by {@link getFirstRequestCohort}.
- * - A new sign-up in Treatment A graduates to B once they have created
- *   {@link FIRST_REQUEST_GRADUATION_THRESHOLD} or more requests.
+ * - A new sign-up in Treatment A graduates to B once they have graduated (created
+ *   at least {@link FIRST_REQUEST_GRADUATION_THRESHOLD} requests — a sticky fact).
  */
 export const getFirstRequestTreatment = ({
   accountCreatedAt,
   experimentLaunchedAt,
-  createdRequests,
+  hasGraduated,
   cohortId,
 }: {
   accountCreatedAt?: number;
   experimentLaunchedAt: number;
-  createdRequests: number;
+  hasGraduated: boolean;
   cohortId: string;
 }): FirstRequestTreatment => {
   if (accountCreatedAt !== undefined && accountCreatedAt < experimentLaunchedAt) {
     return 'B';
   }
 
-  if (createdRequests >= FIRST_REQUEST_GRADUATION_THRESHOLD) {
+  if (hasGraduated) {
     return 'B';
   }
 
@@ -78,25 +80,34 @@ export const getFirstRequestTreatment = ({
 };
 
 /**
- * Reads the server-computed treatment from the user profile, when the backend
- * provides it (field `first_request_treatment`). Returns undefined if absent or
- * invalid, so the caller can fall back to the client-side computation.
- *
- * Typed as `unknown` because the generated `User` SDK type does not include the
- * field yet; remove the cast once the SDK is regenerated with it.
+ * Reads the server-computed treatment from the onboarding resource, when the
+ * backend is steering assignment (field `first_request_treatment`). Returns
+ * undefined if absent or invalid, so the caller can fall back to the client-side
+ * computation.
  */
-export const getBackendFirstRequestTreatment = (user: unknown): FirstRequestTreatment | undefined => {
-  const value = (user as { first_request_treatment?: unknown } | null | undefined)?.first_request_treatment;
+export const getOnboardingTreatment = (
+  onboarding: UserOnboardingState | null | undefined,
+): FirstRequestTreatment | undefined => {
+  const value = onboarding?.first_request_treatment;
   return value === 'A' || value === 'B' ? value : undefined;
 };
 
 /**
- * Reads the server's `is_new_signup` flag from the user profile, when provided.
- * Used to decide whether the user is an experiment participant for analytics.
+ * Reads the server's `is_new_signup` flag from the onboarding resource, when
+ * provided. Used to decide whether the user is an experiment participant.
  */
-export const getBackendIsNewSignup = (user: unknown): boolean | undefined => {
-  const value = (user as { is_new_signup?: unknown } | null | undefined)?.is_new_signup;
+export const getOnboardingIsNewSignup = (onboarding: UserOnboardingState | null | undefined): boolean | undefined => {
+  const value = onboarding?.is_new_signup;
   return typeof value === 'boolean' ? value : undefined;
+};
+
+/**
+ * Reads the sticky "reached the graduation threshold" latch from the onboarding
+ * resource. This is the account-wide, device-independent, irreversible source of
+ * truth for graduation; defaults to false when the server hasn't confirmed it.
+ */
+export const getOnboardingReachedThreshold = (onboarding: UserOnboardingState | null | undefined): boolean => {
+  return onboarding?.has_reached_request_threshold === true;
 };
 
 /**
@@ -145,6 +156,30 @@ export const writeCachedFirstRequestTreatment = (accountId: string, treatment: F
   }
 };
 
+const LATCH_KEY_PREFIX = 'insomnia.firstRequestThresholdLatched';
+const latchKey = (accountId: string) => `${LATCH_KEY_PREFIX}:${accountId || 'anonymous'}`;
+
+/**
+ * Whether this install has already confirmed the graduation-threshold latch with
+ * the server for this account. Purely a local optimisation to avoid re-POSTing an
+ * idempotent latch — the server remains the source of truth.
+ */
+export const isRequestThresholdLatched = (accountId: string): boolean => {
+  try {
+    return window.localStorage.getItem(latchKey(accountId)) === '1';
+  } catch {
+    return false;
+  }
+};
+
+export const markRequestThresholdLatched = (accountId: string): void => {
+  try {
+    window.localStorage.setItem(latchKey(accountId), '1');
+  } catch {
+    // Ignore storage failures; we simply retry the (idempotent) latch next time.
+  }
+};
+
 /**
  * Resolves the treatment through a fallback chain so the experience is robust
  * offline and whether or not the backend has shipped its field yet:
@@ -161,6 +196,7 @@ export const resolveFirstRequestTreatment = ({
   backendTreatment,
   accountCreatedAt,
   experimentLaunchedAt,
+  hasReachedThreshold,
   createdRequests,
   cohortId,
   cachedTreatment,
@@ -168,6 +204,9 @@ export const resolveFirstRequestTreatment = ({
   backendTreatment?: FirstRequestTreatment;
   accountCreatedAt?: number;
   experimentLaunchedAt: number;
+  // Sticky server-confirmed graduation latch; decides B on its own when true.
+  hasReachedThreshold: boolean;
+  // Local per-install created-request count (null while still loading).
   createdRequests: number | null;
   cohortId: string;
   cachedTreatment: FirstRequestTreatment | null;
@@ -183,9 +222,18 @@ export const resolveFirstRequestTreatment = ({
     if (accountCreatedAt < experimentLaunchedAt) {
       return 'B';
     }
-    // New sign-ups need the created-request count to decide graduation.
+    // Server-confirmed graduation is definitive and needs no local stats.
+    if (hasReachedThreshold) {
+      return 'B';
+    }
+    // Otherwise fall back to the local created-request count for graduation.
     if (createdRequests !== null) {
-      return getFirstRequestTreatment({ accountCreatedAt, experimentLaunchedAt, createdRequests, cohortId });
+      return getFirstRequestTreatment({
+        accountCreatedAt,
+        experimentLaunchedAt,
+        hasGraduated: createdRequests >= FIRST_REQUEST_GRADUATION_THRESHOLD,
+        cohortId,
+      });
     }
     // Stats still loading: prefer a cached value over showing nothing.
     return cachedTreatment;

--- a/packages/insomnia/src/ui/utils/first-request-treatment.ts
+++ b/packages/insomnia/src/ui/utils/first-request-treatment.ts
@@ -48,16 +48,6 @@ export const getOnboardingTreatment = (
   return undefined;
 };
 
-/**
- * Reads the server's `is_new_signup` flag from the onboarding resource. This is the
- * sole signal for experiment participation (whether to emit assignment analytics);
- * an absent flag means "not a confirmed participant".
- */
-export const getOnboardingIsNewSignup = (onboarding: OnboardingState | null | undefined): boolean | undefined => {
-  const value = onboarding?.is_new_signup;
-  return typeof value === 'boolean' ? value : undefined;
-};
-
 const cacheKey = (accountId: string) => `${CACHE_KEY_PREFIX}:${accountId || 'anonymous'}`;
 
 /** Last-known treatment for this account, used as an offline fallback. */

--- a/packages/insomnia/src/ui/utils/method-colors.test.ts
+++ b/packages/insomnia/src/ui/utils/method-colors.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  METHOD_DELETE,
+  METHOD_GET,
+  METHOD_POST,
+} from '../../common/constants';
+import { getMethodPillClasses, getMethodTextClasses } from './method-colors';
+
+describe('method-colors', () => {
+  describe('getMethodPillClasses', () => {
+    it('maps a known method to its theme background + font colour', () => {
+      expect(getMethodPillClasses(METHOD_POST)).toContain('bg-(--color-success)');
+      expect(getMethodPillClasses(METHOD_POST)).toContain('text-(--color-font-success)');
+    });
+
+    it('uses the bespoke GET colour with no darkening overlay', () => {
+      expect(getMethodPillClasses(METHOD_GET)).toBe('bg-[#6B6296] text-white');
+      expect(getMethodPillClasses(METHOD_GET)).not.toContain('linear-gradient');
+    });
+
+    it('darkens every themed non-GET method with a 40% black overlay', () => {
+      expect(getMethodPillClasses(METHOD_DELETE)).toContain('linear-gradient(rgba(0,0,0,0.4),rgba(0,0,0,0.4))');
+    });
+
+    it('falls back to the neutral grey pill for unknown/custom methods (e.g. LINK)', () => {
+      expect(getMethodPillClasses('LINK')).toBe('bg-[#424242] text-white');
+    });
+  });
+
+  describe('getMethodTextClasses', () => {
+    it('maps a known method to its theme text colour', () => {
+      expect(getMethodTextClasses(METHOD_GET)).toBe('text-(--color-surprise)');
+    });
+
+    it('falls back to the default font colour for unknown/custom methods', () => {
+      expect(getMethodTextClasses('PURGE')).toBe('text-(--color-font)');
+    });
+  });
+});

--- a/packages/insomnia/src/ui/utils/method-colors.ts
+++ b/packages/insomnia/src/ui/utils/method-colors.ts
@@ -1,0 +1,83 @@
+import {
+  METHOD_DELETE,
+  METHOD_GET,
+  METHOD_HEAD,
+  METHOD_OPTIONS,
+  METHOD_PATCH,
+  METHOD_POST,
+  METHOD_PUT,
+  METHOD_QUERY,
+} from '../../common/constants';
+
+/**
+ * Shared HTTP method → theme colour mapping.
+ *
+ * Each method maps to one of the existing theme colour families (surprise,
+ * success, warning, notice, danger, info). Unknown/custom methods fall back to
+ * a neutral highlight so any string is renderable.
+ */
+
+// Tailwind classes for a filled "pill" button: solid background + matching font.
+// The themed methods use the existing theme colour families (so they recolour
+// with the active theme); in the default theme they render as the design hexes:
+// POST #7ECF2B, PUT #FF9A1F, PATCH #F0E137, DELETE #FF5631, OPTIONS/HEAD #46C1E6.
+const METHOD_PILL_CLASSES: Record<string, string> = {
+  [METHOD_POST]: 'bg-(--color-success) text-(--color-font-success)',
+  [METHOD_PUT]: 'bg-(--color-warning) text-(--color-font-warning)',
+  [METHOD_PATCH]: 'bg-(--color-notice) text-(--color-font-notice)',
+  [METHOD_DELETE]: 'bg-(--color-danger) text-(--color-font-danger)',
+  [METHOD_OPTIONS]: 'bg-(--color-info) text-(--color-font-info)',
+  [METHOD_HEAD]: 'bg-(--color-info) text-(--color-font-info)',
+  [METHOD_QUERY]: 'bg-(--color-surprise) text-(--color-font-surprise)',
+};
+
+// GET uses a bespoke darker purple (#6B6296), not the raw surprise theme colour,
+// and — unlike every other method — is not darkened by the overlay.
+const GET_PILL_CLASSES = 'bg-[#6B6296] text-white';
+
+// Custom/unknown methods (e.g. LINK) use a neutral grey (#424242).
+const NEUTRAL_PILL_CLASSES = 'bg-[#424242] text-white';
+
+// Tailwind classes for the method name rendered as coloured text (no background).
+const METHOD_TEXT_CLASSES: Record<string, string> = {
+  [METHOD_GET]: 'text-(--color-surprise)',
+  [METHOD_POST]: 'text-(--color-success)',
+  [METHOD_PUT]: 'text-(--color-warning)',
+  [METHOD_PATCH]: 'text-(--color-notice)',
+  [METHOD_DELETE]: 'text-(--color-danger)',
+  [METHOD_OPTIONS]: 'text-(--color-info)',
+  [METHOD_HEAD]: 'text-(--color-info)',
+  [METHOD_QUERY]: 'text-(--color-surprise)',
+};
+
+const NEUTRAL_TEXT_CLASSES = 'text-(--color-font)';
+
+// A translucent black overlay (#00000066 → rgba(0,0,0,0.4)) layered on top of the
+// background colour to darken it. Applied to every themed method so the palette
+// reads as a cohesive set of related shades. GET and the neutral fallback are
+// exempt (they already use their final bespoke colour).
+const DARKEN_OVERLAY_CLASS = '[background-image:linear-gradient(rgba(0,0,0,0.4),rgba(0,0,0,0.4))]';
+
+/**
+ * Classes for a filled method pill/button (background + font colour). Themed
+ * methods get the darkening overlay; GET and custom/unknown methods use their
+ * bespoke colour as-is.
+ */
+export const getMethodPillClasses = (method: string): string => {
+  if (method === METHOD_GET) {
+    return GET_PILL_CLASSES;
+  }
+  const base = METHOD_PILL_CLASSES[method];
+  if (!base) {
+    return NEUTRAL_PILL_CLASSES;
+  }
+  return `${base} ${DARKEN_OVERLAY_CLASS}`;
+};
+
+/**
+ * Classes for the method name rendered as coloured text (used for dropdown
+ * menu items).
+ */
+export const getMethodTextClasses = (method: string): string => {
+  return METHOD_TEXT_CLASSES[method] || NEUTRAL_TEXT_CLASSES;
+};


### PR DESCRIPTION
Ships the `new_user_first_request_experience` A/B experiment for the empty-state "first request" pane on the project dashboard (v13.1.0), replacing the old "Welcome, {name}!" textarea experience.

- **Treatment A** ("fancier") — the compact "New request" card (method + URL + collection + Create) **plus** Quick actions and Start-with-an-example rows.
- **Treatment B** ("extra simple") — the same card only, with an inline error line and no quick actions/examples.

Only genuine new sign-ups (<3 requests created) are split ~50/50; existing users and graduated users always get B.

## How assignment works

Treatment is **backend-authoritative** with a client-side fallback so it works before the backend field ships and offline:

1. `first_request_treatment` from `GET /v3/users/me` (authoritative)
2. Client compute — `created_at` vs GA date + deterministic ~50/50 cohort hash + graduation at 3 created requests
3. Cached last-known treatment (offline)
4. Safe default `B`

Assignment analytics (`Experiment Assigned`) is emitted **client-only**, gated on `is_new_signup`, and only on change (initial + A→B).

## Backend dependency

Requires the server changes on `insomnia-api` branch INS-2933:
- Two optional fields on `GET /v3/users/me`: `first_request_treatment` (`"A"`/`"B"`) and `is_new_signup` (bool). Both optional/backward-compatible — client falls back to the local heuristic when absent.
- `POST /v3/users/me/requests-created` — the client now reports each request creation (fire-and-forget, one call per request, no-op when logged out) so the backend keeps a device-independent, account-level count powering graduation.

## Changes

- `first-request-treatment.ts` (+tests) — pure resolution logic: resolution chain, cohort hash, GA constant, backend readers, participant check, per-account cache, analytics mapping.
- `first-request-creation.tsx` — both-treatment card UI + wiring; resolves treatment, caches it, emits assignment analytics.
- `request.new.tsx` — reports request creation to the backend on create.
- `insomnia-api/src/user.ts` (+tests) — `reportRequestsCreated()`.
- `insomnia-analytics/src/events.ts` — `Experiment Assigned` event.
- `method-selector.tsx` + `method-colors.ts` (+tests) — reusable method dropdown, now also used in the request URL bar.

## Notes / follow-ups

- `FIRST_REQUEST_EXPERIMENT_LAUNCH_DATE` is a placeholder (`TODO(INS-2933)`) — set to the real GA instant (UTC) at release. Only used by the client fallback; the GA cutoff is otherwise server config.
- Analytics warehouse work (`experiment_assignments` table) is tracked separately.

## Testing

- `npm test -w packages/insomnia-api` and the new unit tests pass (run under Node 22).
- [ ] Verify A vs B render, graduation at 3 requests, and `Experiment Assigned` emission for new sign-ups only.

