### PR TITLE
fix(script): setting invalid value to environment value should be rejected - INS-2957

### DIFF
--- a/packages/insomnia-scripting-environment/src/objects/__tests__/environments.test.ts
+++ b/packages/insomnia-scripting-environment/src/objects/__tests__/environments.test.ts
@@ -142,7 +142,7 @@ describe('Environment serialization', () => {
   });
 });
 
-describe('set rejects null/undefined', () => {
+describe('set rejects null/undefined/NaN', () => {
   it('Environment.set warns and skips on null', () => {
     const warnSpy = vi.spyOn(getExistingConsole(), 'warn');
     const env = new Environment('test', {});
@@ -164,7 +164,7 @@ describe('set rejects null/undefined', () => {
       localVars: new Environment('local', {}),
     });
     variables.set('key', value);
-    expect(warnSpy).toHaveBeenCalledWith('Variable \"key\" has a null, undefined, or NaN value');
+    expect(warnSpy).toHaveBeenCalledWith('Variable "key" has a null, undefined, or NaN value');
     expect(variables.get('key')).toBeUndefined();
     warnSpy.mockRestore();
   });

--- a/packages/insomnia-scripting-environment/src/objects/__tests__/environments.test.ts
+++ b/packages/insomnia-scripting-environment/src/objects/__tests__/environments.test.ts
@@ -142,17 +142,44 @@ describe('Environment serialization', () => {
   });
 });
 
-describe('set rejects null/undefined/NaN', () => {
-  it('Environment.set warns and skips on null', () => {
+describe('set accepts null but rejects undefined/NaN', () => {
+  it('Environment.set accepts null', () => {
     const warnSpy = vi.spyOn(getExistingConsole(), 'warn');
     const env = new Environment('test', {});
     env.set('key', null);
-    expect(warnSpy).toHaveBeenCalledWith('Variable "key" has a null, undefined, or NaN value');
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(env.has('key')).toBe(true);
+    expect(env.get('key')).toBeNull();
+    warnSpy.mockRestore();
+  });
+
+  it.each([undefined, Number.NaN])('Environment.set warns and skips on %s', value => {
+    const warnSpy = vi.spyOn(getExistingConsole(), 'warn');
+    const env = new Environment('test', {});
+    env.set('key', value);
+    expect(warnSpy).toHaveBeenCalledWith('Variable "key" has an undefined or NaN value');
     expect(env.has('key')).toBe(false);
     warnSpy.mockRestore();
   });
 
-  it.each([null, undefined, Number.NaN])('Variables.set warns and skips on %s', value => {
+  it('Variables.set accepts null', () => {
+    const warnSpy = vi.spyOn(getExistingConsole(), 'warn');
+    const variables = new Variables({
+      baseGlobalVars: new Environment('baseGlobals', {}),
+      globalVars: new Environment('globals', {}),
+      environmentVars: new Environment('environments', {}),
+      collectionVars: new Environment('baseEnvironment', {}),
+      iterationDataVars: new Environment('iterationData', {}),
+      folderLevelVars: [],
+      localVars: new Environment('local', {}),
+    });
+    variables.set('key', null);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(variables.get('key')).toBeNull();
+    warnSpy.mockRestore();
+  });
+
+  it.each([undefined, Number.NaN])('Variables.set warns and skips on %s', value => {
     const warnSpy = vi.spyOn(getExistingConsole(), 'warn');
     const variables = new Variables({
       baseGlobalVars: new Environment('baseGlobals', {}),
@@ -164,7 +191,7 @@ describe('set rejects null/undefined/NaN', () => {
       localVars: new Environment('local', {}),
     });
     variables.set('key', value);
-    expect(warnSpy).toHaveBeenCalledWith('Variable "key" has a null, undefined, or NaN value');
+    expect(warnSpy).toHaveBeenCalledWith('Variable "key" has an undefined or NaN value');
     expect(variables.get('key')).toBeUndefined();
     warnSpy.mockRestore();
   });

--- a/packages/insomnia-scripting-environment/src/objects/__tests__/environments.test.ts
+++ b/packages/insomnia-scripting-environment/src/objects/__tests__/environments.test.ts
@@ -1,6 +1,7 @@
 import { validate } from 'uuid';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
+import { getExistingConsole } from '../console';
 import { Environment, Variables } from '../environments';
 import { Folder, ParentFolders } from '../folders';
 import { Url } from '../urls';
@@ -124,5 +125,33 @@ describe('Environment serialization', () => {
   it('serializes its key-values when logged instead of an empty Map', () => {
     const environment = new Environment('Base Environment', { user_id: 'abc', count: 1 });
     expect(JSON.stringify(environment)).toEqual(JSON.stringify({ user_id: 'abc', count: 1 }));
+  });
+});
+
+describe('set rejects null/undefined', () => {
+  it('Environment.set warns and skips on null', () => {
+    const warnSpy = vi.spyOn(getExistingConsole(), 'warn');
+    const env = new Environment('test', {});
+    env.set('key', null);
+    expect(warnSpy).toHaveBeenCalledWith('Variable "key" has a null value');
+    expect(env.has('key')).toBe(false);
+    warnSpy.mockRestore();
+  });
+
+  it.each([null, undefined])('Variables.set warns and skips on %s', value => {
+    const warnSpy = vi.spyOn(getExistingConsole(), 'warn');
+    const variables = new Variables({
+      baseGlobalVars: new Environment('baseGlobals', {}),
+      globalVars: new Environment('globals', {}),
+      environmentVars: new Environment('environments', {}),
+      collectionVars: new Environment('baseEnvironment', {}),
+      iterationDataVars: new Environment('iterationData', {}),
+      folderLevelVars: [],
+      localVars: new Environment('local', {}),
+    });
+    variables.set('key', value);
+    expect(warnSpy).toHaveBeenCalledWith('Variable "key" has a null or undefined value');
+    expect(variables.get('key')).toBeUndefined();
+    warnSpy.mockRestore();
   });
 });

--- a/packages/insomnia-scripting-environment/src/objects/__tests__/environments.test.ts
+++ b/packages/insomnia-scripting-environment/src/objects/__tests__/environments.test.ts
@@ -142,7 +142,7 @@ describe('Environment serialization', () => {
   });
 });
 
-describe('set accepts null but rejects undefined/NaN', () => {
+describe('set accepts null/undefined but rejects NaN', () => {
   it('Environment.set accepts null', () => {
     const warnSpy = vi.spyOn(getExistingConsole(), 'warn');
     const env = new Environment('test', {});
@@ -153,11 +153,21 @@ describe('set accepts null but rejects undefined/NaN', () => {
     warnSpy.mockRestore();
   });
 
-  it.each([undefined, Number.NaN])('Environment.set warns and skips on %s', value => {
+  it('Environment.set accepts undefined', () => {
     const warnSpy = vi.spyOn(getExistingConsole(), 'warn');
     const env = new Environment('test', {});
-    env.set('key', value);
-    expect(warnSpy).toHaveBeenCalledWith('Variable "key" has an undefined or NaN value');
+    env.set('key', undefined);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(env.has('key')).toBe(true);
+    expect(env.get('key')).toBeUndefined();
+    warnSpy.mockRestore();
+  });
+
+  it('Environment.set warns and skips on NaN', () => {
+    const warnSpy = vi.spyOn(getExistingConsole(), 'warn');
+    const env = new Environment('test', {});
+    env.set('key', Number.NaN);
+    expect(warnSpy).toHaveBeenCalledWith('Variable "key" has a NaN value');
     expect(env.has('key')).toBe(false);
     warnSpy.mockRestore();
   });
@@ -179,7 +189,7 @@ describe('set accepts null but rejects undefined/NaN', () => {
     warnSpy.mockRestore();
   });
 
-  it.each([undefined, Number.NaN])('Variables.set warns and skips on %s', value => {
+  it('Variables.set accepts undefined', () => {
     const warnSpy = vi.spyOn(getExistingConsole(), 'warn');
     const variables = new Variables({
       baseGlobalVars: new Environment('baseGlobals', {}),
@@ -190,8 +200,25 @@ describe('set accepts null but rejects undefined/NaN', () => {
       folderLevelVars: [],
       localVars: new Environment('local', {}),
     });
-    variables.set('key', value);
-    expect(warnSpy).toHaveBeenCalledWith('Variable "key" has an undefined or NaN value');
+    variables.set('key', undefined);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(variables.get('key')).toBeUndefined();
+    warnSpy.mockRestore();
+  });
+
+  it('Variables.set warns and skips on NaN', () => {
+    const warnSpy = vi.spyOn(getExistingConsole(), 'warn');
+    const variables = new Variables({
+      baseGlobalVars: new Environment('baseGlobals', {}),
+      globalVars: new Environment('globals', {}),
+      environmentVars: new Environment('environments', {}),
+      collectionVars: new Environment('baseEnvironment', {}),
+      iterationDataVars: new Environment('iterationData', {}),
+      folderLevelVars: [],
+      localVars: new Environment('local', {}),
+    });
+    variables.set('key', Number.NaN);
+    expect(warnSpy).toHaveBeenCalledWith('Variable "key" has a NaN value');
     expect(variables.get('key')).toBeUndefined();
     warnSpy.mockRestore();
   });

--- a/packages/insomnia-scripting-environment/src/objects/__tests__/environments.test.ts
+++ b/packages/insomnia-scripting-environment/src/objects/__tests__/environments.test.ts
@@ -119,6 +119,20 @@ describe('test Variables object', () => {
     folders.get('folder2').environment.set('value', 'folder1ValueOverride');
     expect(variables.get('value')).toEqual('folder1ValueOverride');
   });
+
+  it.each([0, '', false])('get returns a falsy local value (%s) instead of falling through to lower-precedence scopes', value => {
+    const variables = new Variables({
+      baseGlobalVars: new Environment('baseGlobals', { count: 'baseGlobals-value' }),
+      globalVars: new Environment('globals', {}),
+      environmentVars: new Environment('environments', {}),
+      collectionVars: new Environment('baseEnvironment', {}),
+      iterationDataVars: new Environment('iterationData', {}),
+      folderLevelVars: [],
+      localVars: new Environment('local', { count: value }),
+    });
+
+    expect(variables.get('count')).toBe(value);
+  });
 });
 
 describe('Environment serialization', () => {
@@ -133,12 +147,12 @@ describe('set rejects null/undefined', () => {
     const warnSpy = vi.spyOn(getExistingConsole(), 'warn');
     const env = new Environment('test', {});
     env.set('key', null);
-    expect(warnSpy).toHaveBeenCalledWith('Variable \"key\" has a null or undefined value');
+    expect(warnSpy).toHaveBeenCalledWith('Variable "key" has a null, undefined, or NaN value');
     expect(env.has('key')).toBe(false);
     warnSpy.mockRestore();
   });
 
-  it.each([null, undefined])('Variables.set warns and skips on %s', value => {
+  it.each([null, undefined, Number.NaN])('Variables.set warns and skips on %s', value => {
     const warnSpy = vi.spyOn(getExistingConsole(), 'warn');
     const variables = new Variables({
       baseGlobalVars: new Environment('baseGlobals', {}),
@@ -150,7 +164,7 @@ describe('set rejects null/undefined', () => {
       localVars: new Environment('local', {}),
     });
     variables.set('key', value);
-    expect(warnSpy).toHaveBeenCalledWith('Variable "key" has a null or undefined value');
+    expect(warnSpy).toHaveBeenCalledWith('Variable \"key\" has a null, undefined, or NaN value');
     expect(variables.get('key')).toBeUndefined();
     warnSpy.mockRestore();
   });

--- a/packages/insomnia-scripting-environment/src/objects/__tests__/environments.test.ts
+++ b/packages/insomnia-scripting-environment/src/objects/__tests__/environments.test.ts
@@ -133,7 +133,7 @@ describe('set rejects null/undefined', () => {
     const warnSpy = vi.spyOn(getExistingConsole(), 'warn');
     const env = new Environment('test', {});
     env.set('key', null);
-    expect(warnSpy).toHaveBeenCalledWith('Variable "key" has a null value');
+    expect(warnSpy).toHaveBeenCalledWith('Variable \"key\" has a null or undefined value');
     expect(env.has('key')).toBe(false);
     warnSpy.mockRestore();
   });

--- a/packages/insomnia-scripting-environment/src/objects/environments.ts
+++ b/packages/insomnia-scripting-environment/src/objects/environments.ts
@@ -306,15 +306,15 @@ export class Variables {
 
   /**
    * Sets a local variable with the specified name and value.
-   * If the provided value is `null`, a warning is logged and the variable is not set.
+   * If the provided value is `null` or `undefined`, a warning is logged and the variable is not set.
    *
    * @param variableName - The name of the variable to set.
    * @param variableValue - The value to assign to the variable. Can be a boolean, number, string, undefined, or null.
-   *                        If `null`, the variable will not be set and a warning will be logged.
+   *                        If `null` or `undefined`, the variable will not be set and a warning will be logged.
    */
   set = (variableName: string, variableValue: boolean | number | string | undefined | null) => {
-    if (variableValue === null) {
-      getExistingConsole().warn(`Variable "${variableName}" has a null value`);
+    if (variableValue === null || variableValue === undefined) {
+      getExistingConsole().warn(`Variable "${variableName}" has a null or undefined value`);
       return;
     }
 

--- a/packages/insomnia-scripting-environment/src/objects/environments.ts
+++ b/packages/insomnia-scripting-environment/src/objects/environments.ts
@@ -81,15 +81,15 @@ export class Environment {
 
   /**
    * Sets a variable in the key-value store with the specified name and value.
-   * If the provided value is `undefined` or `NaN`, a warning is logged and the variable is not set.
+   * If the provided value is `NaN`, a warning is logged and the variable is not set.
    *
    * @param variableName - The name of the variable to set.
    * @param variableValue - The value to assign to the variable. Can be a boolean, number, string, undefined, or null.
-   *                        If `undefined` or `NaN`, the variable will not be set, and a warning will be logged.
+   *                        If `NaN`, the variable will not be set, and a warning will be logged.
    */
   set = (variableName: string, variableValue: boolean | number | string | undefined | null) => {
-    if (variableValue === undefined || Number.isNaN(variableValue)) {
-      getExistingConsole().warn(`Variable "${variableName}" has an undefined or NaN value`);
+    if (Number.isNaN(variableValue)) {
+      getExistingConsole().warn(`Variable "${variableName}" has a NaN value`);
       return;
     }
     this.kvs.set(variableName, variableValue);
@@ -300,15 +300,15 @@ export class Variables {
 
   /**
    * Sets a local variable with the specified name and value.
-   * If the provided value is `undefined` or `NaN`, a warning is logged and the variable is not set.
+   * If the provided value is `NaN`, a warning is logged and the variable is not set.
    *
    * @param variableName - The name of the variable to set.
    * @param variableValue - The value to assign to the variable. Can be a boolean, number, string, undefined, or null.
-   *                        If `undefined` or `NaN`, the variable will not be set and a warning will be logged.
+   *                        If `NaN`, the variable will not be set and a warning will be logged.
    */
   set = (variableName: string, variableValue: boolean | number | string | undefined | null) => {
-    if (variableValue === undefined || Number.isNaN(variableValue)) {
-      getExistingConsole().warn(`Variable "${variableName}" has an undefined or NaN value`);
+    if (Number.isNaN(variableValue)) {
+      getExistingConsole().warn(`Variable "${variableName}" has a NaN value`);
       return;
     }
 

--- a/packages/insomnia-scripting-environment/src/objects/environments.ts
+++ b/packages/insomnia-scripting-environment/src/objects/environments.ts
@@ -81,15 +81,15 @@ export class Environment {
 
   /**
    * Sets a variable in the key-value store with the specified name and value.
-   * If the provided value is `null` or `undefined`, a warning is logged and the variable is not set.
+   * If the provided value is `null`, `undefined`, or `NaN`, a warning is logged and the variable is not set.
    *
    * @param variableName - The name of the variable to set.
    * @param variableValue - The value to assign to the variable. Can be a boolean, number, string, undefined, or null.
-   *                        If `null` or `undefined`, the variable will not be set, and a warning will be logged.
+   *                        If `null`, `undefined`, or `NaN`, the variable will not be set, and a warning will be logged.
    */
   set = (variableName: string, variableValue: boolean | number | string | undefined | null) => {
-    if (variableValue === null || variableValue === undefined) {
-      getExistingConsole().warn(`Variable "${variableName}" has a null or undefined value`);
+    if (variableValue === null || variableValue === undefined || Number.isNaN(variableValue)) {
+      getExistingConsole().warn(`Variable "${variableName}" has a null, undefined, or NaN value`);
       return;
     }
     this.kvs.set(variableName, variableValue);
@@ -285,8 +285,7 @@ export class Variables {
    * @returns The value of the variable if found, otherwise undefined
    */
   get = (variableName: string) => {
-    let finalVal: boolean | number | string | object | undefined;
-    [
+    const scope = [
       this.localVars,
       mergeFolderLevelVars(this.folderLevelVars),
       this.iterationDataVars,
@@ -294,27 +293,22 @@ export class Variables {
       this.collectionVars,
       this.globalVars,
       this.baseGlobalVars,
-    ].forEach(vars => {
-      const value = vars.get(variableName);
-      if (!finalVal && value) {
-        finalVal = value;
-      }
-    });
+    ].find(vars => vars.has(variableName));
 
-    return finalVal;
+    return scope?.get(variableName);
   };
 
   /**
    * Sets a local variable with the specified name and value.
-   * If the provided value is `null` or `undefined`, a warning is logged and the variable is not set.
+   * If the provided value is `null`, `undefined`, or `NaN`, a warning is logged and the variable is not set.
    *
    * @param variableName - The name of the variable to set.
    * @param variableValue - The value to assign to the variable. Can be a boolean, number, string, undefined, or null.
-   *                        If `null` or `undefined`, the variable will not be set and a warning will be logged.
+   *                        If `null`, `undefined`, or `NaN`, the variable will not be set and a warning will be logged.
    */
   set = (variableName: string, variableValue: boolean | number | string | undefined | null) => {
-    if (variableValue === null || variableValue === undefined) {
-      getExistingConsole().warn(`Variable "${variableName}" has a null or undefined value`);
+    if (variableValue === null || variableValue === undefined || Number.isNaN(variableValue)) {
+      getExistingConsole().warn(`Variable "${variableName}" has a null, undefined, or NaN value`);
       return;
     }
 

--- a/packages/insomnia-scripting-environment/src/objects/environments.ts
+++ b/packages/insomnia-scripting-environment/src/objects/environments.ts
@@ -81,15 +81,15 @@ export class Environment {
 
   /**
    * Sets a variable in the key-value store with the specified name and value.
-   * If the provided value is `null`, a warning is logged and the variable is not set.
+   * If the provided value is `null` or `undefined`, a warning is logged and the variable is not set.
    *
    * @param variableName - The name of the variable to set.
    * @param variableValue - The value to assign to the variable. Can be a boolean, number, string, undefined, or null.
-   *                        If `null`, the variable will not be set, and a warning will be logged.
+   *                        If `null` or `undefined`, the variable will not be set, and a warning will be logged.
    */
   set = (variableName: string, variableValue: boolean | number | string | undefined | null) => {
-    if (variableValue === null) {
-      getExistingConsole().warn(`Variable "${variableName}" has a null value`);
+    if (variableValue === null || variableValue === undefined) {
+      getExistingConsole().warn(`Variable "${variableName}" has a null or undefined value`);
       return;
     }
     this.kvs.set(variableName, variableValue);

--- a/packages/insomnia-scripting-environment/src/objects/environments.ts
+++ b/packages/insomnia-scripting-environment/src/objects/environments.ts
@@ -35,7 +35,7 @@ export class Environment {
    * It is intended to be a private field and should not be accessed directly outside the class.
    */
   private _name: string;
-  private kvs = new Map<string, boolean | number | string | undefined>();
+  private kvs = new Map<string, boolean | number | string | null | undefined>();
 
   /**
    * Constructs an instance of the environment object.
@@ -81,15 +81,15 @@ export class Environment {
 
   /**
    * Sets a variable in the key-value store with the specified name and value.
-   * If the provided value is `null`, `undefined`, or `NaN`, a warning is logged and the variable is not set.
+   * If the provided value is `undefined` or `NaN`, a warning is logged and the variable is not set.
    *
    * @param variableName - The name of the variable to set.
    * @param variableValue - The value to assign to the variable. Can be a boolean, number, string, undefined, or null.
-   *                        If `null`, `undefined`, or `NaN`, the variable will not be set, and a warning will be logged.
+   *                        If `undefined` or `NaN`, the variable will not be set, and a warning will be logged.
    */
   set = (variableName: string, variableValue: boolean | number | string | undefined | null) => {
-    if (variableValue === null || variableValue === undefined || Number.isNaN(variableValue)) {
-      getExistingConsole().warn(`Variable "${variableName}" has a null, undefined, or NaN value`);
+    if (variableValue === undefined || Number.isNaN(variableValue)) {
+      getExistingConsole().warn(`Variable "${variableName}" has an undefined or NaN value`);
       return;
     }
     this.kvs.set(variableName, variableValue);
@@ -300,15 +300,15 @@ export class Variables {
 
   /**
    * Sets a local variable with the specified name and value.
-   * If the provided value is `null`, `undefined`, or `NaN`, a warning is logged and the variable is not set.
+   * If the provided value is `undefined` or `NaN`, a warning is logged and the variable is not set.
    *
    * @param variableName - The name of the variable to set.
    * @param variableValue - The value to assign to the variable. Can be a boolean, number, string, undefined, or null.
-   *                        If `null`, `undefined`, or `NaN`, the variable will not be set and a warning will be logged.
+   *                        If `undefined` or `NaN`, the variable will not be set and a warning will be logged.
    */
   set = (variableName: string, variableValue: boolean | number | string | undefined | null) => {
-    if (variableValue === null || variableValue === undefined || Number.isNaN(variableValue)) {
-      getExistingConsole().warn(`Variable "${variableName}" has a null, undefined, or NaN value`);
+    if (variableValue === undefined || Number.isNaN(variableValue)) {
+      getExistingConsole().warn(`Variable "${variableName}" has an undefined or NaN value`);
       return;
     }
 

--- a/patches/json-order+1.1.3.patch
+++ b/patches/json-order+1.1.3.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/json-order/dist/parse.js b/node_modules/json-order/dist/parse.js
+index 7d4aad8..8eda055 100644
+--- a/node_modules/json-order/dist/parse.js
++++ b/node_modules/json-order/dist/parse.js
+@@ -12,7 +12,7 @@ var traverseObject = function (obj, map, parentKey, separator) {
+     }
+     childKeys.forEach(function (childKey) {
+         var value = obj[childKey];
+-        if (typeof value === 'object') {
++        if (value !== null && typeof value === 'object') {
+             traverseObject(value, map, "" + parentKey + separator + childKey, separator);
+         }
+     });


### PR DESCRIPTION
### Background
If some invalid values are set to environment in script, an error ""Execute pre-request script failed: Cannot convert undefined or null to object" will be displayed.

### Changes
- [x] setting invalid value (undefined, NaN) to environment value should be rejected.
- [x] Allow setting null to an environment value. 

INS-2957