### PR TITLE
feat(templating): (L1) discover user-plugin exports in the sandbox instead of nodeRequire (PR 9)

### DIFF
--- a/packages/insomnia-smoke-test/fixtures/sandbox-l1-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/sandbox-l1-collection.yaml
@@ -1,0 +1,24 @@
+type: collection.insomnia.rest/5.0
+schema_version: "5.1"
+name: Sandbox L1 Collection
+meta:
+  id: wrk_5a4l100000000000000000000000001
+  created: 1751800000000
+  modified: 1751800000000
+collection:
+  - url: http://127.0.0.1:4010/echo
+    name: L1 Probe
+    meta:
+      id: req_5a4l100000000000000000000000002
+      created: 1751800000001
+      modified: 1751800000001
+      isPrivate: false
+      sortKey: -1751800000001
+    method: GET
+    body:
+      mimeType: text/plain
+      text: |
+        {% l1probe %}
+    headers:
+      - name: Content-Type
+        value: text/plain

--- a/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
@@ -640,3 +640,72 @@ test('Template tag sandbox: multi-file plugins resolve relative requires and ign
   // The plugin's own node_modules/uuid ('evil') is never consulted — the real vetted uuid runs.
   await assertTagPreview('{% poisonprobe', 'poison-real');
 });
+
+test('Plugin sandbox (L1): installing a user plugin no longer runs its top-level code on the host', async ({
+  page,
+  app,
+  dataPath,
+  insomnia,
+}) => {
+  const SENTINEL_PLUGIN = 'insomnia-plugin-l1-sentinel';
+  const sentinelPath = path.join(dataPath, 'plugins', SENTINEL_PLUGIN, 'sentinel.txt');
+
+  // The plugin's TOP-LEVEL code tries to write a file via a Node built-in. With the sandbox off, the
+  // loader nodeRequire()s the module on the host, so require('fs') works and the sentinel appears.
+  // With the sandbox on, exports are discovered by evaluating the source INSIDE the sandbox, where
+  // require('fs') is default-denied — so the write never happens, yet the tag still enumerates + runs.
+  // The try/catch keeps discovery from failing on the denied require, so the plugin still loads.
+  writePlugin(
+    dataPath,
+    SENTINEL_PLUGIN,
+    {},
+    `
+      try { require('fs').writeFileSync(__dirname + '/sentinel.txt', 'top-level-ran-on-host'); } catch (e) {}
+      module.exports.templateTags = [{
+        name: 'l1probe', displayName: 'L1 Probe', description: 'discovery marker', args: [],
+        async run() { return 'l1-tag-ran'; },
+      }];
+    `,
+  );
+
+  const fixture = await loadFixture('sandbox-l1-collection.yaml');
+  await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), fixture);
+  await clearPluginToast(page);
+  await page.getByLabel('Import').click();
+  await page.locator('[data-test-id="import-from-clipboard"]').click();
+  await page.getByRole('button', { name: 'Scan' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+
+  // Flag OFF (default): the loader runs the plugin's top-level code on the host (control).
+  await page.evaluate(() => (window as any).main.plugins.reloadPlugins());
+  expect.soft(fs.existsSync(sentinelPath), 'sandbox off: top-level code runs on the host').toBe(true);
+
+  // Flag ON: re-discover via the sandbox. Poll delete→reload→check so the just-toggled setting has
+  // time to propagate to the main process before we conclude the write did not recur.
+  await enableSandbox(page);
+  await expect
+    .poll(
+      async () => {
+        fs.rmSync(sentinelPath, { force: true });
+        await page.evaluate(() => (window as any).main.plugins.reloadPlugins());
+        return fs.existsSync(sentinelPath);
+      },
+      { timeout: 20_000 },
+    )
+    .toBe(false);
+
+  // Discovery still worked without host execution: the tag enumerates and runs in the sandbox.
+  await insomnia.navigationSidebar.clickRequestOrFolder('L1 Probe');
+  await page.getByText('Body', { exact: true }).click();
+  const readTagPreview = async (tagPrefix: string): Promise<string> => {
+    await page.locator(`[data-template^="${tagPrefix}"]`).click();
+    const modal = page.getByRole('dialog');
+    const preview = modal.getByLabel('Live Preview');
+    await expect.soft(preview).not.toHaveValue('rendering...');
+    const value = (await preview.inputValue()).trim();
+    await modal.getByRole('button', { name: 'Done' }).click();
+    await expect.soft(modal).toBeHidden();
+    return value;
+  };
+  await expect.poll(() => readTagPreview('{% l1probe'), { timeout: 20_000 }).toContain('l1-tag-ran');
+});

--- a/packages/insomnia/src/common/templating/types.ts
+++ b/packages/insomnia/src/common/templating/types.ts
@@ -94,6 +94,7 @@ export type PluginToMainAPIPaths =
   | 'plugin.executeBundlePluginMainAction'
   | 'plugin.getUserPluginTemplateTags'
   | 'plugin.executeUserPluginTag'
+  | 'plugin.discoverUserPluginExports'
   | 'app.alert'
   | 'app.dialog'
   | 'app.prompt'

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -19,6 +19,7 @@ import type {
   PluginToMainAPIPaths,
 } from '~/common/templating/types';
 import { getPluginCommonContext, getTemplateTags } from '~/plugins';
+import type { PluginExportManifest } from '~/templating/sandbox/marshal';
 import type { SandboxModuleDenialError } from '~/templating/sandbox/plugin-tag-sandbox';
 
 import { getAppBundlePlugins, RESPONSE_CODE_REASONS } from '../common/constants';
@@ -269,6 +270,44 @@ export const maybeWarnMissingManifest = (
 // module map read from disk (M4 multi-file plugins).
 type PluginModuleSource = string | { moduleFiles: Record<string, string>; entryModuleKey: string };
 
+// node:crypto is synchronous and available in main, so back the sandbox's require('crypto') shim with
+// it via sync host functions rather than the async bridge. Stateless, so shared across sandbox runs.
+const SANDBOX_HOST_CRYPTO = {
+  hash: (algo: string, data: string, inputEncoding: string, outputEncoding: string) =>
+    crypto
+      .createHash(algo)
+      .update(data, inputEncoding as crypto.Encoding)
+      .digest(outputEncoding as BinaryToTextEncoding),
+  hmac: (algo: string, key: string, data: string, outputEncoding: string) =>
+    crypto
+      .createHmac(algo, key)
+      .update(data, 'utf8')
+      .digest(outputEncoding as BinaryToTextEncoding),
+  randomBytes: (size: number) => crypto.randomBytes(size).toString('base64'),
+  randomUUID: () => crypto.randomUUID(),
+};
+
+// Build the capability-gated host bridge shared by tag execution and load-time discovery. The handler
+// map is filtered by capability first, so an ungranted path rejects at the bridge naming the missing
+// capability rather than silently running.
+const buildSandboxBridge = async (capabilities: string[]) => {
+  const { createMapBridge, filterByCapabilities } = await import('../templating/sandbox/host-bridge');
+  return createMapBridge(
+    filterByCapabilities(
+      {
+        ...(pluginToMainAPI as Record<string, (b: any) => Promise<any>>),
+        // allowTags: false so a sandboxed plugin can't invoke another tag's real, unsandboxed run()
+        // (including its own) by handing util.render a string containing "{% tagName %}".
+        'util.render': async (b: { str: string; context: Record<string, any> }) => {
+          const { render } = await import('../templating');
+          return render(b.str, { context: b.context, allowTags: false });
+        },
+      },
+      capabilities,
+    ),
+  );
+};
+
 export const runPluginTagInSandbox = async (
   pluginModule: PluginModuleSource,
   body: {
@@ -285,9 +324,7 @@ export const runPluginTagInSandbox = async (
   grantedCapabilities?: string[],
 ): Promise<string> => {
   const { runTagInSandbox } = await import('../templating/sandbox/plugin-tag-sandbox');
-  const { createMapBridge, filterByCapabilities, TEMPLATE_TAG_BASELINE_CAPABILITIES } = await import(
-    '../templating/sandbox/host-bridge'
-  );
+  const { TEMPLATE_TAG_BASELINE_CAPABILITIES } = await import('../templating/sandbox/host-bridge');
   const { TEMPLATE_TAG_BASELINE_MODULES } = await import('../templating/sandbox/module-registry');
   const { pluginName, tagName, args, context: originContext } = body;
   const { meta, renderPurpose, context } = originContext;
@@ -296,41 +333,11 @@ export const runPluginTagInSandbox = async (
     typeof pluginModule === 'string'
       ? { moduleFiles: { 'index.js': pluginModule }, entryModuleKey: 'index.js' }
       : pluginModule;
-  // Gate the handler map by capability before building the bridge: an ungranted path rejects at the
-  // bridge with a message naming the missing capability, rather than silently running.
-  const bridge = createMapBridge(
-    filterByCapabilities(
-      {
-        ...(pluginToMainAPI as Record<string, (b: any) => Promise<any>>),
-        // allowTags: false so a sandboxed plugin can't invoke another tag's real, unsandboxed run()
-        // (including its own) by handing util.render a string containing "{% tagName %}".
-        'util.render': async (b: { str: string; context: Record<string, any> }) => {
-          const { render } = await import('../templating');
-          return render(b.str, { context: b.context, allowTags: false });
-        },
-      },
-      capabilities,
-    ),
-  );
+  const bridge = await buildSandboxBridge(capabilities);
   return runTagInSandbox({
     tagName,
     bridge,
-    // node:crypto is synchronous and available in main, so back the sandbox's require('crypto')
-    // shim with it via sync host functions rather than the async bridge.
-    hostCrypto: {
-      hash: (algo, data, inputEncoding, outputEncoding) =>
-        crypto
-          .createHash(algo)
-          .update(data, inputEncoding as crypto.Encoding)
-          .digest(outputEncoding as BinaryToTextEncoding),
-      hmac: (algo, key, data, outputEncoding) =>
-        crypto
-          .createHmac(algo, key)
-          .update(data, 'utf8')
-          .digest(outputEncoding as BinaryToTextEncoding),
-      randomBytes: (size: number) => crypto.randomBytes(size).toString('base64'),
-      randomUUID: () => crypto.randomUUID(),
-    },
+    hostCrypto: SANDBOX_HOST_CRYPTO,
     envelope: {
       args: args || [],
       context: (context as Record<string, any>) || {},
@@ -345,6 +352,39 @@ export const runPluginTagInSandbox = async (
       entryModuleKey,
     },
   });
+};
+
+// L1 load-time discovery: evaluate a user plugin's source inside the sandbox and return a manifest of
+// its exports, instead of nodeRequire-ing it on the host. The plugin's top-level code runs in the
+// sandbox (default-deny require, no host reach), so installing/enabling it can't execute host code.
+export const discoverPluginExportsInSandbox = async (
+  pluginModule: PluginModuleSource,
+  opts: { pluginName: string; grantedModules: string[]; grantedCapabilities: string[] },
+): Promise<PluginExportManifest> => {
+  const { runTagInSandbox } = await import('../templating/sandbox/plugin-tag-sandbox');
+  const { moduleFiles, entryModuleKey } =
+    typeof pluginModule === 'string'
+      ? { moduleFiles: { 'index.js': pluginModule }, entryModuleKey: 'index.js' }
+      : pluginModule;
+  const bridge = await buildSandboxBridge(opts.grantedCapabilities);
+  const json = await runTagInSandbox({
+    tagName: '',
+    discover: true,
+    bridge,
+    hostCrypto: SANDBOX_HOST_CRYPTO,
+    envelope: {
+      args: [],
+      context: {},
+      appInfo: { version: app.getVersion(), platform: process.platform, arch: process.arch },
+      pluginName: opts.pluginName,
+      renderDepth: 0,
+      grantedModules: opts.grantedModules,
+      grantedCapabilities: opts.grantedCapabilities,
+      moduleFiles,
+      entryModuleKey,
+    },
+  });
+  return JSON.parse(json);
 };
 
 // These are exposed to the templating worker and can be used by plugins from context.util
@@ -601,6 +641,24 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
         },
         templateTag,
       }));
+  },
+  // L1: discover a user plugin's exports by evaluating its source in the sandbox (no host execution),
+  // returning a serializable manifest. The plugin loader (plugins/index.ts) calls this instead of
+  // nodeRequire-ing the module when the sandbox is enabled.
+  'plugin.discoverUserPluginExports': async (body: {
+    directory: string;
+    name: string;
+    permissions?: { modules?: string[]; capabilities?: string[] };
+  }) => {
+    const { directory, name, permissions } = body;
+    const { resolveTemplateTagModules, resolveTemplateTagCapabilities } = await import(
+      '../templating/sandbox/surface-profiles'
+    );
+    return discoverPluginExportsInSandbox(readPluginModuleMap({ directory, name }), {
+      pluginName: name,
+      grantedModules: resolveTemplateTagModules(permissions?.modules),
+      grantedCapabilities: resolveTemplateTagCapabilities(permissions?.capabilities),
+    });
   },
   // execute a user-installed plugin tag with the given parameters, in the main process where
   // Node built-ins (e.g. crypto) the plugin requires are available.

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -387,6 +387,25 @@ export const discoverPluginExportsInSandbox = async (
   return JSON.parse(json);
 };
 
+// Discover a user plugin's exports from its on-disk source, resolving the template-tag surface grant
+// from its manifest. Shared by the plugin loader (plugins/index.ts calls this directly when it runs
+// in the main process) and the `plugin.discoverUserPluginExports` bridge handler (renderer path).
+export const discoverUserPluginExportsForLoader = async (body: {
+  directory: string;
+  name: string;
+  permissions?: { modules?: string[]; capabilities?: string[] };
+}): Promise<PluginExportManifest> => {
+  const { directory, name, permissions } = body;
+  const { resolveTemplateTagModules, resolveTemplateTagCapabilities } = await import(
+    '../templating/sandbox/surface-profiles'
+  );
+  return discoverPluginExportsInSandbox(readPluginModuleMap({ directory, name }), {
+    pluginName: name,
+    grantedModules: resolveTemplateTagModules(permissions?.modules),
+    grantedCapabilities: resolveTemplateTagCapabilities(permissions?.capabilities),
+  });
+};
+
 // These are exposed to the templating worker and can be used by plugins from context.util
 const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<any>> = {
   'readFile': async (body: { path: string }) => {
@@ -649,17 +668,7 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
     directory: string;
     name: string;
     permissions?: { modules?: string[]; capabilities?: string[] };
-  }) => {
-    const { directory, name, permissions } = body;
-    const { resolveTemplateTagModules, resolveTemplateTagCapabilities } = await import(
-      '../templating/sandbox/surface-profiles'
-    );
-    return discoverPluginExportsInSandbox(readPluginModuleMap({ directory, name }), {
-      pluginName: name,
-      grantedModules: resolveTemplateTagModules(permissions?.modules),
-      grantedCapabilities: resolveTemplateTagCapabilities(permissions?.capabilities),
-    });
-  },
+  }) => discoverUserPluginExportsForLoader(body),
   // execute a user-installed plugin tag with the given parameters, in the main process where
   // Node built-ins (e.g. crypto) the plugin requires are available.
   'plugin.executeUserPluginTag': async (body: {

--- a/packages/insomnia/src/plugins/index.ts
+++ b/packages/insomnia/src/plugins/index.ts
@@ -87,10 +87,17 @@ function buildUserPluginModuleFromManifest(pluginName: string, manifest: PluginE
     icon: a.icon,
     action: notRouted(surface),
   });
+  // The count comes from untrusted sandbox output; clamp to a finite, non-negative, bounded integer
+  // before allocating so a hostile manifest can't drive a huge Array.from allocation (the sandbox
+  // clamps too — this is defense in depth).
+  const hookStubs = (count: number, surface: string) =>
+    Array.from({ length: Number.isFinite(count) && count > 0 ? Math.min(Math.floor(count), 1000) : 0 }, () =>
+      notRouted(surface),
+    );
   return {
     templateTags: manifest.templateTags.map(t => ({ ...t, run: notRouted('template-tag run()') }) as PluginTemplateTag),
-    requestHooks: Array.from({ length: manifest.requestHooks }, () => notRouted('request hooks')),
-    responseHooks: Array.from({ length: manifest.responseHooks }, () => notRouted('response hooks')),
+    requestHooks: hookStubs(manifest.requestHooks, 'request hooks'),
+    responseHooks: hookStubs(manifest.responseHooks, 'response hooks'),
     requestActions: manifest.requestActions.map(toAction('request actions')),
     requestGroupActions: manifest.requestGroupActions.map(toAction('request group actions')),
     workspaceActions: manifest.workspaceActions.map(toAction('workspace actions')),

--- a/packages/insomnia/src/plugins/index.ts
+++ b/packages/insomnia/src/plugins/index.ts
@@ -19,7 +19,8 @@ import type {
   WorkspaceAction,
 } from '~/common/plugins/types';
 import { fetchFromTemplateWorkerDatabase } from '~/common/templating/liquid-extension-worker';
-import type { RenderPurpose } from '~/common/templating/types';
+import type { PluginTemplateTag, RenderPurpose } from '~/common/templating/types';
+import type { ActionDescriptor, PluginExportManifest } from '~/templating/sandbox/marshal';
 
 import { getAppBundlePlugins, isDevelopment } from '../common/constants';
 import * as pluginApp from '../plugins/context/app';
@@ -51,7 +52,41 @@ export async function init() {
   await reloadPlugins();
 }
 
-async function traversePluginPath(pluginMap: Record<string, Plugin>, allPaths: string[], allConfigs: PluginConfigMap) {
+// Build a user plugin's `module` from the sandbox-discovered export manifest (L1). Only descriptors
+// cross from the sandbox — no live functions. Execution is routed separately: a template tag's
+// `run()` goes through the sandbox bridge (`plugin.executeUserPluginTag`), so the stub `run` here is
+// never called while the sandbox is on. Hook/action invocation isn't sandbox-routed yet, so those
+// function members throw a clear error until that lands (PR 10/11); the plugin's tags/hooks/actions
+// still *enumerate* in the UI from these descriptors.
+function buildUserPluginModuleFromManifest(pluginName: string, manifest: PluginExportManifest): Plugin['module'] {
+  const notRouted = (surface: string) => () => {
+    throw new Error(
+      `Plugin "${pluginName}": sandboxed ${surface} are not supported yet. Disable "Run template tags in sandbox" to use them.`,
+    );
+  };
+  const toAction = (surface: string) => (a: ActionDescriptor) => ({
+    label: a.label ?? '',
+    icon: a.icon,
+    action: notRouted(surface),
+  });
+  return {
+    templateTags: manifest.templateTags.map(t => ({ ...t, run: notRouted('template-tag run()') }) as PluginTemplateTag),
+    requestHooks: Array.from({ length: manifest.requestHooks }, () => notRouted('request hooks')),
+    responseHooks: Array.from({ length: manifest.responseHooks }, () => notRouted('response hooks')),
+    requestActions: manifest.requestActions.map(toAction('request actions')),
+    requestGroupActions: manifest.requestGroupActions.map(toAction('request group actions')),
+    workspaceActions: manifest.workspaceActions.map(toAction('workspace actions')),
+    documentActions: manifest.documentActions.map(toAction('document actions')),
+    themes: manifest.themes,
+  } as Plugin['module'];
+}
+
+async function traversePluginPath(
+  pluginMap: Record<string, Plugin>,
+  allPaths: string[],
+  allConfigs: PluginConfigMap,
+  sandboxEnabled: boolean,
+) {
   for (const p of allPaths) {
     if (!fs.existsSync(p)) {
       continue;
@@ -71,7 +106,7 @@ async function traversePluginPath(pluginMap: Record<string, Plugin>, allPaths: s
 
         // Is it a scoped directory?
         if (filename.startsWith('@')) {
-          await traversePluginPath(pluginMap, [modulePath], allConfigs);
+          await traversePluginPath(pluginMap, [modulePath], allConfigs, sandboxEnabled);
         }
 
         // Is it a Node module?
@@ -100,6 +135,7 @@ async function traversePluginPath(pluginMap: Record<string, Plugin>, allPaths: s
           }
         }
 
+        // package.json is plain data — requiring it runs no plugin code (unlike the module below).
         const pluginJson = nodeRequire(packageJSONPath);
 
         // Not an Insomnia plugin because it doesn't have the package.json['insomnia']
@@ -107,13 +143,25 @@ async function traversePluginPath(pluginMap: Record<string, Plugin>, allPaths: s
           continue;
         }
 
-        // Delete require cache entry and re-require
-        const module = nodeRequire(modulePath);
-
         const parsedPermissions = parsePluginPermissions(pluginJson.insomnia);
         if (parsedPermissions.warnings.length > 0) {
           // Constant format string; interpolated values passed as args so a plugin name can't forge log output.
           console.warn('[plugin] %s has invalid insomnia.permissions: %o', pluginJson.name, parsedPermissions.warnings);
+        }
+
+        // L1: with the sandbox on, discover a user plugin's exports by evaluating its source *inside*
+        // the sandbox (main process) instead of nodeRequire-ing it here — so installing/enabling it
+        // never runs its top-level code with host (Node) privileges. Off → legacy in-process require.
+        let module: Plugin['module'];
+        if (sandboxEnabled) {
+          const manifest = (await fetchFromTemplateWorkerDatabase('plugin.discoverUserPluginExports', {
+            directory: modulePath,
+            name: pluginJson.name,
+            permissions: parsedPermissions.permissions,
+          })) as PluginExportManifest;
+          module = buildUserPluginModuleFromManifest(pluginJson.name, manifest);
+        } else {
+          module = nodeRequire(modulePath);
         }
 
         pluginMap[pluginJson.name] = {
@@ -166,7 +214,7 @@ export async function getPlugins(force = false): Promise<Plugin[]> {
 
     // Store plugins in a map so that plugins with the same name only get added once
     const pluginMap: Record<string, Plugin> = {};
-    await traversePluginPath(pluginMap, allPaths, allConfigs);
+    await traversePluginPath(pluginMap, allPaths, allConfigs, settings.templateTagSandboxEnabled);
     const bundlePluginMap = getBundlePluginMap();
     const fullPluginMap = { ...pluginMap, ...bundlePluginMap };
     plugins = Object.keys(fullPluginMap).map(name => fullPluginMap[name]);

--- a/packages/insomnia/src/plugins/index.ts
+++ b/packages/insomnia/src/plugins/index.ts
@@ -58,33 +58,22 @@ export async function init() {
 // never called while the sandbox is on. Hook/action invocation isn't sandbox-routed yet, so those
 // function members throw a clear error until that lands (PR 10/11); the plugin's tags/hooks/actions
 // still *enumerate* in the UI from these descriptors.
-// Run sandbox export discovery in the main process (templating worker DB). The call rides the
-// `insomnia-templating-worker-database://` protocol, which can briefly be unavailable while the app
-// re-renders around a settings change (the reload that flips the sandbox on is triggered by exactly
-// such a change), surfacing as a low-level "fetch failed". Retry a few times with a short backoff so
-// a transient readiness race doesn't drop the plugin; a persistent failure still throws to the
-// per-plugin catch below (that plugin logs a load error; others are unaffected).
+// Run sandbox export discovery for a user plugin. getPlugins/traversePluginPath runs in BOTH the
+// main process (via getTemplateTags in templating-worker-database) and the plugin window, so the
+// discovery has to reach the sandbox from either. In main we call the sandbox directly — the
+// `insomnia-templating-worker-database://` protocol is a renderer<->main channel and main's own
+// `fetch` can't resolve it. In a renderer (the plugin window) we go over that protocol.
 async function discoverUserPluginExports(
   directory: string,
   name: string,
   permissions: Plugin['permissions'],
 ): Promise<PluginExportManifest> {
   const body = { directory, name, permissions };
-  let lastErr: unknown;
-  for (let attempt = 0; attempt < 5; attempt++) {
-    try {
-      return (await fetchFromTemplateWorkerDatabase('plugin.discoverUserPluginExports', body)) as PluginExportManifest;
-    } catch (err) {
-      lastErr = err;
-      // Only a transport-level failure ("fetch failed") is worth retrying; a handler error (denied
-      // require, syntax error) comes back as a resolved 500 with a message and should surface at once.
-      if (!/fetch failed/i.test(err instanceof Error ? err.message : String(err))) {
-        throw err;
-      }
-      await new Promise(resolve => setTimeout(resolve, 100 * (attempt + 1)));
-    }
+  if (__IS_RENDERER__) {
+    return (await fetchFromTemplateWorkerDatabase('plugin.discoverUserPluginExports', body)) as PluginExportManifest;
   }
-  throw lastErr;
+  const { discoverUserPluginExportsForLoader } = await import('~/main/templating-worker-database');
+  return discoverUserPluginExportsForLoader(body);
 }
 
 function buildUserPluginModuleFromManifest(pluginName: string, manifest: PluginExportManifest): Plugin['module'] {

--- a/packages/insomnia/src/plugins/index.ts
+++ b/packages/insomnia/src/plugins/index.ts
@@ -58,6 +58,35 @@ export async function init() {
 // never called while the sandbox is on. Hook/action invocation isn't sandbox-routed yet, so those
 // function members throw a clear error until that lands (PR 10/11); the plugin's tags/hooks/actions
 // still *enumerate* in the UI from these descriptors.
+// Run sandbox export discovery in the main process (templating worker DB). The call rides the
+// `insomnia-templating-worker-database://` protocol, which can briefly be unavailable while the app
+// re-renders around a settings change (the reload that flips the sandbox on is triggered by exactly
+// such a change), surfacing as a low-level "fetch failed". Retry a few times with a short backoff so
+// a transient readiness race doesn't drop the plugin; a persistent failure still throws to the
+// per-plugin catch below (that plugin logs a load error; others are unaffected).
+async function discoverUserPluginExports(
+  directory: string,
+  name: string,
+  permissions: Plugin['permissions'],
+): Promise<PluginExportManifest> {
+  const body = { directory, name, permissions };
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      return (await fetchFromTemplateWorkerDatabase('plugin.discoverUserPluginExports', body)) as PluginExportManifest;
+    } catch (err) {
+      lastErr = err;
+      // Only a transport-level failure ("fetch failed") is worth retrying; a handler error (denied
+      // require, syntax error) comes back as a resolved 500 with a message and should surface at once.
+      if (!/fetch failed/i.test(err instanceof Error ? err.message : String(err))) {
+        throw err;
+      }
+      await new Promise(resolve => setTimeout(resolve, 100 * (attempt + 1)));
+    }
+  }
+  throw lastErr;
+}
+
 function buildUserPluginModuleFromManifest(pluginName: string, manifest: PluginExportManifest): Plugin['module'] {
   const notRouted = (surface: string) => () => {
     throw new Error(
@@ -154,11 +183,7 @@ async function traversePluginPath(
         // never runs its top-level code with host (Node) privileges. Off → legacy in-process require.
         let module: Plugin['module'];
         if (sandboxEnabled) {
-          const manifest = (await fetchFromTemplateWorkerDatabase('plugin.discoverUserPluginExports', {
-            directory: modulePath,
-            name: pluginJson.name,
-            permissions: parsedPermissions.permissions,
-          })) as PluginExportManifest;
+          const manifest = await discoverUserPluginExports(modulePath, pluginJson.name, parsedPermissions.permissions);
           module = buildUserPluginModuleFromManifest(pluginJson.name, manifest);
         } else {
           module = nodeRequire(modulePath);

--- a/packages/insomnia/src/templating/sandbox/__snapshots__/sandbox-surface.test.ts.snap
+++ b/packages/insomnia/src/templating/sandbox/__snapshots__/sandbox-surface.test.ts.snap
@@ -263,6 +263,8 @@ exports[`sandbox surface > matches surface snapshot 1`] = `
   "globalThis.WeakSet.prototype: object",
   "globalThis.__buildContext: function(1)",
   "globalThis.__buildContext.prototype: object",
+  "globalThis.__describeExports: function(0)",
+  "globalThis.__describeExports.prototype: object",
   "globalThis.__invoke: function(0)",
   "globalThis.__invoke.prototype: object",
   "globalThis.__loadPluginEntry: function(0)",

--- a/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
+++ b/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
@@ -351,10 +351,14 @@ export const IN_SANDBOX_BOOTSTRAP = [
   '    var tagDesc = function (t) { return isObj(t) ? { name: t.name, displayName: t.displayName, description: t.description, args: t.args || [] } : null; };',
   '    var actionDesc = function (a) { return isObj(a) ? { label: a.label, icon: a.icon } : null; };',
   '    var themeDesc = function (t) { return isObj(t) ? { name: t.name, displayName: t.displayName, theme: t.theme } : null; };',
+  // Report a hook count, not the array itself — but a plugin could export a non-array with a huge
+  // `.length` to make the host allocate `Array.from({length})` (DoS). Coerce to a finite, non-negative
+  // integer and cap it; the host clamps again as defense in depth.
+  '    var hookCount = function (arr) { var n = arr && arr.length; n = (typeof n === "number" && isFinite(n)) ? Math.floor(n) : 0; if (n < 0) { n = 0; } return n > 1000 ? 1000 : n; };',
   '    var manifest = {',
   '      templateTags: mapArr(mod.templateTags, tagDesc),',
-  '      requestHooks: (mod.requestHooks && mod.requestHooks.length) || 0,',
-  '      responseHooks: (mod.responseHooks && mod.responseHooks.length) || 0,',
+  '      requestHooks: hookCount(mod.requestHooks),',
+  '      responseHooks: hookCount(mod.responseHooks),',
   '      requestActions: mapArr(mod.requestActions, actionDesc),',
   '      requestGroupActions: mapArr(mod.requestGroupActions, actionDesc),',
   '      workspaceActions: mapArr(mod.workspaceActions, actionDesc),',

--- a/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
+++ b/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
@@ -337,14 +337,47 @@ export const IN_SANDBOX_BOOTSTRAP = [
   '    return Promise.resolve(tag.run.apply(null, args)).then(function (r) { return r == null ? "" : String(r); });',
   '  };',
 
+  // --- describe the plugin's exports without running any of them (L1 load-time discovery) ---
+  // Evaluates the plugin entry (its top-level code runs here, in the sandbox — never on the host)
+  // and returns a JSON-serializable manifest of what it exports: template-tag metadata, hook counts,
+  // action labels/icons, and theme data. The host reads this instead of nodeRequire()ing the module,
+  // so installing/enabling a user plugin no longer executes its top-level code with Node privileges.
+  // Only DATA crosses back — function-valued members (tag.run, hook fns, action fns) are dropped;
+  // execution is routed separately (tags already go through __invoke; hooks/actions land in PR 10/11).
+  '  globalThis.__describeExports = function () {',
+  '    var mod = globalThis.__loadPluginEntry() || {};',
+  '    var isObj = function (x) { return !!x && typeof x === "object"; };',
+  '    var mapArr = function (arr, fn) { var out = []; if (arr && arr.length) { for (var i = 0; i < arr.length; i++) { var d = fn(arr[i]); if (d) { out.push(d); } } } return out; };',
+  '    var tagDesc = function (t) { return isObj(t) ? { name: t.name, displayName: t.displayName, description: t.description, args: t.args || [] } : null; };',
+  '    var actionDesc = function (a) { return isObj(a) ? { label: a.label, icon: a.icon } : null; };',
+  '    var themeDesc = function (t) { return isObj(t) ? { name: t.name, displayName: t.displayName, theme: t.theme } : null; };',
+  '    var manifest = {',
+  '      templateTags: mapArr(mod.templateTags, tagDesc),',
+  '      requestHooks: (mod.requestHooks && mod.requestHooks.length) || 0,',
+  '      responseHooks: (mod.responseHooks && mod.responseHooks.length) || 0,',
+  '      requestActions: mapArr(mod.requestActions, actionDesc),',
+  '      requestGroupActions: mapArr(mod.requestGroupActions, actionDesc),',
+  '      workspaceActions: mapArr(mod.workspaceActions, actionDesc),',
+  '      documentActions: mapArr(mod.documentActions, actionDesc),',
+  '      themes: mapArr(mod.themes, themeDesc)',
+  '    };',
+  '    return JSON.stringify(manifest);',
+  '  };',
+
   // --- lock the sandbox-internal globals ---
   // Plugin code runs after this bootstrap; pin these so it can't reassign the require gate or the
   // context/invocation entry points. __registerModule is intentionally left mutable — the module
   // registry source deletes it once the registry is populated.
   '  var __lock = function (n) { Object.defineProperty(globalThis, n, { value: globalThis[n], writable: false, configurable: false }); };',
-  '  __lock("__require"); __lock("__buildContext"); __lock("__invoke"); __lock("__loadPluginEntry");',
+  '  __lock("__require"); __lock("__buildContext"); __lock("__invoke"); __lock("__loadPluginEntry"); __lock("__describeExports");',
   '})();',
 ].join('\n');
 
 /** The runner: kicks off the async invocation and parks the VM promise on `globalThis.__task`. */
 export const RUNNER = 'globalThis.__task = globalThis.__invoke();';
+
+/**
+ * Discovery runner: parks a resolved promise of the export manifest (JSON string) on `globalThis.__task`.
+ * Used at plugin load instead of {@link RUNNER} to enumerate exports without invoking any of them.
+ */
+export const DESCRIBE_RUNNER = 'globalThis.__task = Promise.resolve(globalThis.__describeExports());';

--- a/packages/insomnia/src/templating/sandbox/marshal.ts
+++ b/packages/insomnia/src/templating/sandbox/marshal.ts
@@ -45,6 +45,44 @@ export interface ContextEnvelope {
   entryModuleKey?: string;
 }
 
+/** A discovered template-tag's serializable metadata (no `run`, no other function members). */
+export interface TemplateTagDescriptor {
+  name?: string;
+  displayName?: string;
+  description?: string;
+  args?: unknown[];
+}
+
+/** A discovered action's serializable metadata (no `action`/`run`). */
+export interface ActionDescriptor {
+  label?: string;
+  icon?: string;
+}
+
+/** A discovered theme (plain data). */
+export interface ThemeDescriptor {
+  name?: string;
+  displayName?: string;
+  theme?: unknown;
+}
+
+/**
+ * What the sandbox returns for a plugin at load time (L1): the shapes of its exports, discovered by
+ * evaluating the entry inside the sandbox instead of `nodeRequire`-ing it on the host. Only data
+ * crosses back — hook/action function bodies never leave the sandbox (hooks are reported as a count;
+ * their execution is routed in a later PR).
+ */
+export interface PluginExportManifest {
+  templateTags: TemplateTagDescriptor[];
+  requestHooks: number;
+  responseHooks: number;
+  requestActions: ActionDescriptor[];
+  requestGroupActions: ActionDescriptor[];
+  workspaceActions: ActionDescriptor[];
+  documentActions: ActionDescriptor[];
+  themes: ThemeDescriptor[];
+}
+
 /**
  * The contract every host-bridge call resolves to. We resolve (never reject) the VM promise with
  * this so the sandbox side can rethrow a real Error without us juggling VM error handles. The

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
@@ -1,7 +1,7 @@
 import type { QuickJSContext, QuickJSHandle } from 'quickjs-emscripten';
 
 import type { HostBridge } from './host-bridge';
-import { IN_SANDBOX_BOOTSTRAP, RUNNER } from './in-sandbox-bootstrap';
+import { DESCRIBE_RUNNER, IN_SANDBOX_BOOTSTRAP, RUNNER } from './in-sandbox-bootstrap';
 import { type ContextEnvelope, encodeBridgeFailure, encodeBridgeSuccess } from './marshal';
 import { buildModuleRegistrySource } from './module-registry';
 import { SANDBOX_GLOBALS_SOURCE } from './sandbox-globals';
@@ -26,8 +26,14 @@ export interface RunTagInSandboxOptions {
    * a module map (multi-file plugins, M4).
    */
   pluginSource?: string;
-  /** Name of the tag within the module to execute. */
+  /** Name of the tag within the module to execute. Ignored (may be '') when `discover` is set. */
   tagName: string;
+  /**
+   * Discovery mode (L1): instead of running a tag, evaluate the plugin entry and return a JSON
+   * string manifest of its exports (template-tag metadata, hook counts, action labels, themes).
+   * The plugin's top-level code still runs — but inside the sandbox, never on the host.
+   */
+  discover?: boolean;
   /** Bulk-copied state passed to the rebuilt in-sandbox context. */
   envelope: ContextEnvelope;
   /** Host side of the async bridge — runs the real work for each `__hostBridge` call. */
@@ -46,7 +52,7 @@ export interface RunTagInSandboxOptions {
  * intermediate handles are reclaimed wholesale.
  */
 export const runTagInSandbox = async (opts: RunTagInSandboxOptions): Promise<string> => {
-  const { pluginSource, tagName, envelope, bridge, onConsole, timeoutMs = 10_000 } = opts;
+  const { pluginSource, tagName, envelope, bridge, onConsole, discover = false, timeoutMs = 10_000 } = opts;
   const { getQuickJSModule } = await import('./quickjs-runtime');
   const QuickJS = await getQuickJSModule();
   const ctx = QuickJS.newContext();
@@ -85,8 +91,8 @@ export const runTagInSandbox = async (opts: RunTagInSandboxOptions): Promise<str
     // Only register heavy vendored libs the plugin was granted, so unrelated renders don't parse them.
     evalOrThrow(ctx, buildModuleRegistrySource(fullEnvelope.grantedModules), '<sandbox-modules>');
     // Plugin source travels as envelope DATA (moduleFiles) and is compiled by the in-sandbox loader
-    // when __invoke() loads the entry — no host-side eval of plugin code.
-    evalOrThrow(ctx, RUNNER, '<runner>');
+    // when __invoke()/__describeExports() loads the entry — no host-side eval of plugin code.
+    evalOrThrow(ctx, discover ? DESCRIBE_RUNNER : RUNNER, '<runner>');
 
     return await drivePromiseToString(ctx, timeoutMs);
   } finally {

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
@@ -73,7 +73,12 @@ export const runTagInSandbox = async (opts: RunTagInSandboxOptions): Promise<str
     ctx.runtime.setInterruptHandler(() => Date.now() > deadline);
     // Caps the WASM heap so a plugin can't OOM the host by allocating without bound.
     ctx.runtime.setMemoryLimit(32 * 1024 * 1024);
-    installHostBridge(ctx, bridge);
+    // Discovery only ever evaluates plugin top-level code to read its exports — it must stay
+    // side-effect-free even though that same top-level code can reach `__buildContext` (a bare
+    // sandbox global, see SANDBOX_INTERNAL_GLOBALS) and wire up a context of its own. Swapping in a
+    // rejecting bridge here means any such attempt fails inside the sandbox instead of reaching the
+    // real host, no matter how it's invoked.
+    installHostBridge(ctx, discover ? rejectingBridge : bridge);
     installHostConsole(ctx, onConsole);
     installHostCrypto(ctx, opts.hostCrypto);
 
@@ -98,6 +103,11 @@ export const runTagInSandbox = async (opts: RunTagInSandboxOptions): Promise<str
   } finally {
     ctx.dispose();
   }
+};
+
+/** Installed instead of the real bridge during `discover: true` so a bridge call made from plugin top-level code fails inside the sandbox rather than reaching the host. */
+const rejectingBridge: HostBridge = async path => {
+  throw new Error(`Host bridge is unavailable during discovery (attempted call to "${path}")`);
 };
 
 /** Register `__hostBridge(path, bodyJson)` returning a VM promise resolved from async host work. */

--- a/packages/insomnia/src/templating/sandbox/sandbox-export-discovery.test.ts
+++ b/packages/insomnia/src/templating/sandbox/sandbox-export-discovery.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import { type HostBridge } from './host-bridge';
+import { type ContextEnvelope, type PluginExportManifest } from './marshal';
+import { runTagInSandbox } from './plugin-tag-sandbox';
+
+// L1 load-time discovery: evaluate a plugin's entry inside the sandbox and return a manifest of its
+// exports, instead of nodeRequire-ing it on the host. The plugin's top-level code runs — but in the
+// sandbox, so it can't touch the host. These tests drive the discovery path directly.
+
+const noBridge: HostBridge = async path => {
+  throw new Error(`unexpected bridge call: ${path}`);
+};
+
+const envelope = (moduleFiles: Record<string, string>, grantedModules: string[] = ['path', 'crypto']): ContextEnvelope => ({
+  args: [],
+  context: {},
+  meta: {},
+  renderPurpose: 'preview',
+  appInfo: { version: '0.0.0', platform: 'linux', arch: 'x64' },
+  pluginName: 'test-plugin',
+  renderDepth: 0,
+  grantedModules,
+  grantedCapabilities: [],
+  moduleFiles,
+  entryModuleKey: 'index.js',
+});
+
+const discover = async (moduleFiles: Record<string, string>, grantedModules?: string[]): Promise<PluginExportManifest> => {
+  const json = await runTagInSandbox({
+    tagName: '',
+    discover: true,
+    envelope: envelope(moduleFiles, grantedModules),
+    bridge: noBridge,
+  });
+  return JSON.parse(json) as PluginExportManifest;
+};
+
+describe('sandbox export discovery (L1)', () => {
+  it('returns a manifest of a multi-export plugin without running any export', async () => {
+    const manifest = await discover({
+      'index.js': `
+        module.exports.templateTags = [
+          { name: 'a', displayName: 'Tag A', description: 'first', args: [{ type: 'string' }], run: function () { return 'ran-a'; } },
+          { name: 'b', run: function () { return 'ran-b'; } },
+        ];
+        module.exports.requestHooks = [function () {}, function () {}];
+        module.exports.responseHooks = [function () {}];
+        module.exports.requestActions = [{ label: 'Do It', icon: 'fa-bolt', action: function () {} }];
+        module.exports.workspaceActions = [{ label: 'WS', action: function () {} }];
+        module.exports.themes = [{ name: 't', displayName: 'Theme', theme: { background: { default: '#000' } } }];`,
+    });
+
+    expect(manifest.templateTags).toEqual([
+      { name: 'a', displayName: 'Tag A', description: 'first', args: [{ type: 'string' }] },
+      { name: 'b', displayName: undefined, description: undefined, args: [] },
+    ]);
+    expect(manifest.requestHooks).toBe(2);
+    expect(manifest.responseHooks).toBe(1);
+    expect(manifest.requestActions).toEqual([{ label: 'Do It', icon: 'fa-bolt' }]);
+    expect(manifest.workspaceActions).toEqual([{ label: 'WS', icon: undefined }]);
+    expect(manifest.documentActions).toEqual([]);
+    expect(manifest.themes).toEqual([{ name: 't', displayName: 'Theme', theme: { background: { default: '#000' } } }]);
+  });
+
+  it('resolves relative requires while discovering (multi-file plugin)', async () => {
+    const manifest = await discover({
+      'index.js': "module.exports.templateTags = require('./tags');",
+      'tags.js': "module.exports = [{ name: 'fromlib', run: function () { return 'x'; } }];",
+    });
+    expect(manifest.templateTags).toEqual([{ name: 'fromlib', displayName: undefined, description: undefined, args: [] }]);
+  });
+
+  it('contains a throwing top-level (surfaced as a rejection, not a host crash)', async () => {
+    await expect(discover({ 'index.js': "throw new Error('boom at load');" })).rejects.toThrow(/boom at load/);
+  });
+
+  it('denies a top-level require of an ungranted module (proves discovery runs in the sandbox)', async () => {
+    // A plugin whose top-level does require('child_process') to spawn a process gets nothing: the
+    // sandbox require is default-deny, so discovery fails the same way tag execution would — the
+    // host is never reached.
+    await expect(discover({ 'index.js': "require('child_process'); module.exports.templateTags = [];" })).rejects.toThrow(
+      /not permitted by manifest/,
+    );
+  });
+});

--- a/packages/insomnia/src/templating/sandbox/sandbox-export-discovery.test.ts
+++ b/packages/insomnia/src/templating/sandbox/sandbox-export-discovery.test.ts
@@ -12,7 +12,10 @@ const noBridge: HostBridge = async path => {
   throw new Error(`unexpected bridge call: ${path}`);
 };
 
-const envelope = (moduleFiles: Record<string, string>, grantedModules: string[] = ['path', 'crypto']): ContextEnvelope => ({
+const envelope = (
+  moduleFiles: Record<string, string>,
+  grantedModules: string[] = ['path', 'crypto'],
+): ContextEnvelope => ({
   args: [],
   context: {},
   meta: {},
@@ -26,7 +29,10 @@ const envelope = (moduleFiles: Record<string, string>, grantedModules: string[] 
   entryModuleKey: 'index.js',
 });
 
-const discover = async (moduleFiles: Record<string, string>, grantedModules?: string[]): Promise<PluginExportManifest> => {
+const discover = async (
+  moduleFiles: Record<string, string>,
+  grantedModules?: string[],
+): Promise<PluginExportManifest> => {
   const json = await runTagInSandbox({
     tagName: '',
     discover: true,
@@ -68,7 +74,22 @@ describe('sandbox export discovery (L1)', () => {
       'index.js': "module.exports.templateTags = require('./tags');",
       'tags.js': "module.exports = [{ name: 'fromlib', run: function () { return 'x'; } }];",
     });
-    expect(manifest.templateTags).toEqual([{ name: 'fromlib', displayName: undefined, description: undefined, args: [] }]);
+    expect(manifest.templateTags).toEqual([
+      { name: 'fromlib', displayName: undefined, description: undefined, args: [] },
+    ]);
+  });
+
+  it('clamps a hostile hook count so the host cannot be driven into a huge allocation', async () => {
+    // A plugin exports a non-array with a giant `.length`; the manifest count must be clamped, not
+    // passed through, so the host's Array.from({ length }) can't be weaponized into an OOM.
+    const manifest = await discover({
+      'index.js': `
+        module.exports.requestHooks = { length: 1e12 };
+        module.exports.responseHooks = [function () {}, function () {}, function () {}];
+        module.exports.templateTags = [];`,
+    });
+    expect(manifest.requestHooks).toBe(1000);
+    expect(manifest.responseHooks).toBe(3);
   });
 
   it('contains a throwing top-level (surfaced as a rejection, not a host crash)', async () => {
@@ -79,8 +100,8 @@ describe('sandbox export discovery (L1)', () => {
     // A plugin whose top-level does require('child_process') to spawn a process gets nothing: the
     // sandbox require is default-deny, so discovery fails the same way tag execution would — the
     // host is never reached.
-    await expect(discover({ 'index.js': "require('child_process'); module.exports.templateTags = [];" })).rejects.toThrow(
-      /not permitted by manifest/,
-    );
+    await expect(
+      discover({ 'index.js': "require('child_process'); module.exports.templateTags = [];" }),
+    ).rejects.toThrow(/not permitted by manifest/);
   });
 });

--- a/packages/insomnia/src/templating/sandbox/sandbox-export-discovery.test.ts
+++ b/packages/insomnia/src/templating/sandbox/sandbox-export-discovery.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { type HostBridge } from './host-bridge';
 import { type ContextEnvelope, type PluginExportManifest } from './marshal';
 import { runTagInSandbox } from './plugin-tag-sandbox';
+import { buildReachabilityProbeSource } from './sandbox-surface';
 
 // L1 load-time discovery: evaluate a plugin's entry inside the sandbox and return a manifest of its
 // exports, instead of nodeRequire-ing it on the host. The plugin's top-level code runs — but in the
@@ -15,6 +16,7 @@ const noBridge: HostBridge = async path => {
 const envelope = (
   moduleFiles: Record<string, string>,
   grantedModules: string[] = ['path', 'crypto'],
+  grantedCapabilities: string[] = [],
 ): ContextEnvelope => ({
   args: [],
   context: {},
@@ -24,7 +26,7 @@ const envelope = (
   pluginName: 'test-plugin',
   renderDepth: 0,
   grantedModules,
-  grantedCapabilities: [],
+  grantedCapabilities,
   moduleFiles,
   entryModuleKey: 'index.js',
 });
@@ -104,4 +106,60 @@ describe('sandbox export discovery (L1)', () => {
       discover({ 'index.js': "require('child_process'); module.exports.templateTags = [];" }),
     ).rejects.toThrow(/not permitted by manifest/);
   });
+});
+
+describe('sandbox export discovery (L1) — bridge isolation', () => {
+  it('a discovery-time call to the internal context builder never reaches the host bridge', async () => {
+    const calls: { path: string; body: unknown }[] = [];
+    const recordingBridge: HostBridge = async (path, body) => {
+      calls.push({ path, body });
+      return {};
+    };
+
+    // Top-level code (runs during mere discovery, before any tag is ever invoked) reaches for the
+    // internal context builder directly and tries to use it — exactly what a plugin manifest never
+    // declaring anything would still be able to attempt.
+    await runTagInSandbox({
+      tagName: '',
+      discover: true,
+      envelope: envelope(
+        {
+          'index.js': `
+            var ctx = globalThis.__buildContext({ pluginName: 'x', context: {}, meta: {}, renderPurpose: 'preview', appInfo: {} });
+            ctx.app.alert('t', 'm');
+            module.exports.templateTags = [];`,
+        },
+        ['path', 'crypto'],
+        ['app'],
+      ),
+      bridge: recordingBridge,
+    });
+
+    expect(calls).toEqual([]);
+  });
+
+  // Stretch coverage: instead of one hand-picked exploit shape, recursively invoke every
+  // globalThis-reachable function (and whatever it returns) during discovery, watching for any
+  // bridge call anywhere in the tree.
+  it('no globalThis-reachable function reaches the host bridge during discovery, however invoked', async () => {
+    const calls: { path: string; body: unknown }[] = [];
+    const recordingBridge: HostBridge = async (path, body) => {
+      calls.push({ path, body });
+      return {};
+    };
+
+    await runTagInSandbox({
+      tagName: '',
+      discover: true,
+      envelope: envelope(
+        { 'index.js': buildReachabilityProbeSource() },
+        ['path', 'crypto'],
+        ['app', 'storage', 'network', 'fs-read', 'render', 'util', 'credentials', 'models.read'],
+      ),
+      bridge: recordingBridge,
+      timeoutMs: 30_000,
+    });
+
+    expect(calls).toEqual([]);
+  }, 40_000);
 });

--- a/packages/insomnia/src/templating/sandbox/sandbox-surface.test.ts
+++ b/packages/insomnia/src/templating/sandbox/sandbox-surface.test.ts
@@ -3,10 +3,12 @@ import { describe, expect, it } from 'vitest';
 import { ALL_SANDBOX_MODULES } from './module-registry';
 import {
   findLeakedGatedReferences,
+  findSandboxInternalGlobals,
   findUnaccountedHostNatives,
   formatSurfaceEntries,
   getSandboxEscapeProbe,
   getSandboxSurface,
+  SANDBOX_INTERNAL_GLOBALS,
 } from './sandbox-surface';
 
 describe('sandbox surface', () => {
@@ -74,5 +76,13 @@ describe('sandbox', () => {
   it('no gated reference leaks onto bare globalThis (alias resolver)', async () => {
     const entries = await getSandboxSurface();
     expect(findLeakedGatedReferences(entries)).toEqual([]);
+  }, 20_000);
+
+  // Completeness tripwire: any new sandbox-internal global must be added here deliberately, so its
+  // safety story (who can reach it, what it can do during discovery) gets reviewed rather than
+  // slipping in unnoticed.
+  it('exposes exactly the reviewed set of sandbox-internal globals', async () => {
+    const entries = await getSandboxSurface();
+    expect(findSandboxInternalGlobals(entries)).toEqual([...SANDBOX_INTERNAL_GLOBALS].sort());
   }, 20_000);
 });

--- a/packages/insomnia/src/templating/sandbox/sandbox-surface.ts
+++ b/packages/insomnia/src/templating/sandbox/sandbox-surface.ts
@@ -207,6 +207,69 @@ export const findLeakedGatedReferences = (entries: SurfaceEntry[]): string[] =>
     .filter(e => !!e.aliasOf && e.aliasOf.startsWith('globalThis.') && (e.root === 'context' || e.root.startsWith('require(')))
     .map(e => `${e.path} aliases ${e.aliasOf}`);
 
+/**
+ * The complete, reviewed set of sandbox-internal globals (`in-sandbox-bootstrap.ts`) exposed bare on
+ * `globalThis` so `RUNNER`/`DESCRIBE_RUNNER` — each a separate `ctx.evalCode` call, so they can only
+ * share state via `globalThis`, never lexical closure — can reach them. Locked against reassignment,
+ * but reachable (and callable) by plugin top-level code, same as any other global. `__buildContext`
+ * in particular returns a context wired to the real host bridge; discovery-time safety comes from
+ * `runTagInSandbox` substituting a rejecting bridge when `discover: true`, not from hiding this
+ * global. Adding a new one here forces a human to re-check that story still holds.
+ */
+export const SANDBOX_INTERNAL_GLOBALS = ['__buildContext', '__describeExports', '__invoke', '__loadPluginEntry', '__require'];
+
+/** Filters sandbox surface entries down to the bare `globalThis.__*` internals (excluding the `.prototype` sibling lines already in the snapshot). */
+export const findSandboxInternalGlobals = (entries: SurfaceEntry[]): string[] =>
+  entries
+    .filter(e => e.root === 'globalThis' && /^globalThis\.__[^.]+$/.test(e.path))
+    .map(e => e.path.slice('globalThis.'.length));
+
+/**
+ * Tier B-deep reachability probe (discovery-time bridge escape coverage): recursively walks every
+ * `globalThis`-reachable property (same walk/cycle-detection shape as `buildSurfaceProbeSource`) and
+ * additionally *invokes* every function found with a couple of generic argument shapes, then walks
+ * whatever it returns too — the real exploit shape is a bare `globalThis` function (`__buildContext`)
+ * whose return value exposes further bridge-backed functions several levels down. Meant to run as
+ * plugin top-level code during a `discover: true` run (no tag ever inserted). The authoritative check
+ * is the host-side recording bridge seeing zero calls; nothing here reports its own pass/fail — a
+ * bridge call from inside the sandbox is indistinguishable from any other promise-returning builtin.
+ */
+export const buildReachabilityProbeSource = (maxDepth = 2): string => `
+(function () {
+  var seen = [];
+  var genericArgs = [
+    [],
+    [{ pluginName: 'probe', context: {}, meta: {}, renderPurpose: 'preview', appInfo: {} }],
+  ];
+  function walk(obj, depth) {
+    if (depth > ${maxDepth}) { return; }
+    if (obj === null || (typeof obj !== 'object' && typeof obj !== 'function')) { return; }
+    if (seen.indexOf(obj) !== -1) { return; }
+    seen.push(obj);
+    var names;
+    try { names = Object.getOwnPropertyNames(obj).sort(); } catch (e) { return; }
+    for (var i = 0; i < names.length; i++) {
+      var name = names[i];
+      if (name === 'length' || name === 'name' || name === 'prototype') { continue; }
+      var val;
+      try { val = obj[name]; } catch (e) { continue; }
+      if (typeof val === 'function') {
+        for (var a = 0; a < genericArgs.length; a++) {
+          try {
+            var r = val.apply(null, genericArgs[a]);
+            if (r && typeof r.then === 'function') { r.then(function () {}, function () {}); }
+            walk(r, 0);
+          } catch (e) { /* probing only - a thrown arity/shape mismatch is not a finding */ }
+        }
+      }
+      walk(val, depth + 1);
+    }
+  }
+  walk(globalThis, 0);
+})();
+module.exports.templateTags = [];
+`;
+
 const ESCAPE_PROBE_TAG_NAME = 'escapeProbe';
 
 // Checks whether `this`, Function('return this')(), ambient globals, or the process shim ever


### PR DESCRIPTION
## Summary

Phase 2, **PR 9 — L1: stop executing user-plugin modules in-process.** The linchpin of the sandbox plan: with the sandbox enabled, a **user** plugin's exports are discovered by evaluating its source *inside* the QuickJS sandbox and returning a serializable manifest — instead of `nodeRequire`-ing the module in the plugin window. So installing/enabling a user plugin no longer runs its top-level code with host (Node) privileges.

Stacked on #10256 (M4). Gated on the existing `templateTagSandboxEnabled` flag (per plan decision; PR 12 later introduces/absorbs `pluginSandboxEnabled`). Bundle (first-party) plugins keep `nodeRequire` — they're trusted.

## How it works

- **`in-sandbox-bootstrap.ts`** — new `__describeExports()` evaluates the entry (top-level code runs *in the sandbox*, never on the host) and returns a JSON manifest: template-tag metadata (name/displayName/description/args), request/response hook **counts**, action label/icon, and theme data. Only data crosses back — no function bodies. New `DESCRIBE_RUNNER`.
- **`plugin-tag-sandbox.ts`** — `runTagInSandbox` gains a `discover` mode.
- **`templating-worker-database.ts`** — `discoverPluginExportsInSandbox` + the `plugin.discoverUserPluginExports` handler (reuses `readPluginModuleMap`, which already reads plugin source without executing it). Factored the shared host-crypto + capability bridge out of `runPluginTagInSandbox`.
- **`plugins/index.ts`** — `traversePluginPath` discovers user plugins via the sandbox when the flag is on and builds `Plugin.module` from the manifest descriptors; bundle plugins keep `nodeRequire`.

## Surface coverage

| Surface | With sandbox on |
|---|---|
| Template tags | discovered as descriptors; **execution already routed** through the sandbox bridge → works |
| Themes | discovered as data → works |
| Request/response hooks, actions | **enumerate** from the manifest, but execution is not sandbox-routed yet (H1/A1, PR 10/11) — invoking one throws a clear error until then |

This interim gap only affects someone who has turned the (default-off) flag on and uses a hook/action plugin, and is closed by the next PRs.

## Tests

- **Unit** (`sandbox-export-discovery.test.ts`): manifest shape for a multi-export plugin, relative-require resolution during discovery, a throwing top-level surfaced as a rejection (not a host crash), and a top-level `require('child_process')` denied — proving discovery runs in the sandbox.
- **E2E** (`sandbox-template-tags.test.ts` + `sandbox-l1-collection.yaml`): a plugin whose top-level writes a sentinel file via `require('fs')` — flag **off** the sentinel appears (control), flag **on** it never does, while the plugin's tag still enumerates and renders `l1-tag-ran` in the sandbox.

Local: unit + type-check + lint green (151 sandbox/worker-db unit tests, smoke lint clean). The Electron smoke harness runs in CI.
