### PR TITLE
feat(INS-2933): add request_url_length to Request Created analytics event

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new.tsx
@@ -134,6 +134,7 @@ export async function clientAction({ params, request }: Route.ClientActionArgs) 
     project_id: projectId,
     collection_id: workspaceId,
     request_key_id: activeRequestId,
+    request_url_length: req?.url?.length || 0,
     has_prescript: !!req?.preRequestScript,
     has_postscript: !!req?.afterResponseScript,
     request_header_names: req?.headers?.map(h => h.name) || [],

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
@@ -208,6 +208,7 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
 
       const requestCreatedProperties = {
         requestType: 'HTTP',
+        request_url_length: 0,
         ...(workspaceData.source && { source: workspaceData.source }),
       };
       window.main.trackAnalyticsEvent({


### PR DESCRIPTION
## Summary
- Adds a `request_url_length` property to the `Request Created` analytics event, computed from the request's URL (`0` for requests created with no URL).
- Covers both places that emit this event: the main request-creation action and the `withRequest` flow (creating a collection + request together, which always creates a blank request).

## Why
Needed to measure whether users are still creating blank requests via the Treatment B "Create HTTP Request" button in the first-request-experience A/B experiment — a `request_url_length` of `0` signals a blank-request creation.
