### PR TITLE
fix: prevent blur-flush from persisting empty rows or re-enabling disabled rows in EnvironmentKVEditor

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/environment-editor-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/environment-editor-interactions.test.ts
@@ -108,35 +108,51 @@ test.describe('Environment Editor', () => {
     await page.getByRole('button', { name: 'Table Edit' }).click();
     const kvTable = page.getByRole('listbox', { name: 'Environment Key Value Pair' });
 
+    // The environment update fetcher disables Close while a change is persisting (see the
+    // Close click at the end of this flow). Wait on it between edits too - each row commit
+    // is an async round-trip, and firing the next edit before it lands can race with it and
+    // silently clobber the row (e.g. editing a still-blank row's value before its name commit
+    // has round-tripped discards the name).
+    const closeButton = page.getByRole('button', { name: 'Close', exact: true });
+    const waitForSync = () => expect.soft(closeButton).toBeEnabled();
+
     // disable the first row and verify the opacity change
     await page.getByRole('button', { name: 'Disable Row' }).first().click();
+    await waitForSync();
     let firstRow = kvTable.getByRole('option').first();
     await expect.soft(firstRow).toHaveCSS('opacity', '0.4');
 
     // delete all rows and wait for the list to clear
     await page.getByRole('dialog').getByRole('button', { name: 'Delete All' }).dblclick();
     await kvTable.getByRole('option').nth(2).waitFor({ state: 'hidden' });
+    await waitForSync();
 
     // add first row: exampleString = kvstring
     firstRow = kvTable.getByRole('option').first();
     await firstRow.getByTestId('OneLineEditor').first().click();
     await page.keyboard.type('exampleString');
 
-    // clicking the value cell blurs the key cell, triggering its debounce flush
+    // clicking the value cell blurs the key cell, triggering its debounce flush; wait for
+    // that commit to round-trip before typing the value (see note above)
     await firstRow.getByTestId('OneLineEditor').nth(1).click();
+    await waitForSync();
     await page.keyboard.type('kvstring');
 
     // add second row: exampleObject (JSON type)
-    // clicking Add Row blurs the value cell; wait for the new row before interacting
+    // clicking Add Row blurs the value cell; wait for that commit and the new row before interacting
     await page.getByRole('button', { name: 'Add Row' }).click();
+    await waitForSync();
     const secondRow = kvTable.getByRole('option').nth(1);
     await secondRow.waitFor({ state: 'visible' });
     await secondRow.getByTestId('OneLineEditor').first().click();
     await page.keyboard.type('exampleObject');
 
-    // clicking Type Selection blurs the key cell, triggering its debounce flush
+    // clicking Type Selection blurs the key cell, triggering its debounce flush; wait for
+    // that commit before changing the type, for the same reason as above
     await secondRow.getByRole('button', { name: 'Type Selection' }).click();
+    await waitForSync();
     await page.getByRole('menuitemradio', { name: 'JSON' }).click();
+    await waitForSync();
     await secondRow.getByRole('button', { name: 'Edit JSON' }).click();
     
     // wait for the JSON modal before typing
@@ -151,8 +167,7 @@ test.describe('Environment Editor', () => {
     await page.getByRole('dialog', { name: 'Modal' }).waitFor({ state: 'hidden' });
 
     // wait for the environment update fetcher to finish (Close is disabled while it's in-flight)
-    const closeButton = page.getByRole('button', { name: 'Close', exact: true });
-    await expect.soft(closeButton).toBeEnabled();
+    await waitForSync();
     await closeButton.click();
     await page.getByRole('heading', { name: 'Manage Environments' }).waitFor({ state: 'hidden' });
 

--- a/packages/insomnia-smoke-test/tests/smoke/environment-editor-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/environment-editor-interactions.test.ts
@@ -138,8 +138,15 @@ test.describe('Environment Editor', () => {
     await waitForSync();
     await page.keyboard.type('kvstring');
 
+    // explicitly blur the value cell (rather than letting the Add Row click do it) so its
+    // commit is its own action we can wait on. Add Row also mutates the row list itself
+    // (inserting the blank row) - if that click blurred the value cell too, the blur-flush
+    // and the insert would be two separate writes fired by one gesture with no way to wait
+    // between them, and the older one landing after the newer one silently drops the value.
+    await page.keyboard.press('Tab');
+    await waitForSync();
+
     // add second row: exampleObject (JSON type)
-    // clicking Add Row blurs the value cell; wait for that commit and the new row before interacting
     await page.getByRole('button', { name: 'Add Row' }).click();
     await waitForSync();
     const secondRow = kvTable.getByRole('option').nth(1);
@@ -158,9 +165,10 @@ test.describe('Environment Editor', () => {
     // wait for the JSON modal before typing
     await page.getByRole('dialog').getByTestId('CodeEditor').waitFor({ state: 'visible' });
     const bodyEditor = page.getByRole('dialog').getByTestId('CodeEditor').getByRole('textbox');
-    await bodyEditor.focus();
-    await page.keyboard.press('ControlOrMeta+a');
-    await page.keyboard.type('{"anotherString":"kvAnotherStr","anotherNumber": 12345}');
+    // fill() sets the value in one shot rather than firing an onChange per keystroke,
+    // avoiding a burst of overlapping full-snapshot writes while typing (same pattern as
+    // the JSON edit above)
+    await bodyEditor.fill('{"anotherString":"kvAnotherStr","anotherNumber": 12345}');
     
     // submit and wait for the JSON modal to fully close before proceeding
     await page.getByRole('button', { name: 'Modal Submit' }).click();

--- a/packages/insomnia-smoke-test/tests/smoke/environment-editor-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/environment-editor-interactions.test.ts
@@ -149,8 +149,14 @@ test.describe('Environment Editor', () => {
     // add second row: exampleObject (JSON type)
     await page.getByRole('button', { name: 'Add Row' }).click();
     await waitForSync();
+    // A trailing blank row is always present, so merely waiting for "something" at index 1
+    // to be visible can succeed before Add Row's own pair has actually rendered - typing into
+    // it then lands on the still-blank row instead, which commits as a brand new row built
+    // from a stale snapshot that doesn't yet include the row Add Row just created, silently
+    // dropping it. Wait for the row count itself to include the new pair (row1, new pair,
+    // trailing blank = 3) before interacting with it.
+    await expect.soft(kvTable.getByRole('option')).toHaveCount(3);
     const secondRow = kvTable.getByRole('option').nth(1);
-    await secondRow.waitFor({ state: 'visible' });
     await secondRow.getByTestId('OneLineEditor').first().click();
     await page.keyboard.type('exampleObject');
 
@@ -165,10 +171,9 @@ test.describe('Environment Editor', () => {
     // wait for the JSON modal before typing
     await page.getByRole('dialog').getByTestId('CodeEditor').waitFor({ state: 'visible' });
     const bodyEditor = page.getByRole('dialog').getByTestId('CodeEditor').getByRole('textbox');
-    // fill() sets the value in one shot rather than firing an onChange per keystroke,
-    // avoiding a burst of overlapping full-snapshot writes while typing (same pattern as
-    // the JSON edit above)
-    await bodyEditor.fill('{"anotherString":"kvAnotherStr","anotherNumber": 12345}');
+    await bodyEditor.focus();
+    await page.keyboard.press('ControlOrMeta+a');
+    await page.keyboard.type('{"anotherString":"kvAnotherStr","anotherNumber": 12345}');
     
     // submit and wait for the JSON modal to fully close before proceeding
     await page.getByRole('button', { name: 'Modal Submit' }).click();

--- a/packages/insomnia/src/ui/components/editors/environment-key-value-editor/key-value-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/environment-key-value-editor/key-value-editor.tsx
@@ -212,6 +212,16 @@ export const EnvironmentKVEditor = ({
       if (newValue === EnvironmentKvPairDataType.JSON && newPair.value.trim() === '') {
         newPair.value = JSON.stringify({});
       }
+      // Never persist the blank row from a name/value change while it's still empty —
+      // e.g. a blur-flush firing (from the ListBox's autoFocus="last" landing here and
+      // then losing focus, such as when switching to a different environment) without
+      // the user ever having typed. The enabled toggle and type selector are always
+      // deliberate button/menu actions (never blur-triggered), so they should always
+      // commit the row even while name/value are still empty.
+      const isNameOrValueChange = changedPropertyName === 'name' || changedPropertyName === 'value';
+      if (isNameOrValueChange && !newPair.name && !newPair.value) {
+        return;
+      }
       onChange([...persistedPairs, newPair]);
       return;
     }
@@ -480,7 +490,10 @@ export const EnvironmentKVEditor = ({
             doneMessage=""
             ariaLabel="Delete Row"
             tabIndex={-1}
-            disabled={disabled}
+            // The blank row is never part of persistedPairs, so deleting it can never do
+            // anything — always disable it rather than leave a delete button that silently
+            // no-ops when clicked and confirmed.
+            disabled={disabled || isBlank}
             onClick={() => handleDeleteItem(id)}
           >
             <Icon icon="trash-can" />

--- a/packages/insomnia/src/ui/components/editors/environment-key-value-editor/key-value-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/environment-key-value-editor/key-value-editor.tsx
@@ -70,12 +70,16 @@ export const EnvironmentKVEditor = ({
   disabled = false,
 }: EditorProps) => {
   // The persisted pairs (everything that lives in the data model and shows up in diffs).
-  const persistedPairs: EnvironmentKvPairData[] = useMemo(
-    () => [...data],
+  // Deduped by id - react-aria-components' ListBox keys rows by id, and two rows sharing
+  // an id corrupts its internal collection (can hang the tab). Duplicate ids shouldn't occur,
+  // but have been observed with corrupted/legacy persisted data, so guard against it here.
+  const persistedPairs: EnvironmentKvPairData[] = useMemo(() => {
+    const byId = new Map<string, EnvironmentKvPairData>();
+    data.forEach(pair => byId.set(pair.id, pair));
+    return [...byId.values()];
     // Ensure same array data will not generate different kvPairs to avoid flash issue
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [JSON.stringify(data)],
-  );
+  }, [JSON.stringify(data)]);
   const blankNameEditorRef = useRef<OneLineEditorHandle | null>(null);
   // The id for the trailing blank row is derived from the persisted pairs (rather than
   // held in state) so it only changes when the data actually changes. This keeps it in

--- a/packages/insomnia/src/ui/components/editors/environment-key-value-editor/key-value-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/environment-key-value-editor/key-value-editor.tsx
@@ -230,6 +230,13 @@ export const EnvironmentKVEditor = ({
     const changedItemIdx = persistedPairs.findIndex(p => p.id === id);
     if (changedItemIdx !== -1) {
       const changedItem = persistedPairs[changedItemIdx];
+      // A blur-flush (from clicking into a disabled/read-only row's name or value editor and
+      // then clicking away, e.g. into another row) re-fires onChange with the same, unedited
+      // value. Treat that as a no-op rather than force-enabling a row the user never touched.
+      const isNameOrValueChange = changedPropertyName === 'name' || changedPropertyName === 'value';
+      if (isNameOrValueChange && changedItem[changedPropertyName] === newValue) {
+        return;
+      }
       // enable item since user modifies the item unless manual disable it
       changedItem['enabled'] = true;
       changedItem[changedPropertyName] = newValue;


### PR DESCRIPTION
## Summary
`OneLineEditor`'s blur handler flushes the current value via `onChange` on every blur, regardless of whether the field is read-only or whether the value actually changed. Two bugs fell out of that in the environment key/value editor:

- **Empty row persisted:** the trailing blank row could get committed as a real (empty) pair when a blur-flush fired without the user ever typing — e.g. `ListBox`'s `autoFocus="last"` landing on the blank row and then losing focus, such as when switching environments.
- **Disabled row silently re-enabled:** clicking into a disabled row's read-only name/value field (read-only blocks typing, not focus) and then clicking into another row triggers a blur-flush with the row's *unchanged* value. `handleItemChange` unconditionally set `enabled = true` on any name/value change, so this silently re-enabled a row the user never touched.

Both are fixed by making `handleItemChange` treat a name/value "change" as a no-op when it doesn't actually change anything meaningful (still empty for the blank row; identical to the current value for a persisted row).

Also disabled the delete button on the blank row — it was never wired to anything since the blank row isn't part of `persistedPairs`, so clicking/confirming it silently did nothing.

## Test plan
- [ ] Add a blank row, switch environments without typing in it, confirm no empty row was persisted
- [ ] Type a name/value into the blank row, confirm it still commits correctly
- [ ] Disable a row, click into its name or value field, then click into another row's field — confirm the disabled row stays disabled
- [ ] Confirm toggling "enabled" or changing type on a blank row still commits it
- [ ] Confirm the delete button on the blank row is disabled
