### PR TITLE
Fix: When paste curl command in request url bar, the import modal did not show

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
@@ -1122,30 +1122,6 @@ const Debug = () => {
                     </GridList>
                   </div>
                 </div>
-                {isImportModalOpen && (
-                  <ImportModal
-                    onHide={() => setIsImportModalOpen(false)}
-                    from={{ type: 'file' }}
-                    projectName={activeProject.name ?? getProductName()}
-                    workspaceName={activeWorkspace.name}
-                    organizationId={organizationId}
-                    defaultProjectId={projectId}
-                    defaultWorkspaceId={workspaceId}
-                  />
-                )}
-                {isPasteCurlModalOpen && (
-                  <PasteCurlModal
-                    onImport={req => {
-                      createRequest({
-                        requestType: 'From Curl',
-                        parentId: workspaceId,
-                        req,
-                      });
-                    }}
-                    defaultValue={pastedCurl}
-                    onHide={() => setPasteCurlModalOpen(false)}
-                  />
-                )}
               </div>
             </Panel>
             <PanelResizeHandle className="h-full w-px bg-(--hl-md)" />
@@ -1220,6 +1196,30 @@ const Debug = () => {
           </PanelGroup>
         </Panel>
       </PanelGroup>
+      {isImportModalOpen && (
+        <ImportModal
+          onHide={() => setIsImportModalOpen(false)}
+          from={{ type: 'file' }}
+          projectName={activeProject.name ?? getProductName()}
+          workspaceName={activeWorkspace.name}
+          organizationId={organizationId}
+          defaultProjectId={projectId}
+          defaultWorkspaceId={workspaceId}
+        />
+      )}
+      {isPasteCurlModalOpen && (
+        <PasteCurlModal
+          onImport={req => {
+            createRequest({
+              requestType: 'From Curl',
+              parentId: workspaceId,
+              req,
+            });
+          }}
+          defaultValue={pastedCurl}
+          onHide={() => setPasteCurlModalOpen(false)}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Fix the issue that can not import request by pasting curl inside url input field.
Move `PasteCurlModal` outside the PanelGroup component which is not rendered in request page

[INS-3019](https://konghq.atlassian.net/browse/INS-3019)

Closes https://github.com/Kong/insomnia/issues/10214

[INS-3019]: https://konghq.atlassian.net/browse/INS-3019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ