### PR TITLE
fix: route v3 spaces SDK through proxy-aware fetch

### DIFF
--- a/packages/insomnia-api/src/__tests__/spaces.test.ts
+++ b/packages/insomnia-api/src/__tests__/spaces.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { configureV3Client, getSpaces } from '../spaces';
+
+const jsonResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } });
+
+// The proxy-aware fetch injected at app startup. In production this is `net.fetch` (main) or
+// the browser/Chromium fetch (renderer) — both honor the system proxy. The bug this guards
+// against was the v3 SDK bypassing it and using Node's global fetch, which ignores the proxy
+// and OS certs, breaking login on proxy-restricted networks.
+const fetchApi = vi.fn();
+
+// `configureV3Client` is a one-time singleton, so configure it once for the whole file.
+configureV3Client({
+  getBaseURL: () => 'https://api.example.test',
+  getClientString: () => 'insomnia/test',
+  generateRequestId: () => 'req_test',
+  fetchApi,
+});
+
+describe('getSpaces', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    fetchApi.mockReset();
+  });
+
+  it('routes SDK requests through the configured proxy-aware fetch, not the global fetch', async () => {
+    // If the fetchApi wiring regresses, the SDK falls back to global fetch — assert it does not.
+    const globalFetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(jsonResponse({ data: [], meta: { page: { next: null } } }));
+    fetchApi.mockResolvedValue(jsonResponse({ data: [], meta: { page: { next: null } } }));
+
+    await getSpaces({ sessionId: 'sess_xyz' });
+
+    expect(fetchApi).toHaveBeenCalledTimes(1);
+    expect(globalFetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns the spaces from the API response', async () => {
+    fetchApi.mockResolvedValue(
+      jsonResponse({
+        data: [
+          { id: 'org_1', name: 'Alpha', is_owner: true },
+          { id: 'org_2', name: 'Beta', is_owner: false },
+        ],
+        meta: { page: { next: null } },
+      }),
+    );
+
+    const spaces = await getSpaces({ sessionId: 'sess_xyz' });
+
+    expect(spaces.map(s => s.id)).toEqual(['org_1', 'org_2']);
+  });
+
+  it('paginates using page[after] from meta.page.next', async () => {
+    fetchApi
+      .mockResolvedValueOnce(
+        jsonResponse({ data: [{ id: 'org_1' }], meta: { page: { next: '/v3/users/me/spaces?page[after]=cursor2' } } }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ data: [{ id: 'org_2' }], meta: { page: { next: null } } }));
+
+    const spaces = await getSpaces({ sessionId: 'sess_xyz' });
+
+    expect(fetchApi).toHaveBeenCalledTimes(2);
+    expect(spaces.map(s => s.id)).toEqual(['org_1', 'org_2']);
+  });
+});

--- a/packages/insomnia-api/src/spaces.ts
+++ b/packages/insomnia-api/src/spaces.ts
@@ -1,6 +1,7 @@
 import {
   Configuration,
   DefaultApi,
+  type FetchAPI,
   type ListCurrentUserSpaces200Response,
   ResponseError,
   type Space,
@@ -14,6 +15,10 @@ interface V3ClientConfig {
   getBaseURL: () => string;
   getClientString: () => string;
   generateRequestId: () => string;
+  // Proxy-aware `fetch` used for every SDK request. Without it the SDK falls back to the
+  // global `fetch`, which in the Electron main/CLI processes is Node's fetch and ignores the
+  // system proxy and OS certs.
+  fetchApi: FetchAPI;
 }
 
 let v3Config: V3ClientConfig | null = null;
@@ -32,6 +37,7 @@ function buildClient(sessionId: string): DefaultApi {
   const baseURL = v3Config.getBaseURL();
   const configuration = new Configuration({
     basePath: `${baseURL}/v3`,
+    fetchApi: v3Config.fetchApi,
     apiKey: name => (name === 'X-Session-ID' ? sessionId : ''),
     headers: {
       'X-Insomnia-Client': v3Config.getClientString(),

--- a/packages/insomnia/src/common/configure-v3-client.ts
+++ b/packages/insomnia/src/common/configure-v3-client.ts
@@ -1,6 +1,7 @@
 import { configureV3Client } from 'insomnia-api';
 
 import { getApiBaseURL, getClientString } from './constants';
+import { proxyAwareFetch } from './insomnia-fetch';
 import { generateId } from './misc';
 
 /**
@@ -14,4 +15,7 @@ export const configureV3ClientDefaults = () =>
     getBaseURL: getApiBaseURL,
     getClientString,
     generateRequestId: () => generateId('desk'),
+    // Mirrors `configureFetch` above: route SDK requests through the same proxy-aware fetch
+    // (net.fetch in main) so system proxy settings work like they did before the v3 migration.
+    fetchApi: proxyAwareFetch,
   });

--- a/packages/insomnia/src/common/insomnia-fetch.ts
+++ b/packages/insomnia/src/common/insomnia-fetch.ts
@@ -12,6 +12,12 @@ export function setFetchImplementation(impl: FetchImplementation) {
   fetchImpl = impl;
 }
 
+// Stable, proxy-aware fetch handle for callers that need a raw `fetch` (e.g. the v3 SDK's
+// Configuration.fetchApi). It delegates to the current `fetchImpl` on every call rather than
+// capturing it, so it works regardless of whether setFetchImplementation() has run yet.
+export const proxyAwareFetch: typeof globalThis.fetch = (input, init) =>
+  fetchImpl(input as string, init as RequestInit | undefined);
+
 // Adds headers, retries and opens deep links returned from the api
 export async function insomniaFetch<T = void>({
   method,


### PR DESCRIPTION
Spaces endpoint doesn't respect proxy settings on macos or within Insomnia preferences, which can block login flow (`syncOrganizations` fails). 

This fix will force the calls made to v3 spaces endpoint to use proxy if specified.

Tested with 13.1 beta (not working) and local build with this fix (working) and also 13.0.2 (originally working) by creating proxy, blocklist to block `api.insomina.rest` and running the proxy as default on macos settings. Observed success.