### PR TITLE
chore: emit and upload junit test results per shard

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -100,3 +100,10 @@ jobs:
           if-no-files-found: ignore
           name: ubuntu-smoke-test-traces-${{ github.run_number }}-shard-${{ matrix.shardIndex }}
           path: packages/insomnia-smoke-test/traces
+      - name: Upload junit results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ !cancelled() }}
+        with:
+          if-no-files-found: ignore
+          name: junit-results-${{ github.run_number }}-shard-${{ matrix.shardIndex }}
+          path: packages/insomnia-smoke-test/test-results.xml

--- a/packages/insomnia-smoke-test/playwright.config.ts
+++ b/packages/insomnia-smoke-test/playwright.config.ts
@@ -58,7 +58,7 @@ const config: PlaywrightTestConfig = {
       sources: true,
     },
   },
-  reporter: process.env.CI ? [['github'], ['line']] : [['dot']],
+  reporter: process.env.CI ? [['github'], ['line'], ['junit', { outputFile: 'test-results.xml' }]] : [['dot']],
   timeout: process.env.CI || isWindows ? 60 * 1000 : 20 * 1000,
   forbidOnly: !!process.env.CI,
   outputDir: 'traces',

--- a/packages/insomnia-smoke-test/playwright.config.ts
+++ b/packages/insomnia-smoke-test/playwright.config.ts
@@ -58,7 +58,9 @@ const config: PlaywrightTestConfig = {
       sources: true,
     },
   },
-  reporter: process.env.CI ? [['github'], ['line'], ['junit', { outputFile: 'test-results.xml' }]] : [['dot']],
+  reporter: process.env.CI
+    ? [['github'], ['line'], ['junit', { outputFile: 'test-results.xml', includeRetries: true }]]
+    : [['dot']],
   timeout: process.env.CI || isWindows ? 60 * 1000 : 20 * 1000,
   forbidOnly: !!process.env.CI,
   outputDir: 'traces',

--- a/packages/insomnia-smoke-test/tests/smoke/cloud-sync.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/cloud-sync.test.ts
@@ -38,7 +38,7 @@ test.describe('Cloud Sync', () => {
     await page.getByLabel('Git Sync').click();
     const discardButton = page.getByLabel('Discard all changes');
     // Wait for discard button to be enabled
-    await expect.soft(discardButton).toHaveAttribute('aria-disabled', 'true');
+    await expect.soft(discardButton).not.toHaveAttribute('aria-disabled', 'true');
     await discardButton.click({ delay: 500 });
     // Check body is reverted
     await page.getByRole('tab', { name: 'Params' }).click();
@@ -48,7 +48,7 @@ test.describe('Cloud Sync', () => {
 
     // Set body and commit change
     await page.getByRole('tab', { name: 'Body' }).click();
-    await page.getByRole('tabpanel').getByTestId('CodeEditor').getByRole('textbox').first().fill('value=changed');
+    await page.getByRole('tabpanel').getByTestId('CodeEditor123').getByRole('textbox').first().fill('value=changed');
     // Click push
     await page.getByLabel('Git Sync').click();
     await page.getByLabel('Commit').click({ delay: 500 });

--- a/packages/insomnia-smoke-test/tests/smoke/cloud-sync.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/cloud-sync.test.ts
@@ -48,7 +48,7 @@ test.describe('Cloud Sync', () => {
 
     // Set body and commit change
     await page.getByRole('tab', { name: 'Body' }).click();
-    await page.getByRole('tabpanel').getByTestId('CodeEditor123').getByRole('textbox').first().fill('value=changed');
+    await page.getByRole('tabpanel').getByTestId('CodeEditor').getByRole('textbox').first().fill('value=changed');
     // Click push
     await page.getByLabel('Git Sync').click();
     await page.getByLabel('Commit').click({ delay: 500 });

--- a/packages/insomnia-smoke-test/tests/smoke/cloud-sync.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/cloud-sync.test.ts
@@ -38,7 +38,7 @@ test.describe('Cloud Sync', () => {
     await page.getByLabel('Git Sync').click();
     const discardButton = page.getByLabel('Discard all changes');
     // Wait for discard button to be enabled
-    await expect.soft(discardButton).not.toHaveAttribute('aria-disabled', 'true');
+    await expect.soft(discardButton).toHaveAttribute('aria-disabled', 'true');
     await discardButton.click({ delay: 500 });
     // Check body is reverted
     await page.getByRole('tab', { name: 'Params' }).click();


### PR DESCRIPTION
Updates the Playwright config to emit `junit` XML test results and uploads them as a CI artifact for each shard in `test-e2e.yml`.

You can view the xml artifacts here: https://github.com/Kong/insomnia/actions/runs/29347661278