### PR TITLE
fix: don't count auto-derived file name as a changed field in new workspace modal

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/git-sync.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/git-sync.test.ts
@@ -182,6 +182,46 @@ test.describe('Git Sync', () => {
     // After discarding all changes the staging modal auto-closes
     await expect.soft(page.getByLabel('Unstaged changes')).toBeHidden();
   });
+
+  // Regression test for a24b1b0: editing only the Name field auto-mirrors it into the
+  // (git-only) File name field. That auto-derived value must NOT count as a second
+  // real unsaved change on top of the Name edit itself — the modal's guard only
+  // prompts once more than one field has genuinely changed (changedFieldCount > 1).
+  test('Editing only the collection name does not trigger the unsaved changes prompt', async ({ page, insomnia }) => {
+    await insomnia.navigationSidebar.selectProjectDropdownOption({
+      actionName: 'Collection',
+      projectName: GIT_PROJECT_NAME,
+    });
+    await page.getByRole('textbox', { name: 'Name', exact: true }).click();
+    await page.getByRole('textbox', { name: 'Name', exact: true }).press('ControlOrMeta+a');
+    await page.getByRole('textbox', { name: 'Name', exact: true }).fill('Name Only Collection');
+
+    // Only Name was touched. Pre-fix, the auto-mirrored File name field also counted
+    // as changed, pushing changedFieldCount to 2 and wrongly triggering this prompt.
+    await page.keyboard.press('Escape');
+    await page.getByText('Create a new Request Collection').waitFor({ state: 'hidden' });
+    await expect.soft(page.getByRole('heading', { name: 'Unsaved changes' })).toBeHidden();
+
+    await insomnia.navigationSidebar.selectProjectDropdownOption({
+      actionName: 'Collection',
+      projectName: GIT_PROJECT_NAME,
+    });
+    await page.getByRole('textbox', { name: 'Name', exact: true }).click();
+    await page.getByRole('textbox', { name: 'Name', exact: true }).press('ControlOrMeta+a');
+    await page.getByRole('textbox', { name: 'Name', exact: true }).fill('Two Real Edits Collection');
+    await page.getByRole('textbox', { name: 'File name' }).click();
+    await page.getByRole('textbox', { name: 'File name' }).press('ControlOrMeta+a');
+    await page.getByRole('textbox', { name: 'File name' }).fill('manually_edited_file_name');
+
+    // Now Name AND File name were both genuinely edited to distinct values, so
+    // changedFieldCount is 2 and the prompt should appear as expected.
+    await page.keyboard.press('Escape');
+    await expect.soft(page.getByRole('heading', { name: 'Unsaved changes' })).toBeVisible();
+    await page.getByRole('button', { name: 'No' }).click();
+    await page.keyboard.press('Escape');
+    await page.getByRole('button', { name: 'Yes' }).click();
+    await page.getByText('Create a new Request Collection').waitFor({ state: 'hidden' });
+  });
 });
 
 async function addAccessTokenGitCredential(insomnia: InsomniaApp) {

--- a/packages/insomnia/src/ui/components/modals/new-workspace-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/new-workspace-modal.tsx
@@ -192,7 +192,7 @@ export const NewWorkspaceModal = ({
 
   const changedFieldCount = [
     workspaceData.name !== defaultNameByScope[scope],
-    workspaceData.fileName !== defaultFileName,
+    hasEditedFileName && workspaceData.fileName !== defaultFileName,
     Boolean(workspaceData.folderPath),
     workspaceData.mockServerType !== defaultMockServerType,
     Boolean(workspaceData.mockServerUrl),
@@ -264,12 +264,14 @@ export const NewWorkspaceModal = ({
                     name="name"
                     value={workspaceData.name}
                     isRequired
-                    onChange={name => setWorkspaceData({
-                      ...workspaceData,
-                      name,
-                      // Keep the file name in sync with the name until the user edits it themselves.
-                      ...(hasEditedFileName ? {} : { fileName: name }),
-                    })}
+                    onChange={name =>
+                      setWorkspaceData({
+                        ...workspaceData,
+                        name,
+                        // Keep the file name in sync with the name until the user edits it themselves.
+                        ...(hasEditedFileName ? {} : { fileName: name }),
+                      })
+                    }
                     className="group relative flex flex-col gap-2"
                   >
                     <Label className="text-sm text-(--hl)">Name</Label>


### PR DESCRIPTION
In the `new-workspace-modal.tsx`, a recent change was made to the Name field's onChange also mirror the typed value into `fileName` (until the user manually edits the file name field). This caused `changedFieldCount` to count both `name` and `fileName` as changed even when the user only edited the workspace name, incorrectly
triggering the unsaved-changes guard after a single field edit (it should be triggered after > 1 fields have been edited by the user). 

[Jira Ticket](https://konghq.atlassian.net/browse/INS-3036)