### PR TITLE
feat(Git Sync): preview Insomnia files before adopting a local folder as a Git project

### DIFF
--- a/packages/insomnia/src/entry.preload.ts
+++ b/packages/insomnia/src/entry.preload.ts
@@ -215,6 +215,7 @@ const git: GitServiceAPI = {
   cloneGitRepo: options => invokeWithNormalizedError('git.cloneGitRepo', options),
   openGitRepo: options => invokeWithNormalizedError('git.openGitRepo', options),
   checkGitRepoDirectory: options => invokeWithNormalizedError('git.checkGitRepoDirectory', options),
+  scanLocalGitFolder: options => invokeWithNormalizedError('git.scanLocalGitFolder', options),
   cleanupGitRepoStorage: options => invokeWithNormalizedError('git.cleanupGitRepoStorage', options),
   relocateGitRepo: options => invokeWithNormalizedError('git.relocateGitRepo', options),
   initGitRepoClone: options => invokeWithNormalizedError('git.initGitRepoClone', options),

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -1107,8 +1107,22 @@ const SCAN_SKIP_DIRS = new Set(['.git', 'node_modules']);
 // Same as recursivelyFindInsomniaFiles, but walks a real directory on disk (rather
 // than an in-memory clone) and skips SCAN_SKIP_DIRS.
 const recursivelyFindInsomniaFilesOnDisk = async (dir: string, files: string[] = []): Promise<string[]> => {
-  const entries = await fs.promises.readdir(dir, { withFileTypes: true });
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(dir, { withFileTypes: true });
+  } catch {
+    // Skip subtrees we can't read (permissions, transient IO errors, broken mounts)
+    // instead of aborting the whole scan.
+    return files;
+  }
+
   for (const entry of entries) {
+    // Never follow symlinks: the folder being scanned isn't trusted yet at this
+    // point, and a planted symlink could otherwise be read as if it were a
+    // regular file in the folder.
+    if (entry.isSymbolicLink()) {
+      continue;
+    }
     const fullPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
       if (SCAN_SKIP_DIRS.has(entry.name)) {

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -1092,6 +1092,37 @@ const recursivelyFindInsomniaFiles = async (
   return files;
 };
 
+export interface ScannedInsomniaFile {
+  scope: WorkspaceScope;
+  name: string;
+  path: string;
+}
+
+// Directories that are never worth walking into when scanning a real folder on
+// disk: .git can hold a full history irrelevant to the scan, and node_modules can
+// contain hundreds of thousands of files in an adopted JS project, making the scan
+// look hung.
+const SCAN_SKIP_DIRS = new Set(['.git', 'node_modules']);
+
+// Same as recursivelyFindInsomniaFiles, but walks a real directory on disk (rather
+// than an in-memory clone) and skips SCAN_SKIP_DIRS.
+const recursivelyFindInsomniaFilesOnDisk = async (dir: string, files: string[] = []): Promise<string[]> => {
+  const entries = await fs.promises.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SCAN_SKIP_DIRS.has(entry.name)) {
+        continue;
+      }
+      await recursivelyFindInsomniaFilesOnDisk(fullPath, files);
+    } else if (await isInsomniaFile(fullPath, fs)) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+};
+
 // Actions
 export const initGitRepoCloneAction = async ({
   uri,
@@ -3447,6 +3478,69 @@ export const checkGitRepoDirectoryAction = async ({
   }
 };
 
+/**
+ * Preview what "Open local folder" will import, without creating anything.
+ * Mirrors the file list initGitRepoCloneAction returns for "Clone from Remote", so
+ * both flows can show the same scan-results screen before the user commits.
+ */
+export const scanLocalGitFolderAction = async ({
+  directory,
+}: {
+  directory: string;
+}): Promise<
+  | {
+      files: ScannedInsomniaFile[];
+    }
+  | {
+      errors: string[];
+    }
+> => {
+  if (!directory || !path.isAbsolute(directory)) {
+    return { errors: ['A valid absolute folder path is required.'] };
+  }
+  const resolvedDirectory = path.resolve(directory);
+
+  try {
+    const stats = await fs.promises.stat(resolvedDirectory);
+    if (!stats.isDirectory()) {
+      return { errors: [`Not a folder: ${resolvedDirectory}`] };
+    }
+  } catch {
+    return {
+      errors: [`Folder is not accessible (check it exists and you have read permission): ${resolvedDirectory}`],
+    };
+  }
+
+  try {
+    const insomniaFilePaths = await recursivelyFindInsomniaFilesOnDisk(resolvedDirectory);
+
+    const files: ScannedInsomniaFile[] = [];
+    for (const filePath of insomniaFilePaths) {
+      const fileContents = await fs.promises.readFile(filePath, 'utf8');
+      const migratedContents = migrateToLatestYaml(fileContents);
+      const yamlDocument = parse(migratedContents);
+      const fileSchemaParser = InsomniaFileSchema.safeParse(yamlDocument);
+      if (fileSchemaParser.success) {
+        const insomniaFile = fileSchemaParser.data;
+        files.push({
+          scope: insomniaSchemaTypeToScope(insomniaFile.type),
+          name: insomniaFile.name || 'Untitled',
+          path: path.relative(resolvedDirectory, filePath),
+        });
+      }
+    }
+
+    const legacyInsomniaFile = await containsLegacyInsomniaDir({ fsClient: fsClient(resolvedDirectory) });
+    if (legacyInsomniaFile) {
+      files.unshift(legacyInsomniaFile);
+    }
+
+    return { files };
+  } catch (e) {
+    return { errors: [e instanceof Error ? e.message : String(e)] };
+  }
+};
+
 export interface GitServiceAPI {
   loadGitRepository: typeof loadGitRepository;
   getGitBranches: typeof getGitBranches;
@@ -3458,6 +3552,7 @@ export interface GitServiceAPI {
   cloneGitRepo: typeof cloneGitRepoAction;
   openGitRepo: typeof openGitRepoAction;
   checkGitRepoDirectory: typeof checkGitRepoDirectoryAction;
+  scanLocalGitFolder: typeof scanLocalGitFolderAction;
   cleanupGitRepoStorage: typeof cleanupGitRepoStorageAction;
   relocateGitRepo: typeof relocateGitRepoAction;
   updateGitRepo: typeof updateGitRepoAction;
@@ -3531,6 +3626,9 @@ export const registerGitServiceAPI = () => {
   ipcMainHandle('git.openGitRepo', (_, options: Parameters<typeof openGitRepoAction>[0]) => openGitRepoAction(options));
   ipcMainHandle('git.checkGitRepoDirectory', (_, options: Parameters<typeof checkGitRepoDirectoryAction>[0]) =>
     checkGitRepoDirectoryAction(options),
+  );
+  ipcMainHandle('git.scanLocalGitFolder', (_, options: Parameters<typeof scanLocalGitFolderAction>[0]) =>
+    scanLocalGitFolderAction(options),
   );
   ipcMainHandle('git.cleanupGitRepoStorage', (_, options: Parameters<typeof cleanupGitRepoStorageAction>[0]) =>
     cleanupGitRepoStorageAction(options),

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -81,6 +81,7 @@ export type HandleChannels =
   | 'git.multipleCommitToGitRepo'
   | 'git.openGitRepo'
   | 'git.checkGitRepoDirectory'
+  | 'git.scanLocalGitFolder'
   | 'git.pullFromGitRemote'
   | 'git.relocateGitRepo'
   | 'git.pushToGitRemote'

--- a/packages/insomnia/src/sync/git/repo-file-watcher.ts
+++ b/packages/insomnia/src/sync/git/repo-file-watcher.ts
@@ -55,6 +55,10 @@ import { SyncQueue } from './sync-queue';
 const POLL_INTERVAL_MS = 10_000;
 const DEBOUNCE_MS = 300;
 const GIT_DIR = '.git';
+// Directories never worth walking when collecting YAML files on an adopted folder —
+// node_modules can contain hundreds of thousands of files in a real JS project,
+// making the initial import look hung.
+const YAML_WALK_SKIP_DIRS = new Set([GIT_DIR, 'node_modules']);
 
 export type FileIssueKind = 'conflict' | 'parse-error';
 
@@ -1020,7 +1024,7 @@ class RepoFileWatcher {
     }
   }
 
-  /** Recursively collect all `.yaml` files under `dir` as normalised absolute paths, skipping `.git`. */
+  /** Recursively collect all `.yaml` files under `dir` as normalised absolute paths, skipping YAML_WALK_SKIP_DIRS. */
   private async collectYamlFiles(dir: string): Promise<string[]> {
     const result: string[] = [];
     let entries: fs.Dirent[];
@@ -1033,7 +1037,7 @@ class RepoFileWatcher {
     for (const entry of entries) {
       const absPath = path.join(dir, entry.name);
       if (entry.isDirectory()) {
-        if (entry.name !== GIT_DIR) {
+        if (!YAML_WALK_SKIP_DIRS.has(entry.name)) {
           subDirectories.push(absPath);
         }
       } else if (entry.isFile() && entry.name.endsWith('.yaml')) {

--- a/packages/insomnia/src/ui/components/project/git-repo-scan-result.tsx
+++ b/packages/insomnia/src/ui/components/project/git-repo-scan-result.tsx
@@ -5,17 +5,18 @@ import { Banner } from '~/basic-components/banner';
 import { Icon } from '~/basic-components/icon';
 import { LearnMoreLink } from '~/basic-components/link';
 import { type ProjectScopeKeys, scopeToIconMap, scopeToLabelMap } from '~/common/get-workspace-label';
-import type { useGitProjectInitCloneActionFetcher } from '~/routes/git.init-clone';
+import type { ScannedInsomniaFile } from '~/main/git-service';
 
 interface Props {
-  initCloneGitRepositoryFetcher: ReturnType<typeof useGitProjectInitCloneActionFetcher>;
-  insomniaFiles:
-    | Extract<ReturnType<typeof useGitProjectInitCloneActionFetcher>['data'], { files: any }>['files']
-    | undefined;
+  isScanning: boolean;
+  insomniaFiles: ScannedInsomniaFile[] | undefined;
   repoURI?: string;
+  // "Open local folder" doesn't clone from anywhere and doesn't necessarily push
+  // anywhere either, so the copy needs to drop the remote-specific wording.
+  isLocalFolder?: boolean;
 }
 
-export const GitRepoScanResult: FC<Props> = ({ initCloneGitRepositoryFetcher, insomniaFiles, repoURI }) => {
+export const GitRepoScanResult: FC<Props> = ({ isScanning, insomniaFiles, repoURI, isLocalFolder }) => {
   const fileTypeCountMap: Partial<Record<ProjectScopeKeys, number>> = {};
 
   insomniaFiles?.forEach(({ scope }) => {
@@ -28,13 +29,13 @@ export const GitRepoScanResult: FC<Props> = ({ initCloneGitRepositoryFetcher, in
   return (
     <>
       <div className="rounded border border-solid border-(--hl-sm) px-4 pt-4 text-left">
-        <h3 className="mb-2 text-lg font-bold text-(--color-font)">Insomnia files in repo</h3>
+        <h3 className="mb-2 text-lg font-bold text-(--color-font)">Insomnia files in {isLocalFolder ? 'folder' : 'repo'}</h3>
         <p className="mb-4 text-(--hl)">{repoURI}</p>
-        {initCloneGitRepositoryFetcher.state !== 'idle' ? (
+        {isScanning ? (
           <div className="flex min-h-[134px] flex-col justify-center">
             <p className="text-center text-base text-(--hl)">
               <Icon icon="circle-notch" className="mr-2 animate-spin" />
-              Scanning remote repo for Insomnia files...
+              {isLocalFolder ? 'Scanning folder for Insomnia files...' : 'Scanning remote repo for Insomnia files...'}
             </p>
           </div>
         ) : insomniaFiles?.length === 0 ? (
@@ -43,8 +44,9 @@ export const GitRepoScanResult: FC<Props> = ({ initCloneGitRepositoryFetcher, in
               <span className="mb-2 block font-bold text-(--color-font)">
                 No Insomnia files found − let’s start something new!
               </span>
-              There were no Insomnia files in the selected repo or branch, so you’ll begin with a blank project locally.
-              When you commit and push changes, they will be available on the remote repo selected.
+              {isLocalFolder
+                ? 'There were no Insomnia files in the selected folder, so you’ll begin with a blank project.'
+                : 'There were no Insomnia files in the selected repo or branch, so you’ll begin with a blank project locally. When you commit and push changes, they will be available on the remote repo selected.'}
             </p>
           </div>
         ) : (

--- a/packages/insomnia/src/ui/components/project/project-create-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-create-form.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useState } from 'react';
 import { Button, Input, Label, TextField } from 'react-aria-components';
 import { useNavigate, useParams } from 'react-router';
 
+import type { ScannedInsomniaFile } from '~/main/git-service';
 import { useGitProjectInitCloneActionFetcher } from '~/routes/git.init-clone';
 import { useProjectNewActionFetcher } from '~/routes/organization.$organizationId.project.new';
 import type { GitProviderOption } from '~/sync/git/providers/types';
@@ -67,6 +68,10 @@ export const ProjectCreateForm: FC<Props> = ({
     name: string;
     organizationId: string;
   } | null>(null);
+  // Preview of what "Open local folder" will import, shown on the same
+  // scan-results screen as "Clone from Remote" before the user commits.
+  const [isScanningFolder, setIsScanningFolder] = useState(false);
+  const [folderScanFiles, setFolderScanFiles] = useState<ScannedInsomniaFile[] | undefined>();
 
   // Local repositories default to the native (system git) credentials, which
   // are always present as a seeded singleton and need no remote configuration.
@@ -85,10 +90,14 @@ export const ProjectCreateForm: FC<Props> = ({
   const initCloneGitRepositoryFetcher = useGitProjectInitCloneActionFetcher();
   const newProjectFetcher = useProjectNewActionFetcher();
 
-  const insomniaFiles =
-    initCloneGitRepositoryFetcher.data && 'files' in initCloneGitRepositoryFetcher.data
+  const isGitOpen = storageType === 'git' && gitMode === 'open';
+
+  const insomniaFiles = isGitOpen
+    ? folderScanFiles
+    : initCloneGitRepositoryFetcher.data && 'files' in initCloneGitRepositoryFetcher.data
       ? initCloneGitRepositoryFetcher.data.files
       : [];
+  const isScanningResults = isGitOpen ? isScanningFolder : initCloneGitRepositoryFetcher.state !== 'idle';
 
   const changedFieldCount = [
     projectData.name !== defaultProjectName,
@@ -107,8 +116,6 @@ export const ProjectCreateForm: FC<Props> = ({
       setError(newProjectFetcher.data.error);
     }
   }, [newProjectFetcher.data, newProjectFetcher.state]);
-
-  const isGitOpen = storageType === 'git' && gitMode === 'open';
 
   // Preselect native git credentials when adopting a local folder so the user
   // isn't forced to pick before continuing.
@@ -166,6 +173,26 @@ export const ProjectCreateForm: FC<Props> = ({
     // before the user tries to open the folder.
     const { project } = await window.main.git.checkGitRepoDirectory({ directory: filePath });
     setExistingFolderProject(project);
+  };
+
+  // Preview what "Open local folder" will import, mirroring the "Scan for files"
+  // step of the clone flow so the user isn't surprised by what does (or doesn't)
+  // come in.
+  const onScanFolder = async () => {
+    if (!openExistingDir) {
+      return;
+    }
+    setActiveView('git-results');
+    setFolderScanFiles(undefined);
+    setIsScanningFolder(true);
+    const result = await window.main.git.scanLocalGitFolder({ directory: openExistingDir });
+    setIsScanningFolder(false);
+    if ('errors' in result) {
+      setActiveView('project');
+      setError(result.errors[0] || 'Failed to scan the selected folder.');
+      return;
+    }
+    setFolderScanFiles(result.files);
   };
 
   // Credentials are only required for the clone flow; opening a folder needs none.
@@ -300,9 +327,10 @@ export const ProjectCreateForm: FC<Props> = ({
 
         <div className={activeView === 'git-results' ? '' : 'hidden'}>
           <GitRepoScanResult
-            initCloneGitRepositoryFetcher={initCloneGitRepositoryFetcher}
+            isScanning={isScanningResults}
             insomniaFiles={insomniaFiles}
-            repoURI={projectData.uri}
+            repoURI={isGitOpen ? openExistingDir : projectData.uri}
+            isLocalFolder={isGitOpen}
           />
         </div>
       </div>
@@ -320,18 +348,22 @@ export const ProjectCreateForm: FC<Props> = ({
                 Cancel
               </Button>
             )}
-            {storageType !== 'git' || projectData.connectRepositoryLater || isGitOpen ? (
+            {storageType !== 'git' || projectData.connectRepositoryLater ? (
               <Button
                 onPress={onUpsertProject}
-                isDisabled={
-                  !storageType ||
-                  newProjectFetcher.state !== 'idle' ||
-                  (isGitOpen && (!openExistingDir || !!existingFolderProject))
-                }
+                isDisabled={!storageType || newProjectFetcher.state !== 'idle'}
                 className="flex h-full w-[10ch] items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
               >
                 {newProjectFetcher.state !== 'idle' && <Icon icon="spinner" className="animate-spin" />}
-                <span>{isGitOpen ? 'Open' : 'Create'}</span>
+                <span>Create</span>
+              </Button>
+            ) : isGitOpen ? (
+              <Button
+                onPress={onScanFolder}
+                isDisabled={!openExistingDir || !!existingFolderProject}
+                className="flex h-full items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
+              >
+                <span>Scan for files</span>
               </Button>
             ) : (
               <Button
@@ -350,7 +382,7 @@ export const ProjectCreateForm: FC<Props> = ({
       {activeView === 'git-results' && (
         <div className="flex items-center justify-end gap-2">
           <Button
-            isDisabled={newProjectFetcher.state !== 'idle' || initCloneGitRepositoryFetcher.state !== 'idle'}
+            isDisabled={newProjectFetcher.state !== 'idle' || isScanningResults}
             onPress={() => {
               setActiveView('project');
               setError(null);
@@ -360,13 +392,13 @@ export const ProjectCreateForm: FC<Props> = ({
             Back
           </Button>
 
-          {initCloneGitRepositoryFetcher.state !== 'idle' ? (
+          {isScanningResults ? (
             <Button
               isDisabled={true}
               type="button"
               className="flex h-full w-[10ch] items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
             >
-              Create
+              {isGitOpen ? 'Open' : 'Create'}
             </Button>
           ) : (
             <Button
@@ -380,13 +412,13 @@ export const ProjectCreateForm: FC<Props> = ({
                   if (insomniaFiles) {
                     if (insomniaFiles.length > 0) {
                       if (insomniaFiles.some(file => file.path === '.insomnia')) {
-                        return 'Clone and Migrate';
+                        return isGitOpen ? 'Open and Migrate' : 'Clone and Migrate';
                       }
-                      return 'Clone Project';
+                      return isGitOpen ? 'Open Project' : 'Clone Project';
                     }
-                    return 'Create Blank Project';
+                    return isGitOpen ? 'Open Blank Project' : 'Create Blank Project';
                   }
-                  return 'Create';
+                  return isGitOpen ? 'Open' : 'Create';
                 })()}
               </span>
             </Button>

--- a/packages/insomnia/src/ui/components/project/project-create-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-create-form.tsx
@@ -185,14 +185,20 @@ export const ProjectCreateForm: FC<Props> = ({
     setActiveView('git-results');
     setFolderScanFiles(undefined);
     setIsScanningFolder(true);
-    const result = await window.main.git.scanLocalGitFolder({ directory: openExistingDir });
-    setIsScanningFolder(false);
-    if ('errors' in result) {
+    try {
+      const result = await window.main.git.scanLocalGitFolder({ directory: openExistingDir });
+      if ('errors' in result) {
+        setActiveView('project');
+        setError(result.errors[0] || 'Failed to scan the selected folder.');
+        return;
+      }
+      setFolderScanFiles(result.files);
+    } catch (e) {
       setActiveView('project');
-      setError(result.errors[0] || 'Failed to scan the selected folder.');
-      return;
+      setError(e instanceof Error ? e.message : 'Failed to scan the selected folder.');
+    } finally {
+      setIsScanningFolder(false);
     }
-    setFolderScanFiles(result.files);
   };
 
   // Credentials are only required for the clone flow; opening a folder needs none.
@@ -348,7 +354,7 @@ export const ProjectCreateForm: FC<Props> = ({
                 Cancel
               </Button>
             )}
-            {storageType !== 'git' || projectData.connectRepositoryLater ? (
+            {storageType !== 'git' || (projectData.connectRepositoryLater && !isGitOpen) ? (
               <Button
                 onPress={onUpsertProject}
                 isDisabled={!storageType || newProjectFetcher.state !== 'idle'}

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -575,7 +575,7 @@ export const ProjectSettingsForm: FC<Props> = ({
 
         <div className={activeView === 'git-results' ? '' : 'hidden'}>
           <GitRepoScanResult
-            initCloneGitRepositoryFetcher={initCloneGitRepositoryFetcher}
+            isScanning={initCloneGitRepositoryFetcher.state !== 'idle'}
             insomniaFiles={insomniaFiles}
             repoURI={projectData.uri}
           />

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
@@ -996,7 +996,20 @@ const ProjectNavigationSidebarInner = (
   const [isShortcutCreateOpen, setIsShortcutCreateOpen] = useState(false);
   // The item that the shortcut create dropdown is targeting by keyboard up and down arrow keys
   const [shortcutTargetItemId, setShortcutTargetItemId] = useState<string | null>(null);
-  const visibleFlatItems = useMemo(() => flatItems.filter(i => !i.hidden), [flatItems]);
+  const visibleFlatItems = useMemo(() => {
+    const seenIds = new Set<string>();
+    // Guard against duplicate doc ids reaching the collection below (e.g. a workspace
+    // that is momentarily listed both as synced locally and as an unsynced remote
+    // file) — React Aria's ListBox/GridList requires unique keys and otherwise crashes
+    // with "Invalid array length" instead of just rendering the item once.
+    return flatItems.filter(item => {
+      if (item.hidden || seenIds.has(item.doc._id)) {
+        return false;
+      }
+      seenIds.add(item.doc._id);
+      return true;
+    });
+  }, [flatItems]);
   const virtualizer = useVirtualizer({
     getScrollElement: () => parentRef.current,
     count: visibleFlatItems.length,


### PR DESCRIPTION
## Summary
- "Open local folder" (adopting an existing directory as a Git-synced project) previously imported whatever it found with no preview, unlike "Clone from Remote" which shows a scan/results step first. Adds the same preview: a new `scanLocalGitFolder` IPC action recursively scans the folder for Insomnia files and the create-project form now shows a "Scan for files" step with results before committing.
- Both the new preview scan and the existing post-adopt import walk (`repo-file-watcher.ts`) skip `node_modules` in addition to `.git` — previously, adopting a real JS project folder (e.g. one with npm workspaces) made the scan/import walk hundreds of thousands of files and appear to hang.
- Fixes a `RangeError: Invalid array length` crash in the project sidebar (`project-navigation-sidebar.tsx`) caused by duplicate item ids reaching a React Aria `GridList`; the sidebar's visible item list is now de-duplicated by id as a defensive guard.
