### PR TITLE
feat: show number of matches when filtering a JSON response

### DIFF
--- a/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
@@ -873,7 +873,7 @@ export const CodeEditor = memo(
                   </Button>
                 ) : null}
               </Toolbar>
-              {jsonFilterMatchCount !== null && (
+              {mode?.includes('json') && jsonFilterMatchCount !== null && (
                 <span className="pr-3 italic">
                   {jsonFilterMatchCount} {jsonFilterMatchCount === 1 ? 'match' : 'matches'}
                 </span>

--- a/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
@@ -194,6 +194,7 @@ export const CodeEditor = memo(
       const textAreaRef = useRef<HTMLTextAreaElement>(null);
       const codeMirror = useRef<CodeMirror.EditorFromTextArea | null>(null);
       const [originalCode, setOriginalCode] = useState('');
+      const [jsonFilterMatchCount, setJsonFilterMatchCount] = useState<number | null>(null);
       const { settings } = useRootLoaderData()!;
       const { isOwner, isEnterprisePlan } = usePlanData();
       const indentSize = settings.editorIndentSize;
@@ -248,9 +249,11 @@ export const CodeEditor = memo(
                 try {
                   const codeObj = JSON.parse(code);
                   const results = JSONPath({ json: codeObj, path: filter.trim() });
+                  setJsonFilterMatchCount(results.length);
                   jsonString = JSON.stringify(results);
                 } catch (err) {
                   console.log('[jsonpath] Error:', err);
+                  setJsonFilterMatchCount(null);
                   jsonString = '[]';
                 }
               }
@@ -803,6 +806,7 @@ export const CodeEditor = memo(
                       if (updateFilter) {
                         updateFilter('');
                       }
+                      setJsonFilterMatchCount(null);
                       maybePrettifyAndSetValue(originalCode, false);
                     }
                   }}
@@ -869,6 +873,11 @@ export const CodeEditor = memo(
                   </Button>
                 ) : null}
               </Toolbar>
+              {jsonFilterMatchCount !== null && (
+                <span className="pr-3 italic">
+                  {jsonFilterMatchCount} {jsonFilterMatchCount === 1 ? 'match' : 'matches'}
+                </span>
+              )}
             </div>
           ) : null}
         </div>

--- a/packages/insomnia/src/ui/components/modals/filter-help-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/filter-help-modal.tsx
@@ -76,9 +76,10 @@ export const FilterHelpModal: FC<FilterHelpModalOptions> = ({ isJSON }) => {
       <DialogTrigger>
         <Button
           key="help"
-          className="flex h-full items-center justify-center gap-2 px-4 py-1 text-xs text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
+          aria-label="Filter Help"
+          className="flex aspect-square h-full items-center justify-center rounded-xs text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
         >
-          <i className="fa fa-question-circle" />
+          <Icon icon="question-circle" />
         </Button>
         <ModalOverlay
           isDismissable


### PR DESCRIPTION
- Displays # of matches next to the response filter bar when a JSONPath filter is applied, so users get immediate feedback on how many results matched.
- Fixes the filter-help icon button to use match the sizing/style of the adjacent filter-history icon. 

[Jira](https://konghq.atlassian.net/browse/INS-2765)