### PR TITLE
chore: enable retries for playwright smoke tests

### DIFF
--- a/packages/insomnia-smoke-test/playwright.config.ts
+++ b/packages/insomnia-smoke-test/playwright.config.ts
@@ -58,7 +58,7 @@ const config: PlaywrightTestConfig = {
       sources: true,
     },
   },
-  reporter: process.env.CI ? [['github'], ['line'], ['junit', { outputFile: 'results.xml' }]] : [['dot']],
+  reporter: process.env.CI ? [['github'], ['line']] : [['dot']],
   timeout: process.env.CI || isWindows ? 60 * 1000 : 20 * 1000,
   forbidOnly: !!process.env.CI,
   outputDir: 'traces',

--- a/packages/insomnia-smoke-test/playwright.config.ts
+++ b/packages/insomnia-smoke-test/playwright.config.ts
@@ -34,7 +34,7 @@ const config: PlaywrightTestConfig = {
       // High-confidence smoke/sanity checks, runs on Test App only on Ubuntu
       name: 'Smoke',
       testMatch: /smoke\/.*.test.ts/,
-      retries: 0,
+      retries: 1,
     },
     {
       // Single critical path test, runs on release recurring
@@ -58,7 +58,7 @@ const config: PlaywrightTestConfig = {
       sources: true,
     },
   },
-  reporter: process.env.CI ? [['github'], ['line']] : [['dot']],
+  reporter: process.env.CI ? [['github'], ['line'], ['junit', { outputFile: 'results.xml' }]] : [['dot']],
   timeout: process.env.CI || isWindows ? 60 * 1000 : 20 * 1000,
   forbidOnly: !!process.env.CI,
   outputDir: 'traces',


### PR DESCRIPTION
This PR updates playwright configuration to enable retries for Insomnia's smoke tests. `retries: 1` means playwright will attempt to re-run a failed test up to one time and if it passes, it will consider the test passed, otherwise it will fail. This should help alleviate some pain manually re-running github actions if a test fails due to transient issues (e.g. network, infra). 

Note, this is part of a larger effort to automate e2e flaky test fixes; we are not enabling retries to mask flaky tests. Enabling retries provides us a better flaky test signal while minimizing manual work needed to accomplish the same thing. [See RFC.](https://konghq.atlassian.net/wiki/spaces/ST/pages/5726732334/DRAFT+RFC+1+-+Mechanism+to+detect+and+fix+flaky+end-to-end+tests+in+Insomnia)
