### PR TITLE
fix(first-request): polish input UI and fix cURL method detection [INS-3055]

### DIFF
--- a/packages/insomnia/src/common/utils/curl.test.ts
+++ b/packages/insomnia/src/common/utils/curl.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { isCurlCommand } from './curl';
+
+describe('isCurlCommand', () => {
+  it('matches a bare curl command', () => {
+    expect(isCurlCommand('curl https://example.com')).toBe(true);
+  });
+
+  it('matches curl with no arguments', () => {
+    expect(isCurlCommand('curl')).toBe(true);
+  });
+
+  it('matches curl prefixed with a shell prompt', () => {
+    expect(isCurlCommand('$ curl https://example.com')).toBe(true);
+  });
+
+  it('matches curl with leading/trailing whitespace', () => {
+    expect(isCurlCommand('  curl https://example.com  ')).toBe(true);
+  });
+
+  it('matches curl regardless of case', () => {
+    expect(isCurlCommand('CURL https://example.com')).toBe(true);
+    expect(isCurlCommand('CuRl https://example.com')).toBe(true);
+  });
+
+  it('matches curl followed by flags', () => {
+    expect(isCurlCommand('curl -X POST https://example.com')).toBe(true);
+  });
+
+  it('does not match a URL that merely starts with "curl"', () => {
+    expect(isCurlCommand('curl.se/docs')).toBe(false);
+  });
+
+  it('does not match "curl" as part of a longer word', () => {
+    expect(isCurlCommand('curling https://example.com')).toBe(false);
+  });
+
+  it('does not match when curl is not the first token', () => {
+    expect(isCurlCommand('echo curl https://example.com')).toBe(false);
+  });
+
+  it('does not match unrelated text', () => {
+    expect(isCurlCommand('https://example.com')).toBe(false);
+    expect(isCurlCommand('')).toBe(false);
+  });
+});

--- a/packages/insomnia/src/common/utils/curl.ts
+++ b/packages/insomnia/src/common/utils/curl.ts
@@ -1,0 +1,5 @@
+// Matches a cURL command, optionally prefixed with a shell prompt (`$ curl ...`).
+// Requires a word boundary after "curl" so URLs like "curl.se/..." aren't misdetected.
+export const CURL_COMMAND_PATTERN = /^\s*\$?\s*curl(?:\s|$)/i;
+
+export const isCurlCommand = (value: string) => CURL_COMMAND_PATTERN.test(value.trim());

--- a/packages/insomnia/src/common/utils/curl.ts
+++ b/packages/insomnia/src/common/utils/curl.ts
@@ -1,5 +1,6 @@
 // Matches a cURL command, optionally prefixed with a shell prompt (`$ curl ...`).
-// Requires a word boundary after "curl" so URLs like "curl.se/..." aren't misdetected.
+// Requires whitespace (or end-of-string) after "curl" so URLs like "curl.se/..." aren't
+// misdetected - a word boundary (\b) would not be enough, since it also matches before ".".
 export const CURL_COMMAND_PATTERN = /^\s*\$?\s*curl(?:\s|$)/i;
 
 export const isCurlCommand = (value: string) => CURL_COMMAND_PATTERN.test(value.trim());

--- a/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
@@ -20,6 +20,7 @@ import { DEBOUNCE_MILLIS } from '~/common/constants';
 import * as misc from '~/common/misc';
 import { type NunjucksParsedTag, type nunjucksTagContextMenuOptions } from '~/common/templating/types';
 import { extractNunjucksTagFromCoords } from '~/common/templating/utils';
+import { isCurlCommand } from '~/common/utils/curl';
 import { useRootLoaderData } from '~/root';
 import { showModal } from '~/ui/components/modals';
 import { NunjucksModal } from '~/ui/components/modals/nunjucks-modal';
@@ -176,9 +177,9 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
       codeMirror.current.on('beforeChange', (_: CodeMirror.Editor, change: CodeMirror.EditorChangeCancellable) => {
         const isPaste = change.text && change.text.length > 1;
         if (isPaste) {
-          const startsWithCurl = change.text[0].startsWith('curl');
-          const isWhitespace = change.text.join('').trim();
-          if (startsWithCurl || !isWhitespace) {
+          const pastedText = change.text.join('\n');
+          const hasContent = pastedText.trim();
+          if (isCurlCommand(pastedText) || !hasContent) {
             change.cancel();
             return;
           }
@@ -188,8 +189,7 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
       });
       codeMirror.current.on('paste', (_, e: ClipboardEvent) => {
         const text = e.clipboardData?.getData('text/plain');
-        // TODO: watch out for pasting urls that are curl<something>, e.g. curl.se would be picked up here without the space
-        if (onPaste && text && text.startsWith('curl ')) {
+        if (onPaste && text && isCurlCommand(text)) {
           onPaste(text);
         }
       });

--- a/packages/insomnia/src/ui/components/dropdowns/method-selector.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/method-selector.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, useCallback, useState } from 'react';
+import type { Placement } from '@react-types/overlays';
+import { forwardRef, useCallback, useState } from 'react';
 import { Button } from 'react-aria-components';
 
 import { HTTP_METHODS } from '../../../common/constants';
@@ -39,6 +40,8 @@ interface Props {
   onChange: (method: string) => void;
   /** Extra classes for the trigger button (e.g. sizing/layout in a given context). */
   className?: string;
+  /** Popover placement relative to the trigger. Defaults to the base Dropdown's 'bottom end'. */
+  placement?: Placement;
 }
 
 /**
@@ -48,7 +51,7 @@ interface Props {
  * opens a dropdown to pick another method (plus a custom-method option). Self
  * contained so it can be dropped into any surface that needs method selection.
  */
-export const MethodSelector = forwardRef<DropdownHandle, Props>(({ method, onChange, className }, ref) => {
+export const MethodSelector = forwardRef<DropdownHandle, Props>(({ method, onChange, className, placement }, ref) => {
   const [recent, setRecent] = useState(readRecentMethods);
 
   const handleSetCustomMethod = useCallback(() => {
@@ -98,6 +101,8 @@ export const MethodSelector = forwardRef<DropdownHandle, Props>(({ method, onCha
     <Dropdown
       ref={ref}
       aria-label="Request Method"
+      placement={placement}
+      className="self-stretch"
       triggerButton={
         <Button
           aria-label="Request Method"

--- a/packages/insomnia/src/ui/components/first-request-creation.tsx
+++ b/packages/insomnia/src/ui/components/first-request-creation.tsx
@@ -9,6 +9,7 @@ import { Button } from '~/basic-components/button';
 import { SelectPopover } from '~/basic-components/select-popover';
 import { getCurrentSessionId } from '~/common/account/session';
 import { METHOD_GET } from '~/common/constants';
+import { isCurlCommand } from '~/common/utils/curl';
 import { setDefaultProtocol } from '~/common/utils/url/protocol';
 import { useRootLoaderData } from '~/root';
 import { AnalyticsEvent } from '~/ui/analytics';
@@ -37,7 +38,6 @@ import { Icon } from './icon';
 // isn't emitted twice within an app session (cross-session de-dup uses the cache).
 const emittedAssignments = new Set<string>();
 
-const CURL_COMMAND_PATTERN = /^\s*\$?\s*curl(?:\s|$)/i;
 const NOTION_MCP_SERVER_URL = 'https://mcp.notion.com/mcp';
 
 const parseCurlImportError = (error: unknown) => {
@@ -81,18 +81,21 @@ const flattenCurlCommand = (value: string) =>
     .replace(/\r?\n\s*/g, ' ')
     .trim();
 
-// Best-effort read of the HTTP method from a cURL string, for keeping the method
-// dropdown in sync while typing/pasting. Explicit -X/--request wins; otherwise a
-// body/form flag implies POST (curl's own default), matching what the importer does.
-const extractCurlMethod = (value: string): string | null => {
-  const explicit = value.match(/(?:-X|--request)\s+['"]?([A-Za-z]+)/);
+// Read the HTTP method from a cURL string, for keeping the method dropdown in
+// sync while typing/pasting/importing. Mirrors the real importer's extractMethod
+// (src/main/importers/importers/curl.ts): explicit -X/--request wins (including
+// curl's cuddled short-flag form, e.g. -XPUT), otherwise a body/form flag implies
+// POST, otherwise GET. Always resolves so the preview never goes stale relative
+// to what the actual import would produce.
+const extractCurlMethod = (value: string): string => {
+  const explicit = value.match(/(?:-X\s*|--request\s+)['"]?([A-Za-z]+)/);
   if (explicit) {
     return explicit[1].toUpperCase();
   }
-  if (/(?:^|\s)(?:-d|--data(?:-raw|-binary|-urlencode)?|-F|--form)\b/.test(value)) {
+  if (/(?:^|\s)(?:-d|--data(?:-raw|-binary|-urlencode|-ascii)?|-F|--form)\b/.test(value)) {
     return 'POST';
   }
-  return null;
+  return METHOD_GET;
 };
 
 interface CollectionItem {
@@ -204,15 +207,14 @@ export const FirstRequestCreation = ({
   };
 
   // Update the input value, clear any stale error, and keep the method dropdown in
-  // sync when the value is a cURL command.
+  // sync when the value is a cURL command. Only touches the method while the input
+  // is recognized as a cURL command, so a manually-selected method (via the dropdown)
+  // is left alone when typing a plain URL.
   const applyRequestInput = (value: string) => {
     setRequestInput(value);
     setErrorText(null);
-    if (CURL_COMMAND_PATTERN.test(value.trim())) {
-      const curlMethod = extractCurlMethod(value);
-      if (curlMethod) {
-        setMethod(curlMethod);
-      }
+    if (isCurlCommand(value)) {
+      setMethod(extractCurlMethod(value));
     }
   };
 
@@ -255,7 +257,7 @@ export const FirstRequestCreation = ({
     }
 
     try {
-      if (CURL_COMMAND_PATTERN.test(trimmedInput)) {
+      if (isCurlCommand(trimmedInput)) {
         let req: Partial<Request>;
         try {
           req = await parseCurlRequest(trimmedInput);
@@ -547,14 +549,14 @@ export const FirstRequestCreation = ({
   return (
     <>
       <div className="rounded-sm bg-[radial-gradient(95.72%_95.72%_at_-0.32%_2.6%,var(--hl-md)_0%,var(--hl-xs)_100%),radial-gradient(100%_100.41%_at_100%_99.92%,var(--hl-md)_0%,var(--hl-xs)_100%)] p-px">
-        <div className="flex w-full flex-col rounded-sm bg-(--color-bg) bg-[linear-gradient(180deg,rgba(var(--color-surprise-rgb),0.2)_0%,color-mix(in_srgb,var(--color-bg)_0%,transparent)_72.8%)] px-6 pt-5 pb-6">
+        <div className="flex w-full flex-col gap-2 rounded-sm bg-(--color-bg) bg-[linear-gradient(180deg,rgba(var(--color-surprise-rgb),0.2)_0%,color-mix(in_srgb,var(--color-bg)_0%,transparent)_72.8%)] px-5 pt-4 pb-2">
           <h2 className="text-lg font-semibold">New request</h2>
-          <div className="mt-4 flex h-8.5 items-center gap-1.5 rounded-md border border-(--hl-md) bg-(--color-bg) px-1">
-            <MethodSelector method={method} onChange={setMethod} className="h-6.5" />
+          <div className="flex h-(--line-height-sm) items-center gap-1.5 rounded-md border border-(--hl-md) bg-(--color-bg) p-1 focus-within:shadow-[0_0_0_4px_#0044F433]">
+            <MethodSelector method={method} onChange={setMethod} className="h-full" placement="bottom start" />
             <input
               ref={inputRef}
               aria-label="Request endpoint or cURL input"
-              className="h-6.5 min-w-0 flex-1 bg-transparent text-[12px]/[18px] font-normal"
+              className="h-6.5 min-w-0 flex-1 bg-transparent px-1 text-[12px]/[18px] font-normal"
               placeholder="Enter a URL or paste cURL"
               value={requestInput}
               onChange={event => applyRequestInput(event.target.value)}
@@ -562,7 +564,7 @@ export const FirstRequestCreation = ({
                 const pasted = event.clipboardData.getData('text');
                 // Flatten a pasted multi-line cURL into a single line ourselves so it
                 // stays a valid command (the native single-line paste would drop the newlines).
-                if (/\r?\n/.test(pasted) && CURL_COMMAND_PATTERN.test(pasted.trim())) {
+                if (/\r?\n/.test(pasted) && isCurlCommand(pasted)) {
                   event.preventDefault();
                   applyRequestInput(flattenCurlCommand(pasted));
                 }
@@ -575,6 +577,7 @@ export const FirstRequestCreation = ({
               isOpen={selectOpen}
               onOpenChange={isOpen => setSelectOpen(isOpen)}
               ariaLabel="Select target collection"
+              placement="bottom end"
               items={collectionItems}
               selectedKey={selectedCollectionId}
               onSelectionChange={key => {
@@ -590,7 +593,7 @@ export const FirstRequestCreation = ({
                   New Collection
                 </Button>
               }
-              triggerClassName="h-6.5 rounded-md px-3 text-[12px]/[18px] font-[590] data-[focus-visible=true]:!ring-0"
+              triggerClassName="h-full rounded-md px-3 text-[12px]/[18px] font-[590] data-[focus-visible=true]:!ring-0"
               popoverClassName="w-[240px]"
               dialogClassName="w-[240px]"
               renderTrigger={selectedItem => (
@@ -610,28 +613,26 @@ export const FirstRequestCreation = ({
               aria-label="Create request"
               primary
               size="md"
-              className="h-6.5 rounded-sm px-2 text-[12px]/[18px] font-[590]"
+              className="h-full rounded-sm px-2 text-[12px]/[18px] font-[590]"
               isDisabled={isCreatingRequest || createWorkspaceFetcher.state !== 'idle'}
               onPress={() => handleCreateRequest()}
             >
               <span>{createButtonLabel}</span>
             </Button>
           </div>
-          {errorText && (
-            <div className="mt-2 text-xs text-[#FF5631]" role="alert" aria-live="polite">
-              {errorText}
-            </div>
-          )}
+          <div className="min-h-4 text-xs text-[#FF5631]" role="alert" aria-live="polite">
+            {errorText}
+          </div>
 
           {treatment === 'A' && (
-            <div className="mt-6 flex flex-wrap gap-x-10 gap-y-6">
+            <div className="mt-1 flex flex-wrap gap-x-10 gap-y-6">
               <div>
                 <p className="text-sm font-semibold text-(--hl)">Quick actions</p>
-                <div className="mt-3 flex flex-wrap gap-2">{quickActions.map(renderQuickStartButton)}</div>
+                <div className="mt-2 flex flex-wrap gap-2">{quickActions.map(renderQuickStartButton)}</div>
               </div>
               <div>
                 <p className="text-sm font-semibold text-(--hl)">Start with an example</p>
-                <div className="mt-3 flex flex-wrap gap-2">{exampleItems.map(renderQuickStartButton)}</div>
+                <div className="mt-2 flex flex-wrap gap-2">{exampleItems.map(renderQuickStartButton)}</div>
               </div>
             </div>
           )}

--- a/packages/insomnia/src/ui/components/first-request-creation.tsx
+++ b/packages/insomnia/src/ui/components/first-request-creation.tsx
@@ -84,15 +84,22 @@ const flattenCurlCommand = (value: string) =>
 // Read the HTTP method from a cURL string, for keeping the method dropdown in
 // sync while typing/pasting/importing. Mirrors the real importer's extractMethod
 // (src/main/importers/importers/curl.ts): explicit -X/--request wins (including
-// curl's cuddled short-flag form, e.g. -XPUT), otherwise a body/form flag implies
-// POST, otherwise GET. Always resolves so the preview never goes stale relative
-// to what the actual import would produce.
+// curl's cuddled short-flag form, e.g. -XPUT); otherwise -G/--get combined with a
+// -d/--data flag moves the data into the query string instead of the body (so the
+// method stays GET); otherwise a body/form flag implies POST, otherwise GET.
+// Always resolves so the preview never goes stale relative to what the actual
+// import would produce.
 const extractCurlMethod = (value: string): string => {
   const explicit = value.match(/(?:-X\s*|--request\s+)['"]?([A-Za-z]+)/);
   if (explicit) {
     return explicit[1].toUpperCase();
   }
-  if (/(?:^|\s)(?:-d|--data(?:-raw|-binary|-urlencode|-ascii)?|-F|--form)\b/.test(value)) {
+  const hasGetFlag = /(?:^|\s)(?:-G|--get)\b/.test(value);
+  const hasDataFlag = /(?:^|\s)(?:-d|--data(?:-raw|-binary|-urlencode|-ascii)?)\b/.test(value);
+  if (hasGetFlag && hasDataFlag) {
+    return METHOD_GET;
+  }
+  if (hasDataFlag || /(?:^|\s)(?:-F|--form)\b/.test(value)) {
     return 'POST';
   }
   return METHOD_GET;

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -308,6 +308,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(
             ref={methodDropdownRef}
             onChange={method => patchRequest(requestId, { method })}
             method={method}
+            placement="bottom start"
           />
         </div>
         <div className="flex flex-1 items-center p-1">


### PR DESCRIPTION
## Summary
- Match the First Request input bar's height/padding/border to the standard request-pane bar, keep the trailing error message space always reserved (no more layout flicker on error appear/disappear), and left-align the Method dropdown vs. right-align the Collection dropdown (previously both defaulted to the same side, which read as inconsistent/misaligned).
- Fix the live cURL method-preview: it missed curl's cuddled short-flag form (`-XPUT`), never went stale-but-still-shown to a manually re-typed method once the `-X` flag was edited away, and could disagree with what the real importer (`curl.ts`) would actually produce.
- Extract cURL-command detection into a shared `isCurlCommand` util (`common/utils/curl.ts`) and fix the same detection bug in the standard request bar's paste handler (`one-line-editor.tsx`): it was silently swallowing multi-line pastes starting with `curl` without a following space/word-boundary (e.g. `curl.se/...`) and missed shell-prompt-prefixed commands (`$ curl ...`).

## Test plan
- [x] `eslint` clean on all changed files
- [x] `tsc --noEmit` shows no new errors
- [x] Manually verify in the app: First Request card layout (height/padding/border/alignment), typing/pasting cURL with `-XPUT`/`-X PUT`/`$ curl ...` syncs the method pill correctly, and pasting a non-curl URL like `curl.se/foo` into the standard request URL bar inserts normally instead of being swallowed

## Screenshots
<img width="1372" height="217" alt="image" src="https://github.com/user-attachments/assets/dfae6c70-6724-41cc-9a6c-2702be8ec8b7" />

<img width="1364" height="144" alt="image" src="https://github.com/user-attachments/assets/4aa664e0-66c5-41f2-9753-31426bac386c" />
