### PR TITLE
fix: collection runner ux

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
@@ -50,10 +50,13 @@ test.describe('runner features tests', () => {
     expect.soft(passedResultCount + failedResultCount + skippedResultCount).toEqual(expectedTotal);
   };
 
-  const selectRunnerRequest = async (page: Page, name: string) => {
-    const row = page.locator(`.runner-request-list-${name}`);
-    await row.waitFor({ state: 'visible' });
-    await row.locator('label[slot="selection"]').click();
+  const selectRunnerRequests = async (page: Page, ...names: string[]) => {
+    await page.getByText('Unselect All').click();
+    for (const name of names) {
+      const row = page.locator(`.runner-request-list-${name}`);
+      await row.waitFor({ state: 'visible' });
+      await row.locator('label[slot="selection"]').click();
+    }
   };
 
   test('run collection runner', async ({ page, insomnia }) => {
@@ -62,9 +65,7 @@ test.describe('runner features tests', () => {
       workspaceName: 'Runner',
     });
 
-    // select requests to test
-    await page.locator('.runner-request-list-req1').click();
-    await page.locator('.runner-request-list-req2').click();
+    await selectRunnerRequests(page, 'req1', 'req2');
 
     // send
     await page.getByTestId('request-pane').getByRole('button', { name: 'Run' }).click();
@@ -107,8 +108,7 @@ test.describe('runner features tests', () => {
       workspaceName: 'Runner',
     });
 
-    await selectRunnerRequest(page, 'delaySkip');
-    await selectRunnerRequest(page, 'fastAfterSkip');
+    await selectRunnerRequests(page, 'delaySkip', 'fastAfterSkip');
 
     await page.getByRole('button', { name: 'Run', exact: true }).click();
 
@@ -130,8 +130,7 @@ test.describe('runner features tests', () => {
       workspaceName: 'Runner',
     });
 
-    await selectRunnerRequest(page, 'delaySkip');
-    await selectRunnerRequest(page, 'fastAfterSkip');
+    await selectRunnerRequests(page, 'delaySkip', 'fastAfterSkip');
 
     await page.getByRole('button', { name: 'Run', exact: true }).click();
 
@@ -160,12 +159,7 @@ test.describe('runner features tests', () => {
     // check iteration number match json data length
     await expect.soft(page.locator('input[name="Iterations"]')).toHaveValue('2');
 
-    // select requests to test
-    await page.locator('.runner-request-list-req1').click();
-    await page.locator('.runner-request-list-req2').click();
-    await page.locator('.runner-request-list-req3').click();
-    await page.locator('.runner-request-list-req4').click();
-    await page.locator('.runner-request-list-req5').click();
+    await selectRunnerRequests(page, 'req1', 'req2', 'req3', 'req4', 'req5');
 
     // send
     await page.getByTestId('request-pane').getByRole('button', { name: 'Run' }).click();
@@ -195,7 +189,7 @@ test.describe('runner features tests', () => {
       actionName: 'Run Collection',
       workspaceName: 'Runner',
     });
-    await page.locator('.runner-request-list-req4').click();
+    await selectRunnerRequests(page, 'req4');
 
     // send
     await page.getByRole('button', { name: 'Run', exact: true }).click();
@@ -213,7 +207,7 @@ test.describe('runner features tests', () => {
       actionName: 'Run Collection',
       workspaceName: 'Runner',
     });
-    await page.locator('.runner-request-list-await-test').click();
+    await selectRunnerRequests(page, 'await-test');
 
     // send
     await page.getByRole('button', { name: 'Run', exact: true }).click();
@@ -231,7 +225,7 @@ test.describe('runner features tests', () => {
       actionName: 'Run Collection',
       workspaceName: 'Runner',
     });
-    await page.locator('.runner-request-list-req5').click();
+    await selectRunnerRequests(page, 'req5');
 
     // send
     await page.getByRole('button', { name: 'Run', exact: true }).click();
@@ -249,9 +243,7 @@ test.describe('runner features tests', () => {
       actionName: 'Run Collection',
       workspaceName: 'Runner',
     });
-    await page.locator('.runner-request-list-req0').click();
-    await page.locator('.runner-request-list-req01').click();
-    await page.locator('.runner-request-list-req02').click();
+    await selectRunnerRequests(page, 'req0', 'req01', 'req02');
 
     // send
     await page.getByRole('button', { name: 'Run', exact: true }).click();
@@ -275,8 +267,7 @@ test.describe('runner features tests', () => {
       workspaceName: 'Runner',
     });
 
-    await page.locator('.runner-request-list-set-var1').click();
-    await page.locator('.runner-request-list-read-var1').click();
+    await selectRunnerRequests(page, 'set-var1', 'read-var1');
 
     // send
     await page.getByRole('button', { name: 'Run', exact: true }).click();
@@ -295,7 +286,7 @@ test.describe('runner features tests', () => {
       workspaceName: 'Runner',
     });
 
-    await page.locator('.runner-request-list-async-test').click();
+    await selectRunnerRequests(page, 'async-test');
 
     // send
     await page.getByRole('button', { name: 'Run', exact: true }).click();
@@ -385,8 +376,7 @@ test.describe('runner features tests', () => {
     await iterationsInput.clear();
     await expect.soft(iterationsInput).toHaveValue('');
 
-    // select a request and run
-    await page.locator('.runner-request-list-req1').click();
+    await selectRunnerRequests(page, 'req1');
     await page.getByTestId('request-pane').getByRole('button', { name: 'Run' }).click();
 
     // should have run 2 iterations (last valid value)
@@ -401,17 +391,11 @@ test.describe('runner features tests', () => {
       workspaceName: 'Runner',
     });
 
-    // Select the request via its selection checkbox. The list is a drag-and-drop
-    // GridList, so a plain row click can be read as the start of a drag on slower
-    // CI and swallow the selection toggle — clicking the checkbox is reliable.
-    const printLogsRow = page.locator('.runner-request-list-printLogs');
-    await printLogsRow.waitFor({ state: 'visible' });
-    await printLogsRow.locator('label[slot="selection"]').click();
+    await selectRunnerRequests(page, 'printLogs');
 
     await page.getByRole('tab', { name: 'advanced' }).click();
     await page.locator('input[name="enable-log"]').click();
 
-    // Run becomes enabled only once a request is selected; selecting printLogs above enables it
     const runButton = page.getByRole('button', { name: 'Run', exact: true });
     await expect.soft(runButton).toBeEnabled();
     await runButton.click();

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.runner.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.runner.tsx
@@ -41,6 +41,7 @@ import { Dropdown, DropdownItem, ItemContent } from '~/ui/components/base/dropdo
 import { ErrorBoundary } from '~/ui/components/error-boundary';
 import { HelpTooltip } from '~/ui/components/help-tooltip';
 import { Icon } from '~/ui/components/icon';
+import { useDocBodyKeyboardShortcuts } from '~/ui/components/keydown-binder';
 import { showModal } from '~/ui/components/modals';
 import { AlertModal } from '~/ui/components/modals/alert-modal';
 import { CLIPreviewModal } from '~/ui/components/modals/cli-preview-modal';
@@ -164,6 +165,7 @@ export const Runner: FC = () => {
     direction: 'vertical' | 'horizontal';
   };
   const [isRunning, setIsRunning] = useState(false);
+  const [canceledRun, setCanceledRun] = useState(false);
 
   // For backward compatibility，the runnerId we use for testResult in database is no prefix with 'runner_'
   const runnerId = targetFolderId ? targetFolderId : workspaceId;
@@ -182,7 +184,7 @@ export const Runner: FC = () => {
   const {
     iterationCount = 1,
     delay = 0,
-    selectedKeys = new Set<Key>(),
+    selectedKeys = 'all',
     advancedConfig = defaultAdvancedConfig,
     uploadData = [],
     file,
@@ -283,6 +285,7 @@ export const Runner: FC = () => {
     if (isRunning) {
       return;
     }
+    setCanceledRun(false);
     setIsRunning(true);
 
     window.main.trackAnalyticsEvent({
@@ -482,14 +485,21 @@ export const Runner: FC = () => {
   }, [executionResult, isRunning]);
 
   const [selectedTab, setSelectedTab] = React.useState<Key>('results');
-  const [canceledRun, setCanceledRun] = useState(false);
   const activeTab = isRunning ? 'results' : selectedTab;
 
   const allKeys = reqList.map(item => item.id);
   const disabledKeys = useMemo(() => {
     return isRunning ? allKeys : [];
   }, [isRunning, allKeys]);
-  const isDisabled = isRunning || Array.from(selectedKeys).length === 0;
+  const isDisabled = isRunning || (selectedKeys !== 'all' && Array.from(selectedKeys).length === 0);
+
+  useDocBodyKeyboardShortcuts({
+    request_send: () => {
+      if (!isDisabled) {
+        onRun();
+      }
+    },
+  });
 
   const [deletedItems, setDeletedItems] = useState<string[]>([]);
   const deleteHistoryItem = (item: RunnerTestResult) => {
@@ -820,17 +830,15 @@ export const Runner: FC = () => {
         className={direction === 'horizontal' ? 'h-full w-px bg-(--hl-md)' : 'h-px w-full bg-(--hl-md)'}
       />
       <Panel id="pane-two" className="pane-two theme--pane">
-        <PaneHeader className="row-spaced">
-          <Heading className="flex h-(--line-height-sm) w-full items-center border-b border-solid border-b-(--hl-md) pl-3">
-            {executionResult?.duration ? (
+        {executionResult?.duration ? (
+          <PaneHeader className="row-spaced">
+            <Heading className="flex h-(--line-height-sm) w-full items-center border-b border-solid border-b-(--hl-md) pl-3">
               <div className="bg-info tag">
                 <strong>{`${totalTime.duration} ${totalTime.unit}`}</strong>
               </div>
-            ) : (
-              <span className="font-bold">Collection Runner</span>
-            )}
-          </Heading>
-        </PaneHeader>
+            </Heading>
+          </PaneHeader>
+        ) : null}
         <Tabs
           selectedKey={activeTab}
           onSelectionChange={setSelectedTab}
@@ -859,7 +867,7 @@ export const Runner: FC = () => {
               className="flex h-full shrink-0 cursor-pointer items-center justify-between gap-2 px-3 py-1 text-(--hl) outline-hidden transition-colors duration-300 select-none hover:bg-(--hl-sm) hover:text-(--color-font) focus:bg-(--hl-sm) aria-selected:bg-(--hl-xs) aria-selected:text-(--color-font) aria-selected:hover:bg-(--hl-sm) aria-selected:focus:bg-(--hl-sm)"
               id="history"
             >
-              Test History
+              History
             </Tab>
             <Tab
               className="flex h-full shrink-0 cursor-pointer items-center justify-between gap-2 px-3 py-1 text-(--hl) outline-hidden transition-colors duration-300 select-none hover:bg-(--hl-sm) hover:text-(--color-font) focus:bg-(--hl-sm) aria-selected:bg-(--hl-xs) aria-selected:text-(--color-font) aria-selected:hover:bg-(--hl-sm) aria-selected:focus:bg-(--hl-sm)"

--- a/packages/insomnia/src/ui/components/panes/request-result-card.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-result-card.tsx
@@ -19,10 +19,18 @@ interface Props {
   targetTests?: string;
   onSkip?: () => void;
   testId?: string;
+  defaultExpanded?: boolean;
 }
 
-export const RequestResultCard: FC<Props> = ({ item, resultFilter = '', targetTests = 'all', onSkip, testId }) => {
-  const [isExpanded, setIsExpanded] = useState(!!targetTests);
+export const RequestResultCard: FC<Props> = ({
+  item,
+  resultFilter = '',
+  targetTests = 'all',
+  onSkip,
+  testId,
+  defaultExpanded = false,
+}) => {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
   const status: RunnerItemStatus =
     'status' in item ? item.status : item.skipped ? 'skipped' : item.responseCode > 0 ? 'completed' : 'failed';
   const isSkipped = status === 'skipped';

--- a/packages/insomnia/src/ui/components/panes/runner-live-progress-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/runner-live-progress-pane.tsx
@@ -38,10 +38,11 @@ export const RunnerLiveProgressPane: FC<Props> = ({ items, isRunning, handleCanc
             .filter(item => item.iteration === iteration)
             .map(item => (
               <RequestResultCard
-                key={item.key}
+                key={`${item.key}-${isRunning}`}
                 item={item}
                 testId={`runner-live-item-${item.requestName}`}
                 onSkip={() => handleSkip(item.key)}
+                defaultExpanded={!isRunning}
               />
             ))}
         </div>

--- a/packages/insomnia/src/ui/components/panes/runner-test-result-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/runner-test-result-pane.tsx
@@ -2,6 +2,9 @@ import type { BaseRunnerTestResult, RunnerResultPerRequest } from 'insomnia-data
 import React, { type FC, useState } from 'react';
 import { Toolbar } from 'react-aria-components';
 
+import { useRootLoaderData } from '~/root';
+import { Hotkey } from '~/ui/components/hotkey';
+
 import { RequestResultCard } from './request-result-card';
 
 type TargetTestType = 'all' | 'passed' | 'failed' | 'skipped';
@@ -18,15 +21,30 @@ interface Props {
 export const RunnerTestResultPane: FC<Props> = ({ result }) => {
   const [targetTests, setTargetTests] = useState<TargetTestType>('all');
   const [resultFilter, setResultFilter] = useState('');
+  const { settings } = useRootLoaderData()!;
 
-  const noTestFoundPage = (
-    <div className="mt-5 text-center">
-      <div className="">No test result found</div>
-      <div className="text-sm text-neutral-400">Add test cases in scripts and run them to see results.</div>
-    </div>
-  );
-  if (!result || result.iterationResults.length === 0) {
-    return noTestFoundPage;
+  if (!result) {
+    return (
+      <div className="mt-5 text-center">
+        <div>Run results will appear here</div>
+        <div className="mt-2 flex items-center justify-center gap-1.5 text-sm text-neutral-400">
+          <span>Select requests and press</span>
+          <code>
+            <Hotkey keyBindings={settings.hotKeyRegistry.request_send} useFallbackMessage />
+          </code>
+          <span>to run</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (result.iterationResults.length === 0) {
+    return (
+      <div className="mt-5 text-center">
+        <div>No results from this run</div>
+        <div className="text-sm text-neutral-400">Add test cases in scripts and run them to see results.</div>
+      </div>
+    );
   }
 
   const selectAllTests = () => setTargetTests('all');
@@ -47,6 +65,7 @@ export const RunnerTestResultPane: FC<Props> = ({ result }) => {
             resultFilter={resultFilter}
             targetTests={targetTests}
             testId={key}
+            defaultExpanded
           />
         );
       });

--- a/packages/insomnia/src/ui/components/workspace/use-workspace-breadcrumb.tsx
+++ b/packages/insomnia/src/ui/components/workspace/use-workspace-breadcrumb.tsx
@@ -2,19 +2,23 @@ import { models } from 'insomnia-data';
 import { useMemo } from 'react';
 import { useParams } from 'react-router';
 
+import { Icon } from '~/basic-components/icon';
 import { useWorkspaceLoaderData } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
 import { useRequestLoaderData } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId';
 import { useRequestGroupLoaderData } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.$requestGroupId';
 import type { PaneBreadcrumb } from '~/ui/components/pane-header';
 import { ResourceIcon } from '~/ui/components/workspace/resource-icon';
-import { buildResourceUrl } from '~/ui/hooks/use-insomnia-navigation';
+import { buildResourceUrl, useInsomniaNavigation } from '~/ui/hooks/use-insomnia-navigation';
 
 export function useWorkspaceBreadcrumbs() {
   const { activeWorkspace, activeProject, collection } = useWorkspaceLoaderData()!;
   const { activeRequest } = useRequestLoaderData() || {};
   const { activeRequestGroup } = useRequestGroupLoaderData() || {};
   const { organizationId } = useParams();
+  const { routeInfo } = useInsomniaNavigation();
   const isMcp = activeWorkspace && models.workspace.isMcp(activeWorkspace);
+  const isRunner = routeInfo?.routeId === 'runner';
+  const runnerFolderId = isRunner ? routeInfo.searchParams.get('folder') : null;
 
   const resourcesById = useMemo(() => {
     const map = new Map<string, (typeof collection)[number]['doc']>();
@@ -24,7 +28,9 @@ export function useWorkspaceBreadcrumbs() {
     return map;
   }, [collection]);
 
-  const reqOrGrpId = activeRequest?._id || activeRequestGroup?._id;
+  const runnerFolder = runnerFolderId ? collection.find(col => col.doc._id === runnerFolderId) : undefined;
+  const folder = activeRequestGroup || runnerFolder?.doc;
+  const reqOrGrpId = activeRequest?._id || folder?._id;
   const reqOrGrp = collection.find(col => col.doc._id === reqOrGrpId);
 
   // workspace is not in collection, so we need to filter it out.
@@ -83,16 +89,41 @@ export function useWorkspaceBreadcrumbs() {
         label: activeRequest.name || 'Untitled request',
         icon: <ResourceIcon resource={activeRequest} />,
       });
-    } else if (activeRequestGroup) {
+    } else if (folder) {
       crumbs.push({
-        id: activeRequestGroup._id,
-        label: activeRequestGroup.name || 'Untitled group',
-        icon: <ResourceIcon resource={activeRequestGroup} />,
+        id: folder._id,
+        label: folder.name || 'Untitled folder',
+        to: isRunner
+          ? buildResourceUrl({
+              organizationId: organizationId!,
+              projectId: activeProject._id,
+              workspaceId: activeWorkspace!._id,
+              resource: folder,
+            })
+          : undefined,
+        icon: <ResourceIcon resource={folder} />,
+      });
+    }
+
+    if (isRunner) {
+      crumbs.push({
+        id: 'runner',
+        label: 'Runner',
+        icon: <Icon icon="play" className="w-2.5 shrink-0" />,
       });
     }
 
     return crumbs;
-  }, [activeProject, activeWorkspace, ancestors, activeRequest, activeRequestGroup, organizationId, isMcp]);
+  }, [
+    activeProject,
+    activeWorkspace,
+    ancestors,
+    activeRequest,
+    folder,
+    organizationId,
+    isMcp,
+    isRunner,
+  ]);
 
   return breadcrumbs;
 }

--- a/packages/insomnia/src/ui/hooks/use-runner-request-list.tsx
+++ b/packages/insomnia/src/ui/hooks/use-runner-request-list.tsx
@@ -60,6 +60,7 @@ export const useRunnerRequestList = (organizationId: string, targetFolderId: str
     if (!runnerStateRef?.current?.[organizationId]?.[runnerId]) {
       updateRunnerState(organizationId, runnerId, {
         reqList: requestRows,
+        selectedKeys: 'all',
       });
     }
   }, [organizationId, requestRows, runnerId, runnerStateRef, updateRunnerState]);


### PR DESCRIPTION
Current:
<img width="1008" height="202" alt="Screenshot 2026-07-17 at 09 45 12" src="https://github.com/user-attachments/assets/9f1a9675-b0c6-47c0-84f1-815750a4c759" />

New:
<img width="908" height="257" alt="Screenshot 2026-07-17 at 09 44 12" src="https://github.com/user-attachments/assets/1f82975b-13fd-439a-9ad8-66b79c20908f" />

- Moved `Collection Runner` title into `Runner` breadcrumb (to match tab title)
- Renamed `Test History` to `History`
- Defaults to all requests selected
- Changes placeholder view to prompt a run with a keyboard shortcut