### PR TITLE
feat: add a tooltip for show/hide secret on auth tab

### DIFF
--- a/packages/insomnia/src/ui/components/editors/auth/components/auth-input-row.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/components/auth-input-row.tsx
@@ -3,6 +3,7 @@ import * as reactUse from 'react-use';
 
 import { useRootLoaderData } from '~/root';
 import { OneLineEditor, type OneLineEditorHandle } from '~/ui/components/.client/codemirror/one-line-editor';
+import { Tooltip } from '~/ui/components/tooltip';
 
 import { toKebabCase } from '../../../../../common/misc';
 import {
@@ -113,13 +114,19 @@ export const AuthInputRow: FC<Props> = ({
         getAutocompleteConstants={getAutocompleteConstants}
       />
       {canBeMasked ? (
-        <button className="btn btn--super-super-compact pointer" onClick={toggleMask} disabled={disabled}>
-          {isMasked ? (
-            <i className="fa fa-eye" data-testid="reveal-password-icon" />
-          ) : (
-            <i className="fa fa-eye-slash" data-testid="mask-password-icon" />
-          )}
-        </button>
+        <Tooltip message={isMasked ? 'Show Value' : 'Hide Value'} position="top">
+          <button
+            className="btn btn--super-super-compact pointer"
+            onClick={toggleMask}
+            disabled={disabled}
+          >
+            {isMasked ? (
+              <i className="fa fa-eye" data-testid="reveal-password-icon" />
+            ) : (
+              <i className="fa fa-eye-slash" data-testid="mask-password-icon" />
+            )}
+          </button>
+        </Tooltip>
       ) : null}
       {copyBtn && (
         <button className="btn btn--super-super-compact pointer btn--forever-enabled" onClick={onCopy}>

--- a/packages/insomnia/src/ui/components/editors/auth/components/auth-input-row.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/components/auth-input-row.tsx
@@ -117,9 +117,11 @@ export const AuthInputRow: FC<Props> = ({
       {canBeMasked ? (
         <Tooltip message={isMasked ? 'Show Value' : 'Hide Value'} position="top">
           <button
-            className="btn btn--super-super-compact pointer"
+            type="button"
+            className={`btn btn--super-super-compact pointer${disabled ? ' pointer-events-none' : ''}`}
             onClick={toggleMask}
             disabled={disabled}
+            aria-label={isMasked ? 'Show Value' : 'Hide Value'}
           >
             {isMasked ? (
               <i className="fa fa-eye" data-testid="reveal-password-icon" />


### PR DESCRIPTION
This change wraps the button on the Auth tab for masking/unmasking a password/secret value inside the Tooltip component. On hover, the button will now surface `Show Value` or `Hide Value` text.