### PR TITLE
fix(templating): canonicalize declared module aliases in resolveTemplateTagModules

### DIFF
--- a/packages/insomnia/src/templating/sandbox/module-registry.ts
+++ b/packages/insomnia/src/templating/sandbox/module-registry.ts
@@ -129,11 +129,17 @@ export const TEMPLATE_TAG_BASELINE_MODULES: string[] = ['path', 'crypto'];
  * they simply fail at require time with "not available in sandbox" (parse and grant are separate
  * concerns). Profile-ceiling intersection is added in P1.
  */
+// alias -> canonical (e.g. "node:events" -> "events"); a Map so keys like "__proto__" stay literal.
+const canonicalModuleName = new Map<string, string>(
+  SANDBOX_MODULES.flatMap(m => [[m.name, m.name], ...(m.aliases ?? []).map(a => [a, m.name] as [string, string])]),
+);
+
 export const resolveTemplateTagModules = (declaredModules: string[] = []): string[] => {
   const resolved = [...TEMPLATE_TAG_BASELINE_MODULES];
   for (const name of declaredModules) {
-    if (!resolved.includes(name)) {
-      resolved.push(name);
+    const canonical = canonicalModuleName.get(name) ?? name;
+    if (!resolved.includes(canonical)) {
+      resolved.push(canonical);
     }
   }
   return resolved;

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
@@ -435,6 +435,22 @@ describe('manifest-declared module grants (C3)', () => {
     expect(resolveTemplateTagModules(['path'])).toEqual(TEMPLATE_TAG_BASELINE_MODULES);
   });
 
+  it('canonicalizes declared aliases so the node:-prefixed form grants the module', () => {
+    expect(resolveTemplateTagModules(['node:events'])).toEqual([...TEMPLATE_TAG_BASELINE_MODULES, 'events']);
+    // node:crypto resolves to the already-baseline crypto without duplicating it.
+    expect(resolveTemplateTagModules(['node:crypto'])).toEqual(TEMPLATE_TAG_BASELINE_MODULES);
+  });
+
+  it('a plugin declaring the node:events alias can use EventEmitter', async () => {
+    const actual = await runTagInSandbox({
+      pluginSource: eventsTag,
+      tagName: 'r',
+      envelope: envelope([], resolveTemplateTagModules(['node:events'])),
+      bridge: noBridge,
+    });
+    expect(actual).toBe('fired');
+  });
+
   it('a plugin granted "events" can use EventEmitter', async () => {
     const actual = await runTagInSandbox({
       pluginSource: eventsTag,


### PR DESCRIPTION
## What this PR does

A plugin manifest declaring the node:-prefixed alias (e.g. "modules": ["node:events"]) stored that literal in grantedModules. At require time __require canonicalized it to "events", which was not in the granted list, causing a silent denial despite a valid declaration.

A alias-to-canonical Map from SANDBOX_MODULES canonicalizes each declared name before appending to the resolved set. Unknown names pass through unchanged and fail-closed at require. Two new tests cover the alias form granting the module and EventEmitter being usable after a node:events declaration.
