### PR TITLE
fix: propagate system proxy settings to user requests (INS-2943)

### DIFF
--- a/packages/insomnia/src/main/api.protocol.ts
+++ b/packages/insomnia/src/main/api.protocol.ts
@@ -2,12 +2,12 @@ import path from 'node:path';
 import { Readable } from 'node:stream';
 import { parse as urlParse } from 'node:url';
 
-import { Curl, CurlAuth, CurlFeature, CurlProxy, CurlSslOpt, type HeaderInfo } from '@getinsomnia/node-libcurl';
+import { Curl, CurlAuth, CurlFeature, CurlSslOpt, type HeaderInfo } from '@getinsomnia/node-libcurl';
 import { app, net, protocol, session } from 'electron';
 import { services } from 'insomnia-data';
 
 import { getApiBaseURL } from '../common/constants';
-import { setDefaultProtocol, shouldBypassProxyForHost } from './network/libcurl-promise';
+import { parseResolvedProxy, setDefaultProtocol, shouldBypassProxyForHost } from './network/libcurl-promise';
 import { resolveDbByKey } from './templating-worker-database';
 
 export interface RegisterProtocolOptions {
@@ -54,7 +54,7 @@ export async function registerInsomniaProtocols() {
       const settings = await services.settings.get();
       // systemProxy follows the PAC return value format.
       // https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_PAC_file#return_value_format
-      let systemProxyStr = await session.defaultSession.resolveProxy(urlStr);
+      const systemProxyStr = await session.defaultSession.resolveProxy(urlStr);
 
       // here we use libcurl to forward the SSE request because the SSE request sent by net.fetch can not be disconnected correctly in some cases
       // see https://github.com/electron/electron/issues/47097
@@ -68,64 +68,12 @@ export async function registerInsomniaProtocols() {
 
           if (!settings.proxyEnabled) {
             // follow system proxy
-            if (!systemProxyStr) {
-              // if systemProxy is empty, it means no proxy is used
-              systemProxyStr = 'DIRECT';
-            }
-
-            const proxy = systemProxyStr
-              .trim()
-              .split(/\s*;\s*/g)
-              .find(Boolean);
-
-            // only the first proxy specified will be used
-            const firstProxy = proxy;
-            const parts = firstProxy?.split(/\s+/);
-
-            const proxyType = parts?.[0];
-
-            if (proxyType === 'DIRECT') {
-              curl.setOpt(Curl.option.PROXY, '');
+            const resolved = parseResolvedProxy(systemProxyStr);
+            if (resolved) {
+              curl.setOpt(Curl.option.PROXYTYPE, resolved.proxyType);
+              curl.setOpt(Curl.option.PROXY, resolved.proxyUrl);
             } else {
-              let unknownProxy = false;
-              let curlOptProxyType = CurlProxy.Http;
-              switch (proxyType) {
-                case 'PROXY': {
-                  curlOptProxyType = CurlProxy.Http;
-                  break;
-                }
-                case 'HTTP': {
-                  curlOptProxyType = CurlProxy.Http;
-                  break;
-                }
-                case 'SOCKS': {
-                  curlOptProxyType = CurlProxy.Socks4;
-                  break;
-                }
-                case 'HTTPS': {
-                  curlOptProxyType = CurlProxy.Https;
-                  break;
-                }
-                case 'SOCKS4': {
-                  curlOptProxyType = CurlProxy.Socks4;
-                  break;
-                }
-                case 'SOCKS5': {
-                  curlOptProxyType = CurlProxy.Socks5;
-                  break;
-                }
-                default: {
-                  // unknown proxy type
-                  unknownProxy = true;
-                  break;
-                }
-              }
-              if (unknownProxy) {
-                curl.setOpt(Curl.option.PROXY, '');
-              } else if (parts?.[1]) {
-                curl.setOpt(Curl.option.PROXYTYPE, curlOptProxyType);
-                curl.setOpt(Curl.option.PROXY, parts[1]);
-              }
+              curl.setOpt(Curl.option.PROXY, '');
             }
           } else {
             const { protocol, hostname } = urlParse(urlStr);

--- a/packages/insomnia/src/main/api.protocol.ts
+++ b/packages/insomnia/src/main/api.protocol.ts
@@ -54,7 +54,12 @@ export async function registerInsomniaProtocols() {
       const settings = await services.settings.get();
       // systemProxy follows the PAC return value format.
       // https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_PAC_file#return_value_format
-      const systemProxyStr = await session.defaultSession.resolveProxy(urlStr);
+      let systemProxyStr: string | undefined;
+      try {
+        systemProxyStr = await session.defaultSession.resolveProxy(urlStr);
+      } catch {
+        // If resolveProxy fails, fall back to direct connection
+      }
 
       // here we use libcurl to forward the SSE request because the SSE request sent by net.fetch can not be disconnected correctly in some cases
       // see https://github.com/electron/electron/issues/47097

--- a/packages/insomnia/src/main/network/curl.ts
+++ b/packages/insomnia/src/main/network/curl.ts
@@ -152,14 +152,15 @@ const openCurlConnection = async (
   try {
     invariant(options.url, 'URL must be defined');
     invariant(!options.url.startsWith('file://'), 'Local file URIs are not supported');
-    
+
     const readyStateChannel = `${protocolName}.${request._id}.${REALTIME_EVENTS_CHANNELS.READY_STATE}`;
 
     const settings = await services.settings.get();
     const start = performance.now();
     const clientCertificates = await services.clientCertificate.findByParentId(options.workspaceId);
     const filteredClientCertificates = filterClientCertificates(clientCertificates, options.url, 'https:');
-    const { curl, debugTimeline } = createConfiguredCurlInstance({
+
+    const { curl, debugTimeline } = await createConfiguredCurlInstance({
       req: { ...request, cookieJar: options.cookieJar, cookies: [], suppressUserAgent: options.suppressUserAgent },
       finalUrl: options.url,
       settings,

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -289,11 +289,11 @@ export const curlRequest = (options: CurlRequestOptions) =>
 
 /**
  * Parse a PAC-format proxy string (from Electron's session.resolveProxy) into
- * a curl proxy URL and type.  Returns empty string when DIRECT.
+ * a curl proxy URL and type.  Returns null when DIRECT.
  * Format: "PROXY host:port", "HTTPS host:port", "SOCKS host:port", etc.
  * https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_PAC_file#return_value_format
  */
-export function parseResolvedProxy(pacString: string | undefined): { proxyUrl: string; proxyType: number } | null {
+export function parseResolvedProxy(pacString: string | undefined): { proxyUrl: string; proxyType: CurlProxy } | null {
   if (!pacString) {
     return null;
   }
@@ -314,7 +314,7 @@ export function parseResolvedProxy(pacString: string | undefined): { proxyUrl: s
   if (!proxyAddr) {
     return null;
   }
-  let curlProxyType: number;
+  let curlProxyType: CurlProxy;
   switch (proxyType) {
     case 'PROXY':
     case 'HTTP': {
@@ -421,8 +421,13 @@ export const createConfiguredCurlInstance = async ({
 
   if (!settings.proxyEnabled) {
     // When proxy is not explicitly configured, fall back to system proxy
-    const systemProxy = await electron.session.defaultSession.resolveProxy(finalUrl);
-    const resolved = parseResolvedProxy(systemProxy);
+    let resolved: ReturnType<typeof parseResolvedProxy> = null;
+    try {
+      const systemProxy = await electron.session.defaultSession.resolveProxy(finalUrl);
+      resolved = parseResolvedProxy(systemProxy);
+    } catch {
+      // If resolveProxy fails (e.g. invalid URL, session issues), fall back to direct connection
+    }
     if (resolved) {
       curl.setOpt(Curl.option.PROXYTYPE, resolved.proxyType);
       curl.setOpt(Curl.option.PROXY, resolved.proxyUrl);

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -13,6 +13,7 @@ import {
   CurlHttpVersion,
   CurlInfoDebug,
   CurlNetrc,
+  CurlProxy,
   CurlSslOpt,
 } from '@getinsomnia/node-libcurl';
 import { isValid } from 'date-fns';
@@ -123,7 +124,7 @@ export const curlRequest = (options: CurlRequestOptions) =>
       invariant(!finalUrl.startsWith('file://'), 'Local file URIs are not supported');
       const caCert = caCertficatePath && (await insecureReadFile(caCertficatePath));
 
-      const { curl, debugTimeline } = createConfiguredCurlInstance({
+      const { curl, debugTimeline } = await createConfiguredCurlInstance({
         req,
         finalUrl,
         settings,
@@ -286,7 +287,61 @@ export const curlRequest = (options: CurlRequestOptions) =>
     }
   });
 
-export const createConfiguredCurlInstance = ({
+/**
+ * Parse a PAC-format proxy string (from Electron's session.resolveProxy) into
+ * a curl proxy URL and type.  Returns empty string when DIRECT.
+ * Format: "PROXY host:port", "HTTPS host:port", "SOCKS host:port", etc.
+ * https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_PAC_file#return_value_format
+ */
+export function parseResolvedProxy(pacString: string | undefined): { proxyUrl: string; proxyType: number } | null {
+  if (!pacString) {
+    return null;
+  }
+  // only the first proxy specified will be used
+  const proxy = pacString
+    .trim()
+    .split(/\s*;\s*/g)
+    .find(Boolean);
+  if (!proxy) {
+    return null;
+  }
+  const parts = proxy.split(/\s+/);
+  const proxyType = parts[0];
+  if (proxyType === 'DIRECT') {
+    return null;
+  }
+  const proxyAddr = parts[1];
+  if (!proxyAddr) {
+    return null;
+  }
+  let curlProxyType: number;
+  switch (proxyType) {
+    case 'PROXY':
+    case 'HTTP': {
+      curlProxyType = CurlProxy.Http;
+      break;
+    }
+    case 'HTTPS': {
+      curlProxyType = CurlProxy.Https;
+      break;
+    }
+    case 'SOCKS':
+    case 'SOCKS4': {
+      curlProxyType = CurlProxy.Socks4;
+      break;
+    }
+    case 'SOCKS5': {
+      curlProxyType = CurlProxy.Socks5;
+      break;
+    }
+    default: {
+      return null;
+    }
+  }
+  return { proxyUrl: proxyAddr, proxyType: curlProxyType };
+}
+
+export const createConfiguredCurlInstance = async ({
   req,
   finalUrl,
   settings,
@@ -365,7 +420,16 @@ export const createConfiguredCurlInstance = ({
   }
 
   if (!settings.proxyEnabled) {
-    curl.setOpt(Curl.option.PROXY, '');
+    // When proxy is not explicitly configured, fall back to system proxy
+    const systemProxy = await electron.session.defaultSession.resolveProxy(finalUrl);
+    const resolved = parseResolvedProxy(systemProxy);
+    if (resolved) {
+      curl.setOpt(Curl.option.PROXYTYPE, resolved.proxyType);
+      curl.setOpt(Curl.option.PROXY, resolved.proxyUrl);
+      debugTimeline.push({ value: `Using system proxy: ${resolved.proxyUrl}`, name: 'Text', timestamp: Date.now() });
+    } else {
+      curl.setOpt(Curl.option.PROXY, '');
+    }
   } else {
     const { protocol, hostname } = urlParse(req.url);
     const { httpProxy, httpsProxy, noProxy } = settings;

--- a/packages/insomnia/src/main/proxy.ts
+++ b/packages/insomnia/src/main/proxy.ts
@@ -31,6 +31,7 @@ async function updateProxy() {
       await session.defaultSession.setProxy({
         proxyRules: proxyRules.join(';'),
         proxyBypassRules: noProxy ?? '',
+        mode: 'fixed_servers',
       });
       return;
     } catch (err) {

--- a/packages/insomnia/src/main/proxy.ts
+++ b/packages/insomnia/src/main/proxy.ts
@@ -27,7 +27,6 @@ async function updateProxy() {
       }
 
       // Set proxy rules in the main session https://www.electronjs.org/docs/latest/api/structures/proxy-config
-      // no mode here — it overrides proxyRules ('system' ignores them)
       await session.defaultSession.setProxy({
         proxyRules: proxyRules.join(';'),
         proxyBypassRules: noProxy ?? '',


### PR DESCRIPTION
## Problem

When `proxyEnabled` is `false` in Insomnia Preferences, the request engine (`node-libcurl`) explicitly sets `CURLOPT_PROXY` to an empty string, which prevents libcurl from using **any** proxy — including the OS system proxy.

Meanwhile, Insomnia's own internal API calls (via Chromium/Electron's network stack) correctly fall back to the system proxy through `session.defaultSession` with `mode: 'system'`.

This causes a confusing behavior where:
- Insomnia's internal requests (cloud sync, analytics) respect the system proxy ✅
- User-initiated HTTP requests bypass the system proxy entirely ❌

## Fix

When `proxyEnabled` is `false`, call `session.defaultSession.resolveProxy(url)` to resolve the system proxy for the request URL, then apply it to the libcurl handle via `CURLOPT_PROXY` and `CURLOPT_PROXYTYPE`.

### Changes:
- **`libcurl-promise.ts`**: Add `parseResolvedProxy()` helper to parse PAC-format proxy strings; make `createConfiguredCurlInstance()` async and call `resolveProxy()` internally when proxy is not explicitly configured
- **`curl.ts`**: Await the now-async `createConfiguredCurlInstance()`
- **`api.protocol.ts`**: Use the shared `parseResolvedProxy()` helper, removing ~50 lines of duplicated proxy parsing logic

## Testing

Verified with a local HTTP/HTTPS proxy server:

| Scenario | User request goes through proxy? |
|----------|--------------------------------|
| Insomnia Preferences proxy configured | ✅ (before & after) |
| System proxy only (before fix) | ❌ |
| System proxy only (after fix) | ✅ |

Resolves [INS-2943](https://konghq.atlassian.net/browse/INS-2943)

[INS-2943]: https://konghq.atlassian.net/browse/INS-2943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ