### PR TITLE
fix: Previous response will show after a request is sent successfully

### DIFF
--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -3,6 +3,7 @@ import { services } from 'insomnia-data';
 import { PREVIEW_MODE_SOURCE } from 'insomnia-data/common';
 import { type FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { Tab, TabList, TabPanel, Tabs, Toolbar } from 'react-aria-components';
+import { useFetcher } from 'react-router';
 
 import { bodyBufferToUtf8 } from '~/common/utils/utf8-bytes';
 import { useRootLoaderData } from '~/root';
@@ -64,6 +65,8 @@ export const ResponsePane: FC<Props> = ({ activeRequestId }) => {
     responseFilterHistory.unshift(responseFilter);
     patchRequestMeta(requestId, { responseFilterHistory });
   };
+  const requestSendingFetcher = useFetcher({ key: `send-request-${activeRequest._id}` });
+  const isRequestSending = requestSendingFetcher.state !== 'idle';
 
   const { isExecuting, steps } = useExecutionState({ requestId: activeRequest._id });
 
@@ -276,7 +279,7 @@ export const ResponsePane: FC<Props> = ({ activeRequestId }) => {
         </TabPanel>
       </Tabs>
       <ErrorBoundary errorClassName="font-error pad text-center">
-        {isExecuting && (
+        {(isExecuting || isRequestSending) && (
           <ResponseTimer
             handleCancel={() => cancelRequestById(activeRequest._id)}
             activeRequestId={activeRequestId}

--- a/packages/insomnia/src/ui/components/panes/response-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/response-pane.tsx
@@ -65,6 +65,8 @@ export const ResponsePane: FC<Props> = ({ activeRequestId }) => {
     responseFilterHistory.unshift(responseFilter);
     patchRequestMeta(requestId, { responseFilterHistory });
   };
+
+  // Check if the request is sending by fetcher key
   const requestSendingFetcher = useFetcher({ key: `send-request-${activeRequest._id}` });
   const isRequestSending = requestSendingFetcher.state !== 'idle';
 

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -148,7 +148,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(
     const [currentInterval, setCurrentInterval] = useState<number | null>(null);
     const [currentTimeout, setCurrentTimeout] = useState<number | undefined>();
     const connectRequestFetcher = useRequestConnectActionFetcher();
-    const sendRequestFetcher = useDebugRequestSendActionFetcher();
+    const sendRequestFetcher = useDebugRequestSendActionFetcher({ key: `send-request-${activeRequest._id}` });
 
     const { updateTabById } = useInsomniaTabContext();
 

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -148,6 +148,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(
     const [currentInterval, setCurrentInterval] = useState<number | null>(null);
     const [currentTimeout, setCurrentTimeout] = useState<number | undefined>();
     const connectRequestFetcher = useRequestConnectActionFetcher();
+    // Add a key here for other components to track the send action state
     const sendRequestFetcher = useDebugRequestSendActionFetcher({ key: `send-request-${activeRequest._id}` });
 
     const { updateTabById } = useInsomniaTabContext();


### PR DESCRIPTION
# Problem:
When we send a request, the response pane will show the previous response first, then change back to the current response result.
The reason is that `isExecuting` is set to false while the request send action is still running. The `activeResponse` is not updated.

# Changes:
- Add a `key` for the action to send request in request-pane.
- The response-pane will track the action status by the key. 

[INS-3027](https://konghq.atlassian.net/browse/INS-3027)


[INS-3027]: https://konghq.atlassian.net/browse/INS-3027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ