### PR TITLE
fix: deep-link mcp workspace matching

### DIFF
--- a/packages/insomnia/src/common/__tests__/import.test.ts
+++ b/packages/insomnia/src/common/__tests__/import.test.ts
@@ -732,7 +732,9 @@ describe('MCP run deep-link import', () => {
 
   it('imports an MCP url into an MCP workspace and exposes its client', async () => {
     const project = await services.project.create();
-    const scanResult = await importUtil.scanResources([{ contentStr: mcpUrlToInsomniaV5Yaml(mcpUrl), oriFileName: 'mcp' }]);
+    const scanResult = await importUtil.scanResources([
+      { contentStr: mcpUrlToInsomniaV5Yaml(mcpUrl), oriFileName: 'mcp' },
+    ]);
 
     expect(scanResult[0].errors).toEqual([]);
     expect(scanResult[0].mcpRequests).toHaveLength(1);
@@ -748,7 +750,7 @@ describe('MCP run deep-link import', () => {
     expect((requests[0] as McpRequest).url).toBe(mcpUrl);
   });
 
-  it('findExistingImportedMcp returns the MCP client with the same URL', async () => {
+  it('findExistingImportedWorkspace returns the MCP client with the same URL', async () => {
     const project = await services.project.create();
     await importUtil.scanResources([{ contentStr: mcpUrlToInsomniaV5Yaml(mcpUrl), oriFileName: 'mcp' }]);
     const [workspace] = await importUtil.importResourcesToProject({ projectId: project._id });
@@ -756,14 +758,14 @@ describe('MCP run deep-link import', () => {
     expect(existingRequest?.url).toBe(mcpUrl);
 
     await importUtil.scanResources([{ contentStr: mcpUrlToInsomniaV5Yaml(mcpUrl), oriFileName: 'mcp' }]);
-    const match = await importUtil.findExistingImportedMcp(project._id);
+    const match = await importUtil.findExistingImportedWorkspace(project._id);
     expect(match).toEqual({
       workspace: expect.objectContaining({ _id: workspace._id, scope: 'mcp' }),
-      mcpRequest: expect.objectContaining({ _id: existingRequest?._id, url: mcpUrl }),
+      model: expect.objectContaining({ _id: existingRequest?._id, url: mcpUrl }),
     });
   });
 
-  it('findExistingImportedMcp returns undefined for a different MCP URL', async () => {
+  it('findExistingImportedWorkspace returns undefined for a different MCP URL', async () => {
     const project = await services.project.create();
     await importUtil.scanResources([{ contentStr: mcpUrlToInsomniaV5Yaml(mcpUrl), oriFileName: 'mcp' }]);
     await importUtil.importResourcesToProject({ projectId: project._id });
@@ -771,7 +773,7 @@ describe('MCP run deep-link import', () => {
     await importUtil.scanResources([
       { contentStr: mcpUrlToInsomniaV5Yaml('https://mcp.example.com/other'), oriFileName: 'mcp' },
     ]);
-    const match = await importUtil.findExistingImportedMcp(project._id);
+    const match = await importUtil.findExistingImportedWorkspace(project._id);
     expect(match).toBeUndefined();
   });
 });

--- a/packages/insomnia/src/common/__tests__/import.test.ts
+++ b/packages/insomnia/src/common/__tests__/import.test.ts
@@ -747,4 +747,31 @@ describe('MCP run deep-link import', () => {
     expect(models.mcpRequest.isMcpRequest(requests[0])).toBe(true);
     expect((requests[0] as McpRequest).url).toBe(mcpUrl);
   });
+
+  it('findExistingImportedMcp returns the MCP client with the same URL', async () => {
+    const project = await services.project.create();
+    await importUtil.scanResources([{ contentStr: mcpUrlToInsomniaV5Yaml(mcpUrl), oriFileName: 'mcp' }]);
+    const [workspace] = await importUtil.importResourcesToProject({ projectId: project._id });
+    const existingRequest = await services.mcpRequest.getByParentId(workspace._id);
+    expect(existingRequest?.url).toBe(mcpUrl);
+
+    await importUtil.scanResources([{ contentStr: mcpUrlToInsomniaV5Yaml(mcpUrl), oriFileName: 'mcp' }]);
+    const match = await importUtil.findExistingImportedMcp(project._id);
+    expect(match).toEqual({
+      workspace: expect.objectContaining({ _id: workspace._id, scope: 'mcp' }),
+      mcpRequest: expect.objectContaining({ _id: existingRequest?._id, url: mcpUrl }),
+    });
+  });
+
+  it('findExistingImportedMcp returns undefined for a different MCP URL', async () => {
+    const project = await services.project.create();
+    await importUtil.scanResources([{ contentStr: mcpUrlToInsomniaV5Yaml(mcpUrl), oriFileName: 'mcp' }]);
+    await importUtil.importResourcesToProject({ projectId: project._id });
+
+    await importUtil.scanResources([
+      { contentStr: mcpUrlToInsomniaV5Yaml('https://mcp.example.com/other'), oriFileName: 'mcp' },
+    ]);
+    const match = await importUtil.findExistingImportedMcp(project._id);
+    expect(match).toBeUndefined();
+  });
 });

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -831,7 +831,7 @@ export async function findExistingImportedMcp(projectId?: string, organizationId
     const workspaces = await services.workspace.listByParentId(pid);
     for (const ws of workspaces.filter(models.workspace.isMcp)) {
       const mcpRequest = await services.mcpRequest.getByParentId(ws._id);
-      if (mcpRequest?.url.trim() === incomingUrl) {
+      if (mcpRequest?.url?.trim() === incomingUrl) {
         return { workspace: ws, mcpRequest };
       }
     }

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -804,6 +804,41 @@ export async function findExistingImportedSpec(
   return undefined;
 }
 
+export async function findExistingImportedMcp(projectId?: string, organizationId?: string) {
+  let incomingUrl: string | undefined;
+  for (const cache of resourceCacheList) {
+    const mcpRequest = cache.resources.find(models.mcpRequest.isMcpRequest);
+    if (mcpRequest?.url?.trim()) {
+      incomingUrl = mcpRequest.url.trim();
+      break;
+    }
+  }
+  if (!incomingUrl) return;
+
+  const filteredProjects = organizationId
+    ? await services.project.listByOrganizationIds(organizationId)
+    : await services.project.list();
+
+  const projectIds = new Set<string>();
+  if (projectId) {
+    projectIds.add(projectId);
+  }
+  for (const p of filteredProjects) {
+    projectIds.add(p._id);
+  }
+
+  for (const pid of projectIds) {
+    const workspaces = await services.workspace.listByParentId(pid);
+    for (const ws of workspaces.filter(models.workspace.isMcp)) {
+      const mcpRequest = await services.mcpRequest.getByParentId(ws._id);
+      if (mcpRequest?.url.trim() === incomingUrl) {
+        return { workspace: ws, mcpRequest };
+      }
+    }
+  }
+  return;
+}
+
 export function pathPatternMatches(pattern: string, concretePath: string): boolean {
   if (!pattern || pattern.length > 200) {
     return false;

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -754,16 +754,7 @@ function getOasTitleAndVersion(content: string): { title: string; version: strin
   }
 }
 
-export async function findExistingImportedSpec(
-  projectId?: string,
-  organizationId?: string,
-): Promise<
-  | {
-      workspace: Workspace;
-      apiSpec: ApiSpec;
-    }
-  | undefined
-> {
+export async function findExistingImportedWorkspace(projectId?: string, organizationId?: string) {
   const filteredProjects = organizationId
     ? await services.project.listByOrganizationIds(organizationId)
     : await services.project.list();
@@ -777,62 +768,42 @@ export async function findExistingImportedSpec(
     projectIds.add(p._id);
   }
 
-  for (const cache of resourceCacheList) {
-    if (!isApiSpecImport(cache.importer)) continue;
-
-    const incoming = getOasTitleAndVersion(cache.content);
-    if (!incoming) continue;
-
-    for (const pid of projectIds) {
-      const workspaces = await services.workspace.listByParentId(pid);
-      const designWorkspaces = workspaces.filter(w => w.scope === 'design');
-
-      for (const ws of designWorkspaces) {
-        const expectedName = `${incoming.title} ${incoming.version}`;
-        if (ws.name !== expectedName) continue;
-
-        const apiSpec = await services.apiSpec.getByParentId(ws._id);
-        if (!apiSpec) continue;
-
-        const stored = getOasTitleAndVersion(apiSpec.contents);
-        if (!stored || stored.title !== incoming.title || stored.version !== incoming.version) continue;
-
-        return { workspace: ws, apiSpec };
-      }
-    }
-  }
-  return undefined;
-}
-
-export async function findExistingImportedMcp(projectId?: string, organizationId?: string) {
-  let incomingUrl: string | undefined;
+  let incomingMcpUrl: string | undefined;
+  let incomingOasTitleAndVersion: { title: string; version: string } | undefined;
   for (const cache of resourceCacheList) {
     const mcpRequest = cache.resources.find(models.mcpRequest.isMcpRequest);
     if (mcpRequest?.url?.trim()) {
-      incomingUrl = mcpRequest.url.trim();
-      break;
+      incomingMcpUrl = mcpRequest?.url?.trim();
     }
-  }
-  if (!incomingUrl) return;
+    if (isApiSpecImport(cache.importer)) {
+      incomingOasTitleAndVersion = getOasTitleAndVersion(cache.content);
+    }
 
-  const filteredProjects = organizationId
-    ? await services.project.listByOrganizationIds(organizationId)
-    : await services.project.list();
+    if (!incomingOasTitleAndVersion && !incomingMcpUrl) continue;
 
-  const projectIds = new Set<string>();
-  if (projectId) {
-    projectIds.add(projectId);
-  }
-  for (const p of filteredProjects) {
-    projectIds.add(p._id);
-  }
+    for (const pid of projectIds) {
+      const workspaces = await services.workspace.listByParentId(pid);
+      for (const ws of workspaces) {
+        // spec/document branch
+        if (incomingOasTitleAndVersion && models.workspace.isDesign(ws)) {
+          const { title, version } = incomingOasTitleAndVersion;
+          const expectedName = `${title} ${version}`;
+          if (ws.name !== expectedName) continue;
 
-  for (const pid of projectIds) {
-    const workspaces = await services.workspace.listByParentId(pid);
-    for (const ws of workspaces.filter(models.workspace.isMcp)) {
-      const mcpRequest = await services.mcpRequest.getByParentId(ws._id);
-      if (mcpRequest?.url?.trim() === incomingUrl) {
-        return { workspace: ws, mcpRequest };
+          const apiSpec = await services.apiSpec.getByParentId(ws._id);
+          if (!apiSpec) continue;
+
+          const stored = getOasTitleAndVersion(apiSpec.contents);
+          if (!stored || stored.title !== title || stored.version !== version) continue;
+          return { workspace: ws, model: apiSpec };
+        }
+        // mcp branch
+        if (incomingMcpUrl && models.workspace.isMcp(ws)) {
+          const mcpRequest = await services.mcpRequest.getByParentId(ws._id);
+          if (mcpRequest?.url?.trim() === incomingMcpUrl) {
+            return { workspace: ws, model: mcpRequest };
+          }
+        }
       }
     }
   }

--- a/packages/insomnia/src/routes/import.resources.tsx
+++ b/packages/insomnia/src/routes/import.resources.tsx
@@ -4,6 +4,7 @@ import { href } from 'react-router';
 
 import {
   clearResourceCache,
+  findExistingImportedMcp,
   findExistingImportedSpec,
   findRequestInExistingWorkspace,
   importResourcesToProject,
@@ -62,19 +63,19 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
     invariant(typeof projectId === 'string', 'ProjectId is required.');
 
     if (!workspaceId && data.skipImportIfDuplicate) {
-      const existing = await findExistingImportedSpec(projectId, organizationId);
-      if (existing) {
-        const matchedRequest = await findRequestInExistingWorkspace(
-          existing.workspace,
-          data.endpoint,
-          data.operationId,
-        );
-        clearResourceCache(); // skipping import to navigate to existing, avoid stale resource cache
+      const existingSpec = await findExistingImportedSpec(projectId, organizationId);
+      const existingMcp = existingSpec ? undefined : await findExistingImportedMcp(projectId, organizationId);
+      const workspace = existingSpec?.workspace ?? existingMcp?.workspace;
+      if (workspace) {
+        const matchedRequest = existingSpec
+          ? await findRequestInExistingWorkspace(workspace, data.endpoint, data.operationId)
+          : existingMcp?.mcpRequest;
+        clearResourceCache();
         return {
           done: true,
-          singleImportedWorkspace: existing.workspace,
+          singleImportedWorkspace: workspace,
           singleImportedRequest: matchedRequest,
-          singleImportedProjectId: existing.workspace.parentId,
+          singleImportedProjectId: workspace.parentId,
         };
       }
     }

--- a/packages/insomnia/src/routes/import.resources.tsx
+++ b/packages/insomnia/src/routes/import.resources.tsx
@@ -1,11 +1,10 @@
 import type { Workspace } from 'insomnia-data';
-import { services } from 'insomnia-data';
+import { models, services } from 'insomnia-data';
 import { href } from 'react-router';
 
 import {
   clearResourceCache,
-  findExistingImportedMcp,
-  findExistingImportedSpec,
+  findExistingImportedWorkspace,
   findRequestInExistingWorkspace,
   importResourcesToProject,
   importResourcesToWorkspace,
@@ -63,19 +62,17 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
     invariant(typeof projectId === 'string', 'ProjectId is required.');
 
     if (!workspaceId && data.skipImportIfDuplicate) {
-      const existingSpec = await findExistingImportedSpec(projectId, organizationId);
-      const existingMcp = existingSpec ? undefined : await findExistingImportedMcp(projectId, organizationId);
-      const workspace = existingSpec?.workspace ?? existingMcp?.workspace;
-      if (workspace) {
-        const matchedRequest = existingSpec
-          ? await findRequestInExistingWorkspace(workspace, data.endpoint, data.operationId)
-          : existingMcp?.mcpRequest;
+      const existing = await findExistingImportedWorkspace(projectId, organizationId);
+      if (existing) {
+        const matchedRequest = models.apiSpec.isApiSpec(existing.model)
+          ? await findRequestInExistingWorkspace(existing.workspace, data.endpoint, data.operationId)
+          : existing.model;
         clearResourceCache();
         return {
           done: true,
-          singleImportedWorkspace: workspace,
+          singleImportedWorkspace: existing.workspace,
           singleImportedRequest: matchedRequest,
-          singleImportedProjectId: workspace.parentId,
+          singleImportedProjectId: existing.workspace.parentId,
         };
       }
     }

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -16,6 +16,7 @@ import { Checkbox } from '~/ui/components/base/checkbox';
 
 import {
   clearResourceCache,
+  findExistingImportedMcp,
   findExistingImportedSpec,
   findRequestInExistingWorkspace,
   type ImportSourceType,
@@ -33,7 +34,7 @@ import { ModalHeader } from '../../base/modal-header';
 import { HelpTooltip } from '../../help-tooltip';
 import { Icon } from '../../icon';
 import { Button } from '../../themed-button';
-import { CurlIcon, isApiSpecScanResult, ScanResultsTable, SupportedFormats, validImportExtensions } from './shared';
+import { CurlIcon, isApiSpecScanResult, requiresNewWorkspace, ScanResultsTable, SupportedFormats, validImportExtensions } from './shared';
 
 export const Radio: FC<{
   name: string;
@@ -236,11 +237,13 @@ export const ImportModal: FC<ImportModalProps> = ({
   }, [autoScan, from.type, from.defaultValue, scanResourcesFetcher, scanResourcesFetcherData]);
 
   const hasApiSpecScanResult = scanResourcesFetcherData?.some(isApiSpecScanResult);
+  const hasMcpScanResult = scanResourcesFetcherData?.some(r => (r.mcpRequests?.length ?? 0) > 0);
+  const mustCreateNewWorkspace = scanResourcesFetcherData?.some(requiresNewWorkspace);
   const [showForm, setShowForm] = useState(!autoScan);
   const [createdProjectId, setCreatedProjectId] = useState<string | null>(null);
   const dupCheckRef = useRef(false);
   useEffect(() => {
-    if (!autoScan || !hasApiSpecScanResult || !organizationId) return;
+    if (!autoScan || (!hasApiSpecScanResult && !hasMcpScanResult) || !organizationId) return;
     if (!defaultProjectId) {
       setShowForm(true);
       return;
@@ -249,24 +252,38 @@ export const ImportModal: FC<ImportModalProps> = ({
     const valid = scanResourcesFetcherData?.some(({ errors }) => !errors.length);
     if (!valid) return;
     dupCheckRef.current = true;
-    findExistingImportedSpec(defaultProjectId, organizationId).then(existing => {
-      if (!existing) return setShowForm(true);
-      findRequestInExistingWorkspace(existing.workspace, from.endpoint, from.operationId).then(req => {
+
+    if (hasApiSpecScanResult) {
+      findExistingImportedSpec(defaultProjectId, organizationId).then(existing => {
+        if (!existing) return setShowForm(true);
+        findRequestInExistingWorkspace(existing.workspace, from.endpoint, from.operationId).then(req => {
+          const targetProjectId = existing.workspace.parentId || defaultProjectId;
+          const path = req
+            ? `/organization/${organizationId}/project/${targetProjectId}/workspace/${existing.workspace._id}/debug/request/${req._id}`
+            : `/organization/${organizationId}/project/${targetProjectId}/workspace/${existing.workspace._id}/${models.workspace.scopeToActivity(existing.workspace.scope)}`;
+          clearResourceCache();
+          navigate(path);
+          modalRef.current?.hide();
+        });
+      });
+    } else {
+      findExistingImportedMcp(defaultProjectId, organizationId).then(existing => {
+        if (!existing) return setShowForm(true);
         const targetProjectId = existing.workspace.parentId || defaultProjectId;
-        const path = req
-          ? `/organization/${organizationId}/project/${targetProjectId}/workspace/${existing.workspace._id}/debug/request/${req._id}`
-          : `/organization/${organizationId}/project/${targetProjectId}/workspace/${existing.workspace._id}/${models.workspace.scopeToActivity(existing.workspace.scope)}`;
         clearResourceCache();
-        navigate(path);
+        navigate(
+          `/organization/${organizationId}/project/${targetProjectId}/workspace/${existing.workspace._id}/debug/request/${existing.mcpRequest._id}`,
+        );
         modalRef.current?.hide();
       });
-    });
+    }
   }, [
     autoScan,
     defaultProjectId,
     from.endpoint,
     from.operationId,
     hasApiSpecScanResult,
+    hasMcpScanResult,
     navigate,
     organizationId,
     scanResourcesFetcherData,
@@ -320,7 +337,7 @@ export const ImportModal: FC<ImportModalProps> = ({
       ) || 0
     );
   }, [scanResourcesFetcherData]);
-  const shouldImportToWorkspace = !!defaultWorkspaceId && totalWorkspacesCount <= 1 && !hasApiSpecScanResult;
+  const shouldImportToWorkspace = !!defaultWorkspaceId && totalWorkspacesCount <= 1 && !mustCreateNewWorkspace;
   // Check if base environment is being imported to existing workspace
   const isImportingBaseEnvironmentToWorkspace =
     shouldImportToWorkspace &&
@@ -356,7 +373,7 @@ export const ImportModal: FC<ImportModalProps> = ({
     <OverlayContainer onClick={e => e.stopPropagation()}>
       <Modal ref={modalRef} onHide={onHide}>
         <ModalHeader>{header}</ModalHeader>
-        {autoScan && hasApiSpecScanResult && hasAnyDataToImport && !showForm ? (
+        {autoScan && (hasApiSpecScanResult || hasMcpScanResult) && hasAnyDataToImport && !showForm ? (
           <div className="flex items-center justify-center p-8">
             <i className="fa fa-spinner fa-spin fa-2x" />
           </div>
@@ -366,6 +383,7 @@ export const ImportModal: FC<ImportModalProps> = ({
             errors={importErrors}
             loading={importFetcher.state !== 'idle'}
             disabled={importErrors.length > 0}
+            autoScan={autoScan}
             isImportingBaseEnvironmentToWorkspace={!!isImportingBaseEnvironmentToWorkspace}
             onImport={async (
               overrideBaseEnvironmentData: boolean,
@@ -392,7 +410,7 @@ export const ImportModal: FC<ImportModalProps> = ({
                 organizationId,
                 projectId: targetProjectId,
                 workspaceId:
-                  hasApiSpecScanResult || newProjectName
+                  mustCreateNewWorkspace || newProjectName
                     ? undefined
                     : selectedWorkspaceId || undefined,
                 endpoint: from.endpoint,
@@ -625,6 +643,7 @@ const ImportResourcesForm = ({
   errors,
   disabled,
   loading,
+  autoScan,
   isImportingBaseEnvironmentToWorkspace,
 }: {
   scanResults: ScanResult[];
@@ -637,6 +656,7 @@ const ImportResourcesForm = ({
   ) => void;
   disabled: boolean;
   loading: boolean;
+  autoScan: boolean;
   isImportingBaseEnvironmentToWorkspace: boolean;
 }) => {
   const { organizationId, projectId, workspaceId } = useParams() as {
@@ -646,7 +666,7 @@ const ImportResourcesForm = ({
   };
   const [overrideBaseEnvironmentData, setOverrideBaseEnvironmentData] = useState(true);
   const workspacesFetcher = useProjectListWorkspacesLoaderFetcher();
-  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState(workspaceId || '');
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState(autoScan ? '' : workspaceId || '');
   const [selectedProjectId, setSelectedProjectId] = useState(projectId || '');
   const [newProjectName, setNewProjectName] = useState(() => {
     for (const result of scanResults) {
@@ -678,7 +698,8 @@ const ImportResourcesForm = ({
         .map(w => ({ ...w.workspace, lastModifiedTimestamp: w.lastModifiedTimestamp }))
         .filter(isNotNullOrUndefined)
         .filter(w => w.scope === 'collection' || w.scope === 'design') || [];
-  const shouldShowWorkspaceSelect = workspacesForActiveProject.length > 0;
+  const shouldShowWorkspaceSelect =
+    !scanResults.some(requiresNewWorkspace) && workspacesForActiveProject.length > 0;
   return (
     <Fragment>
       <div className="flex max-h-[50vh] flex-col gap-(--padding-md) overflow-auto">

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -16,8 +16,7 @@ import { Checkbox } from '~/ui/components/base/checkbox';
 
 import {
   clearResourceCache,
-  findExistingImportedMcp,
-  findExistingImportedSpec,
+  findExistingImportedWorkspace,
   findRequestInExistingWorkspace,
   type ImportSourceType,
   type ScanResult,
@@ -34,7 +33,14 @@ import { ModalHeader } from '../../base/modal-header';
 import { HelpTooltip } from '../../help-tooltip';
 import { Icon } from '../../icon';
 import { Button } from '../../themed-button';
-import { CurlIcon, isApiSpecScanResult, requiresNewWorkspace, ScanResultsTable, SupportedFormats, validImportExtensions } from './shared';
+import {
+  CurlIcon,
+  isApiSpecScanResult,
+  requiresNewWorkspace,
+  ScanResultsTable,
+  SupportedFormats,
+  validImportExtensions,
+} from './shared';
 
 export const Radio: FC<{
   name: string;
@@ -253,30 +259,24 @@ export const ImportModal: FC<ImportModalProps> = ({
     if (!valid) return;
     dupCheckRef.current = true;
 
-    if (hasApiSpecScanResult) {
-      findExistingImportedSpec(defaultProjectId, organizationId).then(existing => {
-        if (!existing) return setShowForm(true);
-        findRequestInExistingWorkspace(existing.workspace, from.endpoint, from.operationId).then(req => {
-          const targetProjectId = existing.workspace.parentId || defaultProjectId;
-          const path = req
-            ? `/organization/${organizationId}/project/${targetProjectId}/workspace/${existing.workspace._id}/debug/request/${req._id}`
-            : `/organization/${organizationId}/project/${targetProjectId}/workspace/${existing.workspace._id}/${models.workspace.scopeToActivity(existing.workspace.scope)}`;
-          clearResourceCache();
-          navigate(path);
-          modalRef.current?.hide();
-        });
-      });
-    } else {
-      findExistingImportedMcp(defaultProjectId, organizationId).then(existing => {
-        if (!existing) return setShowForm(true);
-        const targetProjectId = existing.workspace.parentId || defaultProjectId;
+    findExistingImportedWorkspace(defaultProjectId, organizationId).then(existing => {
+      if (!existing) return setShowForm(true);
+      const { workspace, model } = existing;
+      const targetProjectId = workspace.parentId || defaultProjectId;
+      const navigateTo = (requestId?: string) => {
+        const path = requestId
+          ? `/organization/${organizationId}/project/${targetProjectId}/workspace/${workspace._id}/debug/request/${requestId}`
+          : `/organization/${organizationId}/project/${targetProjectId}/workspace/${workspace._id}/${models.workspace.scopeToActivity(workspace.scope)}`;
         clearResourceCache();
-        navigate(
-          `/organization/${organizationId}/project/${targetProjectId}/workspace/${existing.workspace._id}/debug/request/${existing.mcpRequest._id}`,
-        );
+        navigate(path);
         modalRef.current?.hide();
-      });
-    }
+      };
+      if (models.mcpRequest.isMcpRequest(model)) {
+        navigateTo(model._id);
+      } else {
+        findRequestInExistingWorkspace(workspace, from.endpoint, from.operationId).then(req => navigateTo(req?._id));
+      }
+    });
   }, [
     autoScan,
     defaultProjectId,
@@ -409,10 +409,7 @@ export const ImportModal: FC<ImportModalProps> = ({
               importFetcher.submit({
                 organizationId,
                 projectId: targetProjectId,
-                workspaceId:
-                  mustCreateNewWorkspace || newProjectName
-                    ? undefined
-                    : selectedWorkspaceId || undefined,
+                workspaceId: mustCreateNewWorkspace || newProjectName ? undefined : selectedWorkspaceId || undefined,
                 endpoint: from.endpoint,
                 operationId: from.operationId,
                 skipImportIfDuplicate: autoScan,
@@ -698,8 +695,7 @@ const ImportResourcesForm = ({
         .map(w => ({ ...w.workspace, lastModifiedTimestamp: w.lastModifiedTimestamp }))
         .filter(isNotNullOrUndefined)
         .filter(w => w.scope === 'collection' || w.scope === 'design') || [];
-  const shouldShowWorkspaceSelect =
-    !scanResults.some(requiresNewWorkspace) && workspacesForActiveProject.length > 0;
+  const shouldShowWorkspaceSelect = !scanResults.some(requiresNewWorkspace) && workspacesForActiveProject.length > 0;
   return (
     <Fragment>
       <div className="flex max-h-[50vh] flex-col gap-(--padding-md) overflow-auto">

--- a/packages/insomnia/src/ui/components/modals/import-modal/shared.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/shared.tsx
@@ -188,6 +188,14 @@ export function isApiSpecScanResult(scanResult: ScanResult) {
   );
 }
 
+export function requiresNewWorkspace(scanResult: ScanResult) {
+  return (
+    isApiSpecScanResult(scanResult) ||
+    (scanResult.mcpRequests?.length ?? 0) > 0 ||
+    !!scanResult.workspaces?.some(w => w.scope === 'design' || w.scope === 'mcp')
+  );
+}
+
 function getWorkspaceCountsByScope(workspaces: { scope?: string }[], scanResult: ScanResult) {
   const defaultScope = isApiSpecScanResult(scanResult) ? 'design' : 'collection';
   const counts = new Map<string, number>();


### PR DESCRIPTION
This PR fixes an issue where deep-link `mcpRequest` imports were invisibly added to a focused `mcpClient` workspace. Now, `autoScan`/deep-link imports do not inherit the currently focused workspace

Also adds an `mcpRequest` matcher similar to specs so that repeated deep-link imports focus one that already exists

