### PR TITLE
fix(sandbox): M2 stdlib parity fixes + bridge hardening

### DIFF
--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -43,7 +43,7 @@ export const resolveDbByKey = async (request: Request) => {
     : undefined;
   try {
     if (typeof handler !== 'function') {
-      throw new Error(`No host bridge handler registered for "${urlHostLowerCase}"`);
+      throw new TypeError(`No host bridge handler registered for "${urlHostLowerCase}"`);
     }
     const result = await handler(body);
     return new Response(JSON.stringify(result));

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -174,7 +174,7 @@ export const runPluginTagInSandbox = async (
       context: (context as Record<string, any>) || {},
       meta,
       renderPurpose,
-      appInfo: { version: app.getVersion(), platform: process.platform },
+      appInfo: { version: app.getVersion(), platform: process.platform, arch: process.arch },
       pluginName,
       renderDepth: 0,
       grantedModules: grantedModules ?? [...TEMPLATE_TAG_BASELINE_MODULES],

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -37,8 +37,15 @@ export const resolveDbByKey = async (request: Request) => {
     Object.entries(pluginToMainAPI).map(([key, value]) => [key.toLowerCase(), value]),
   );
   const urlHostLowerCase = url.host.toLowerCase();
+  // Own-property + function check so a key like "constructor" can't resolve to an inherited member.
+  const handler = Object.prototype.hasOwnProperty.call(withLowercasedKeys, urlHostLowerCase)
+    ? withLowercasedKeys[urlHostLowerCase]
+    : undefined;
   try {
-    const result = await withLowercasedKeys[urlHostLowerCase](body);
+    if (typeof handler !== 'function') {
+      throw new Error(`No host bridge handler registered for "${urlHostLowerCase}"`);
+    }
+    const result = await handler(body);
     return new Response(JSON.stringify(result));
   } catch (err) {
     console.error(`Error resolving db by key ${urlHostLowerCase}:`, err);

--- a/packages/insomnia/src/templating/sandbox/host-bridge.ts
+++ b/packages/insomnia/src/templating/sandbox/host-bridge.ts
@@ -23,7 +23,7 @@ export const createMapBridge =
     // an inherited Object.prototype member instead of a real handler.
     const handler = Object.prototype.hasOwnProperty.call(handlers, path) ? handlers[path] : undefined;
     if (typeof handler !== 'function') {
-      throw new Error(`No host bridge handler registered for "${path}"`);
+      throw new TypeError(`No host bridge handler registered for "${path}"`);
     }
     return handler(body);
   };

--- a/packages/insomnia/src/templating/sandbox/host-bridge.ts
+++ b/packages/insomnia/src/templating/sandbox/host-bridge.ts
@@ -19,8 +19,10 @@ export type HostBridge = (path: string, body: unknown) => Promise<unknown>;
 export const createMapBridge =
   (handlers: Record<string, (body: any) => Promise<unknown>>): HostBridge =>
   async (path, body) => {
-    const handler = handlers[path];
-    if (!handler) {
+    // Own-property + function check so a path like "constructor"/"hasOwnProperty" can't resolve to
+    // an inherited Object.prototype member instead of a real handler.
+    const handler = Object.prototype.hasOwnProperty.call(handlers, path) ? handlers[path] : undefined;
+    if (typeof handler !== 'function') {
       throw new Error(`No host bridge handler registered for "${path}"`);
     }
     return handler(body);

--- a/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
+++ b/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
@@ -113,8 +113,11 @@ export const IN_SANDBOX_BOOTSTRAP = [
   '  globalThis.console = { log: __log("log"), info: __log("info"), warn: __log("warn"), error: __log("error"), debug: __log("debug") };',
 
   // --- the single async bridge helper ---
+  // Capture then drop the global so plugin code can't call the raw bridge, bypassing context.*.
+  '  var __hostBridgeFn = globalThis.__hostBridge;',
+  '  delete globalThis.__hostBridge;',
   '  function __bridge(path, body) {',
-  '    return globalThis.__hostBridge(path, JSON.stringify(body || {})).then(function (raw) {',
+  '    return __hostBridgeFn(path, JSON.stringify(body || {})).then(function (raw) {',
   '      var res = JSON.parse(raw);',
   '      if (!res.ok) { throw new Error(res.error && res.error.message ? res.error.message : "host bridge error: " + path); }',
   '      return res.value;',

--- a/packages/insomnia/src/templating/sandbox/marshal.ts
+++ b/packages/insomnia/src/templating/sandbox/marshal.ts
@@ -16,7 +16,7 @@ export interface ContextEnvelope {
   /** Result of the host-side `getPurpose()` call. */
   renderPurpose?: RenderPurpose;
   /** `app.getInfo()` is synchronous, so its value is copied in rather than bridged. */
-  appInfo: { version: string; platform: string };
+  appInfo: { version: string; platform: string; arch: string };
   /** Owning plugin name — needed to scope `store.*` (pluginData) bridge calls. */
   pluginName: string;
   /** Unused: recursion via util.render is now prevented by rejecting {% tag %} syntax there, not by depth-limiting. */

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
@@ -564,6 +564,11 @@ describe('ambient globals — sandbox stdlib (M2)', () => {
       );
       expect(actual).toBe(nodeCrypto.createHash('sha256').update('insomnia').digest('hex'));
     });
+
+    it('randomUUID returns a v4 UUID (host-backed, matches node:crypto shape)', async () => {
+      const actual = await runGlobal('return crypto.randomUUID();');
+      expect(actual).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    });
   });
 
   describe('URL', () => {

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
@@ -635,6 +635,14 @@ describe('ambient globals — sandbox stdlib (M2)', () => {
       expect(new URLSearchParams(actual).get('q')).toBe('c d');
     });
 
+    it('copy-constructs from another URLSearchParams instance', async () => {
+      const actual = await runGlobal(
+        "var a = new URLSearchParams('x=1&y=2&x=3'); var b = new URLSearchParams(a); return b.toString();",
+      );
+      expect(actual).toBe(new URLSearchParams(new URLSearchParams('x=1&y=2&x=3')).toString());
+      expect(actual).toBe('x=1&y=2&x=3');
+    });
+
     it('set updates the first occurrence in place and drops the rest', async () => {
       const actual = await runGlobal("var p = new URLSearchParams('a=1&b=2&a=3'); p.set('a', '9'); return p.toString();");
       const expected = new URLSearchParams('a=1&b=2&a=3');

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
@@ -634,5 +634,13 @@ describe('ambient globals — sandbox stdlib (M2)', () => {
       // Parity: our '+'-encoding round-trips through node's URLSearchParams.
       expect(new URLSearchParams(actual).get('q')).toBe('c d');
     });
+
+    it('set updates the first occurrence in place and drops the rest', async () => {
+      const actual = await runGlobal("var p = new URLSearchParams('a=1&b=2&a=3'); p.set('a', '9'); return p.toString();");
+      const expected = new URLSearchParams('a=1&b=2&a=3');
+      expected.set('a', '9');
+      expect(actual).toBe(expected.toString());
+      expect(actual).toBe('a=9&b=2');
+    });
   });
 });

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
@@ -74,7 +74,7 @@ const envelope = (args: unknown[], grantedModules: string[] = TEMPLATE_TAG_BASEL
   context: {},
   meta: {},
   renderPurpose: 'preview',
-  appInfo: { version: '0.0.0', platform: 'linux' },
+  appInfo: { version: '0.0.0', platform: 'linux', arch: 'arm64' },
   pluginName: 'test-plugin',
   renderDepth: 0,
   grantedModules,
@@ -517,6 +517,11 @@ describe('ambient globals — sandbox stdlib (M2)', () => {
     it('exposes the host platform from the envelope', async () => {
       // envelope() sets appInfo.platform = 'linux'
       expect(await runGlobal('return process.platform;')).toBe('linux');
+    });
+
+    it('exposes the host arch from the envelope', async () => {
+      // envelope() sets appInfo.arch = 'arm64'; the stub must mirror it (not fall back to "unknown")
+      expect(await runGlobal('return process.arch;')).toBe('arm64');
     });
 
     it('has a frozen, empty env (no host environment leak)', async () => {

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
@@ -652,3 +652,13 @@ describe('ambient globals — sandbox stdlib (M2)', () => {
     });
   });
 });
+
+describe('createMapBridge — resolves only registered own handlers', () => {
+  it('rejects inherited Object.prototype keys instead of invoking them', async () => {
+    const bridge = createMapBridge({ real: async () => 'ok' });
+    expect(await bridge('real', {})).toBe('ok');
+    for (const evil of ['constructor', '__proto__', 'hasOwnProperty', 'toString']) {
+      await expect(bridge(evil, {})).rejects.toThrow(`No host bridge handler registered for "${evil}"`);
+    }
+  });
+});

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
@@ -653,6 +653,28 @@ describe('ambient globals — sandbox stdlib (M2)', () => {
   });
 });
 
+describe('raw host bridge is not reachable from plugin code', () => {
+  it('deletes __hostBridge from the sandbox global while context.* still round-trips', async () => {
+    const probe = await runTagInSandbox({
+      pluginSource: "module.exports.templateTags = [{ name: 'g', run: function () { return typeof globalThis.__hostBridge; } }];",
+      tagName: 'g',
+      envelope: envelope([]),
+      bridge: noBridge,
+    });
+    expect(probe).toBe('undefined');
+
+    const bridge = createMapBridge({ nodeOS: async () => ({ arch: 'test-arch' }) });
+    const viaContext = await runTagInSandbox({
+      pluginSource:
+        "module.exports.templateTags = [{ name: 'g', run: function (context) { return context.util.nodeOS().then(function (o) { return o.arch; }); } }];",
+      tagName: 'g',
+      envelope: envelope([]),
+      bridge,
+    });
+    expect(viaContext).toBe('test-arch');
+  });
+});
+
 describe('createMapBridge — resolves only registered own handlers', () => {
   it('rejects inherited Object.prototype keys instead of invoking them', async () => {
     const bridge = createMapBridge({ real: async () => 'ok' });

--- a/packages/insomnia/src/templating/sandbox/sandbox-globals.ts
+++ b/packages/insomnia/src/templating/sandbox/sandbox-globals.ts
@@ -153,6 +153,10 @@ export const SANDBOX_GLOBALS_SOURCE = [
   '        }',
   '      } else if (Object.prototype.toString.call(init) === "[object Array]") {',
   '        for (var a = 0; a < init.length; a++) { this._p.push([String(init[a][0]), String(init[a][1])]); }',
+  // Copy-construct from another URLSearchParams; without this the object branch would read its
+  // internal _p field as a bogus "_p" param.
+  '      } else if (init instanceof USP) {',
+  '        for (var c = 0; c < init._p.length; c++) { this._p.push([init._p[c][0], init._p[c][1]]); }',
   '      } else if (typeof init === "object") {',
   '        for (var key in init) { if (Object.prototype.hasOwnProperty.call(init, key)) { this._p.push([key, String(init[key])]); } }',
   '      }',

--- a/packages/insomnia/src/templating/sandbox/sandbox-globals.ts
+++ b/packages/insomnia/src/templating/sandbox/sandbox-globals.ts
@@ -96,10 +96,15 @@ export const SANDBOX_GLOBALS_SOURCE = [
   '    globalThis.process = Object.freeze(proc);',
   '  }',
 
-  // --- crypto (Web Crypto subset: getRandomValues + subtle.digest), host-backed ---
+  // --- crypto (Web Crypto subset: getRandomValues + randomUUID + subtle.digest), host-backed ---
   '  if (typeof globalThis.crypto === "undefined") {',
   '    var __algoMap = { "SHA-1": "sha1", "SHA-256": "sha256", "SHA-384": "sha384", "SHA-512": "sha512" };',
   '    globalThis.crypto = {',
+  // host-backed; throw (not weak fallback) when the host binding is absent, like getRandomValues.
+  '      randomUUID: function () {',
+  '        if (typeof globalThis.__cryptoRandomUUID !== "function") { throw new Error("crypto.randomUUID is not available in this sandbox"); }',
+  '        return globalThis.__cryptoRandomUUID();',
+  '      },',
   '      getRandomValues: function (typedArray) {',
   '        if (typeof globalThis.__cryptoRandomBytes !== "function") { throw new Error("crypto.getRandomValues is not available in this sandbox"); }',
   '        if (!typedArray || typeof typedArray.byteLength !== "number") { throw new TypeError("getRandomValues expects a TypedArray"); }',

--- a/packages/insomnia/src/templating/sandbox/sandbox-globals.ts
+++ b/packages/insomnia/src/templating/sandbox/sandbox-globals.ts
@@ -159,9 +159,10 @@ export const SANDBOX_GLOBALS_SOURCE = [
   '    };',
   '    var __enc = function (s) { return encodeURIComponent(s).replace(/%20/g, "+"); };',
   '    USP.prototype.append = function (k, v) { this._p.push([String(k), String(v)]); };',
+  // WHATWG: update the FIRST match in place, drop later ones; append if absent.
   '    USP.prototype.set = function (k, v) {',
   '      var found = false; k = String(k); v = String(v);',
-  '      for (var i = this._p.length - 1; i >= 0; i--) { if (this._p[i][0] === k) { if (found) { this._p.splice(i, 1); } else { this._p[i][1] = v; found = true; } } }',
+  '      for (var i = 0; i < this._p.length;) { if (this._p[i][0] === k) { if (found) { this._p.splice(i, 1); continue; } this._p[i][1] = v; found = true; } i++; }',
   '      if (!found) { this._p.push([k, v]); }',
   '    };',
   '    USP.prototype.get = function (k) { k = String(k); for (var i = 0; i < this._p.length; i++) { if (this._p[i][0] === k) { return this._p[i][1]; } } return null; };',


### PR DESCRIPTION
## What this PR does 

### Parity fixes (shim values that silently diverged from the host)
* `process.arch` — plumbed host arch through the envelope; was always `"unknown"`
* `crypto.randomUUID()` — wired to the existing host binding; was missing from the ambient shim
* `URLSearchParams.set()` — keeps the first occurrence (WHATWG), not the last
* `new URLSearchParams(instance)` — copy-constructs instead of reading its internal field

Bridge hardening (defense-in-depth ahead of C1 gating)
* Guard bridge dispatch — reject inherited keys (`constructor`, `hasOwnProperty`) instead of resolving them as handlers
* Hide raw `__hostBridge` from plugin code — captured into closure + global deleted, so plugins can't bypass the `context.*` wrappers