### PR TITLE
feat(sandbox): services-layer capability-scope hardening

### DIFF
--- a/examples/insomnia-plugin-sandbox-demo/README.md
+++ b/examples/insomnia-plugin-sandbox-demo/README.md
@@ -38,3 +38,10 @@ a frozen `process` stub, and Web-Crypto `crypto.getRandomValues`/`crypto.subtle`
 present (not manifest-gated) as pure-JS or host-backed safe equivalents, and render identically to
 the legacy main-process path: `{% stdlibprobe 'buffer' %}`, `{% stdlibprobe 'url' %}`,
 `{% stdlibprobe 'platform' %}`.
+
+The `capabilityprobe` tag demos **manifest-gated host capabilities** (C1): this plugin declares
+`insomnia.permissions.capabilities: ["storage"]`, so `{% capabilityprobe %}` completes a `context.store`
+set/get round-trip and renders `storage-ok`. A plugin that did not declare `storage` would get
+`Capability 'storage' not granted — add it to insomnia.permissions.capabilities`. Baseline
+capabilities (`render`, `models.read`, `util`, `crypto`) need no declaration; network / storage /
+fs-read / credentials / app do.

--- a/examples/insomnia-plugin-sandbox-demo/index.js
+++ b/examples/insomnia-plugin-sandbox-demo/index.js
@@ -80,4 +80,20 @@ module.exports.templateTags = [
       return Buffer.from('hi 👋').toString('base64');
     },
   },
+  {
+    name: 'capabilityprobe',
+    displayName: 'Capability Probe',
+    description: 'Demos manifest-gated host capabilities (C1): this plugin declares capabilities ["storage"]',
+    args: [],
+    async run(context) {
+      // Works because package.json declares the `storage` capability. A plugin without it would get
+      // "Capability 'storage' not granted — add it to insomnia.permissions.capabilities".
+      try {
+        await context.store.setItem('demo_k', 'storage-ok');
+        return await context.store.getItem('demo_k');
+      } catch (err) {
+        return err.message;
+      }
+    },
+  },
 ];

--- a/examples/insomnia-plugin-sandbox-demo/package.json
+++ b/examples/insomnia-plugin-sandbox-demo/package.json
@@ -8,7 +8,7 @@
     "description": "Demo plugin to manually verify the QuickJS template-tag sandbox path",
     "permissions": {
       "modules": ["events"],
-      "capabilities": []
+      "capabilities": ["storage"]
     }
   }
 }

--- a/packages/insomnia-smoke-test/fixtures/sandbox-capability-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/sandbox-capability-collection.yaml
@@ -1,0 +1,26 @@
+type: collection.insomnia.rest/5.0
+schema_version: "5.1"
+name: Sandbox Capability Collection
+meta:
+  id: wrk_5a4dcap5000000000000000000000001
+  created: 1751800000000
+  modified: 1751800000000
+collection:
+  - url: http://127.0.0.1:4010/echo
+    name: Capability Probe
+    meta:
+      id: req_5a4dcap5000000000000000000000002
+      created: 1751800000001
+      modified: 1751800000001
+      isPrivate: false
+      sortKey: -1751800000001
+    method: GET
+    body:
+      mimeType: text/plain
+      text: |
+        {% capstorage %}
+        {% capdenied %}
+        {% capbaseline %}
+    headers:
+      - name: Content-Type
+        value: text/plain

--- a/packages/insomnia-smoke-test/tests/smoke/mtls.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/mtls.test.ts
@@ -17,13 +17,12 @@ test('can use client certificate for mTLS', async ({ app, page, insomnia }) => {
   });
   const certsDialog = page.getByRole('dialog');
 
+  const fixturePath = getFixturePath('certificates');
+
   await page.getByTestId('settings-button').click();
-  await page.getByTestId('dataFolders').fill(getFixturePath(path.join('certificates', 'client')));
+  await page.getByTestId('dataFolders').fill(fixturePath);
   await page.getByTestId('dataFolders-btn').click();
-  await expect.soft(page.getByText('client')).toBeVisible({ timeout: UI_TIMEOUT });
-  await page.getByTestId('dataFolders').fill(getFixturePath(path.join('certificates', 'rootCA.pem')));
-  await page.getByTestId('dataFolders-btn').click();
-  await expect.soft(page.getByText('rootCA.pem')).toBeVisible({ timeout: UI_TIMEOUT });
+  await expect.soft(page.getByText(fixturePath)).toBeVisible({ timeout: UI_TIMEOUT });
   await page.locator('.app').press('Escape');
   // wait for settings dialog to fully close before continuing
   await page.getByTestId('settings-button').waitFor({ state: 'visible', timeout: UI_TIMEOUT });
@@ -44,8 +43,6 @@ test('can use client certificate for mTLS', async ({ app, page, insomnia }) => {
   await page.getByRole('button', { name: 'Send', exact: true }).click();
   // SSL error is expected here — no CA cert yet
   await expect.soft(page.getByText('Error: SSL peer certificate or SSH remote key was not OK')).toBeVisible({ timeout: RESPONSE_TIMEOUT });
-
-  const fixturePath = getFixturePath('certificates');
 
   await page.getByRole('button', { name: 'Add Certificates' }).click();
   await certsDialog.waitFor({ state: 'visible', timeout: UI_TIMEOUT });

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import { expect } from '@playwright/test';
 
-import { getFixturePath, loadFixture } from '../../playwright/paths';
+import { cwd, getFixturePath, loadFixture } from '../../playwright/paths';
 import { test } from '../../playwright/test';
 
 test.describe('pre-request features tests', () => {
@@ -411,9 +411,9 @@ test.describe('pre-request features tests', () => {
     await page.getByTestId('dataFolders-btn').click();
     await expect.soft(page.getByText('fake.pfx')).toBeVisible();
 
-    await page.getByTestId('dataFolders').fill('invalid');
+    await page.getByTestId('dataFolders').fill(cwd);
     await page.getByTestId('dataFolders-btn').click();
-    await expect.soft(page.getByText('invalid')).toBeVisible();
+    await expect.soft(page.getByText(cwd)).toBeVisible();
 
     await page.locator('.app').press('Escape');
 
@@ -444,9 +444,9 @@ test.describe('pre-request features tests', () => {
     await insomnia.navigationSidebar.clickRequestOrFolder('test certificate manipulation');
 
     await page.getByTestId('settings-button').click();
-    await page.getByTestId('dataFolders').fill('invalid');
+    await page.getByTestId('dataFolders').fill(cwd);
     await page.getByTestId('dataFolders-btn').click();
-    await expect.soft(page.getByText('invalid')).toBeVisible();
+    await expect.soft(page.getByText(cwd)).toBeVisible();
     await page.locator('.app').press('Escape');
 
     // send

--- a/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
@@ -354,3 +354,75 @@ test('Template tag sandbox: manifest grants a non-baseline module and is shown i
     .toContainText('baseline access');
   await expect.soft(page.getByTestId('plugin-permission-warning-insomnia-plugin-events-malformed')).toBeVisible();
 });
+
+// Tag-object source factories (composed into a plugin's templateTags array below). Each reports its
+// result, or the bridge's error message if the capability was denied.
+// A storage round-trip (set then get) — needs the `storage` capability.
+const storageTagObject = (tagName: string) => `{
+  name: '${tagName}', displayName: '${tagName}', args: [],
+  async run(context) {
+    try {
+      await context.store.setItem('cap_k', 'cap-storage-ok');
+      return await context.store.getItem('cap_k');
+    } catch (err) { return err.message; }
+  }
+}`;
+// A util.render call — baseline (no manifest needed).
+const renderTagObject = (tagName: string) => `{
+  name: '${tagName}', displayName: '${tagName}', args: [],
+  async run(context) {
+    try { return await context.util.render('baseline-ok'); } catch (err) { return err.message; }
+  }
+}`;
+
+test('Template tag sandbox: host capabilities are gated by the manifest (C1)', async ({
+  page,
+  app,
+  dataPath,
+  insomnia,
+}) => {
+  // Plugin A declares the `storage` capability; plugin B declares nothing. B also exposes a baseline
+  // tag (util.render) to prove gating is per-capability, not all-or-nothing.
+  writePlugin(
+    dataPath,
+    'insomnia-plugin-cap-granted',
+    { permissions: { capabilities: ['storage'] } },
+    `module.exports.templateTags = [${storageTagObject('capstorage')}];`,
+  );
+  writePlugin(
+    dataPath,
+    'insomnia-plugin-cap-baseline',
+    {},
+    `module.exports.templateTags = [${storageTagObject('capdenied')}, ${renderTagObject('capbaseline')}];`,
+  );
+
+  await clearPluginToast(page);
+  await page.evaluate(() => (window as any).main.plugins.reloadPlugins());
+
+  const fixture = await loadFixture('sandbox-capability-collection.yaml');
+  await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), fixture);
+  await page.getByLabel('Import').click();
+  await page.locator('[data-test-id="import-from-clipboard"]').click();
+  await page.getByRole('button', { name: 'Scan' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+
+  await enableSandbox(page);
+
+  await insomnia.navigationSidebar.clickRequestOrFolder('Capability Probe');
+  await page.getByText('Body', { exact: true }).click();
+
+  const assertTagPreview = async (tagPrefix: string, expected: string) => {
+    await page.locator(`[data-template^="${tagPrefix}"]`).click();
+    const modal = page.getByRole('dialog');
+    await expect.soft(modal.getByLabel('Live Preview')).toContainText(expected);
+    await modal.getByRole('button', { name: 'Done' }).click();
+    await expect.soft(modal).toBeHidden();
+  };
+
+  // Declared `storage` → the set/get round-trip flows end-to-end through the gated bridge.
+  await assertTagPreview('{% capstorage', 'cap-storage-ok');
+  // Undeclared → the exact denial naming the capability (tells the author what to add).
+  await assertTagPreview('{% capdenied', "Capability 'storage' not granted");
+  // Baseline `render` still works for the same no-manifest plugin — gating is per-capability.
+  await assertTagPreview('{% capbaseline', 'baseline-ok');
+});

--- a/packages/insomnia/src/main/__tests__/secure-read-file.test.ts
+++ b/packages/insomnia/src/main/__tests__/secure-read-file.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({ default: { app: { getPath: () => '/home/user/Insomnia' } } }));
+vi.mock('insomnia-data', () => ({ services: { settings: { getOrCreate: vi.fn() } } }));
+
+import { isPathAllowed } from '../secure-read-file';
+
+describe('isPathAllowed enforces a separator boundary on allowed roots', () => {
+  const root = '/opt/allowed-root';
+
+  it('allows the allowed root itself and files inside it', () => {
+    expect(isPathAllowed(root, [root]).isAllowed).toBe(true);
+    expect(isPathAllowed(`${root}/sub/file.txt`, [root]).isAllowed).toBe(true);
+  });
+
+  it('rejects a sibling directory that merely shares a name prefix', () => {
+    expect(isPathAllowed(`${root}-evil/secret`, [root]).isAllowed).toBe(false);
+  });
+
+  it('rejects a sibling install sharing a name prefix (e.g. Insomnia Nightly vs Insomnia)', () => {
+    const insomnia = '/apps/Insomnia';
+    expect(isPathAllowed('/apps/Insomnia Nightly/insomnia.OAuth2Token.db', [insomnia]).isAllowed).toBe(false);
+    expect(isPathAllowed('/apps/Insomnia/insomnia.Request.db', [insomnia]).isAllowed).toBe(true);
+  });
+});

--- a/packages/insomnia/src/main/__tests__/secure-read-file.test.ts
+++ b/packages/insomnia/src/main/__tests__/secure-read-file.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('electron', () => ({ default: { app: { getPath: () => '/home/user/Insomnia' } } }));
 vi.mock('insomnia-data', () => ({ services: { settings: { getOrCreate: vi.fn() } } }));
@@ -21,5 +25,42 @@ describe('isPathAllowed enforces a separator boundary on allowed roots', () => {
     const insomnia = '/apps/Insomnia';
     expect(isPathAllowed('/apps/Insomnia Nightly/insomnia.OAuth2Token.db', [insomnia]).isAllowed).toBe(false);
     expect(isPathAllowed('/apps/Insomnia/insomnia.Request.db', [insomnia]).isAllowed).toBe(true);
+  });
+});
+
+describe('isPathAllowed resolves symlinks before checking the allow list', () => {
+  const realTmpdir = os.tmpdir();
+  let allowedDir: string;
+  let outsideDir: string;
+
+  beforeEach(() => {
+    allowedDir = fs.mkdtempSync(path.join(realTmpdir, 'insomnia-allowed-'));
+    outsideDir = fs.mkdtempSync(path.join(realTmpdir, 'insomnia-outside-'));
+    // tmpdir and userData are always allowed roots (for buildMultipart / the db); pin both away from
+    // realTmpdir so the "outside" fixture dir below isn't allowed by those carve-outs instead of by
+    // the symlink check under test.
+    vi.spyOn(os, 'tmpdir').mockReturnValue('/insomnia-test-mock-tmpdir');
+    vi.stubEnv('INSOMNIA_DATA_PATH', '/insomnia-test-mock-userdata');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    fs.rmSync(allowedDir, { recursive: true, force: true });
+    fs.rmSync(outsideDir, { recursive: true, force: true });
+  });
+
+  it('rejects a symlink inside the allowed dir whose real target is outside it', () => {
+    const target = path.join(outsideDir, 'secret.txt');
+    fs.writeFileSync(target, 'secret');
+    const link = path.join(allowedDir, 'link.txt');
+    fs.symlinkSync(target, link);
+    expect(isPathAllowed(link, [allowedDir]).isAllowed).toBe(false);
+  });
+
+  it('allows a real file inside the allowed dir', () => {
+    const real = path.join(allowedDir, 'file.txt');
+    fs.writeFileSync(real, 'ok');
+    expect(isPathAllowed(real, [allowedDir]).isAllowed).toBe(true);
   });
 });

--- a/packages/insomnia/src/main/__tests__/secure-read-file.test.ts
+++ b/packages/insomnia/src/main/__tests__/secure-read-file.test.ts
@@ -14,7 +14,7 @@ describe('isPathAllowed enforces a separator boundary on allowed roots', () => {
   });
 
   it('rejects a sibling directory that merely shares a name prefix', () => {
-    expect(isPathAllowed(`${root}-evil/secret`, [root]).isAllowed).toBe(false);
+    expect(isPathAllowed(`${root}-other/secret`, [root]).isAllowed).toBe(false);
   });
 
   it('rejects a sibling install sharing a name prefix (e.g. Insomnia Nightly vs Insomnia)', () => {

--- a/packages/insomnia/src/main/__tests__/templating-worker-database.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database.test.ts
@@ -30,8 +30,7 @@ import { services } from 'insomnia-data';
 
 import { getPluginEntrySource, runPluginTagInSandbox } from '../templating-worker-database';
 
-// Run a one-tag plugin whose `run` body is `body`, through the real pluginToMainAPI bridge (services
-// mocked above). Returns the rendered string. `caps` overrides granted capabilities.
+// Runs a one-tag plugin through the real pluginToMainAPI bridge; `caps` overrides granted capabilities.
 const runTag = (runBody: string, caps?: string[]) =>
   runPluginTagInSandbox(
     `module.exports.templateTags = [{ name: 't', run: async function (context) { ${runBody} } }];`,
@@ -124,7 +123,7 @@ describe('cloudCredential.update cannot forge type/_id to write another collecti
     (services.cloudCredential.getById as any).mockResolvedValue(existing);
     (services.cloudCredential.update as any).mockResolvedValue(existing);
     await runTag(
-      "return await context.util.models.cloudCredential.update({ _id: 'cred1' }, { name: 'new', type: 'Settings', _id: 'evil' });",
+      "return await context.util.models.cloudCredential.update({ _id: 'cred1' }, { name: 'new', type: 'Settings', _id: 'other-id' });",
       CREDS,
     );
     const [docArg, patchArg] = (services.cloudCredential.update as any).mock.calls[0];
@@ -152,10 +151,9 @@ describe('response.getBodyBuffer reads only the server-loaded response body', ()
   it('reads the server-loaded response bodyPath, ignoring a plugin-supplied path', async () => {
     (services.response.getById as any).mockResolvedValue({ _id: 'r1', bodyPath: '/app/owned/body', bodyCompression: null });
     (services.helpers.getResponseBodyBuffer as any).mockImplementation(async (resp: any) => `read:${resp?.bodyPath}`);
-    // The plugin fabricates bodyPath: '/etc/passwd'; the handler must re-load by _id and read only
-    // the server-owned path.
+    // The plugin fabricates bodyPath; the handler must re-load by _id and read only the server-owned path.
     const result = await runTag(
-      "return await context.util.models.response.getBodyBuffer({ _id: 'r1', bodyPath: '/etc/passwd' });",
+      "return await context.util.models.response.getBodyBuffer({ _id: 'r1', bodyPath: '/home/user/.ssh/id_rsa' });",
     );
     expect(services.response.getById).toHaveBeenCalledWith('r1');
     expect(result).toBe('read:/app/owned/body');
@@ -165,7 +163,7 @@ describe('response.getBodyBuffer reads only the server-loaded response body', ()
     (services.response.getById as any).mockResolvedValue(null);
     (services.helpers.getResponseBodyBuffer as any).mockClear();
     const result = await runTag(
-      "return await context.util.models.response.getBodyBuffer({ bodyPath: '/etc/passwd' }, 'FAIL');",
+      "return await context.util.models.response.getBodyBuffer({ bodyPath: '/home/user/.ssh/id_rsa' }, 'FAIL');",
     );
     expect(result).toBe('FAIL');
     expect(services.helpers.getResponseBodyBuffer).not.toHaveBeenCalled();

--- a/packages/insomnia/src/main/__tests__/templating-worker-database.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database.test.ts
@@ -12,7 +12,7 @@ vi.mock('insomnia-data', () => ({
     workspace: { getById: vi.fn() },
     oAuth2Token: { getByParentId: vi.fn() },
     cookieJar: { getOrCreateForParentId: vi.fn() },
-    response: { getLatestForRequestId: vi.fn() },
+    response: { getLatestForRequestId: vi.fn(), getById: vi.fn() },
     helpers: { getResponseBodyBuffer: vi.fn() },
     settings: { get: vi.fn() },
   },
@@ -26,7 +26,19 @@ vi.mock('../network/libcurl-promise', () => ({ curlRequest: vi.fn() }));
 vi.mock('../prompt-bridge', () => ({ requestPromptFromRenderer: vi.fn() }));
 vi.mock('../secure-read-file', () => ({ secureReadFile: vi.fn() }));
 
+import { services } from 'insomnia-data';
+
 import { getPluginEntrySource, runPluginTagInSandbox } from '../templating-worker-database';
+
+// Run a one-tag plugin whose `run` body is `body`, through the real pluginToMainAPI bridge (services
+// mocked above). Returns the rendered string. `caps` overrides granted capabilities.
+const runTag = (runBody: string, caps?: string[]) =>
+  runPluginTagInSandbox(
+    `module.exports.templateTags = [{ name: 't', run: async function (context) { ${runBody} } }];`,
+    { args: [], pluginName: 'p', tagName: 't', context: { meta: {}, renderPurpose: 'send' as const, context: {} as any } },
+    undefined,
+    caps,
+  );
 
 describe('getPluginEntrySource', () => {
   let dir: string;
@@ -89,5 +101,29 @@ describe('runPluginTagInSandbox — util.render escape', () => {
         context: { meta: {}, renderPurpose: 'send' as const, context: { name: 'kyle' } as any },
       }),
     ).resolves.toBe('hello kyle');
+  });
+});
+
+describe('response.getBodyBuffer — no arbitrary file read (S1)', () => {
+  it('reads the server-loaded response bodyPath, ignoring a plugin-supplied path', async () => {
+    (services.response.getById as any).mockResolvedValue({ _id: 'r1', bodyPath: '/app/owned/body', bodyCompression: null });
+    (services.helpers.getResponseBodyBuffer as any).mockImplementation(async (resp: any) => `read:${resp?.bodyPath}`);
+    // The plugin fabricates bodyPath: '/etc/passwd'; the handler must re-load by _id and read only
+    // the server-owned path.
+    const result = await runTag(
+      "return await context.util.models.response.getBodyBuffer({ _id: 'r1', bodyPath: '/etc/passwd' });",
+    );
+    expect(services.response.getById).toHaveBeenCalledWith('r1');
+    expect(result).toBe('read:/app/owned/body');
+  });
+
+  it('returns the read-failure value (never touches disk) when the response id is unknown', async () => {
+    (services.response.getById as any).mockResolvedValue(null);
+    (services.helpers.getResponseBodyBuffer as any).mockClear();
+    const result = await runTag(
+      "return await context.util.models.response.getBodyBuffer({ bodyPath: '/etc/passwd' }, 'FAIL');",
+    );
+    expect(result).toBe('FAIL');
+    expect(services.helpers.getResponseBodyBuffer).not.toHaveBeenCalled();
   });
 });

--- a/packages/insomnia/src/main/__tests__/templating-worker-database.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database.test.ts
@@ -104,6 +104,21 @@ describe('runPluginTagInSandbox — util.render escape', () => {
   });
 });
 
+describe('NeDB operator-injection hardening (S3)', () => {
+  it('coerces an object id to a string so it cannot become a Mongo-style operator query', async () => {
+    (services.request.getById as any).mockResolvedValue(null);
+    await runTag('return String(await context.util.models.request.getById({ $ne: null }));');
+    // The handler must pass a primitive string, not the { $ne: null } object, to the query layer.
+    expect(services.request.getById).toHaveBeenCalledWith('[object Object]');
+  });
+
+  it('coerces oAuth2Token parentId likewise', async () => {
+    (services.oAuth2Token.getByParentId as any).mockResolvedValue(null);
+    await runTag('return String(await context.util.models.oAuth2Token.getByRequestId({ $exists: true }));');
+    expect(services.oAuth2Token.getByParentId).toHaveBeenCalledWith('[object Object]');
+  });
+});
+
 describe('response.getBodyBuffer — no arbitrary file read (S1)', () => {
   it('reads the server-loaded response bodyPath, ignoring a plugin-supplied path', async () => {
     (services.response.getById as any).mockResolvedValue({ _id: 'r1', bodyPath: '/app/owned/body', bodyCompression: null });

--- a/packages/insomnia/src/main/__tests__/templating-worker-database.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database.test.ts
@@ -104,7 +104,36 @@ describe('runPluginTagInSandbox — util.render escape', () => {
   });
 });
 
-describe('NeDB operator-injection hardening (S3)', () => {
+describe('cloudCredential.update cannot forge type/_id to write another collection', () => {
+  const CREDS = ['render', 'models.read', 'util', 'crypto', 'credentials'];
+
+  it('rejects when the id does not resolve to an existing cloud credential', async () => {
+    (services.cloudCredential.getById as any).mockResolvedValue(null);
+    (services.cloudCredential.update as any).mockClear();
+    await expect(
+      runTag(
+        "return await context.util.models.cloudCredential.update({ type: 'Settings', _id: 'settings-id', dataFolders: ['/'] }, {});",
+        CREDS,
+      ),
+    ).rejects.toThrow(/not found/);
+    expect(services.cloudCredential.update).not.toHaveBeenCalled();
+  });
+
+  it('updates the re-loaded credential and drops identity fields from the patch', async () => {
+    const existing = { _id: 'cred1', type: 'CloudProviderCredential', name: 'orig' };
+    (services.cloudCredential.getById as any).mockResolvedValue(existing);
+    (services.cloudCredential.update as any).mockResolvedValue(existing);
+    await runTag(
+      "return await context.util.models.cloudCredential.update({ _id: 'cred1' }, { name: 'new', type: 'Settings', _id: 'evil' });",
+      CREDS,
+    );
+    const [docArg, patchArg] = (services.cloudCredential.update as any).mock.calls[0];
+    expect(docArg).toBe(existing); // authoritative reloaded doc, not the caller's object
+    expect(patchArg).toEqual({ name: 'new' }); // type/_id stripped
+  });
+});
+
+describe('id arguments are string-coerced before reaching the query layer', () => {
   it('coerces an object id to a string so it cannot become a Mongo-style operator query', async () => {
     (services.request.getById as any).mockResolvedValue(null);
     await runTag('return String(await context.util.models.request.getById({ $ne: null }));');
@@ -119,7 +148,7 @@ describe('NeDB operator-injection hardening (S3)', () => {
   });
 });
 
-describe('response.getBodyBuffer — no arbitrary file read (S1)', () => {
+describe('response.getBodyBuffer reads only the server-loaded response body', () => {
   it('reads the server-loaded response bodyPath, ignoring a plugin-supplied path', async () => {
     (services.response.getById as any).mockResolvedValue({ _id: 'r1', bodyPath: '/app/owned/body', bodyCompression: null });
     (services.helpers.getResponseBodyBuffer as any).mockImplementation(async (resp: any) => `read:${resp?.bodyPath}`);

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -323,32 +323,39 @@ export const createConfiguredCurlInstance = ({
   // Use the system's native CA store for SSL certificate verification
   curl.setOpt(Curl.option.SSL_OPTIONS, CurlSslOpt.NativeCa);
   certificates.forEach(validCert => {
-    const { passphrase, cert, key, pfx } = validCert;
-    if (cert) {
-      const { isAllowed, securedPath } = isPathAllowed(cert, settings.dataFolders);
-      invariant(isAllowed, cannotAccessPathError(securedPath));
+    // A disallowed path on one certificate must not prevent other certificates in this request
+    // from being applied, so each one is isolated rather than letting invariant() abort the loop.
+    try {
+      const { passphrase, cert, key, pfx } = validCert;
+      if (cert) {
+        const { isAllowed, securedPath } = isPathAllowed(cert, settings.dataFolders);
+        invariant(isAllowed, cannotAccessPathError(securedPath));
 
-      curl.setOpt(Curl.option.SSLCERT, cert);
-      curl.setOpt(Curl.option.SSLCERTTYPE, 'PEM');
-      debugTimeline.push({ value: 'Adding SSL PEM certificate', name: 'Text', timestamp: Date.now() });
-    }
-    if (pfx) {
-      const { isAllowed, securedPath } = isPathAllowed(pfx, settings.dataFolders);
-      invariant(isAllowed, cannotAccessPathError(securedPath));
+        curl.setOpt(Curl.option.SSLCERT, cert);
+        curl.setOpt(Curl.option.SSLCERTTYPE, 'PEM');
+        debugTimeline.push({ value: 'Adding SSL PEM certificate', name: 'Text', timestamp: Date.now() });
+      }
+      if (pfx) {
+        const { isAllowed, securedPath } = isPathAllowed(pfx, settings.dataFolders);
+        invariant(isAllowed, cannotAccessPathError(securedPath));
 
-      curl.setOpt(Curl.option.SSLCERT, pfx);
-      curl.setOpt(Curl.option.SSLCERTTYPE, 'P12');
-      debugTimeline.push({ value: 'Adding SSL P12 certificate', name: 'Text', timestamp: Date.now() });
-    }
-    if (key) {
-      const { isAllowed, securedPath } = isPathAllowed(key, settings.dataFolders);
-      invariant(isAllowed, cannotAccessPathError(securedPath));
+        curl.setOpt(Curl.option.SSLCERT, pfx);
+        curl.setOpt(Curl.option.SSLCERTTYPE, 'P12');
+        debugTimeline.push({ value: 'Adding SSL P12 certificate', name: 'Text', timestamp: Date.now() });
+      }
+      if (key) {
+        const { isAllowed, securedPath } = isPathAllowed(key, settings.dataFolders);
+        invariant(isAllowed, cannotAccessPathError(securedPath));
 
-      curl.setOpt(Curl.option.SSLKEY, key);
-      debugTimeline.push({ value: 'Adding SSL KEY certificate', name: 'Text', timestamp: Date.now() });
-    }
-    if (passphrase) {
-      curl.setOpt(Curl.option.KEYPASSWD, passphrase);
+        curl.setOpt(Curl.option.SSLKEY, key);
+        debugTimeline.push({ value: 'Adding SSL KEY certificate', name: 'Text', timestamp: Date.now() });
+      }
+      if (passphrase) {
+        curl.setOpt(Curl.option.KEYPASSWD, passphrase);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      debugTimeline.push({ value: `Skipping client certificate: ${message}`, name: 'Text', timestamp: Date.now() });
     }
   });
   const httpVersion = getHttpVersion(settings.preferredHttpVersion);

--- a/packages/insomnia/src/main/secure-read-file.ts
+++ b/packages/insomnia/src/main/secure-read-file.ts
@@ -12,8 +12,7 @@ import { SECURITY_SETTINGS_PATH_LABEL } from '../common/misc';
 export const isPathAllowed = (filePath: string, userAllowList: string[]) => {
   const allowList = getSecuredFolderAllowList(userAllowList);
   const securedPath = securePath(filePath);
-  // Require an exact match or a separator-bounded prefix so a sibling dir sharing a name prefix
-  // (e.g. ".../Insomnia Nightly" for a ".../Insomnia" root) can't pass a bare `startsWith`.
+  // Match the root exactly or bound the prefix by a separator, so a same-prefix sibling dir can't pass.
   const isAllowed = allowList.some(f => {
     const root = path.resolve(f);
     if (root === '') {

--- a/packages/insomnia/src/main/secure-read-file.ts
+++ b/packages/insomnia/src/main/secure-read-file.ts
@@ -11,10 +11,11 @@ import { SECURITY_SETTINGS_PATH_LABEL } from '../common/misc';
 
 export const isPathAllowed = (filePath: string, userAllowList: string[]) => {
   const allowList = getSecuredFolderAllowList(userAllowList);
-  const securedPath = securePath(filePath);
+  // Resolve symlinks so a link inside an allowed dir can't point outside it.
+  const securedPath = resolveRealPath(securePath(filePath));
   // Match the root exactly or bound the prefix by a separator, so a same-prefix sibling dir can't pass.
   const isAllowed = allowList.some(f => {
-    const root = path.resolve(f);
+    const root = resolveRealPath(path.resolve(f));
     if (root === '') {
       return false;
     }
@@ -24,6 +25,13 @@ export const isPathAllowed = (filePath: string, userAllowList: string[]) => {
   return { isAllowed, securedPath };
 };
 const securePath = (filePath: string) => path.resolve(decodeURIComponent(filePath));
+const resolveRealPath = (resolvedPath: string) => {
+  try {
+    return fs.realpathSync(resolvedPath);
+  } catch {
+    return resolvedPath;
+  }
+};
 const getSecuredFolderAllowList = (userAllowList: string[]) => {
   const userdataDirectory = process.env.INSOMNIA_DATA_PATH || electron.app.getPath('userData');
   // we use tmpdir for buildMultipart

--- a/packages/insomnia/src/main/secure-read-file.ts
+++ b/packages/insomnia/src/main/secure-read-file.ts
@@ -12,7 +12,16 @@ import { SECURITY_SETTINGS_PATH_LABEL } from '../common/misc';
 export const isPathAllowed = (filePath: string, userAllowList: string[]) => {
   const allowList = getSecuredFolderAllowList(userAllowList);
   const securedPath = securePath(filePath);
-  const isAllowed = allowList.some(f => path.resolve(f) !== '' && securedPath.startsWith(path.resolve(f)));
+  // Require an exact match or a separator-bounded prefix so a sibling dir sharing a name prefix
+  // (e.g. ".../Insomnia Nightly" for a ".../Insomnia" root) can't pass a bare `startsWith`.
+  const isAllowed = allowList.some(f => {
+    const root = path.resolve(f);
+    if (root === '') {
+      return false;
+    }
+    const rootWithSep = root.endsWith(path.sep) ? root : root + path.sep;
+    return securedPath === root || securedPath.startsWith(rootWithSep);
+  });
   return { isAllowed, securedPath };
 };
 const securePath = (filePath: string) => path.resolve(decodeURIComponent(filePath));

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -226,27 +226,27 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
     return crypto.createHash('md5').update(body.input).digest(body.encoding);
   },
   'request.getById': async (body: { id: string }) => {
-    return await services.request.getById(body.id);
+    return await services.request.getById(String(body.id));
   },
   'request.getAncestors': async (body: { request: DBRequest | RequestGroup | Workspace; types: AllTypes[] }) => {
     return await db.withAncestors<DBRequest | RequestGroup | Workspace>(body.request, body.types);
   },
   'workspace.getById': async (body: { id: string }) => {
-    return await services.workspace.getById(body.id);
+    return await services.workspace.getById(String(body.id));
   },
   'oAuth2Token.getByRequestId': async (body: { parentId: string }) => {
-    return await services.oAuth2Token.getByParentId(body.parentId);
+    return await services.oAuth2Token.getByParentId(String(body.parentId));
   },
   'cookieJar.getOrCreateForParentId': async (body: { parentId: string }) => {
-    return await services.cookieJar.getOrCreateForParentId(body.parentId);
+    return await services.cookieJar.getOrCreateForParentId(String(body.parentId));
   },
   'cookieJar.getCookiesForUrl': async (body: { parentId: string; url: string }) => {
-    const cookies = await services.cookieJar.getOrCreateForParentId(body.parentId);
+    const cookies = await services.cookieJar.getOrCreateForParentId(String(body.parentId));
     const jar = jarFromCookies(cookies.cookies);
     return jar.getCookiesSync(body.url).map(c => c.toJSON());
   },
   'response.getLatestForRequestId': async (body: { requestId: string; environmentId: string }) => {
-    return await services.response.getLatestForRequestId(body.requestId, body.environmentId);
+    return await services.response.getLatestForRequestId(String(body.requestId), body.environmentId);
   },
   'response.getBodyBuffer': async (body: {
     response?: { _id?: string; bodyPath?: string; bodyCompression?: any };
@@ -262,18 +262,18 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
     return await services.helpers.getResponseBodyBuffer(real, body.readFailureValue);
   },
   'pluginData.hasItem': async (body: { pluginName: string; key: string }) => {
-    const doc = await services.pluginData.getByKey(body.pluginName, body.key);
+    const doc = await services.pluginData.getByKey(body.pluginName, String(body.key));
     return doc !== null;
   },
   'pluginData.setItem': async (body: { pluginName: string; key: string; value: string }) => {
-    return services.pluginData.upsertByKey(body.pluginName, body.key, String(body.value));
+    return services.pluginData.upsertByKey(body.pluginName, String(body.key), String(body.value));
   },
   'pluginData.getItem': async (body: { pluginName: string; key: string }) => {
-    const doc = await services.pluginData.getByKey(body.pluginName, body.key);
+    const doc = await services.pluginData.getByKey(body.pluginName, String(body.key));
     return doc ? doc.value : null;
   },
   'pluginData.removeItem': async (body: { pluginName: string; key: string }) => {
-    return services.pluginData.removeByKey(body.pluginName, body.key);
+    return services.pluginData.removeByKey(body.pluginName, String(body.key));
   },
   'pluginData.clear': async (body: { pluginName: string }) => {
     return services.pluginData.removeAll(body.pluginName);
@@ -286,7 +286,7 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
     }));
   },
   'cloudCredential.getById': async (body: { id: string }) => {
-    return await services.cloudCredential.getById(body.id);
+    return await services.cloudCredential.getById(String(body.id));
   },
   'cloudCredential.update': async (body: {
     originCredential: CloudProviderCredential;

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -252,8 +252,7 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
     response?: { _id?: string; bodyPath?: string; bodyCompression?: any };
     readFailureValue?: string;
   }) => {
-    // Re-load the response by id and read only its server-owned bodyPath — never a caller-supplied
-    // path — so a plugin can't turn this into an arbitrary-file read.
+    // Re-load by id and read only the server-owned bodyPath, never a caller-supplied one.
     const id = body.response?._id;
     const real = typeof id === 'string' ? await services.response.getById(id) : null;
     if (!real) {
@@ -292,9 +291,7 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
     originCredential: CloudProviderCredential;
     patch: Partial<CloudProviderCredential>;
   }) => {
-    // Re-load the real credential by id and strip identity fields from the patch so a plugin can't
-    // forge `type`/`_id` to upsert into another collection (e.g. Settings). Only an existing cloud
-    // credential can be updated.
+    // Re-load by id and strip identity fields from the patch, so a plugin can't forge type/_id to write another collection.
     const id = String(body.originCredential?._id);
     const existing = await services.cloudCredential.getById(id);
     if (!existing) {

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -292,7 +292,19 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
     originCredential: CloudProviderCredential;
     patch: Partial<CloudProviderCredential>;
   }) => {
-    return await services.cloudCredential.update(body.originCredential, body.patch);
+    // Re-load the real credential by id and strip identity fields from the patch so a plugin can't
+    // forge `type`/`_id` to upsert into another collection (e.g. Settings). Only an existing cloud
+    // credential can be updated.
+    const id = String(body.originCredential?._id);
+    const existing = await services.cloudCredential.getById(id);
+    if (!existing) {
+      throw new Error(`Cloud credential '${id}' not found`);
+    }
+    const patch = { ...body.patch };
+    delete (patch as { _id?: unknown })._id;
+    delete (patch as { type?: unknown }).type;
+    delete (patch as { parentId?: unknown }).parentId;
+    return await services.cloudCredential.update(existing, patch);
   },
   'settings.get': async () => {
     return await services.settings.get();

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -249,10 +249,17 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
     return await services.response.getLatestForRequestId(body.requestId, body.environmentId);
   },
   'response.getBodyBuffer': async (body: {
-    response?: { bodyPath?: string; bodyCompression?: any };
+    response?: { _id?: string; bodyPath?: string; bodyCompression?: any };
     readFailureValue?: string;
   }) => {
-    return await services.helpers.getResponseBodyBuffer(body.response, body.readFailureValue);
+    // Re-load the response by id and read only its server-owned bodyPath — never a caller-supplied
+    // path — so a plugin can't turn this into an arbitrary-file read.
+    const id = body.response?._id;
+    const real = typeof id === 'string' ? await services.response.getById(id) : null;
+    if (!real) {
+      return body.readFailureValue ?? '';
+    }
+    return await services.helpers.getResponseBodyBuffer(real, body.readFailureValue);
   },
   'pluginData.hasItem': async (body: { pluginName: string; key: string }) => {
     const doc = await services.pluginData.getByKey(body.pluginName, body.key);

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -426,10 +426,14 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
         const settings = await services.settings.get();
         if (settings.templateTagSandboxEnabled) {
           const { ALL_CAPABILITIES } = await import('../templating/sandbox/host-bridge');
+          const { ALL_SANDBOX_MODULES } = await import('../templating/sandbox/module-registry');
           // Bundle plugins are first-party and trusted: grant every module + capability.
-          return runPluginTagInSandbox(getPluginEntrySource({ directory: '', name: pluginName }), body, undefined, [
-            ...ALL_CAPABILITIES,
-          ]);
+          return runPluginTagInSandbox(
+            getPluginEntrySource({ directory: '', name: pluginName }),
+            body,
+            [...ALL_SANDBOX_MODULES],
+            [...ALL_CAPABILITIES],
+          );
         }
         return runPluginTag(targetTag.run, body);
       }

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -141,21 +141,34 @@ export const runPluginTagInSandbox = async (
   // Registry-module names the plugin may require(). Defaults to the baseline floor; callers pass the
   // plugin's manifest-resolved grant (baseline ∪ insomnia.permissions.modules).
   grantedModules?: string[],
+  // Capability groups the plugin may reach through the host bridge. Defaults to the baseline floor;
+  // callers pass baseline ∪ insomnia.permissions.capabilities (bundle plugins pass ALL_CAPABILITIES).
+  grantedCapabilities?: string[],
 ): Promise<string> => {
   const { runTagInSandbox } = await import('../templating/sandbox/plugin-tag-sandbox');
-  const { createMapBridge } = await import('../templating/sandbox/host-bridge');
+  const { createMapBridge, filterByCapabilities, TEMPLATE_TAG_BASELINE_CAPABILITIES } = await import(
+    '../templating/sandbox/host-bridge'
+  );
   const { TEMPLATE_TAG_BASELINE_MODULES } = await import('../templating/sandbox/module-registry');
   const { pluginName, tagName, args, context: originContext } = body;
   const { meta, renderPurpose, context } = originContext;
-  const bridge = createMapBridge({
-    ...(pluginToMainAPI as Record<string, (b: any) => Promise<any>>),
-    // allowTags: false so a sandboxed plugin can't invoke another tag's real, unsandboxed run()
-    // (including its own) by handing util.render a string containing "{% tagName %}".
-    'util.render': async (b: { str: string; context: Record<string, any> }) => {
-      const { render } = await import('../templating');
-      return render(b.str, { context: b.context, allowTags: false });
-    },
-  });
+  const capabilities = grantedCapabilities ?? [...TEMPLATE_TAG_BASELINE_CAPABILITIES];
+  // Gate the handler map by capability before building the bridge: an ungranted path rejects at the
+  // bridge with a message naming the missing capability, rather than silently running.
+  const bridge = createMapBridge(
+    filterByCapabilities(
+      {
+        ...(pluginToMainAPI as Record<string, (b: any) => Promise<any>>),
+        // allowTags: false so a sandboxed plugin can't invoke another tag's real, unsandboxed run()
+        // (including its own) by handing util.render a string containing "{% tagName %}".
+        'util.render': async (b: { str: string; context: Record<string, any> }) => {
+          const { render } = await import('../templating');
+          return render(b.str, { context: b.context, allowTags: false });
+        },
+      },
+      capabilities,
+    ),
+  );
   return runTagInSandbox({
     pluginSource,
     tagName,
@@ -185,6 +198,7 @@ export const runPluginTagInSandbox = async (
       pluginName,
       renderDepth: 0,
       grantedModules: grantedModules ?? [...TEMPLATE_TAG_BASELINE_MODULES],
+      grantedCapabilities: capabilities,
     },
   });
 };
@@ -411,7 +425,11 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
       if (targetTag) {
         const settings = await services.settings.get();
         if (settings.templateTagSandboxEnabled) {
-          return runPluginTagInSandbox(getPluginEntrySource({ directory: '', name: pluginName }), body);
+          const { ALL_CAPABILITIES } = await import('../templating/sandbox/host-bridge');
+          // Bundle plugins are first-party and trusted: grant every module + capability.
+          return runPluginTagInSandbox(getPluginEntrySource({ directory: '', name: pluginName }), body, undefined, [
+            ...ALL_CAPABILITIES,
+          ]);
         }
         return runPluginTag(targetTag.run, body);
       }
@@ -451,10 +469,12 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
       const settings = await services.settings.get();
       if (settings.templateTagSandboxEnabled) {
         const { resolveTemplateTagModules } = await import('../templating/sandbox/module-registry');
+        const { resolveTemplateTagCapabilities } = await import('../templating/sandbox/host-bridge');
         return runPluginTagInSandbox(
           getPluginEntrySource({ directory: targetTag.plugin.directory, name: pluginName }),
           body,
           resolveTemplateTagModules(targetTag.plugin.permissions?.modules),
+          resolveTemplateTagCapabilities(targetTag.plugin.permissions?.capabilities),
         );
       }
       return runPluginTag(targetTag.templateTag.run, body);

--- a/packages/insomnia/src/templating/sandbox/host-bridge.ts
+++ b/packages/insomnia/src/templating/sandbox/host-bridge.ts
@@ -27,3 +27,131 @@ export const createMapBridge =
     }
     return handler(body);
   };
+
+/**
+ * Capability groups (axis 2, sandbox plan C1). Every side-effecting bridge path belongs to exactly
+ * one group; a plugin may reach a path only if its effective grant includes that group. Names match
+ * what a manifest declares in `insomnia.permissions.capabilities`.
+ */
+export type Capability =
+  | 'render' // recursive template render (util.render)
+  | 'models.read' // read-only model + settings lookups
+  | 'util' // pure/benign host helpers (nodeOS/decode/encode) — mirrors the built-in os/base64 tags
+  | 'crypto' // sync host crypto (no bridge path; kept for profile/manifest consistency)
+  | 'network' // sending HTTP requests
+  | 'storage' // per-plugin key/value store (pluginData.*)
+  | 'fs-read' // reading files off disk (readFile)
+  | 'credentials' // cloud provider credential read/write
+  | 'app'; // host UI + shell (dialogs, clipboard, openInBrowser)
+
+/**
+ * The single source of truth mapping every sandbox-callable bridge path to its capability. Kept in
+ * sync with the `__bridge("…")` calls in `in-sandbox-bootstrap.ts` by a completeness unit test — a
+ * new bridge path added there without an entry here fails that test (fail-closed, never ungated).
+ */
+export const BRIDGE_PATH_CAPABILITIES: Record<string, Capability> = {
+  'util.render': 'render',
+
+  'request.getById': 'models.read',
+  'request.getAncestors': 'models.read',
+  'workspace.getById': 'models.read',
+  'oAuth2Token.getByRequestId': 'models.read',
+  'cookieJar.getOrCreateForParentId': 'models.read',
+  'cookieJar.getCookiesForUrl': 'models.read',
+  'response.getLatestForRequestId': 'models.read',
+  'response.getBodyBuffer': 'models.read',
+  'settings.get': 'models.read',
+
+  'nodeOS': 'util',
+  'decode': 'util',
+  'encode': 'util',
+
+  'network.sendRequest': 'network',
+  'network.sendRequestWithoutSideEffects': 'network',
+
+  'pluginData.hasItem': 'storage',
+  'pluginData.setItem': 'storage',
+  'pluginData.getItem': 'storage',
+  'pluginData.removeItem': 'storage',
+  'pluginData.clear': 'storage',
+  'pluginData.all': 'storage',
+
+  'readFile': 'fs-read',
+
+  'cloudCredential.getById': 'credentials',
+  'cloudCredential.update': 'credentials',
+
+  'app.alert': 'app',
+  'app.dialog': 'app',
+  'app.prompt': 'app',
+  'app.getPath': 'app',
+  'app.showSaveDialog': 'app',
+  'app.clipboard.readText': 'app',
+  'app.clipboard.writeText': 'app',
+  'app.clipboard.clear': 'app',
+  'openInBrowser': 'app',
+};
+
+/** Every capability that exists — the trusted grant for first-party bundle plugins. */
+export const ALL_CAPABILITIES: Capability[] = [
+  'render',
+  'models.read',
+  'util',
+  'crypto',
+  'network',
+  'storage',
+  'fs-read',
+  'credentials',
+  'app',
+];
+
+/**
+ * The capability floor every template-tag plugin receives with no manifest: recursive render,
+ * read-only model access, pure util helpers, and (sync) crypto. Notably NOT network / storage /
+ * fs / credentials / app — those must be declared. `util` (nodeOS/decode/encode) is baseline because
+ * the same information is already freely available through the built-in `os`/`base64` tags.
+ */
+export const TEMPLATE_TAG_BASELINE_CAPABILITIES: Capability[] = ['render', 'models.read', 'util', 'crypto'];
+
+/**
+ * Resolve the capability set a template-tag plugin gets: the baseline floor plus whatever it
+ * declared in `insomnia.permissions.capabilities` (unknown names are ignored — they map to no
+ * bridge path). Profile-ceiling intersection is added in P1.
+ */
+export const resolveTemplateTagCapabilities = (declaredCapabilities: string[] = []): string[] => {
+  const resolved: string[] = [...TEMPLATE_TAG_BASELINE_CAPABILITIES];
+  for (const name of declaredCapabilities) {
+    if (!resolved.includes(name as Capability)) {
+      resolved.push(name);
+    }
+  }
+  return resolved;
+};
+
+/**
+ * Wrap a `pluginToMainAPI`-shaped handler map so each path rejects unless its capability is granted.
+ * This is the host-side gate (defense at the bridge); C2 additionally omits ungranted branches from
+ * the in-sandbox `context` so the API surface itself reflects the grant. A path with no capability
+ * mapping fails closed — it can never be reached without an explicit entry in
+ * `BRIDGE_PATH_CAPABILITIES`.
+ */
+export const filterByCapabilities = (
+  handlers: Record<string, (body: any) => Promise<unknown>>,
+  granted: string[],
+): Record<string, (body: any) => Promise<unknown>> => {
+  const grantedSet = new Set(granted);
+  const filtered: Record<string, (body: any) => Promise<unknown>> = {};
+  for (const [path, handler] of Object.entries(handlers)) {
+    const capability = BRIDGE_PATH_CAPABILITIES[path];
+    filtered[path] = async (body: any) => {
+      if (capability === undefined) {
+        throw new Error(`Bridge path "${path}" has no capability mapping — refusing to call it`);
+      }
+      if (!grantedSet.has(capability)) {
+        throw new Error(`Capability '${capability}' not granted — add it to insomnia.permissions.capabilities`);
+      }
+      return handler(body);
+    };
+  }
+  return filtered;
+};

--- a/packages/insomnia/src/templating/sandbox/host-bridge.ts
+++ b/packages/insomnia/src/templating/sandbox/host-bridge.ts
@@ -114,14 +114,15 @@ export const ALL_CAPABILITIES: Capability[] = [
 export const TEMPLATE_TAG_BASELINE_CAPABILITIES: Capability[] = ['render', 'models.read', 'util', 'crypto'];
 
 /**
- * Resolve the capability set a template-tag plugin gets: the baseline floor plus whatever it
- * declared in `insomnia.permissions.capabilities` (unknown names are ignored — they map to no
- * bridge path). Profile-ceiling intersection is added in P1.
+ * Resolve the capability set a template-tag plugin gets: the baseline floor plus whatever known
+ * capabilities it declared in `insomnia.permissions.capabilities`. Unknown names are dropped (they
+ * map to no bridge path), so the resolved set only ever contains real `Capability` values — which
+ * keeps the envelope clean for the P1 profile-ceiling intersection.
  */
 export const resolveTemplateTagCapabilities = (declaredCapabilities: string[] = []): string[] => {
   const resolved: string[] = [...TEMPLATE_TAG_BASELINE_CAPABILITIES];
   for (const name of declaredCapabilities) {
-    if (!resolved.includes(name as Capability)) {
+    if (ALL_CAPABILITIES.includes(name as Capability) && !resolved.includes(name as Capability)) {
       resolved.push(name);
     }
   }

--- a/packages/insomnia/src/templating/sandbox/marshal.ts
+++ b/packages/insomnia/src/templating/sandbox/marshal.ts
@@ -27,6 +27,12 @@ export interface ContextEnvelope {
    * `TEMPLATE_TAG_BASELINE_MODULES` baseline.
    */
   grantedModules: string[];
+  /**
+   * Capability groups the plugin may reach through the host bridge (axis 2, default-deny; see
+   * `host-bridge.ts`). The bridge is gated host-side (C1); C2 reads this to omit ungranted branches
+   * from the rebuilt `context`.
+   */
+  grantedCapabilities: string[];
 }
 
 /**

--- a/packages/insomnia/src/templating/sandbox/module-registry.ts
+++ b/packages/insomnia/src/templating/sandbox/module-registry.ts
@@ -123,6 +123,9 @@ export const SANDBOX_MODULES: SandboxModuleDefinition[] = [
  */
 export const TEMPLATE_TAG_BASELINE_MODULES: string[] = ['path', 'crypto'];
 
+/** Every registered module name — the trusted grant for first-party bundle plugins. */
+export const ALL_SANDBOX_MODULES: string[] = SANDBOX_MODULES.map(m => m.name);
+
 /**
  * Resolve the module set a template-tag plugin may `require()`: the baseline floor plus whatever the
  * plugin declared in `insomnia.permissions.modules`. Unknown declared names are harmless here —

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
@@ -3,7 +3,16 @@ import nodeCrypto from 'node:crypto';
 import { describe, expect, it } from 'vitest';
 
 import { localTemplateTags } from '../../common/templating/local-template-tags';
-import { createMapBridge, type HostBridge } from './host-bridge';
+import {
+  ALL_CAPABILITIES,
+  BRIDGE_PATH_CAPABILITIES,
+  createMapBridge,
+  filterByCapabilities,
+  type HostBridge,
+  resolveTemplateTagCapabilities,
+  TEMPLATE_TAG_BASELINE_CAPABILITIES,
+} from './host-bridge';
+import { IN_SANDBOX_BOOTSTRAP } from './in-sandbox-bootstrap';
 import type { ContextEnvelope } from './marshal';
 import { resolveTemplateTagModules, SANDBOX_MODULES, TEMPLATE_TAG_BASELINE_MODULES } from './module-registry';
 import { type HostCrypto, runTagInSandbox } from './plugin-tag-sandbox';
@@ -69,7 +78,11 @@ module.exports.templateTags = [{
   }
 }];`;
 
-const envelope = (args: unknown[], grantedModules: string[] = TEMPLATE_TAG_BASELINE_MODULES): ContextEnvelope => ({
+const envelope = (
+  args: unknown[],
+  grantedModules: string[] = TEMPLATE_TAG_BASELINE_MODULES,
+  grantedCapabilities: string[] = ALL_CAPABILITIES,
+): ContextEnvelope => ({
   args,
   context: {},
   meta: {},
@@ -78,6 +91,7 @@ const envelope = (args: unknown[], grantedModules: string[] = TEMPLATE_TAG_BASEL
   pluginName: 'test-plugin',
   renderDepth: 0,
   grantedModules,
+  grantedCapabilities,
 });
 
 const noBridge: HostBridge = async path => {
@@ -682,5 +696,94 @@ describe('createMapBridge — resolves only registered own handlers', () => {
     for (const evil of ['constructor', '__proto__', 'hasOwnProperty', 'toString']) {
       await expect(bridge(evil, {})).rejects.toThrow(`No host bridge handler registered for "${evil}"`);
     }
+  });
+});
+
+describe('capability gating at the host bridge (C1)', () => {
+  // Completeness: every bridge path the sandbox can actually call (every __bridge("…") in the
+  // bootstrap) must have a capability mapping, or filterByCapabilities fails it closed. A new
+  // bridge path added without a mapping fails this test.
+  it('maps every sandbox-callable bridge path to a capability', () => {
+    const calledPaths = new Set([...IN_SANDBOX_BOOTSTRAP.matchAll(/__bridge\("([^"]+)"/g)].map(m => m[1]));
+    expect(calledPaths.size).toBeGreaterThan(0);
+    for (const path of calledPaths) {
+      expect(BRIDGE_PATH_CAPABILITIES, `bridge path "${path}" needs a capability mapping`).toHaveProperty(path);
+    }
+  });
+
+  describe('resolveTemplateTagCapabilities', () => {
+    it('defaults to the baseline floor', () => {
+      expect(resolveTemplateTagCapabilities()).toEqual(TEMPLATE_TAG_BASELINE_CAPABILITIES);
+    });
+    it('unions declared capabilities onto the baseline without duplicating', () => {
+      expect(resolveTemplateTagCapabilities(['network', 'render'])).toEqual([
+        ...TEMPLATE_TAG_BASELINE_CAPABILITIES,
+        'network',
+      ]);
+    });
+  });
+
+  describe('filterByCapabilities', () => {
+    const handlers = { 'network.sendRequest': async () => 'sent', 'pluginData.getItem': async () => 'stored' };
+
+    it('passes a granted path through to its handler', async () => {
+      const filtered = filterByCapabilities(handlers, ['network']);
+      await expect(filtered['network.sendRequest']({})).resolves.toBe('sent');
+    });
+
+    it('rejects an ungranted path with a message naming the capability', async () => {
+      const filtered = filterByCapabilities(handlers, ['render']);
+      await expect(filtered['network.sendRequest']({})).rejects.toThrow(
+        "Capability 'network' not granted — add it to insomnia.permissions.capabilities",
+      );
+    });
+
+    it('fails closed for a path with no capability mapping', async () => {
+      const filtered = filterByCapabilities({ 'made.up.path': async () => 'x' }, ALL_CAPABILITIES);
+      await expect(filtered['made.up.path']({})).rejects.toThrow(/no capability mapping/);
+    });
+  });
+
+  // End-to-end through the sandbox: the gate is at the bridge, so the branch still exists in context
+  // (C2 removes it) but calling it rejects unless the capability is granted.
+  const runGated = (body: string, granted: string[], handlers: Record<string, (b: any) => Promise<unknown>>) =>
+    runTagInSandbox({
+      pluginSource: `module.exports.templateTags = [{ name: 'g', run: async function (context) { ${body} } }];`,
+      tagName: 'g',
+      envelope: envelope([], TEMPLATE_TAG_BASELINE_MODULES, granted),
+      bridge: createMapBridge(filterByCapabilities(handlers, granted)),
+    });
+
+  it('allows a baseline util call (nodeOS) with no declared capabilities', async () => {
+    const actual = await runGated(
+      'var os = await context.util.nodeOS(); return os.arch;',
+      [...TEMPLATE_TAG_BASELINE_CAPABILITIES],
+      { nodeOS: async () => ({ arch: 'x64' }) },
+    );
+    expect(actual).toBe('x64');
+  });
+
+  it('denies a non-baseline capability (storage) and names it', async () => {
+    await expect(
+      runGated("return await context.store.getItem('k');", [...TEMPLATE_TAG_BASELINE_CAPABILITIES], {
+        'pluginData.getItem': async () => 'stored-value',
+      }),
+    ).rejects.toThrow("Capability 'storage' not granted");
+  });
+
+  it('allows the same call once the capability is declared', async () => {
+    const actual = await runGated(
+      "return await context.store.getItem('k');",
+      resolveTemplateTagCapabilities(['storage']),
+      { 'pluginData.getItem': async () => 'stored-value' },
+    );
+    expect(actual).toBe('stored-value');
+  });
+
+  it('gating is per-capability, not all-or-nothing: baseline render still works when network is denied', async () => {
+    const actual = await runGated('return await context.util.render("x");', [...TEMPLATE_TAG_BASELINE_CAPABILITIES], {
+      'util.render': async () => 'rendered',
+    });
+    expect(actual).toBe('rendered');
   });
 });


### PR DESCRIPTION
## What this PR does
* Reload the response by `_id` in `getBodyBuffer` instead of trusting a plugin-supplied path. This is used to block arbitrary file reads via models.read
* Reload the credential by `_id` in `cloudCredential.update` and strip identity fields from the patch. This is used to block cross-collection writes via credentials. 
* Coerce id/parentId/key args to String(...) before they reach NeDB queries. This is used to block Mongo-operator injection (`$ne`, `$where`, etc.). 
* Require an exact match or separator-bounded prefix in secureReadFile's allowlist. 
* Resolve symlinks before checking secureReadFile's allowlist. 