### PR TITLE
fix: restore project modal top-anchored positioning

### DIFF
--- a/packages/insomnia/src/ui/components/modals/project-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/project-modal.tsx
@@ -58,11 +58,11 @@ export const ProjectModal = ({
             if (!open) requestClose();
           }}
           isDismissable={false}
-          className="fixed top-0 left-0 z-10 flex h-(--visual-viewport-height) w-full items-center justify-center bg-black/30"
+          className="fixed top-0 right-0 bottom-0 left-0 z-10 flex items-start justify-center bg-black/30 pt-[70px]"
         >
           <Modal
             ref={modalRef}
-            className="flex h-max max-h-[calc(100%-var(--padding-xl))] w-full max-w-3xl flex-col overflow-hidden rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) text-(--color-font)"
+            className="flex max-h-[calc(var(--visual-viewport-height)-140px)] w-full max-w-3xl flex-col overflow-hidden rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) text-(--color-font)"
           >
             <Dialog
               aria-label="Create or update dialog"


### PR DESCRIPTION
### Summary  
- Restores the `ModalOverlay` to `items-start pt-[70px]` positioning, reverting a regression that switched the modal to vertically centered. After some discussion with the design team, top-anchored positioning is intentional: it pins the modal's top edge so that as form content grows (e.g. git credentials expanding), the modal extends downward rather than shifting both edges symmetrically, preventing a seemingly "jumping" behaviour. This change should also fix the overflow issue where the `Scan for files` button was not visible on shorter viewports. 

### Root Cause
- #10097 accidentally changed `pt-[70px]` → `pt-[200px]`. #10144 fixed the overflow issue that was a consequence of the padding styling changes, but switched to `items-center justify-center`, removing the top-anchored positioning the design requires.
