### PR TITLE
fix: support prompt tag in main process

### DIFF
--- a/packages/insomnia/src/common/templating/liquid-extension-worker.ts
+++ b/packages/insomnia/src/common/templating/liquid-extension-worker.ts
@@ -8,6 +8,7 @@ import packageJson from '../../../package.json';
 import { resolveArg } from './resolve-arg';
 import { tokenizeArgs } from './tokenize-args';
 import type {
+  AppPromptOptions,
   BaseRenderContext,
   NodeCurlRequestOptions,
   PluginTemplateTag,
@@ -81,10 +82,8 @@ export function createLiquidTagWorker(
           alert: async (title: string, message?: string) =>
             fetchFromTemplateWorkerDatabase('app.alert', { title, message }),
           dialog: async (title: string) => fetchFromTemplateWorkerDatabase('app.dialog', { title }),
-          prompt: async (
-            title: string,
-            options?: { label?: string; defaultValue?: string; submitName?: string; inputType?: string },
-          ) => fetchFromTemplateWorkerDatabase('app.prompt', { title, options }),
+          prompt: async (title: string, options?: AppPromptOptions) =>
+            fetchFromTemplateWorkerDatabase('app.prompt', { title, options }),
           getPath: async (name: string) => fetchFromTemplateWorkerDatabase('app.getPath', { name }),
           getInfo: () => ({ version: packageJson.version, platform }),
           showSaveDialog: async (options?: { defaultPath?: string }) =>

--- a/packages/insomnia/src/common/templating/types.ts
+++ b/packages/insomnia/src/common/templating/types.ts
@@ -264,21 +264,11 @@ export interface BaseRenderContext {
   [key: string]: any;
 }
 
-interface PromptModalOptions {
-  title: string;
+export interface AppPromptOptions {
+  label?: string;
   defaultValue?: string;
   submitName?: string;
-  selectText?: boolean;
-  upperCase?: boolean;
-  hint?: string;
   inputType?: string;
-  placeholder?: string;
-  validate?: (arg0: string) => string;
-  label?: string;
-  hints?: string[];
-  onComplete?: (arg0: string) => Promise<void> | void;
-  onHide?: () => void;
-  onDeleteHint?: (arg0?: string) => void;
 }
 
 export interface AppContext {
@@ -288,10 +278,7 @@ export interface AppContext {
     body: HTMLElement,
     options?: { onHide?: () => void; tall?: boolean; skinny?: boolean; wide?: boolean },
   ) => Promise<void>;
-  prompt: (
-    title: string,
-    options?: Pick<PromptModalOptions, 'label' | 'defaultValue' | 'submitName' | 'inputType'>,
-  ) => Promise<string>;
+  prompt: (title: string, options?: AppPromptOptions) => Promise<string>;
   getPath: (name: string) => Promise<string>;
   getInfo: () => { version: string; platform: NodeJS.Platform };
   showSaveDialog: (options?: { defaultPath?: string }) => Promise<string | null>;

--- a/packages/insomnia/src/main/__tests__/templating-worker-database.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database.test.ts
@@ -41,9 +41,9 @@ vi.mock('../network/libcurl-promise', () => ({ curlRequest: vi.fn() }));
 vi.mock('../prompt-bridge', () => ({ requestPromptFromRenderer: vi.fn() }));
 vi.mock('../secure-read-file', () => ({ secureReadFile: vi.fn() }));
 
-import { requestPromptFromRenderer } from '../prompt-bridge';
 import { parsePluginPermissions } from '~/common/plugins/permissions';
 
+import { requestPromptFromRenderer } from '../prompt-bridge';
 import {
   _testOnlyResetMigrationWarnings,
   getPluginEntrySource,

--- a/packages/insomnia/src/main/__tests__/templating-worker-database.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database.test.ts
@@ -48,8 +48,8 @@ import {
   _testOnlyResetMigrationWarnings,
   getPluginEntrySource,
   maybeWarnMissingManifest,
-  resolveDbByKey,
   readPluginModuleMap,
+  resolveDbByKey,
   runPluginTagInSandbox,
 } from '../templating-worker-database';
 

--- a/packages/insomnia/src/main/__tests__/templating-worker-database.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database.test.ts
@@ -41,12 +41,14 @@ vi.mock('../network/libcurl-promise', () => ({ curlRequest: vi.fn() }));
 vi.mock('../prompt-bridge', () => ({ requestPromptFromRenderer: vi.fn() }));
 vi.mock('../secure-read-file', () => ({ secureReadFile: vi.fn() }));
 
+import { requestPromptFromRenderer } from '../prompt-bridge';
 import { parsePluginPermissions } from '~/common/plugins/permissions';
 
 import {
   _testOnlyResetMigrationWarnings,
   getPluginEntrySource,
   maybeWarnMissingManifest,
+  resolveDbByKey,
   readPluginModuleMap,
   runPluginTagInSandbox,
 } from '../templating-worker-database';
@@ -97,7 +99,7 @@ describe('readPluginModuleMap (M4 multi-file plugin reader)', () => {
 
   it('rejects a plugin with more than MAX_PLUGIN_MODULE_FILES source files', () => {
     fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ main: 'index.js' }));
-    fs.writeFileSync(path.join(dir, 'index.js'), "module.exports = {};");
+    fs.writeFileSync(path.join(dir, 'index.js'), 'module.exports = {};');
     for (let i = 0; i < 500; i++) {
       fs.writeFileSync(path.join(dir, `f${i}.js`), 'module.exports = {};');
     }
@@ -245,5 +247,29 @@ describe('runPluginTagInSandbox — util.render escape', () => {
         context: { meta: {}, renderPurpose: 'send' as const, context: { name: 'kyle' } as any },
       }),
     ).resolves.toBe('hello kyle');
+  });
+});
+
+describe('resolveDbByKey — app.prompt', () => {
+  it('routes prompt requests to the renderer prompt bridge', async () => {
+    vi.mocked(requestPromptFromRenderer).mockResolvedValueOnce('typed value');
+
+    const response = await resolveDbByKey(
+      new Request('insomnia-templating-worker-database://app.prompt', {
+        method: 'post',
+        body: JSON.stringify({
+          title: 'Title',
+          options: { label: 'Label', defaultValue: 'cached value', inputType: 'password' },
+        }),
+      }),
+    );
+
+    await expect(response.json()).resolves.toBe('typed value');
+    expect(requestPromptFromRenderer).toHaveBeenCalledWith({
+      title: 'Title',
+      label: 'Label',
+      defaultValue: 'cached value',
+      inputType: 'password',
+    });
   });
 });

--- a/packages/insomnia/src/main/plugin-window.ts
+++ b/packages/insomnia/src/main/plugin-window.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import { app, BrowserWindow, ipcMain } from 'electron';
 
-import { requestPromptFromRenderer } from './prompt-bridge';
+import { type PromptRequestOptions, requestPromptFromRenderer } from './prompt-bridge';
 import { getMainWindow } from './window-utils';
 
 let pluginWindow: BrowserWindow | null = null;
@@ -107,7 +107,7 @@ function ensureIpcListeners() {
     if (event.sender !== pluginWindow?.webContents) {
       return null;
     }
-    return requestPromptFromRenderer(options as { title: string; label?: string; defaultValue?: string });
+    return requestPromptFromRenderer(options as unknown as PromptRequestOptions);
   });
 
   ipcMain.on(

--- a/packages/insomnia/src/main/prompt-bridge.ts
+++ b/packages/insomnia/src/main/prompt-bridge.ts
@@ -2,15 +2,17 @@ import { randomUUID } from 'node:crypto';
 
 import { ipcMain } from 'electron';
 
+import type { AppPromptOptions } from '~/common/templating/types';
+
 import { getMainWindow } from './window-utils';
+
+export interface PromptRequestOptions extends AppPromptOptions {
+  title: string;
+}
 
 const promptPendingRequests = new Map<string, (value: string | null) => void>();
 
-export function requestPromptFromRenderer(options: {
-  title: string;
-  label?: string;
-  defaultValue?: string;
-}): Promise<string | null> {
+export function requestPromptFromRenderer(options: PromptRequestOptions): Promise<string | null> {
   const mainWindow = getMainWindow();
   if (!mainWindow) {
     return Promise.resolve(null);

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -12,7 +12,12 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { jarFromCookies } from '~/common/cookies';
 import { type Plugin, type TemplateTag } from '~/common/plugins/types';
-import type { PluginTemplateTag, PluginTemplateTagContext, PluginToMainAPIPaths } from '~/common/templating/types';
+import type {
+  AppPromptOptions,
+  PluginTemplateTag,
+  PluginTemplateTagContext,
+  PluginToMainAPIPaths,
+} from '~/common/templating/types';
 import { getPluginCommonContext, getTemplateTags } from '~/plugins';
 import type { SandboxModuleDenialError } from '~/templating/sandbox/plugin-tag-sandbox';
 
@@ -657,8 +662,9 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
   'app.dialog': async (body: { title: string; message?: string }) => {
     await dialog.showMessageBox({ type: 'info', title: body.title, message: body.message || '' });
   },
-  'app.prompt': async (body: { title: string; options?: { label?: string; defaultValue?: string } }) => {
+  'app.prompt': async (body: { title: string; options?: AppPromptOptions }) => {
     return requestPromptFromRenderer({
+      ...body.options,
       title: body.title,
       label: body.options?.label ?? body.title,
       defaultValue: body.options?.defaultValue ?? '',

--- a/packages/insomnia/src/plugins/context/__tests__/app.test.ts
+++ b/packages/insomnia/src/plugins/context/__tests__/app.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import appPackageJson from '../../../../package.json';
+import * as runtimes from '../../../runtimes';
 import * as plugin from '../app';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('init()', () => {
   it('initializes correctly', async () => {
@@ -21,5 +26,37 @@ describe('app.getInfo()', () => {
       version: appPackageJson.version,
       platform: process.platform,
     });
+  });
+});
+
+describe('app.prompt()', () => {
+  it('uses the registered non-renderer prompt handler', async () => {
+    const handler = vi.fn(async () => 'typed value');
+    const options = { label: 'Label', defaultValue: 'cached value', inputType: 'password' };
+
+    vi.spyOn(runtimes, 'getRuntime').mockReturnValue({ app: { prompt: handler } } as any);
+
+    await expect(plugin.init('send').app.prompt('Title', options)).resolves.toBe('typed value');
+    expect(handler).toHaveBeenCalledWith('Title', options);
+  });
+
+  it('rejects when the registered non-renderer prompt handler rejects', async () => {
+    vi.spyOn(runtimes, 'getRuntime').mockReturnValue({
+      app: {
+        prompt: vi.fn(async () => {
+          throw new Error('Prompt Title cancelled');
+        }),
+      },
+    } as any);
+
+    await expect(plugin.init('send').app.prompt('Title')).rejects.toThrow('Prompt Title cancelled');
+  });
+
+  it('falls back to the default value without a non-renderer app runtime', async () => {
+    vi.spyOn(runtimes, 'getRuntime').mockReturnValue({} as any);
+
+    await expect(plugin.init('send').app.prompt('Title', { defaultValue: 'cached value' })).resolves.toBe(
+      'cached value',
+    );
   });
 });

--- a/packages/insomnia/src/plugins/context/app.ts
+++ b/packages/insomnia/src/plugins/context/app.ts
@@ -3,6 +3,7 @@ import type { AppContext, RenderPurpose } from 'insomnia/src/common/templating/t
 import { platform } from 'insomnia-data/common';
 
 import { invariant } from '~/common/utils/invariant';
+import { getRuntime } from '~/runtimes';
 
 export const init = (renderPurpose: RenderPurpose = 'general'): { app: AppContext } => ({
   app: {
@@ -20,9 +21,13 @@ export const init = (renderPurpose: RenderPurpose = 'general'): { app: AppContex
         });
       }
     },
-    prompt: (title, options) => {
+    prompt: async (title, options) => {
       if (!__IS_RENDERER__) {
-        return Promise.resolve(options?.defaultValue || '');
+        const appRuntime = getRuntime().app;
+        if (appRuntime) {
+          return appRuntime.prompt(title, options);
+        }
+        return options?.defaultValue || '';
       }
       // This custom promise converts the prompt modal from being callback-based to reject when the modal is cancelled and resolve when the modal is submitted and hidden
       return new Promise<string>((resolve, reject) => {

--- a/packages/insomnia/src/runtimes/app/app-adapter.node.ts
+++ b/packages/insomnia/src/runtimes/app/app-adapter.node.ts
@@ -1,0 +1,10 @@
+import type { AppRuntime } from '../types';
+
+export const prompt: AppRuntime['prompt'] = async (title, options) => {
+  const { requestPromptFromRenderer } = await import('../../main/prompt-bridge');
+  const value = await requestPromptFromRenderer({
+    ...options,
+    title,
+  });
+  return value ?? options?.defaultValue ?? '';
+};

--- a/packages/insomnia/src/runtimes/app/app-adapter.node.ts
+++ b/packages/insomnia/src/runtimes/app/app-adapter.node.ts
@@ -6,5 +6,9 @@ export const prompt: AppRuntime['prompt'] = async (title, options) => {
     ...options,
     title,
   });
-  return value ?? options?.defaultValue ?? '';
+  if (value === null) {
+    throw new Error('Prompt cancelled');
+  }
+
+  return value;
 };

--- a/packages/insomnia/src/runtimes/runtime.node.ts
+++ b/packages/insomnia/src/runtimes/runtime.node.ts
@@ -1,3 +1,4 @@
+import * as appAdapter from './app/app-adapter.node';
 import * as cryptAdapter from './crypto/crypto-adapter.node';
 import * as importAdapter from './import/import-adapter.node';
 import * as networkAdapter from './network/network-adapter.node';
@@ -11,4 +12,5 @@ export const nodeRuntime = {
   templating: renderAdapter,
   secretStorage: secretStorageAdapter,
   importer: importAdapter,
+  app: appAdapter,
 } satisfies RuntimeCapabilities;

--- a/packages/insomnia/src/runtimes/types.ts
+++ b/packages/insomnia/src/runtimes/types.ts
@@ -1,6 +1,6 @@
 import type { AESMessage, Cookie, RequestHeader } from 'insomnia-data';
 
-import type { RenderedRequest, RenderInputType } from '~/common/templating/types';
+import type { AppPromptOptions, RenderedRequest, RenderInputType } from '~/common/templating/types';
 
 import type { RequestContext } from '../../../insomnia-scripting-environment/src/objects';
 import type { ConvertResult } from '../main/importers/convert';
@@ -62,10 +62,15 @@ export interface ImportRuntime {
   convert: (importEntry: ImportEntry, options?: { importerId?: string }) => Promise<ConvertResult>;
 }
 
+export interface AppRuntime {
+  prompt: (title: string, options?: AppPromptOptions) => Promise<string>;
+}
+
 export interface RuntimeCapabilities {
   network: NetworkRuntime;
   crypto: CryptoRuntime;
   templating: TemplatingRuntime;
   secretStorage: SecretStorageRuntime;
   importer: ImportRuntime;
+  app?: AppRuntime;
 }


### PR DESCRIPTION
Fix: INS-2909

## Problem
the prompt template tag no longer appears when a request containing the prompt tag is executed indirectly [`via chained request`] through a Response tag dependency (Trigger = Always). Instead, insomnia skips the prompt and uses the previously cached response from the dependent request.

## Changes

- Add `app.prompt` into the Node.js runtime and leverage `prompt-bridge` capability
- abstract common type for prompt option