### PR TITLE
fix: plugin response body encoding

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/graphql.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/graphql.test.ts
@@ -1,7 +1,12 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
 import { expect } from '@playwright/test';
 
 import { loadFixture } from '../../playwright/paths';
 import { test } from '../../playwright/test';
+
+const RESPONSE_BODY_PLUGIN = 'insomnia-plugin-graphql-response-body';
 
 test('can render schema and send GraphQL requests', async ({ app, page, insomnia }) => {
   test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
@@ -148,6 +153,51 @@ test('can send GraphQL requests after editing and prettifying query', async ({ a
   await page.locator('pre[role="presentation"]:has-text("bearer")').click();
   await page.locator('.app').press('Enter');
   await page.locator('text=Prettify GraphQL').click();
+  await page.click('[data-testid="request-pane"] >> text=Send');
+  const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
+  await expect.soft(statusTag).toContainText('200 OK');
+
+  const responseBody = page.locator('[data-testid="response-pane"] >> [data-testid="CodeEditor"]:visible', {
+    has: page.locator('.CodeMirror-activeline'),
+  });
+  await expect.soft(responseBody).toContainText('"bearer": "Gandalf"');
+});
+
+test('renders the GraphQL response as text when a response-hook plugin reads the body', async ({
+  app,
+  page,
+  dataPath,
+  insomnia,
+}) => {
+  test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
+
+  const text = await loadFixture('graphql.yaml');
+  await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
+  await page.getByLabel('Import').click();
+  await page.locator('[data-test-id="import-from-clipboard"]').click();
+  await page.getByRole('button', { name: 'Scan' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+
+  await insomnia.navigationSidebar.clickRequestOrFolder('GraphQL request');
+  await page.getByRole('tab', { name: 'Body' }).click();
+  await expect.soft(page.getByText('Schema fetched just now')).toBeVisible();
+
+  const pluginDir = path.join(dataPath, 'plugins', RESPONSE_BODY_PLUGIN);
+  fs.mkdirSync(pluginDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pluginDir, 'package.json'),
+    JSON.stringify({ name: RESPONSE_BODY_PLUGIN, version: '1.0.0', main: 'index.js', insomnia: {} }),
+  );
+  fs.writeFileSync(
+    path.join(pluginDir, 'index.js'),
+    `module.exports.responseHooks = [async context => {
+       const body = await context.response.getBody();
+       context.response.setBody(Buffer.from(body.toString('utf8')));
+     }];`,
+  );
+  await page.evaluate(() => (window as any).main.plugins.reloadPlugins());
+  await page.getByText('Plugin system updated').waitFor({ state: 'hidden', timeout: 20_000 });
+
   await page.click('[data-testid="request-pane"] >> text=Send');
   const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
   await expect.soft(statusTag).toContainText('200 OK');

--- a/packages/insomnia/src/plugins/context/__tests__/response.test.ts
+++ b/packages/insomnia/src/plugins/context/__tests__/response.test.ts
@@ -3,7 +3,8 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import { services } from 'insomnia-data';
-import { describe, expect, it } from 'vitest';
+import { servicesNodeImpl } from 'insomnia-data/node';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import * as plugin from '../response';
 
@@ -32,6 +33,10 @@ describe('init()', () => {
 });
 
 describe('response.*', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('works for basic and full response', async () => {
     const bodyPath = path.join(tmpdir(), 'response.zip');
     fs.writeFileSync(bodyPath, Buffer.from('Hello World!'));
@@ -60,6 +65,34 @@ describe('response.*', () => {
     expect(result.response.getBytesRead()).toBe(0);
     expect(result.response.getTime()).toBe(0);
     expect((await result.response.getBody())?.length).toBe(0);
+  });
+
+  it('getBody returns a decodable Buffer even when the services bridge resolves a Uint8Array', async () => {
+    const decoded = '{"echoNum":777}';
+    const bridged = new Uint8Array(Buffer.from(decoded)) as unknown as Buffer;
+    vi.spyOn(servicesNodeImpl.helpers, 'getResponseBodyBuffer').mockResolvedValue(bridged);
+
+    const body = await plugin.init({ bodyPath: '/tmp/does-not-matter', statusCode: 200 }).response.getBody();
+
+    expect(Buffer.isBuffer(body)).toBe(true);
+    expect((body as Buffer).toString('utf8')).toBe(decoded);
+  });
+
+  it('setBody accepts bytes and strings, and rejects other values', () => {
+    const bodyPath = path.join(tmpdir(), 'set-body.response');
+    const { response } = plugin.init({ bodyPath });
+
+    response.setBody(Buffer.from('from-buffer'));
+    expect(fs.readFileSync(bodyPath, 'utf8')).toBe('from-buffer');
+
+    response.setBody(new Uint8Array(Buffer.from('from-uint8')));
+    expect(fs.readFileSync(bodyPath, 'utf8')).toBe('from-uint8');
+
+    response.setBody('from-string');
+    expect(fs.readFileSync(bodyPath, 'utf8')).toBe('from-string');
+
+    expect(() => response.setBody(Promise.resolve() as unknown as string)).toThrow(TypeError);
+    expect(() => response.setBody({} as unknown as string)).toThrow(/Buffer, Uint8Array, or string/);
   });
 
   it('works for getting headers', () => {

--- a/packages/insomnia/src/plugins/context/response.ts
+++ b/packages/insomnia/src/plugins/context/response.ts
@@ -47,8 +47,10 @@ export function init(response?: MaybeResponse) {
         return response.elapsedTime || 0;
       },
 
-      getBody() {
-        return services.helpers.getResponseBodyBuffer(response);
+      getBody(): Promise<Buffer | string> {
+        return services.helpers
+          .getResponseBodyBuffer(response)
+          .then(result => (typeof result === 'string' ? result : Buffer.from(result)));
       },
 
       getBodyStream() {
@@ -77,15 +79,19 @@ export function init(response?: MaybeResponse) {
         return getResponseBodyStream(response);
       },
 
-      setBody(body: Buffer) {
+      setBody(body: Buffer | Uint8Array | string) {
         // Should never happen but just in case it does...
         if (!response.bodyPath) {
           throw new Error('Could not set body without existing body path');
         }
 
+        if (typeof body !== 'string' && !ArrayBuffer.isView(body)) {
+          throw new TypeError('response.setBody expects a Buffer, Uint8Array, or string');
+        }
+
         const fs = require('node:fs');
         fs.writeFileSync(response.bodyPath, body);
-        response.bytesContent = body.length;
+        response.bytesContent = Buffer.byteLength(body);
       },
 
       getHeader(name: string): string | string[] | null {


### PR DESCRIPTION
Prevents plugin-accessed responses from stringifying to `Uint8Array` bytes

To be confirmed, but should close #10216 