### PR TITLE
fix: cloud sync test flaky

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.insomnia-sync.pull-remote-file.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.insomnia-sync.pull-remote-file.tsx
@@ -2,6 +2,7 @@ import { models, services } from 'insomnia-data';
 import { href, redirect } from 'react-router';
 
 import { invariant } from '~/common/utils/invariant';
+import uiEventBus, { CLOUD_SYNC_FILE_CHANGE } from '~/ui/event-bus';
 import { createFetcherSubmitHook } from '~/ui/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.insomnia-sync.pull-remote-file';
@@ -27,6 +28,7 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
     const workspace = await services.workspace.getById(workspaceId);
 
     invariant(workspace, 'Workspace not found');
+    uiEventBus.emit(CLOUD_SYNC_FILE_CHANGE);
     const activity = models.workspace.scopeToActivity(workspace?.scope);
 
     return redirect(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/${activity}`);

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
@@ -278,6 +278,13 @@ const ProjectNavigationSidebarInner = (
   const cachedCollectionChildrenAndMetaRef = useRef<Map<string, AllRequestsAndMetaInWorkspace>>(new Map());
   // ref to track whether we are currently fetching unsynced files for cloud sync projects to avoid duplicate requests
   const isFetchingUnsyncedFilesRef = useRef(false);
+  const [workspaceCacheVersion, setWorkspaceCacheVersion] = useState(0);
+
+  const clearWorkspaceCaches = useCallback(() => {
+    cachedWorkspacesRef.current.clear();
+    cachedCollectionChildrenAndMetaRef.current.clear();
+    setWorkspaceCacheVersion(version => version + 1);
+  }, []);
 
   const syncKonnectProjectsAndNotifyRef = useRef<(konnectOrganizationId?: string | null) => Promise<void>>(
     async () => {},
@@ -488,18 +495,18 @@ const ProjectNavigationSidebarInner = (
   useEffect(() => {
     getAllRemoteFilesByProjectId();
     const updateUnsyncedFiles = () => {
+      clearWorkspaceCaches();
       getAllRemoteFilesByProjectId();
     };
     // Subscribe to changes in unsynced workspace files to keep the sidebar up to date.
     // The subscribe is triggered in insomnia-event-stream-context when cloud sync files is changed remotely
     return uiEventBus.on(CLOUD_SYNC_FILE_CHANGE, updateUnsyncedFiles);
-  }, [getAllRemoteFilesByProjectId, organizationId]);
+  }, [clearWorkspaceCaches, getAllRemoteFilesByProjectId, organizationId]);
 
   useEffect(() => {
     // clear caches on any router data change to avoid showing stale data
-    cachedWorkspacesRef.current.clear();
-    cachedCollectionChildrenAndMetaRef.current.clear();
-  }, [projectLoaderData]);
+    clearWorkspaceCaches();
+  }, [clearWorkspaceCaches, projectLoaderData]);
 
   useEffect(() => {
     const tryToGetWorkspacesFromCache = async (projectIds: string[]) => {
@@ -785,6 +792,7 @@ const ProjectNavigationSidebarInner = (
     localWorkspaceOrders,
     organizationId,
     projectsWithPresence,
+    workspaceCacheVersion,
     unsyncedFilesByProjectId,
   ]);
 

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
@@ -278,12 +278,10 @@ const ProjectNavigationSidebarInner = (
   const cachedCollectionChildrenAndMetaRef = useRef<Map<string, AllRequestsAndMetaInWorkspace>>(new Map());
   // ref to track whether we are currently fetching unsynced files for cloud sync projects to avoid duplicate requests
   const isFetchingUnsyncedFilesRef = useRef(false);
-  const [workspaceCacheVersion, setWorkspaceCacheVersion] = useState(0);
 
   const clearWorkspaceCaches = useCallback(() => {
     cachedWorkspacesRef.current.clear();
     cachedCollectionChildrenAndMetaRef.current.clear();
-    setWorkspaceCacheVersion(version => version + 1);
   }, []);
 
   const syncKonnectProjectsAndNotifyRef = useRef<(konnectOrganizationId?: string | null) => Promise<void>>(
@@ -792,7 +790,6 @@ const ProjectNavigationSidebarInner = (
     localWorkspaceOrders,
     organizationId,
     projectsWithPresence,
-    workspaceCacheVersion,
     unsyncedFilesByProjectId,
   ]);
 


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
In some cases the sidebar data is not rebuilt after pulling the remote workspace, resulting in a flaky test.