### PR TITLE
sync sec/sandbox-services-fixes with develop, resolve C1/C2 test conflicts

### DIFF
--- a/examples/insomnia-plugin-sandbox-demo/index.js
+++ b/examples/insomnia-plugin-sandbox-demo/index.js
@@ -8,7 +8,7 @@ module.exports.templateTags = [
     async run(context, label = 'hello') {
       // The sandbox sets INSOMNIA_TEMPLATE_SANDBOX; the legacy main-process path does not. (Both now
       // have `process` — the sandbox provides a stub since M2 — so it can't be the discriminator.)
-      // eslint-disable-next-line no-undef -- sandbox-only global; guarded by typeof
+
       const ranIn = typeof INSOMNIA_TEMPLATE_SANDBOX !== 'undefined' ? 'sandbox' : 'main-process';
 
       // Exercise an async host bridge — proves __hostBridge + the executePendingJobs driver loop

--- a/examples/insomnia-plugin-sandbox-demo/package.json
+++ b/examples/insomnia-plugin-sandbox-demo/package.json
@@ -7,8 +7,12 @@
     "name": "sandbox-demo",
     "description": "Demo plugin to manually verify the QuickJS template-tag sandbox path",
     "permissions": {
-      "modules": ["events"],
-      "capabilities": ["storage"]
+      "modules": [
+        "events"
+      ],
+      "capabilities": [
+        "storage"
+      ]
     }
   }
 }

--- a/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
@@ -355,16 +355,16 @@ test('Template tag sandbox: manifest grants a non-baseline module and is shown i
   await expect.soft(page.getByTestId('plugin-permission-warning-insomnia-plugin-events-malformed')).toBeVisible();
 });
 
-// Tag-object source factories (composed into a plugin's templateTags array below). Each reports its
-// result, or the bridge's error message if the capability was denied.
-// A storage round-trip (set then get) — needs the `storage` capability.
+// Tag-object source factories (composed into a plugin's templateTags array below).
+// A storage round-trip (set then get) — needs the `storage` capability. Under C2 an ungranted
+// plugin has no `context.store` branch at all, so it feature-detects and reports that rather than
+// throwing — the idiomatic graceful-degradation pattern.
 const storageTagObject = (tagName: string) => `{
   name: '${tagName}', displayName: '${tagName}', args: [],
   async run(context) {
-    try {
-      await context.store.setItem('cap_k', 'cap-storage-ok');
-      return await context.store.getItem('cap_k');
-    } catch (err) { return err.message; }
+    if (!context.store) { return 'no-storage-capability'; }
+    await context.store.setItem('cap_k', 'cap-storage-ok');
+    return await context.store.getItem('cap_k');
   }
 }`;
 // A util.render call — baseline (no manifest needed).
@@ -375,7 +375,7 @@ const renderTagObject = (tagName: string) => `{
   }
 }`;
 
-test('Template tag sandbox: host capabilities are gated by the manifest (C1)', async ({
+test('Template tag sandbox: host capabilities are gated by the manifest (C1 + C2)', async ({
   page,
   app,
   dataPath,
@@ -421,8 +421,8 @@ test('Template tag sandbox: host capabilities are gated by the manifest (C1)', a
 
   // Declared `storage` → the set/get round-trip flows end-to-end through the gated bridge.
   await assertTagPreview('{% capstorage', 'cap-storage-ok');
-  // Undeclared → the exact denial naming the capability (tells the author what to add).
-  await assertTagPreview('{% capdenied', "Capability 'storage' not granted");
+  // Undeclared → `context.store` is absent (C2), so the plugin feature-detects and degrades.
+  await assertTagPreview('{% capdenied', 'no-storage-capability');
   // Baseline `render` still works for the same no-manifest plugin — gating is per-capability.
   await assertTagPreview('{% capbaseline', 'baseline-ok');
 });

--- a/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
+++ b/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
@@ -41,6 +41,12 @@ export const IN_SANDBOX_BOOTSTRAP = [
   // method syntax / String() so the gate never routes through a plugin-mutable intrinsic.
   '  var __arrIndexOf = Function.prototype.call.bind(Array.prototype.indexOf);',
 
+  // --- capability grants (axis 2, C2): drives capability-aware context construction ---
+  // Read from the same captured envelope as the module grant, using the pristine indexOf so a
+  // plugin can\'t forge membership. __buildContext attaches only granted branches (below).
+  '  var __grantedCaps = (__env && __env.grantedCapabilities) || [];',
+  '  function __hasCap(c) { return __arrIndexOf(__grantedCaps, c) !== -1; }',
+
   '  var T = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";',
 
   // --- btoa / atob (operate on Latin1 binary strings, matching the browser) ---
@@ -160,9 +166,14 @@ export const IN_SANDBOX_BOOTSTRAP = [
   '  };',
 
   // --- rebuild the plugin context over the bulk-copied envelope ---
+  // Every branch is built here, then the ones whose capability is not granted are removed below, so
+  // `context.network` (etc.) is `undefined` — not a present-but-rejecting stub — when ungated. This
+  // is defense in depth over the host-side bridge gate (C1): a plugin can feature-detect
+  // (`if (context.network)`) and degrade gracefully, and touching an ungranted branch fails at the
+  // property access in the plugin\'s own code rather than as a later async rejection.
   '  globalThis.__buildContext = function (env) {',
   '    var P = env.pluginName;',
-  '    return {',
+  '    var ctx = {',
   '      app: {',
   '        alert: function (title, message) { return __bridge("app.alert", { title: title, message: message }); },',
   '        dialog: function (title) { return __bridge("app.dialog", { title: title }); },',
@@ -221,6 +232,22 @@ export const IN_SANDBOX_BOOTSTRAP = [
   '        }',
   '      }',
   '    };',
+  // Remove ungranted branches. Kept in lockstep with BRIDGE_PATH_CAPABILITIES (host-bridge.ts): a
+  // branch is present iff its capability is granted, so C1 (bridge) and C2 (shape) can never
+  // disagree. Baseline caps (render, models.read, util, crypto) are always granted, so their
+  // branches always remain. `context`/`meta`/`renderPurpose` are plain data — never gated.
+  '    if (!__hasCap("app")) { delete ctx.app; delete ctx.util.openInBrowser; }',
+  '    if (!__hasCap("storage")) { delete ctx.store; }',
+  '    if (!__hasCap("network")) { delete ctx.network; }',
+  '    if (!__hasCap("fs-read")) { delete ctx.util.readFile; }',
+  '    if (!__hasCap("render")) { delete ctx.util.render; }',
+  '    if (!__hasCap("util")) { delete ctx.util.nodeOS; delete ctx.util.decode; delete ctx.util.encode; }',
+  '    if (!__hasCap("credentials")) { delete ctx.util.models.cloudCredential; }',
+  '    if (!__hasCap("models.read")) {',
+  '      delete ctx.util.models.request; delete ctx.util.models.workspace; delete ctx.util.models.oAuth2Token;',
+  '      delete ctx.util.models.cookieJar; delete ctx.util.models.response; delete ctx.util.models.settings;',
+  '    }',
+  '    return ctx;',
   '  };',
 
   // --- find the requested tag in the evaluated plugin module and run it ---

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
@@ -658,7 +658,9 @@ describe('ambient globals — sandbox stdlib (M2)', () => {
     });
 
     it('set updates the first occurrence in place and drops the rest', async () => {
-      const actual = await runGlobal("var p = new URLSearchParams('a=1&b=2&a=3'); p.set('a', '9'); return p.toString();");
+      const actual = await runGlobal(
+        "var p = new URLSearchParams('a=1&b=2&a=3'); p.set('a', '9'); return p.toString();",
+      );
       const expected = new URLSearchParams('a=1&b=2&a=3');
       expected.set('a', '9');
       expect(actual).toBe(expected.toString());
@@ -670,7 +672,8 @@ describe('ambient globals — sandbox stdlib (M2)', () => {
 describe('raw host bridge is not reachable from plugin code', () => {
   it('deletes __hostBridge from the sandbox global while context.* still round-trips', async () => {
     const probe = await runTagInSandbox({
-      pluginSource: "module.exports.templateTags = [{ name: 'g', run: function () { return typeof globalThis.__hostBridge; } }];",
+      pluginSource:
+        "module.exports.templateTags = [{ name: 'g', run: function () { return typeof globalThis.__hostBridge; } }];",
       tagName: 'g',
       envelope: envelope([]),
       bridge: noBridge,
@@ -763,10 +766,22 @@ describe('capability gating at the host bridge (C1)', () => {
     expect(actual).toBe('x64');
   });
 
-  it('denies a non-baseline capability (storage) and names it', async () => {
+  it('the bridge rejects an ungranted capability even if the context branch is present (backstop)', async () => {
+    // Defense in depth: grant `storage` to the context (so C2 keeps `context.store`) but withhold it
+    // from the bridge filter. The store call reaches the bridge, which is the backstop and rejects
+    // with the capability message. (The no-manifest case where the branch is simply absent is
+    // covered by the C2 "omits non-baseline branches" test.)
     await expect(
-      runGated("return await context.store.getItem('k');", [...TEMPLATE_TAG_BASELINE_CAPABILITIES], {
-        'pluginData.getItem': async () => 'stored-value',
+      runTagInSandbox({
+        pluginSource:
+          "module.exports.templateTags = [{ name: 'g', run: async function (context) { return await context.store.getItem('k'); } }];",
+        tagName: 'g',
+        envelope: envelope([], TEMPLATE_TAG_BASELINE_MODULES, resolveTemplateTagCapabilities(['storage'])),
+        bridge: createMapBridge(
+          filterByCapabilities({ 'pluginData.getItem': async () => 'stored-value' }, [
+            ...TEMPLATE_TAG_BASELINE_CAPABILITIES,
+          ]),
+        ),
       }),
     ).rejects.toThrow("Capability 'storage' not granted");
   });
@@ -785,5 +800,112 @@ describe('capability gating at the host bridge (C1)', () => {
       'util.render': async () => 'rendered',
     });
     expect(actual).toBe('rendered');
+  });
+});
+
+describe('capability-aware context construction (C2)', () => {
+  // Reports the shape of the rebuilt context: which branches exist for a given capability grant.
+  // No bridge is called — only `typeof` introspection — so noBridge is fine.
+  const SHAPE_PROBE = `module.exports.templateTags = [{ name: 's', run: function (context) {
+    return JSON.stringify({
+      app: typeof context.app,
+      store: typeof context.store,
+      network: typeof context.network,
+      render: typeof context.util.render,
+      readFile: typeof context.util.readFile,
+      nodeOS: typeof context.util.nodeOS,
+      openInBrowser: typeof context.util.openInBrowser,
+      modelsRequest: typeof context.util.models.request,
+      cloudCredential: typeof context.util.models.cloudCredential,
+      contextData: typeof context.context
+    });
+  } }];`;
+
+  const shape = async (granted: string[]) => {
+    const raw = await runTagInSandbox({
+      pluginSource: SHAPE_PROBE,
+      tagName: 's',
+      envelope: envelope([], TEMPLATE_TAG_BASELINE_MODULES, granted),
+      bridge: noBridge,
+    });
+    return JSON.parse(raw) as Record<string, string>;
+  };
+
+  it('omits non-baseline branches with only the baseline grant', async () => {
+    const s = await shape([...TEMPLATE_TAG_BASELINE_CAPABILITIES]);
+    // Baseline present:
+    expect(s.render).toBe('function');
+    expect(s.nodeOS).toBe('function');
+    expect(s.modelsRequest).toBe('object');
+    expect(s.contextData).toBe('object'); // plain data, never gated
+    // Non-baseline absent:
+    expect(s.app).toBe('undefined');
+    expect(s.store).toBe('undefined');
+    expect(s.network).toBe('undefined');
+    expect(s.readFile).toBe('undefined');
+    expect(s.openInBrowser).toBe('undefined');
+    expect(s.cloudCredential).toBe('undefined');
+  });
+
+  it('attaches context.network / context.store exactly as declared (feature-detect matrix)', async () => {
+    const none = await shape([...TEMPLATE_TAG_BASELINE_CAPABILITIES]);
+    expect(`${none.network}:${none.store}`).toBe('undefined:undefined');
+
+    const net = await shape(resolveTemplateTagCapabilities(['network']));
+    expect(`${net.network}:${net.store}`).toBe('object:undefined');
+
+    const both = await shape(resolveTemplateTagCapabilities(['network', 'storage']));
+    expect(`${both.network}:${both.store}`).toBe('object:object');
+  });
+
+  it('supports graceful degradation via feature detection', async () => {
+    const detect = `module.exports.templateTags = [{ name: 'd', run: function (context) {
+      return context.network ? 'online-mode' : 'offline-mode';
+    } }];`;
+    const offline = await runTagInSandbox({
+      pluginSource: detect,
+      tagName: 'd',
+      envelope: envelope([], TEMPLATE_TAG_BASELINE_MODULES, [...TEMPLATE_TAG_BASELINE_CAPABILITIES]),
+      bridge: noBridge,
+    });
+    expect(offline).toBe('offline-mode');
+    const online = await runTagInSandbox({
+      pluginSource: detect,
+      tagName: 'd',
+      envelope: envelope([], TEMPLATE_TAG_BASELINE_MODULES, resolveTemplateTagCapabilities(['network'])),
+      bridge: noBridge,
+    });
+    expect(online).toBe('online-mode');
+  });
+
+  it('attaches app + fs-read + credentials branches only when their capability is granted', async () => {
+    const s = await shape(resolveTemplateTagCapabilities(['app', 'fs-read', 'credentials']));
+    expect(s.app).toBe('object');
+    expect(s.openInBrowser).toBe('function'); // openInBrowser is under the app capability
+    expect(s.readFile).toBe('function');
+    expect(s.cloudCredential).toBe('object');
+  });
+
+  // The two layers must never disagree: a context branch is attached iff its bridge path's
+  // capability (C1's BRIDGE_PATH_CAPABILITIES) is granted. For each non-baseline branch, granting
+  // its bridge-path capability makes it present; the baseline-only grant leaves it absent.
+  it('context shape agrees with the bridge capability map (C1 ↔ C2)', async () => {
+    const branchToBridgePath: Record<string, string> = {
+      network: 'network.sendRequest',
+      store: 'pluginData.getItem',
+      readFile: 'readFile',
+      openInBrowser: 'openInBrowser',
+      cloudCredential: 'cloudCredential.getById',
+    };
+    const baseline = await shape([...TEMPLATE_TAG_BASELINE_CAPABILITIES]);
+    for (const [branch, bridgePath] of Object.entries(branchToBridgePath)) {
+      const capability = BRIDGE_PATH_CAPABILITIES[bridgePath];
+      expect(capability, `${bridgePath} must be a mapped bridge path`).toBeTruthy();
+      // Absent under baseline (none of these capabilities are baseline)…
+      expect(baseline[branch], `${branch} should be absent without ${capability}`).toBe('undefined');
+      // …present once its capability is granted.
+      const granted = await shape(resolveTemplateTagCapabilities([capability]));
+      expect(granted[branch], `${branch} should be present with ${capability}`).not.toBe('undefined');
+    }
   });
 });


### PR DESCRIPTION
## What this PR does

Brings `sec/sandbox-services-fixes` up to date with `develop` and resolves the resulting conflicts, so #10232 can actually be merged. From reviewing #10232, this branch was forked before two related commits landed independently on `develop`:

- `e4f4cd5945` feat(templating): capability-gate the sandbox host bridge (C1)
- `911e188654` feat(templating): capability-aware sandbox context construction (C2)

Both implement the same host-bridge capability model this PR also implements (`host-bridge.ts` / `marshal.ts` are byte-identical between this branch and `develop`), so merging `develop` in is a no-op for that code. The real, hand-resolved conflicts were:

1. **`examples/insomnia-plugin-sandbox-demo/package.json`** — pure JSON formatting difference (multi-line vs single-line arrays), content identical either way. Took `develop`'s formatting.
2. **`packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts`** and **`packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts`** — semantic conflict. This PR's tests assert the pre-C2 behavior (an ungranted plugin still gets a `context.store` branch, and calling it throws `"Capability 'storage' not granted"` from the bridge). `develop`'s already-shipped C2 work removes the branch entirely for ungranted plugins (feature-detection: `if (!context.store) return 'no-storage-capability'`). Took `develop`'s versions, which are a strict superset (they include the C1 "backstop" test and the full C2 context-shape test suite that this PR's copies were missing).

`packages/insomnia/src/main/network/libcurl-promise.ts` merged automatically — `develop` has since gained an async `createConfiguredCurlInstance` + `parseResolvedProxy` (INS-2943 proxy work) that predates this PR's fork point; git's 3-way merge correctly folded this PR's per-certificate try/catch isolation into that newer function shape without any manual edits.

No other files needed manual changes — everything else is `develop`'s unrelated intervening history (first-request-experience A/B, method-selector, etc.) coming along for the ride, not part of this PR's intent.

## Validation

Run from the merged branch:
- `npx vitest run` on the touched suites (`secure-read-file.test.ts`, `templating-worker-database.test.ts`, `plugin-tag-sandbox.test.ts`) — 101/101 passing
- `npm run type-check -w packages/insomnia` — clean
- `eslint` on all touched files — clean

## Note

This PR intentionally targets `sec/sandbox-services-fixes`, not `develop` — merge this into that branch first, then #10232 should be mergeable into `develop` with the security fixes (`secure-read-file.ts` symlink/prefix hardening, the `pluginToMainAPI` id-coercion / `cloudCredential.update` / `getBodyBuffer` fixes) intact and reconciled with what already shipped.
