### PR TITLE
feat(templating): (H1) route user-plugin request hooks through the sandbox (PR 10a)

### DIFF
--- a/packages/insomnia-smoke-test/fixtures/sandbox-hook-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/sandbox-hook-collection.yaml
@@ -1,0 +1,20 @@
+type: collection.insomnia.rest/5.0
+schema_version: "5.1"
+name: Sandbox Hook Collection
+meta:
+  id: wrk_5a4h100000000000000000000000001
+  created: 1751800000000
+  modified: 1751800000000
+collection:
+  - url: http://127.0.0.1:4010/echo
+    name: Hook Request
+    meta:
+      id: req_5a4h100000000000000000000000002
+      created: 1751800000001
+      modified: 1751800000001
+      isPrivate: false
+      sortKey: -1751800000001
+    method: GET
+    headers:
+      - name: Content-Type
+        value: text/plain

--- a/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
@@ -121,7 +121,12 @@ const writePlugin = (dataPath: string, name: string, insomnia: unknown, indexJs:
 };
 
 // Seed the once-only guard for the persistent "Plugin system updated" toast (it intercepts pointer
-// events over the page) and dismiss any toast already in flight, before driving the UI.
+// events over the page) and dismiss any toast already in flight, before driving the UI. The toast
+// can re-render mid-dismiss (its DOM node gets swapped out during its exit transition), which made
+// a plain `.click()` here flake: Playwright's actionability wait would see the button go from
+// stable -> detached and retry forever, eventually blowing the whole test's timeout. `force: true`
+// skips that stability wait (fires the click at whatever is there right now), and the loop is
+// bounded by wall-clock time instead of trusting the button count to reach zero.
 const clearPluginToast = async (page: Page) => {
   await page.getByLabel('Import').waitFor();
   await page.evaluate(() => localStorage.setItem('plugin-system-changes-toast-shown', 'true'));
@@ -130,8 +135,9 @@ const clearPluginToast = async (page: Page) => {
     .first()
     .waitFor({ timeout: 3000 })
     .catch(() => {});
-  while ((await dismissButtons.count()) > 0) {
-    await dismissButtons.first().click();
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline && (await dismissButtons.count()) > 0) {
+    await dismissButtons.first().click({ force: true, timeout: 500 }).catch(() => {});
   }
 };
 
@@ -159,21 +165,7 @@ test('Template tag sandbox: flag routes plugin tag execution into the QuickJS sa
   insomnia,
 }) => {
   installProbePlugin(dataPath);
-
-  // The persistent "Plugin system updated" notification fires from a Root mount effect whenever
-  // user plugins exist on disk, and its toast region intercepts pointer events over the page.
-  // Seed its once-only guard so route remounts can't re-raise it, then clear any toast already
-  // in flight before driving the UI.
-  await page.getByLabel('Import').waitFor();
-  await page.evaluate(() => localStorage.setItem('plugin-system-changes-toast-shown', 'true'));
-  const dismissButtons = page.getByRole('button', { name: 'Dismiss' });
-  await dismissButtons
-    .first()
-    .waitFor({ timeout: 3000 })
-    .catch(() => {});
-  while ((await dismissButtons.count()) > 0) {
-    await dismissButtons.first().click();
-  }
+  await clearPluginToast(page);
 
   // Import a collection whose request body contains the probe tags (the tags render as pills
   // lexically, so importing before the plugin is registered is fine).

--- a/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
@@ -709,3 +709,62 @@ test('Plugin sandbox (L1): installing a user plugin no longer runs its top-level
   };
   await expect.poll(() => readTagPreview('{% l1probe'), { timeout: 20_000 }).toContain('l1-tag-ran');
 });
+
+test('Request hook sandbox (H1): a user plugin request hook runs in the sandbox and mutates the request', async ({
+  page,
+  app,
+  dataPath,
+  insomnia,
+}) => {
+  // The hook injects two headers: X-Ran-In reports its execution environment (the canary — the
+  // sandbox sets INSOMNIA_TEMPLATE_SANDBOX; the legacy in-process path does not), and X-Sandbox-Hook
+  // is a fixed marker. The request targets the echo server, which reflects request headers into the
+  // response body, so both headers appear there.
+  writePlugin(
+    dataPath,
+    'insomnia-plugin-hook-probe',
+    {},
+    `
+      module.exports.requestHooks = [
+        function (context) {
+          var ranIn = typeof INSOMNIA_TEMPLATE_SANDBOX !== 'undefined' ? 'sandbox' : 'main-process';
+          context.request.setHeader('X-Ran-In', ranIn);
+          context.request.setHeader('X-Sandbox-Hook', 'sandbox-hook-value');
+        },
+      ];
+    `,
+  );
+
+  const fixture = await loadFixture('sandbox-hook-collection.yaml');
+  await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), fixture);
+  await clearPluginToast(page);
+  await page.getByLabel('Import').click();
+  await page.locator('[data-test-id="import-from-clipboard"]').click();
+  await page.getByRole('button', { name: 'Scan' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+  await page.evaluate(() => (window as any).main.plugins.reloadPlugins());
+
+  await insomnia.navigationSidebar.clickRequestOrFolder('Hook Request');
+  const responsePane = page.getByTestId('response-pane');
+
+  // Flag OFF (default): the hook runs in-process (control).
+  await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
+  await expect.soft(page.locator('[data-testid="response-status-tag"]:visible')).toContainText('200');
+  await expect.soft(responsePane).toContainText('main-process');
+
+  // Flag ON: the same hook now runs in the QuickJS sandbox, still mutating the request. Poll the send
+  // so the just-toggled setting has propagated before we assert the sandbox canary.
+  await enableSandbox(page);
+  await expect
+    .poll(
+      async () => {
+        await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
+        return (await responsePane.textContent()) || '';
+      },
+      { timeout: 25_000 },
+    )
+    .toContain('sandbox');
+  // The header mutation round-tripped through the sandbox and reached the wire.
+  await expect.soft(responsePane).toContainText('X-Sandbox-Hook');
+  await expect.soft(responsePane).toContainText('sandbox-hook-value');
+});

--- a/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
@@ -716,10 +716,11 @@ test('Request hook sandbox (H1): a user plugin request hook runs in the sandbox 
   dataPath,
   insomnia,
 }) => {
-  // The hook injects two headers: X-Ran-In reports its execution environment (the canary — the
-  // sandbox sets INSOMNIA_TEMPLATE_SANDBOX; the legacy in-process path does not), and X-Sandbox-Hook
-  // is a fixed marker. The request targets the echo server, which reflects request headers into the
-  // response body, so both headers appear there.
+  // The hook injects two headers, and the request targets the echo server, which reflects request
+  // headers into the response body. We assert on the header *values* (not names) because the echo
+  // lowercases header names but preserves values. X-Ran-In's value is the canary — the sandbox sets
+  // INSOMNIA_TEMPLATE_SANDBOX, the legacy in-process path does not — and the values are chosen so
+  // neither is a substring of the other (or of the marker), keeping the assertions unambiguous.
   writePlugin(
     dataPath,
     'insomnia-plugin-hook-probe',
@@ -727,9 +728,9 @@ test('Request hook sandbox (H1): a user plugin request hook runs in the sandbox 
     `
       module.exports.requestHooks = [
         function (context) {
-          var ranIn = typeof INSOMNIA_TEMPLATE_SANDBOX !== 'undefined' ? 'sandbox' : 'main-process';
+          var ranIn = typeof INSOMNIA_TEMPLATE_SANDBOX !== 'undefined' ? 'ranin-sandboxed' : 'ranin-mainprocess';
           context.request.setHeader('X-Ran-In', ranIn);
-          context.request.setHeader('X-Sandbox-Hook', 'sandbox-hook-value');
+          context.request.setHeader('X-Hook-Marker', 'hook-marker-9k2x');
         },
       ];
     `,
@@ -750,7 +751,7 @@ test('Request hook sandbox (H1): a user plugin request hook runs in the sandbox 
   // Flag OFF (default): the hook runs in-process (control).
   await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
   await expect.soft(page.locator('[data-testid="response-status-tag"]:visible')).toContainText('200');
-  await expect.soft(responsePane).toContainText('main-process');
+  await expect.soft(responsePane).toContainText('ranin-mainprocess');
 
   // Flag ON: the same hook now runs in the QuickJS sandbox, still mutating the request. Poll the send
   // so the just-toggled setting has propagated before we assert the sandbox canary.
@@ -763,8 +764,7 @@ test('Request hook sandbox (H1): a user plugin request hook runs in the sandbox 
       },
       { timeout: 25_000 },
     )
-    .toContain('sandbox');
-  // The header mutation round-tripped through the sandbox and reached the wire.
-  await expect.soft(responsePane).toContainText('X-Sandbox-Hook');
-  await expect.soft(responsePane).toContainText('sandbox-hook-value');
+    .toContain('ranin-sandboxed');
+  // The second header mutation also round-tripped through the sandbox and reached the wire.
+  await expect.soft(responsePane).toContainText('hook-marker-9k2x');
 });

--- a/packages/insomnia/src/common/templating/liquid-extension-worker.ts
+++ b/packages/insomnia/src/common/templating/liquid-extension-worker.ts
@@ -37,9 +37,18 @@ export function decodeEncodingWorker<T>(value: T) {
   return value;
 }
 
+// Set by each JS realm that calls fetchFromTemplateWorkerDatabase, since none of them share
+// module state with each other.
+let templatingDbAuthToken: string | null = null;
+
+export const setTemplatingDbAuthToken = (token: string | null) => {
+  templatingDbAuthToken = token;
+};
+
 export const fetchFromTemplateWorkerDatabase = async (path: PluginToMainAPIPaths, body: any) => {
   const resp = await fetch('insomnia-templating-worker-database://' + path, {
     method: 'post',
+    headers: templatingDbAuthToken ? { 'x-insomnia-templating-auth': templatingDbAuthToken } : undefined,
     body: JSON.stringify(body),
   });
   let result;

--- a/packages/insomnia/src/common/templating/types.ts
+++ b/packages/insomnia/src/common/templating/types.ts
@@ -95,6 +95,7 @@ export type PluginToMainAPIPaths =
   | 'plugin.getUserPluginTemplateTags'
   | 'plugin.executeUserPluginTag'
   | 'plugin.discoverUserPluginExports'
+  | 'plugin.runUserRequestHook'
   | 'app.alert'
   | 'app.dialog'
   | 'app.prompt'

--- a/packages/insomnia/src/entry.client.tsx
+++ b/packages/insomnia/src/entry.client.tsx
@@ -8,6 +8,7 @@ import { hydrateRoot } from 'react-dom/client';
 import { HydratedRouter } from 'react-router/dom';
 
 import { insomniaFetch } from '~/common/insomnia-fetch';
+import { setTemplatingDbAuthToken } from '~/common/templating/liquid-extension-worker';
 import { initRuntime } from '~/runtimes';
 import { rendererRuntime } from '~/runtimes/runtime.renderer';
 import { migrateFromLocalStorage, type SessionData, setSessionData, setVaultSessionData } from '~/ui/account/session';
@@ -28,6 +29,9 @@ import { initializeSentry } from './ui/sentry';
 import { registerSyncMergeConflictListener } from './ui/utils/insomnia-sync';
 
 initializeSentry();
+
+// Fetch the templating-db auth token once so it's available for every templating call in this window.
+setTemplatingDbAuthToken(await window.main.templatingDb.getAuthToken());
 
 // Initialize database for renderer process
 await initDatabase(clientDatabase);

--- a/packages/insomnia/src/entry.plugin-window.ts
+++ b/packages/insomnia/src/entry.plugin-window.ts
@@ -1,6 +1,7 @@
 import { ipcRenderer } from 'electron';
 import { initDatabase, initServices } from 'insomnia-data';
 
+import { setTemplatingDbAuthToken } from './common/templating/liquid-extension-worker';
 import { pluginWindowDatabase } from './main/database.plugin-window';
 import { invokePluginMethod } from './plugins/invoke-method';
 import { initRuntime } from './runtimes';
@@ -28,6 +29,8 @@ ipcRenderer.on('plugins.invoke', async (_event, { id, method, args }: PluginInvo
 // getPlugins() calls services.settings.get(), which requires this to be done first.
 (async () => {
   try {
+    // Fetch the auth token before any plugin code can call fetchFromTemplateWorkerDatabase.
+    setTemplatingDbAuthToken(await ipcRenderer.invoke('templatingDb.getAuthToken'));
     await initDatabase(pluginWindowDatabase);
     initServices(servicesProxy);
     initRuntime(rendererRuntime);

--- a/packages/insomnia/src/entry.preload.ts
+++ b/packages/insomnia/src/entry.preload.ts
@@ -451,6 +451,9 @@ const main: Window['main'] = {
     getBridgeMetrics: () => invokeWithNormalizedError('plugins.getBridgeMetrics'),
   },
   notifyPromptResult: (id: string, value: string | null) => ipcRenderer.send('ui.promptResult', { id, value }),
+  templatingDb: {
+    getAuthToken: () => invokeWithNormalizedError('templatingDb.getAuthToken'),
+  },
   timeline: {
     getPath: (responseId: string) => invokeWithNormalizedError('timeline.getPath', responseId) as Promise<string>,
     appendToFile: (options: { timelinePath: string; data: string }) =>

--- a/packages/insomnia/src/main/__tests__/plugin-window-ipc-authorization.test.ts
+++ b/packages/insomnia/src/main/__tests__/plugin-window-ipc-authorization.test.ts
@@ -1,0 +1,180 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Verifies every `plugin-window.ts` IPC channel is registered through one of the three
+// sender-checked wrappers and rejects a forged sender. One test statically checks the source
+// for bare `ipcMain` calls outside those wrappers; the rest iterate every channel actually
+// registered at runtime, so a future channel is covered automatically.
+
+const registeredHandlers = new Map<string, (...args: any[]) => any>();
+const registeredListeners = new Map<string, (...args: any[]) => any>();
+
+const fakePluginWebContents = {
+  send: vi.fn(),
+  on: vi.fn(),
+  once: vi.fn(),
+  off: vi.fn(),
+};
+
+const fakePluginWindow = {
+  isDestroyed: () => false,
+  webContents: fakePluginWebContents,
+  on: vi.fn(),
+  loadFile: vi.fn(),
+};
+
+const fakeMainWebContents = { send: vi.fn() };
+const fakeMainWindow = { webContents: fakeMainWebContents };
+
+// A sender that is neither the real plugin window nor the real main window.
+const forgedSender = { id: 'forged-sender' };
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => '/fake/userData') },
+  BrowserWindow: vi.fn(() => fakePluginWindow),
+  ipcMain: {
+    handle: vi.fn((channel: string, fn: (...args: any[]) => any) => registeredHandlers.set(channel, fn)),
+    on: vi.fn((channel: string, fn: (...args: any[]) => any) => registeredListeners.set(channel, fn)),
+  },
+}));
+
+vi.mock('../window-utils', () => ({
+  getMainWindow: vi.fn(() => fakeMainWindow),
+}));
+
+vi.mock('../prompt-bridge', () => ({
+  requestPromptFromRenderer: vi.fn(),
+}));
+
+describe('plugin-window.ts IPC dispatch: sender authorization', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    registeredHandlers.clear();
+    registeredListeners.clear();
+    fakePluginWebContents.send.mockClear();
+    fakeMainWebContents.send.mockClear();
+  });
+
+  // Fails the build if a channel is ever registered outside the three wrapper bodies.
+  it('every ipcMain.handle/.on call is confined to the three sender-checked wrappers', () => {
+    const source = readFileSync(path.join(__dirname, '..', 'plugin-window.ts'), 'utf8');
+
+    const wrapperNames = ['handleFromMainWindow', 'onFromPluginWindow', 'handleFromPluginWindow'];
+    let withoutWrapperBodies = source;
+    for (const name of wrapperNames) {
+      const start = source.indexOf(`function ${name}`);
+      expect(start, `expected to find the ${name} wrapper definition`).toBeGreaterThan(-1);
+      // Matches the closing brace by depth rather than a fixed line count.
+      let depth = 0;
+      let end = -1;
+      for (let i = source.indexOf('{', start); i < source.length; i++) {
+        if (source[i] === '{') depth++;
+        if (source[i] === '}') {
+          depth--;
+          if (depth === 0) {
+            end = i + 1;
+            break;
+          }
+        }
+      }
+      expect(end, `expected to find the end of the ${name} wrapper body`).toBeGreaterThan(start);
+      withoutWrapperBodies = withoutWrapperBodies.replace(source.slice(start, end), '');
+    }
+
+    expect(withoutWrapperBodies).not.toMatch(/\bipcMain\.handle\(/);
+    expect(withoutWrapperBodies).not.toMatch(/\bipcMain\.on\(/);
+  });
+
+  // Reads the live registration map, not a hardcoded channel list.
+  it('every channel registered by registerPluginIpcHandlers() rejects a forged sender', async () => {
+    const { registerPluginIpcHandlers } = await import('../plugin-window');
+    registerPluginIpcHandlers();
+
+    expect(registeredHandlers.size).toBeGreaterThan(0);
+    for (const [channel, handler] of registeredHandlers) {
+      expect(
+        () => handler({ sender: forgedSender }, {}),
+        `expected plugins channel "${channel}" to reject a forged sender`,
+      ).toThrow(/sender is not the main app window/);
+    }
+  });
+
+  it('every channel registered by registerPluginIpcHandlers() accepts the real main window', async () => {
+    const { registerPluginIpcHandlers } = await import('../plugin-window');
+    registerPluginIpcHandlers();
+
+    for (const [channel, handler] of registeredHandlers) {
+      expect(
+        () => handler({ sender: fakeMainWebContents }, {}),
+        `expected plugins channel "${channel}" to accept the real main window sender`,
+      ).not.toThrow();
+    }
+  });
+
+  // A forged sender is rejected before it ever reaches the plugin window.
+  it('plugins.applyRequestHooks rejects a forged sender', async () => {
+    const { registerPluginIpcHandlers } = await import('../plugin-window');
+    registerPluginIpcHandlers();
+
+    const applyRequestHooksHandler = registeredHandlers.get('plugins.applyRequestHooks');
+    expect(applyRequestHooksHandler).toBeTypeOf('function');
+
+    const forgedArgs = {
+      renderedRequest: { _id: 'req_forged', url: 'https://example.com/resource', headers: [] },
+      projectId: 'proj_not_mine',
+      environment: { BASE_URL: 'https://example.com' },
+    };
+
+    expect(() => applyRequestHooksHandler!({ sender: forgedSender }, forgedArgs)).toThrow(
+      /sender is not the main app window/,
+    );
+    expect(fakePluginWebContents.send).not.toHaveBeenCalled();
+  });
+
+  // The reverse-direction (plugin-window -> host) callbacks enforce sender checks too.
+  it('plugins.uiAlert still ignores a forged sender', async () => {
+    const { registerPluginIpcHandlers, createPluginWindow } = await import('../plugin-window');
+    registerPluginIpcHandlers();
+    createPluginWindow();
+
+    const uiAlertListener = registeredListeners.get('plugins.uiAlert');
+    expect(uiAlertListener).toBeTypeOf('function');
+
+    uiAlertListener!({ sender: forgedSender }, { message: 'hi' });
+
+    expect(fakeMainWebContents.send).not.toHaveBeenCalled();
+  });
+
+  // Sanity check the fix doesn't break the legitimate dispatch path.
+  it('a legitimate main-window call to plugins.applyRequestHooks still dispatches to the plugin window', async () => {
+    const { registerPluginIpcHandlers } = await import('../plugin-window');
+    registerPluginIpcHandlers();
+
+    const applyRequestHooksHandler = registeredHandlers.get('plugins.applyRequestHooks')!;
+    const legitimateArgs = {
+      renderedRequest: { _id: 'req_1', url: 'https://example.com', headers: [] },
+      projectId: 'proj_1',
+      environment: {},
+    };
+
+    const invokePromise = applyRequestHooksHandler({ sender: fakeMainWebContents }, legitimateArgs);
+
+    await vi.advanceTimersByTimeAsync(0);
+    const windowReadyListener = registeredListeners.get('plugins.windowReady');
+    windowReadyListener!({ sender: fakePluginWebContents });
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(fakePluginWebContents.send).toHaveBeenCalledWith(
+      'plugins.invoke',
+      expect.objectContaining({ method: 'applyRequestHooks', args: legitimateArgs }),
+    );
+
+    const [, { id }] = fakePluginWebContents.send.mock.calls[0];
+    const invokeResultListener = registeredListeners.get('plugins.invokeResult');
+    invokeResultListener!({ sender: fakePluginWebContents }, { id, result: {} });
+    await expect(invokePromise).resolves.toEqual({});
+  });
+});

--- a/packages/insomnia/src/main/__tests__/templating-worker-database-protocol-authorization.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database-protocol-authorization.test.ts
@@ -1,0 +1,350 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Verifies every path in `resolveDbByKey`'s `pluginToMainAPI` map requires a valid auth token,
+// resolves plugin directories from the trusted registry rather than the request body, and
+// strips dangerous keys from sandbox output consistently. Iterates the live map so a future
+// path is covered automatically.
+
+vi.mock('electron', () => ({
+  app: { getVersion: () => '1.0.0', getPath: () => '/fake/userData' },
+  clipboard: { readText: vi.fn(), writeText: vi.fn(), clear: vi.fn() },
+  dialog: { showMessageBox: vi.fn() },
+  shell: { openExternal: vi.fn() },
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+vi.mock('insomnia-data', () => ({
+  services: {
+    request: { getById: vi.fn() },
+    workspace: { getById: vi.fn() },
+    oAuth2Token: { getByParentId: vi.fn() },
+    cookieJar: { getOrCreateForParentId: vi.fn() },
+    response: { getLatestForRequestId: vi.fn() },
+    helpers: { getResponseBodyBuffer: vi.fn() },
+    pluginData: { getByKey: vi.fn(), upsertByKey: vi.fn(), removeByKey: vi.fn(), removeAll: vi.fn(), all: vi.fn() },
+    cloudCredential: { getById: vi.fn(), update: vi.fn() },
+    settings: { get: vi.fn().mockResolvedValue({}) },
+  },
+}));
+vi.mock('~/plugins', () => ({
+  getPluginCommonContext: vi.fn(),
+  getTemplateTags: vi.fn().mockResolvedValue([]),
+  getPlugins: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('~/common/cookies', () => ({ jarFromCookies: vi.fn() }));
+vi.mock('../common/database', () => ({ database: {} }));
+vi.mock('../network/network', () => ({
+  fetchRequestData: vi.fn(),
+  sendCurlAndWriteTimeline: vi.fn(),
+  tryToInterpolateRequest: vi.fn(),
+}));
+vi.mock('../network/libcurl-promise', () => ({ curlRequest: vi.fn() }));
+vi.mock('../prompt-bridge', () => ({ requestPromptFromRenderer: vi.fn() }));
+vi.mock('../secure-read-file', () => ({ secureReadFile: vi.fn() }));
+
+import {
+  _testOnlyResetTemplatingDbAuthToken,
+  getOrCreateTemplatingDbAuthToken,
+  TEMPLATING_DB_AUTH_HEADER,
+} from '../templating-worker-database-auth';
+
+describe('resolveDbByKey requires a valid protocol auth token', () => {
+  beforeEach(() => {
+    _testOnlyResetTemplatingDbAuthToken();
+  });
+
+  it('every registered path rejects a request with no auth token at all', async () => {
+    const { resolveDbByKey, pluginToMainAPI } = await import('../templating-worker-database');
+    const paths = Object.keys(pluginToMainAPI);
+    expect(paths.length).toBeGreaterThan(0);
+    for (const p of paths) {
+      const req = new Request(`insomnia-templating-worker-database://${p.toLowerCase()}`, {
+        method: 'POST',
+        body: '{}',
+      });
+      const res = await resolveDbByKey(req);
+      expect(res.status, `expected path "${p}" to reject a request with no auth token`).toBe(401);
+    }
+  });
+
+  it('every registered path rejects a forged/invalid auth token', async () => {
+    getOrCreateTemplatingDbAuthToken();
+    const { resolveDbByKey, pluginToMainAPI } = await import('../templating-worker-database');
+    for (const p of Object.keys(pluginToMainAPI)) {
+      const req = new Request(`insomnia-templating-worker-database://${p.toLowerCase()}`, {
+        method: 'POST',
+        headers: { [TEMPLATING_DB_AUTH_HEADER]: 'deadbeef-not-the-real-token' },
+        body: '{}',
+      });
+      const res = await resolveDbByKey(req);
+      expect(res.status, `expected path "${p}" to reject a forged auth token`).toBe(401);
+    }
+  });
+
+  it('every registered path is dispatched (not rejected as unauthorized) given the real token', async () => {
+    const token = getOrCreateTemplatingDbAuthToken();
+    const { resolveDbByKey, pluginToMainAPI } = await import('../templating-worker-database');
+    for (const p of Object.keys(pluginToMainAPI)) {
+      const req = new Request(`insomnia-templating-worker-database://${p.toLowerCase()}`, {
+        method: 'POST',
+        headers: { [TEMPLATING_DB_AUTH_HEADER]: token },
+        body: '{}',
+      });
+      const res = await resolveDbByKey(req);
+      expect(res.status, `expected path "${p}" not to be rejected as unauthorized with a valid token`).not.toBe(401);
+    }
+  });
+
+  it('plugin.runUserRequestHook rejects a forged, tokenless call before any hook runs', async () => {
+    const { resolveDbByKey } = await import('../templating-worker-database');
+    const req = new Request('insomnia-templating-worker-database://plugin.runuserrequesthook', {
+      method: 'POST',
+      body: JSON.stringify({
+        plugin: { directory: '/tmp/anything', name: 'insomnia-plugin-forged' },
+        hookIndex: 0,
+        renderedRequest: { url: 'https://example.com', headers: [] },
+        renderContext: {},
+      }),
+    });
+    const res = await resolveDbByKey(req);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('protocol-dispatch handlers resolve `directory` from the trusted registry, not the request body', () => {
+  let legitDir: string;
+  let foreignDir: string;
+
+  beforeEach(async () => {
+    _testOnlyResetTemplatingDbAuthToken();
+    legitDir = fs.mkdtempSync(path.join(os.tmpdir(), 'insomnia-plugin-legit-'));
+    fs.writeFileSync(path.join(legitDir, 'package.json'), JSON.stringify({ main: 'index.js' }));
+    fs.writeFileSync(
+      path.join(legitDir, 'index.js'),
+      `module.exports.templateTags = [{ name: "legit_tag", displayName: "legit", run: function () {} }];
+       module.exports.requestHooks = [function (context) {
+         context.request.setHeader('X-Plugin-Source', 'legit');
+       }];`,
+    );
+
+    foreignDir = fs.mkdtempSync(path.join(os.tmpdir(), 'insomnia-plugin-foreign-'));
+    fs.writeFileSync(path.join(foreignDir, 'package.json'), JSON.stringify({ main: 'index.js' }));
+    fs.writeFileSync(
+      path.join(foreignDir, 'index.js'),
+      `module.exports.templateTags = [{ name: "forged_tag", displayName: "forged", run: function () {} }];
+       module.exports.requestHooks = [function (context) {
+         context.request.setHeader('X-Plugin-Source', 'foreign');
+       }];`,
+    );
+
+    const { getPlugins } = await import('~/plugins');
+    (getPlugins as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { name: 'insomnia-plugin-legit', directory: legitDir, permissions: {} },
+    ]);
+  });
+
+  afterEach(() => {
+    fs.rmSync(legitDir, { recursive: true, force: true });
+    fs.rmSync(foreignDir, { recursive: true, force: true });
+  });
+
+  it('a forged directory in the request body is ignored in favor of the registry-resolved one', async () => {
+    const token = getOrCreateTemplatingDbAuthToken();
+    const { resolveDbByKey } = await import('../templating-worker-database');
+    const req = new Request('insomnia-templating-worker-database://plugin.discoveruserpluginexports', {
+      method: 'POST',
+      headers: { [TEMPLATING_DB_AUTH_HEADER]: token },
+      body: JSON.stringify({ directory: foreignDir, name: 'insomnia-plugin-legit' }),
+    });
+    const res = await resolveDbByKey(req);
+    expect(res.status).toBe(200);
+    const manifest = await res.json();
+    const tagNames = manifest.templateTags.map((t: { name: string }) => t.name);
+    expect(tagNames).toContain('legit_tag');
+    expect(tagNames).not.toContain('forged_tag');
+  });
+
+  it('rejects a plugin name that is not in the trusted registry, regardless of directory', async () => {
+    const token = getOrCreateTemplatingDbAuthToken();
+    const { resolveDbByKey } = await import('../templating-worker-database');
+    const req = new Request('insomnia-templating-worker-database://plugin.discoveruserpluginexports', {
+      method: 'POST',
+      headers: { [TEMPLATING_DB_AUTH_HEADER]: token },
+      body: JSON.stringify({ directory: foreignDir, name: 'insomnia-plugin-unregistered' }),
+    });
+    const res = await resolveDbByKey(req);
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/Unknown plugin/);
+  });
+
+  // Mirrors the discoverUserPluginExports case above on the request-hook path — before this branch,
+  // `plugin.discoverUserPluginExports` and `plugin.runUserRequestHook` each trusted their own copy of
+  // `body.(plugin.)directory` independently, so a guard proven on one handler didn't imply the other
+  // was covered (this is exactly how the `permissions` gap in the describe block below went
+  // unnoticed alongside the `directory` fix). Test both handlers explicitly rather than one.
+  it('a forged directory in plugin.runUserRequestHook\'s request body is ignored in favor of the registry-resolved one', async () => {
+    const token = getOrCreateTemplatingDbAuthToken();
+    const { resolveDbByKey } = await import('../templating-worker-database');
+    const req = new Request('insomnia-templating-worker-database://plugin.runuserrequesthook', {
+      method: 'POST',
+      headers: { [TEMPLATING_DB_AUTH_HEADER]: token },
+      body: JSON.stringify({
+        plugin: { name: 'insomnia-plugin-legit', directory: foreignDir },
+        hookIndex: 0,
+        renderedRequest: { _id: 'req_1', url: 'https://example.com', headers: [], body: {} },
+        renderContext: {},
+      }),
+    });
+    const res = await resolveDbByKey(req);
+    expect(res.status).toBe(200);
+    const mutated = await res.json();
+    const source = mutated.headers.find((h: { name: string }) => h.name === 'X-Plugin-Source')?.value;
+    expect(source).toBe('legit');
+  });
+});
+
+// H1-followup finding (fixed): F2' resolved `directory` server-side from the trusted registry
+// (getPlugins()), but originally left `permissions` as a caller-supplied field on the request body
+// for both `plugin.runUserRequestHook` and `plugin.discoverUserPluginExports`. Now both handlers
+// resolve `permissions` from the trusted registry the same way they resolve `directory`, so a
+// forged `permissions` in the request body no longer grants a broader capability set than the
+// plugin's own registered manifest declares.
+describe('protocol-dispatch handlers resolve `permissions` from the trusted registry, not the request body', () => {
+  let pluginDir: string;
+
+  beforeEach(async () => {
+    _testOnlyResetTemplatingDbAuthToken();
+    pluginDir = fs.mkdtempSync(path.join(os.tmpdir(), 'insomnia-plugin-restricted-'));
+    fs.writeFileSync(path.join(pluginDir, 'package.json'), JSON.stringify({ main: 'index.js' }));
+    fs.writeFileSync(
+      path.join(pluginDir, 'index.js'),
+      // Reports whether the `network` capability made it into the hook's context — deleted from
+      // `context` entirely unless granted (in-sandbox-bootstrap.ts `__hasCap`).
+      `module.exports.requestHooks = [function (context) {
+        context.request.setBody({ text: JSON.stringify({ hasNetwork: typeof context.network !== 'undefined' }) });
+      }];`,
+    );
+
+    // The registry's source of truth for this plugin declares NO capabilities (no manifest) —
+    // real callers (the plugin loader, invoke-method.ts) would only ever send this plugin's hook
+    // with baseline capabilities, which do not include `network`.
+    const { getPlugins } = await import('~/plugins');
+    (getPlugins as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { name: 'insomnia-plugin-restricted', directory: pluginDir, permissions: {} },
+    ]);
+  });
+
+  afterEach(() => {
+    fs.rmSync(pluginDir, { recursive: true, force: true });
+  });
+
+  const runHook = async (permissions?: { capabilities?: string[] }) => {
+    const token = getOrCreateTemplatingDbAuthToken();
+    const { resolveDbByKey } = await import('../templating-worker-database');
+    const req = new Request('insomnia-templating-worker-database://plugin.runuserrequesthook', {
+      method: 'POST',
+      headers: { [TEMPLATING_DB_AUTH_HEADER]: token },
+      body: JSON.stringify({
+        plugin: { name: 'insomnia-plugin-restricted', permissions },
+        hookIndex: 0,
+        renderedRequest: { _id: 'req_1', url: 'https://example.com', headers: [], body: {} },
+        renderContext: {},
+      }),
+    });
+    const res = await resolveDbByKey(req);
+    expect(res.status).toBe(200);
+    const mutated = await res.json();
+    return JSON.parse(mutated.body.text) as { hasNetwork: boolean };
+  };
+
+  it('baseline: a request that omits permissions gets the registry-appropriate (no-network) grant', async () => {
+    const { hasNetwork } = await runHook();
+    expect(hasNetwork).toBe(false);
+  });
+
+  // The plugin's *registered* manifest (mocked above) declares no capabilities. A forged
+  // `permissions.capabilities: ['network']` in the request body must not grant `network` — the
+  // handler resolves `permissions` from `getPlugins()` by name, the same trusted-registry pattern
+  // F2' applies to `directory`, rather than trusting the request body.
+  it('a forged `permissions.capabilities` in the request body is ignored; the registry still denies network', async () => {
+    const { hasNetwork } = await runHook({ capabilities: ['network'] });
+    expect(hasNetwork).toBe(false);
+  });
+});
+
+// Symmetric coverage for the other handler that resolves `permissions`: the describe block above
+// only exercises `plugin.runUserRequestHook`. `plugin.discoverUserPluginExports` takes the same
+// `resolveTrustedPlugin(...).permissions` value but on the *module* grant, not the capability grant
+// (discovery evaluates the plugin's top-level code, which can only reach gated `require(...)`, not
+// hook-time `context.*`). Exercising both fields on both handlers is the point: the permissions gap
+// this branch fixed existed specifically because the `directory` fix was verified per-handler but
+// `permissions` wasn't checked on every handler that resolves it.
+describe('plugin.discoverUserPluginExports resolves `permissions.modules` from the trusted registry, not the request body', () => {
+  let pluginDir: string;
+
+  beforeEach(async () => {
+    _testOnlyResetTemplatingDbAuthToken();
+    pluginDir = fs.mkdtempSync(path.join(os.tmpdir(), 'insomnia-plugin-nomodules-'));
+    fs.writeFileSync(path.join(pluginDir, 'package.json'), JSON.stringify({ main: 'index.js' }));
+    fs.writeFileSync(
+      path.join(pluginDir, 'index.js'),
+      // `events` is not in the baseline module grant (`path`/`crypto` only), so a top-level require
+      // of it only succeeds if `permissions.modules` grants it.
+      "require('events'); module.exports.templateTags = [];",
+    );
+
+    // The registry declares no extra modules for this plugin — a real caller (the plugin loader)
+    // would only ever discover this plugin's exports with the baseline module grant.
+    const { getPlugins } = await import('~/plugins');
+    (getPlugins as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { name: 'insomnia-plugin-nomodules', directory: pluginDir, permissions: {} },
+    ]);
+  });
+
+  afterEach(() => {
+    fs.rmSync(pluginDir, { recursive: true, force: true });
+  });
+
+  it('a forged `permissions.modules` in the request body is ignored; the registry still denies the module', async () => {
+    const token = getOrCreateTemplatingDbAuthToken();
+    const { resolveDbByKey } = await import('../templating-worker-database');
+    const req = new Request('insomnia-templating-worker-database://plugin.discoveruserpluginexports', {
+      method: 'POST',
+      headers: { [TEMPLATING_DB_AUTH_HEADER]: token },
+      body: JSON.stringify({
+        name: 'insomnia-plugin-nomodules',
+        permissions: { modules: ['events'] },
+      }),
+    });
+    const res = await resolveDbByKey(req);
+    // Discovery surfaces a denied top-level require as a rejection, not a 200 with an empty manifest.
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/not permitted by manifest/);
+  });
+});
+
+describe('discoverPluginExportsInSandbox strips dangerous JSON keys, symmetric with the hook path', () => {
+  it('a plugin export that plants a __proto__ own-key does not survive into the manifest', async () => {
+    const { discoverPluginExportsInSandbox } = await import('../templating-worker-database');
+    // `themeDesc` passes `theme: t.theme` through verbatim, a nested object that needs the same
+    // dangerous-key stripping as the hook-result path.
+    const source = `
+      var evilTheme = JSON.parse('{"__proto__": {"polluted": true}, "safe": 1}');
+      module.exports.themes = [{ name: "t", displayName: "T", theme: evilTheme }];
+    `;
+    const manifest = await discoverPluginExportsInSandbox(source, {
+      pluginName: 'p',
+      grantedModules: [],
+      grantedCapabilities: [],
+    });
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    const theme = manifest.themes[0]?.theme as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(theme, '__proto__')).toBe(false);
+    expect(theme.safe).toBe(1);
+  });
+});

--- a/packages/insomnia/src/main/__tests__/templating-worker-database.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database.test.ts
@@ -29,7 +29,11 @@ vi.mock('insomnia-data', () => ({
   },
   models: {},
 }));
-vi.mock('~/plugins', () => ({ getPluginCommonContext: vi.fn(), getTemplateTags: vi.fn().mockResolvedValue([]) }));
+vi.mock('~/plugins', () => ({
+  getPluginCommonContext: vi.fn(),
+  getTemplateTags: vi.fn().mockResolvedValue([]),
+  getPlugins: vi.fn().mockResolvedValue([]),
+}));
 vi.mock('~/common/cookies', () => ({ jarFromCookies: vi.fn() }));
 vi.mock('../common/database', () => ({ database: {} }));
 vi.mock('../network/network', () => ({
@@ -52,6 +56,7 @@ import {
   resolveDbByKey,
   runPluginTagInSandbox,
 } from '../templating-worker-database';
+import { getOrCreateTemplatingDbAuthToken, TEMPLATING_DB_AUTH_HEADER } from '../templating-worker-database-auth';
 
 describe('readPluginModuleMap (M4 multi-file plugin reader)', () => {
   let dir: string;
@@ -253,10 +258,12 @@ describe('runPluginTagInSandbox — util.render escape', () => {
 describe('resolveDbByKey — app.prompt', () => {
   it('routes prompt requests to the renderer prompt bridge', async () => {
     vi.mocked(requestPromptFromRenderer).mockResolvedValueOnce('typed value');
+    const token = getOrCreateTemplatingDbAuthToken();
 
     const response = await resolveDbByKey(
       new Request('insomnia-templating-worker-database://app.prompt', {
         method: 'post',
+        headers: { [TEMPLATING_DB_AUTH_HEADER]: token },
         body: JSON.stringify({
           title: 'Title',
           options: { label: 'Label', defaultValue: 'cached value', inputType: 'password' },

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -177,6 +177,7 @@ export type HandleChannels =
   | 'syncNewWorkspaceIfNeeded'
   | 'sync.invoke'
   | 'sync.pullRemoteBackendProject'
+  | 'templatingDb.getAuthToken'
   | 'socketIO.open'
   | 'socketIO.readyState'
   | 'webSocket.event.findMany'

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -91,6 +91,7 @@ import type { electronStorageBridgeAPI } from './electron-storage';
 import extractPostmanDataDumpHandler from './extract-postman-data-dump';
 import type { gRPCBridgeAPI } from './grpc';
 import type { secretStorageBridgeAPI } from './secret-storage';
+import { registerTemplatingDbAuthIpcHandler } from './templating-db-auth';
 
 let lintProcess: Electron.UtilityProcess | null = null;
 
@@ -341,6 +342,9 @@ export interface RendererToMainBridgeAPI {
   >;
   syncNewWorkspaceIfNeeded: typeof syncNewWorkspaceIfNeeded;
   plugins: PluginsBridgeAPI;
+  templatingDb: {
+    getAuthToken: () => Promise<string>;
+  };
   notifyPromptResult: (id: string, value: string | null) => void;
   vault: {
     encryptSecretValue: (rawValue: string, symmetricKey: JsonWebKey) => Promise<string>;
@@ -948,4 +952,5 @@ export function registerMainHandlers() {
   });
 
   registerPluginIpcHandlers();
+  registerTemplatingDbAuthIpcHandler();
 }

--- a/packages/insomnia/src/main/ipc/templating-db-auth.ts
+++ b/packages/insomnia/src/main/ipc/templating-db-auth.ts
@@ -1,0 +1,20 @@
+import type { IpcMainInvokeEvent } from 'electron';
+
+import { getPluginWindow } from '../plugin-window';
+import { getOrCreateTemplatingDbAuthToken } from '../templating-worker-database-auth';
+import { getMainWindow } from '../window-utils';
+import { ipcMainHandle } from './electron';
+
+// Only hands the templating db auth token to the main app window or the hidden plugin window.
+export function registerTemplatingDbAuthIpcHandler() {
+  ipcMainHandle('templatingDb.getAuthToken', (event: IpcMainInvokeEvent) => {
+    const isMainWindow = event.sender === getMainWindow()?.webContents;
+    const isPluginWindow = event.sender === getPluginWindow()?.webContents;
+    if (!isMainWindow && !isPluginWindow) {
+      throw new Error(
+        '[templating-db-auth] rejected templatingDb.getAuthToken: sender is neither the main app window nor the plugin window',
+      );
+    }
+    return getOrCreateTemplatingDbAuthToken();
+  });
+}

--- a/packages/insomnia/src/main/plugin-window.ts
+++ b/packages/insomnia/src/main/plugin-window.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow, ipcMain, type IpcMainEvent, type IpcMainInvokeEvent } from 'electron';
 
-import { type PromptRequestOptions, requestPromptFromRenderer } from './prompt-bridge';
+import { requestPromptFromRenderer } from './prompt-bridge';
 import { getMainWindow } from './window-utils';
 
 let pluginWindow: BrowserWindow | null = null;
@@ -69,6 +69,58 @@ export function getBridgeMetricsSnapshot() {
   };
 }
 
+// --- Sender-checked IPC registration wrappers -------------------------------------------
+//
+// Every `ipcMain.handle`/`ipcMain.on` call in this file must go through one of the three
+// wrappers below instead of the raw `ipcMain` API, so each channel enforces which window is
+// allowed to be its caller. `plugin-window-ipc-authorization.test.ts` fails the build if a bare
+// `ipcMain` call is added to this file outside these three function bodies.
+
+/**
+ * Registers a channel that dispatches a plugin operation into the hidden plugin window
+ * (`getThemes`, `applyRequestHooks`, `executeAction`, etc.), forwarding caller-supplied data to
+ * `invokeInPluginWindow`. Restricted to the real main app window; any other sender gets a
+ * rejected promise instead of a result.
+ */
+function handleFromMainWindow<Args = unknown, R = unknown>(
+  channel: string,
+  handler: (args: Args) => R | Promise<R>,
+): void {
+  ipcMain.handle(channel, (event: IpcMainInvokeEvent, args: Args) => {
+    if (event.sender !== getMainWindow()?.webContents) {
+      throw new Error(`[plugin-bridge] rejected ${channel}: sender is not the main app window`);
+    }
+    return handler(args);
+  });
+}
+
+/**
+ * Registers a fire-and-forget callback that the hidden plugin window sends back to the host
+ * (a UI callback, an invoke result). Restricted to the plugin window itself; any other sender
+ * is silently ignored, matching how these "reverse direction" messages already behaved.
+ */
+function onFromPluginWindow<Args = unknown>(channel: string, handler: (args: Args) => void): void {
+  ipcMain.on(channel, (event: IpcMainEvent, args: Args) => {
+    if (event.sender !== pluginWindow?.webContents) {
+      return;
+    }
+    handler(args);
+  });
+}
+
+/** Like {@link onFromPluginWindow}, but for the one plugin-window callback that replies (`plugins.uiPrompt`). */
+function handleFromPluginWindow<Args = unknown, R = unknown>(
+  channel: string,
+  handler: (args: Args) => R | Promise<R>,
+): void {
+  ipcMain.handle(channel, (event: IpcMainInvokeEvent, args: Args) => {
+    if (event.sender !== pluginWindow?.webContents) {
+      return null;
+    }
+    return handler(args);
+  });
+}
+
 // Registered once so that persistent `ipcMain.on` handlers don't accumulate across window recreations.
 let ipcListenersRegistered = false;
 
@@ -78,10 +130,7 @@ function ensureIpcListeners() {
   }
   ipcListenersRegistered = true;
 
-  ipcMain.on('plugins.windowReady', event => {
-    if (event.sender !== pluginWindow?.webContents) {
-      return;
-    }
+  onFromPluginWindow<void>('plugins.windowReady', () => {
     windowReady = true;
     const startedAt = bridgeMetrics.lastStartupAt;
     const startupMs = startedAt ? Date.now() - startedAt : 0;
@@ -89,33 +138,21 @@ function ensureIpcListeners() {
     console.log(`[plugin-bridge] window_ready startup_ms=${startupMs}`);
   });
 
-  ipcMain.on('plugins.uiAlert', (event, options: Record<string, unknown>) => {
-    if (event.sender !== pluginWindow?.webContents) {
-      return;
-    }
+  onFromPluginWindow<Record<string, unknown>>('plugins.uiAlert', options => {
     getMainWindow()?.webContents.send('plugins.uiAlert', options);
   });
 
-  ipcMain.on('plugins.uiDialog', (event, options: Record<string, unknown>) => {
-    if (event.sender !== pluginWindow?.webContents) {
-      return;
-    }
+  onFromPluginWindow<Record<string, unknown>>('plugins.uiDialog', options => {
     getMainWindow()?.webContents.send('plugins.uiDialog', options);
   });
 
-  ipcMain.handle('plugins.uiPrompt', async (event, options: Record<string, unknown>) => {
-    if (event.sender !== pluginWindow?.webContents) {
-      return null;
-    }
-    return requestPromptFromRenderer(options as unknown as PromptRequestOptions);
-  });
+  handleFromPluginWindow<{ title: string; label?: string; defaultValue?: string }>('plugins.uiPrompt', options =>
+    requestPromptFromRenderer(options),
+  );
 
-  ipcMain.on(
+  onFromPluginWindow<{ id: string; result?: unknown; error?: string }>(
     'plugins.invokeResult',
-    (event, { id, result, error }: { id: string; result?: unknown; error?: string }) => {
-      if (event.sender !== pluginWindow?.webContents) {
-        return;
-      }
+    ({ id, result, error }) => {
       const pending = pendingRequests.get(id);
       if (!pending) {
         return;
@@ -257,40 +294,38 @@ export function reloadPluginsInWindow() {
 }
 
 export function registerPluginIpcHandlers() {
-  ipcMain.handle('plugins.getThemes', () => invokeInPluginWindow('getThemes'));
-  ipcMain.handle('plugins.getPlugins', () => invokeInPluginWindow('getPlugins'));
-  ipcMain.handle('plugins.getActivePlugins', () => invokeInPluginWindow('getActivePlugins'));
-  ipcMain.handle('plugins.reloadPlugins', async () => {
+  handleFromMainWindow('plugins.getThemes', () => invokeInPluginWindow('getThemes'));
+  handleFromMainWindow('plugins.getPlugins', () => invokeInPluginWindow('getPlugins'));
+  handleFromMainWindow('plugins.getActivePlugins', () => invokeInPluginWindow('getActivePlugins'));
+  handleFromMainWindow('plugins.reloadPlugins', async () => {
     cachedHasRequestHooks = null;
     cachedHasResponseHooks = null;
     await invokeInPluginWindow('reloadPlugins');
   });
-  ipcMain.handle('plugins.getRequestActions', () => invokeInPluginWindow('getRequestActions'));
-  ipcMain.handle('plugins.getRequestGroupActions', () => invokeInPluginWindow('getRequestGroupActions'));
-  ipcMain.handle('plugins.getWorkspaceActions', () => invokeInPluginWindow('getWorkspaceActions'));
-  ipcMain.handle('plugins.getDocumentActions', () => invokeInPluginWindow('getDocumentActions'));
-  ipcMain.handle('plugins.executeAction', (_event, args) => invokeInPluginWindow('executeAction', args));
-  ipcMain.handle('plugins.getTemplateTags', () => invokeInPluginWindow('getTemplateTags'));
-  ipcMain.handle('plugins.runTemplateTagAction', (_event, args) => invokeInPluginWindow('runTemplateTagAction', args));
-  ipcMain.handle('plugins.getBundlePlugins', () => invokeInPluginWindow('getBundlePlugins'));
-  ipcMain.handle('plugins.executePluginMainAction', (_event, args) =>
-    invokeInPluginWindow('executePluginMainAction', args),
-  );
-  ipcMain.handle('plugins.hasRequestHooks', async () => {
+  handleFromMainWindow('plugins.getRequestActions', () => invokeInPluginWindow('getRequestActions'));
+  handleFromMainWindow('plugins.getRequestGroupActions', () => invokeInPluginWindow('getRequestGroupActions'));
+  handleFromMainWindow('plugins.getWorkspaceActions', () => invokeInPluginWindow('getWorkspaceActions'));
+  handleFromMainWindow('plugins.getDocumentActions', () => invokeInPluginWindow('getDocumentActions'));
+  handleFromMainWindow('plugins.executeAction', args => invokeInPluginWindow('executeAction', args));
+  handleFromMainWindow('plugins.getTemplateTags', () => invokeInPluginWindow('getTemplateTags'));
+  handleFromMainWindow('plugins.runTemplateTagAction', args => invokeInPluginWindow('runTemplateTagAction', args));
+  handleFromMainWindow('plugins.getBundlePlugins', () => invokeInPluginWindow('getBundlePlugins'));
+  handleFromMainWindow('plugins.executePluginMainAction', args => invokeInPluginWindow('executePluginMainAction', args));
+  handleFromMainWindow('plugins.hasRequestHooks', async () => {
     if (cachedHasRequestHooks === null) {
       cachedHasRequestHooks = (await invokeInPluginWindow('hasRequestHooks')) as boolean;
     }
     return cachedHasRequestHooks;
   });
-  ipcMain.handle('plugins.hasResponseHooks', async () => {
+  handleFromMainWindow('plugins.hasResponseHooks', async () => {
     if (cachedHasResponseHooks === null) {
       cachedHasResponseHooks = (await invokeInPluginWindow('hasResponseHooks')) as boolean;
     }
     return cachedHasResponseHooks;
   });
-  ipcMain.handle('plugins.applyRequestHooks', (_event, args) => invokeInPluginWindow('applyRequestHooks', args));
-  ipcMain.handle('plugins.applyResponseHooks', (_event, args) => invokeInPluginWindow('applyResponseHooks', args));
-  ipcMain.handle('plugins.getBridgeMetrics', () => getBridgeMetricsSnapshot());
+  handleFromMainWindow('plugins.applyRequestHooks', args => invokeInPluginWindow('applyRequestHooks', args));
+  handleFromMainWindow('plugins.applyResponseHooks', args => invokeInPluginWindow('applyResponseHooks', args));
+  handleFromMainWindow('plugins.getBridgeMetrics', () => getBridgeMetricsSnapshot());
 }
 
 export function getAppUserDataPath() {

--- a/packages/insomnia/src/main/templating-worker-database-auth.ts
+++ b/packages/insomnia/src/main/templating-worker-database-auth.ts
@@ -1,0 +1,25 @@
+import crypto from 'node:crypto';
+
+// Per-process secret required on every request to the templating db protocol, since that
+// protocol has no sender identity to check on its own.
+let token: string | null = null;
+
+export const getOrCreateTemplatingDbAuthToken = (): string => {
+  if (!token) {
+    token = crypto.randomBytes(32).toString('hex');
+  }
+  return token;
+};
+
+export const TEMPLATING_DB_AUTH_HEADER = 'x-insomnia-templating-auth';
+
+export const isValidTemplatingDbAuthToken = (candidate: string | null | undefined): boolean => {
+  if (!token || !candidate || candidate.length !== token.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(Buffer.from(candidate), Buffer.from(token));
+};
+
+export const _testOnlyResetTemplatingDbAuthToken = () => {
+  token = null;
+};

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -18,8 +18,8 @@ import type {
   PluginTemplateTagContext,
   PluginToMainAPIPaths,
 } from '~/common/templating/types';
-import { getPluginCommonContext, getTemplateTags } from '~/plugins';
-import type { PluginExportManifest } from '~/templating/sandbox/marshal';
+import { getPluginCommonContext, getPlugins, getTemplateTags } from '~/plugins';
+import { HOOK_REQUEST_FIELDS, type PluginExportManifest, stripDangerousKeysReviver } from '~/templating/sandbox/marshal';
 import type { SandboxModuleDenialError } from '~/templating/sandbox/plugin-tag-sandbox';
 
 import { getAppBundlePlugins, RESPONSE_CODE_REASONS } from '../common/constants';
@@ -29,15 +29,22 @@ import { fetchRequestData, sendCurlAndWriteTimeline, tryToInterpolateRequest } f
 import { curlRequest } from './network/libcurl-promise';
 import { requestPromptFromRenderer } from './prompt-bridge';
 import { secureReadFile } from './secure-read-file';
+import { isValidTemplatingDbAuthToken, TEMPLATING_DB_AUTH_HEADER } from './templating-worker-database-auth';
 
 const bundlePluginModuleMap: Record<string, Plugin['module']> = {};
 
 export const resolveDbByKey = async (request: Request) => {
+  // Reject before parsing the body, so a forged call never reaches a handler with attacker-supplied data.
+  if (!isValidTemplatingDbAuthToken(request.headers.get(TEMPLATING_DB_AUTH_HEADER))) {
+    return new Response(JSON.stringify({ error: 'Unauthorized: missing or invalid templating database auth token' }), {
+      status: 401,
+    });
+  }
   const url = new URL(request.url);
   let body;
   try {
     // We expect this to throw if a db call returns undefined
-    body = await request.json();
+    body = JSON.parse(await request.text(), stripDangerousKeysReviver);
   } catch {}
   // url get normalized to lowercase, so we need to normalize the keys to lower case as well
   const withLowercasedKeys = Object.fromEntries(
@@ -58,6 +65,20 @@ export const resolveDbByKey = async (request: Request) => {
     console.error(`Error resolving db by key ${urlHostLowerCase}:`, err);
     return new Response(JSON.stringify({ error: err.message }), { status: 500 });
   }
+};
+
+// Resolves a plugin's on-disk directory and manifest-declared permissions from the trusted plugin
+// registry by name, so the two protocol-dispatch handlers below never trust a caller-supplied
+// directory path or permissions object.
+const resolveTrustedPlugin = async (
+  pluginName: string,
+): Promise<{ directory: string; permissions: { modules: string[]; capabilities: string[] } }> => {
+  const plugins = await getPlugins();
+  const plugin = plugins.find(p => p.name === pluginName);
+  if (!plugin) {
+    throw new Error(`Unknown plugin: ${pluginName}`);
+  }
+  return { directory: plugin.directory, permissions: plugin.permissions };
 };
 
 const getBundlePluginModule = (pluginName: string): Plugin['module'] => {
@@ -384,7 +405,7 @@ export const discoverPluginExportsInSandbox = async (
       entryModuleKey,
     },
   });
-  return JSON.parse(json);
+  return JSON.parse(json, stripDangerousKeysReviver);
 };
 
 // Discover a user plugin's exports from its on-disk source, resolving the template-tag surface grant
@@ -405,25 +426,6 @@ export const discoverUserPluginExportsForLoader = async (body: {
     grantedCapabilities: resolveTemplateTagCapabilities(permissions?.capabilities),
   });
 };
-
-// The serializable RenderedRequest fields a request hook may read or mutate — the subset marshaled
-// into and out of the sandbox (mirrors what plugins/context/request.ts touches on the request).
-const HOOK_REQUEST_FIELDS = [
-  '_id',
-  'name',
-  'url',
-  'method',
-  'headers',
-  'parameters',
-  'authentication',
-  'body',
-  'cookies',
-  'settingSendCookies',
-  'settingStoreCookies',
-  'settingEncodeUrl',
-  'settingDisableRenderRequestBody',
-  'settingFollowRedirects',
-] as const;
 
 const pickHookRequestFields = (req: Record<string, any>): Record<string, any> => {
   const out: Record<string, any> = {};
@@ -473,12 +475,13 @@ export const runRequestHookInSandbox = async (
       hookRequest,
     },
   });
-  const result = JSON.parse(json) as { request?: Record<string, any> };
+  const result = JSON.parse(json, stripDangerousKeysReviver) as { request?: Record<string, any> };
   return result.request ?? hookRequest;
 };
 
-// These are exposed to the templating worker and can be used by plugins from context.util
-const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<any>> = {
+// These are exposed to the templating worker and can be used by plugins from context.util.
+// Exported so tests can enumerate every registered path.
+export const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<any>> = {
   'readFile': async (body: { path: string }) => {
     return secureReadFile(body.path);
   },
@@ -739,7 +742,14 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
     directory: string;
     name: string;
     permissions?: { modules?: string[]; capabilities?: string[] };
-  }) => discoverUserPluginExportsForLoader(body),
+  }) => {
+    const trusted = await resolveTrustedPlugin(body.name);
+    return discoverUserPluginExportsForLoader({
+      ...body,
+      directory: trusted.directory,
+      permissions: trusted.permissions,
+    });
+  },
   // H1: run a user plugin's request hook in the sandbox (plugin-window path reaches this over the
   // templating-worker-database protocol; the node runtime calls runRequestHookInSandbox directly).
   'plugin.runUserRequestHook': async (body: {
@@ -747,7 +757,15 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
     hookIndex: number;
     renderedRequest: Record<string, any>;
     renderContext: Record<string, any>;
-  }) => runRequestHookInSandbox(body.plugin, body.hookIndex, body.renderedRequest, body.renderContext),
+  }) => {
+    const trusted = await resolveTrustedPlugin(body.plugin.name);
+    return runRequestHookInSandbox(
+      { ...body.plugin, directory: trusted.directory, permissions: trusted.permissions },
+      body.hookIndex,
+      body.renderedRequest,
+      body.renderContext,
+    );
+  },
   // execute a user-installed plugin tag with the given parameters, in the main process where
   // Node built-ins (e.g. crypto) the plugin requires are available.
   'plugin.executeUserPluginTag': async (body: {

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -406,6 +406,77 @@ export const discoverUserPluginExportsForLoader = async (body: {
   });
 };
 
+// The serializable RenderedRequest fields a request hook may read or mutate — the subset marshaled
+// into and out of the sandbox (mirrors what plugins/context/request.ts touches on the request).
+const HOOK_REQUEST_FIELDS = [
+  '_id',
+  'name',
+  'url',
+  'method',
+  'headers',
+  'parameters',
+  'authentication',
+  'body',
+  'cookies',
+  'settingSendCookies',
+  'settingStoreCookies',
+  'settingEncodeUrl',
+  'settingDisableRenderRequestBody',
+  'settingFollowRedirects',
+] as const;
+
+const pickHookRequestFields = (req: Record<string, any>): Record<string, any> => {
+  const out: Record<string, any> = {};
+  for (const key of HOOK_REQUEST_FIELDS) {
+    if (req[key] !== undefined) {
+      out[key] = req[key];
+    }
+  }
+  return out;
+};
+
+// H1: run a user plugin's request hook (at hookIndex) inside the sandbox, capability-gated. The hook
+// mutates the request in the sandbox; we marshal the mutated field subset back for the caller to
+// merge onto the request it is building. Reuses the same bridge/grants/crypto as tag execution.
+export const runRequestHookInSandbox = async (
+  plugin: { directory: string; name: string; permissions?: { modules?: string[]; capabilities?: string[] } },
+  hookIndex: number,
+  renderedRequest: Record<string, any>,
+  renderContext: Record<string, any>,
+): Promise<Record<string, any>> => {
+  const { runTagInSandbox } = await import('../templating/sandbox/plugin-tag-sandbox');
+  const { resolveTemplateTagModules, resolveTemplateTagCapabilities } = await import(
+    '../templating/sandbox/surface-profiles'
+  );
+  const grantedCapabilities = resolveTemplateTagCapabilities(plugin.permissions?.capabilities);
+  const bridge = await buildSandboxBridge(grantedCapabilities);
+  const { moduleFiles, entryModuleKey } = readPluginModuleMap({ directory: plugin.directory, name: plugin.name });
+  const hookRequest = pickHookRequestFields(renderedRequest);
+  const json = await runTagInSandbox({
+    tagName: '',
+    bridge,
+    hostCrypto: SANDBOX_HOST_CRYPTO,
+    envelope: {
+      args: [],
+      context: (renderContext as Record<string, any>) || {},
+      meta: {},
+      renderPurpose: 'send',
+      appInfo: { version: app.getVersion(), platform: process.platform, arch: process.arch },
+      pluginName: plugin.name,
+      renderDepth: 0,
+      grantedModules: resolveTemplateTagModules(plugin.permissions?.modules),
+      grantedCapabilities,
+      moduleFiles,
+      entryModuleKey,
+      hookKind: 'request',
+      hookIndex,
+      hookRequest,
+    },
+  });
+  const result = JSON.parse(json) as { request?: Record<string, any> };
+  return result.request ?? hookRequest;
+};
+
 // These are exposed to the templating worker and can be used by plugins from context.util
 const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<any>> = {
   'readFile': async (body: { path: string }) => {
@@ -669,6 +740,14 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
     name: string;
     permissions?: { modules?: string[]; capabilities?: string[] };
   }) => discoverUserPluginExportsForLoader(body),
+  // H1: run a user plugin's request hook in the sandbox (plugin-window path reaches this over the
+  // templating-worker-database protocol; the node runtime calls runRequestHookInSandbox directly).
+  'plugin.runUserRequestHook': async (body: {
+    plugin: { directory: string; name: string; permissions?: { modules?: string[]; capabilities?: string[] } };
+    hookIndex: number;
+    renderedRequest: Record<string, any>;
+    renderContext: Record<string, any>;
+  }) => runRequestHookInSandbox(body.plugin, body.hookIndex, body.renderedRequest, body.renderContext),
   // execute a user-installed plugin tag with the given parameters, in the main process where
   // Node built-ins (e.g. crypto) the plugin requires are available.
   'plugin.executeUserPluginTag': async (body: {

--- a/packages/insomnia/src/plugins/__tests__/invoke-method.test.ts
+++ b/packages/insomnia/src/plugins/__tests__/invoke-method.test.ts
@@ -20,7 +20,12 @@ vi.mock('insomnia-data', () => ({
   },
 }));
 
+vi.mock('~/common/templating/liquid-extension-worker', () => ({
+  fetchFromTemplateWorkerDatabase: vi.fn(),
+}));
+
 import type { Plugin } from '~/common/plugins/types';
+import { fetchFromTemplateWorkerDatabase } from '~/common/templating/liquid-extension-worker';
 
 import { _testOnlySetPlugins } from '../index';
 import { invokePluginMethod } from '../invoke-method';
@@ -76,6 +81,8 @@ describe('invokePluginMethod', () => {
   it('preserves plugin-prefixed request hook errors', async () => {
     const hook = vi.fn().mockRejectedValue(new Error('boom'));
     _testOnlySetPlugins([makePlugin({ module: { requestHooks: [hook] } })]);
+
+    vi.mocked(fetchFromTemplateWorkerDatabase).mockResolvedValue({});
 
     await expect(
       invokePluginMethod('applyRequestHooks', {

--- a/packages/insomnia/src/plugins/invoke-method.ts
+++ b/packages/insomnia/src/plugins/invoke-method.ts
@@ -6,6 +6,7 @@ import type {
   RunTemplateTagActionArgs,
 } from '~/common/plugins/bridge-types';
 import type { Plugin } from '~/common/plugins/types';
+import { fetchFromTemplateWorkerDatabase } from '~/common/templating/liquid-extension-worker';
 import { deserializeRenderContext } from '~/common/templating/render-context-serialization';
 
 import * as pluginApp from './context/app';
@@ -193,16 +194,33 @@ export async function invokePluginMethod(method: PluginInvokeMethod, args?: unkn
       const { renderedRequest, projectId, environment } = args as ApplyRequestHooksArgs;
       const newRenderedRequest = { ...renderedRequest };
       const renderedContext = deserializeRenderContext(environment);
+      // H1: with the sandbox on, a user plugin's hook (a throw-stub here after discovery) runs in the
+      // main-process sandbox over the templating-worker-database protocol; bundle plugins and the
+      // flag-off path run in-process. Per-plugin counter recovers the hook's index within its array.
+      const settings = await fetchFromTemplateWorkerDatabase('settings.get', {});
+      const sandboxEnabled = !!settings?.templateTagSandboxEnabled;
+      const hookIndexByPlugin: Record<string, number> = {};
 
       for (const { plugin, hook } of await getRequestHooks()) {
-        const context = {
-          ...pluginApp.init(),
-          ...pluginData.init(projectId),
-          ...(pluginStore.init(plugin) as Record<string, any>),
-          ...(pluginRequest.init(newRenderedRequest as any, renderedContext) as Record<string, any>),
-          ...(pluginNetwork.init() as Record<string, any>),
-        };
+        const hookIndex = (hookIndexByPlugin[plugin.name] = (hookIndexByPlugin[plugin.name] ?? -1) + 1);
         try {
+          if (sandboxEnabled && plugin.directory !== '') {
+            const mutated = await fetchFromTemplateWorkerDatabase('plugin.runUserRequestHook', {
+              plugin: { directory: plugin.directory, name: plugin.name, permissions: plugin.permissions },
+              hookIndex,
+              renderedRequest: newRenderedRequest,
+              renderContext: renderedContext,
+            });
+            Object.assign(newRenderedRequest, mutated);
+            continue;
+          }
+          const context = {
+            ...pluginApp.init(),
+            ...pluginData.init(projectId),
+            ...(pluginStore.init(plugin) as Record<string, any>),
+            ...(pluginRequest.init(newRenderedRequest as any, renderedContext) as Record<string, any>),
+            ...(pluginNetwork.init() as Record<string, any>),
+          };
           await hook(context);
         } catch (err) {
           const error = err instanceof Error ? err : new Error(String(err));

--- a/packages/insomnia/src/plugins/invoke-method.ts
+++ b/packages/insomnia/src/plugins/invoke-method.ts
@@ -8,6 +8,7 @@ import type {
 import type { Plugin } from '~/common/plugins/types';
 import { fetchFromTemplateWorkerDatabase } from '~/common/templating/liquid-extension-worker';
 import { deserializeRenderContext } from '~/common/templating/render-context-serialization';
+import { mergeHookRequestMutation } from '~/templating/sandbox/marshal';
 
 import * as pluginApp from './context/app';
 import * as pluginData from './context/data';
@@ -211,7 +212,8 @@ export async function invokePluginMethod(method: PluginInvokeMethod, args?: unkn
               renderedRequest: newRenderedRequest,
               renderContext: renderedContext,
             });
-            Object.assign(newRenderedRequest, mutated);
+            // Only copies the allowlisted request fields a hook is permitted to touch.
+            mergeHookRequestMutation(newRenderedRequest, mutated);
             continue;
           }
           const context = {

--- a/packages/insomnia/src/runtimes/network/network-adapter.node.ts
+++ b/packages/insomnia/src/runtimes/network/network-adapter.node.ts
@@ -78,15 +78,31 @@ export async function applyRequestHooks(
 ): Promise<RenderedRequest> {
   const newRenderedRequest = applyDefaultHeaders(renderedRequest, renderedContext['DEFAULT_HEADERS']);
   const pluginIndex = await import('../../plugins/index');
+  const { services } = await import('insomnia-data');
+  // H1: with the sandbox on, a user plugin's hook runs in QuickJS (its `hook` here is a throw-stub
+  // from discovery); bundle plugins and the flag-off path run in-process as before.
+  const sandboxEnabled = (await services.settings.get()).templateTagSandboxEnabled;
+  // getRequestHooks flattens each plugin's requestHooks in order, so a per-plugin running counter
+  // recovers the hook's index within its own array (what the sandbox loads by).
+  const hookIndexByPlugin: Record<string, number> = {};
   for (const { plugin, hook } of await pluginIndex.getRequestHooks()) {
-    const context = {
-      ...(pluginApp.init() as Record<string, any>),
-      ...pluginData.init(renderedContext.getProjectId()),
-      ...(pluginStore.init(plugin) as Record<string, any>),
-      ...(pluginRequest.init(newRenderedRequest, renderedContext) as Record<string, any>),
-      ...(pluginNetwork.init() as Record<string, any>),
-    };
+    const hookIndex = (hookIndexByPlugin[plugin.name] = (hookIndexByPlugin[plugin.name] ?? -1) + 1);
     try {
+      if (sandboxEnabled && plugin.directory !== '') {
+        const { runRequestHookInSandbox } = await import('../../main/templating-worker-database');
+        // The hook mutates the request in the sandbox; merge the returned fields back so the next
+        // hook (and the send pipeline) sees the mutation, exactly like the in-place path below.
+        const mutated = await runRequestHookInSandbox(plugin, hookIndex, newRenderedRequest, renderedContext);
+        Object.assign(newRenderedRequest, mutated);
+        continue;
+      }
+      const context = {
+        ...(pluginApp.init() as Record<string, any>),
+        ...pluginData.init(renderedContext.getProjectId()),
+        ...(pluginStore.init(plugin) as Record<string, any>),
+        ...(pluginRequest.init(newRenderedRequest, renderedContext) as Record<string, any>),
+        ...(pluginNetwork.init() as Record<string, any>),
+      };
       await hook(context);
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));

--- a/packages/insomnia/src/runtimes/network/network-adapter.node.ts
+++ b/packages/insomnia/src/runtimes/network/network-adapter.node.ts
@@ -94,10 +94,12 @@ export async function applyRequestHooks(
     try {
       if (sandboxEnabled && plugin.directory !== '') {
         const { runRequestHookInSandbox } = await import('../../main/templating-worker-database');
+        const { mergeHookRequestMutation } = await import('../../templating/sandbox/marshal');
         // The hook mutates the request in the sandbox; merge the returned fields back so the next
         // hook (and the send pipeline) sees the mutation, exactly like the in-place path below.
+        // Only copies the allowlisted request fields a hook is permitted to touch.
         const mutated = await runRequestHookInSandbox(plugin, hookIndex, newRenderedRequest, renderedContext);
-        Object.assign(newRenderedRequest, mutated);
+        mergeHookRequestMutation(newRenderedRequest, mutated);
         continue;
       }
       const context = {

--- a/packages/insomnia/src/runtimes/network/network-adapter.node.ts
+++ b/packages/insomnia/src/runtimes/network/network-adapter.node.ts
@@ -81,7 +81,11 @@ export async function applyRequestHooks(
   const { services } = await import('insomnia-data');
   // H1: with the sandbox on, a user plugin's hook runs in QuickJS (its `hook` here is a throw-stub
   // from discovery); bundle plugins and the flag-off path run in-process as before.
-  const sandboxEnabled = (await services.settings.get()).templateTagSandboxEnabled;
+  // The sandbox host (templating-worker-database) statically imports `electron`, so it can only be
+  // reached from an Electron process. This node runtime also backs the pure-Node inso CLI, which has
+  // no `electron` — there the sandbox is unavailable, so hooks run in-process as they always have.
+  const canSandbox = !!process.type;
+  const sandboxEnabled = canSandbox && (await services.settings.get()).templateTagSandboxEnabled;
   // getRequestHooks flattens each plugin's requestHooks in order, so a per-plugin running counter
   // recovers the hook's index within its own array (what the sandbox loads by).
   const hookIndexByPlugin: Record<string, number> = {};

--- a/packages/insomnia/src/templating/sandbox/H1-FOLLOWUP-PERMISSIONS-TRUST-SECURITY-REVIEW.md
+++ b/packages/insomnia/src/templating/sandbox/H1-FOLLOWUP-PERMISSIONS-TRUST-SECURITY-REVIEW.md
@@ -1,0 +1,164 @@
+# Security review — PR #10290 (H1, "route user-plugin request hooks through the sandbox (PR 10a) — sec request hooks review")
+
+## Context
+
+This PR (branch `review/pr10-hooks-security-fixes`) adds the templating-db protocol auth token
+(F1), server-side `directory` resolution (F2'), and symmetric `stripDangerousKeysReviver` coverage
+(F3) — closing the three findings recorded in
+[H1-HOOK-CONTROL-BYPASS-REMEDIATION-PLAN.md](H1-HOOK-CONTROL-BYPASS-REMEDIATION-PLAN.md). This
+review was scoped specifically to the authorization token added for `insomnia-templating-worker-
+database://` IPC/protocol dispatch: (1) whether the token check itself can be circumvented, (2)
+whether any existing caller doesn't correctly participate in it (breakage), and (3) if a gap is
+found, why the branch's own dynamic tests didn't catch it.
+
+Checked against the migration plan gist (fetched fresh this run): this PR is Phase 2, ticket H1,
+depending on L1 (PR 9, landed) and preceding A1 (PR 11, actions-via-bridge — not yet landed). C1
+(bridge capability gating), C2 (capability-aware context), and C3 (manifest schema/loader) — the
+Phase 1 tickets that make `insomnia.permissions` a live enforcement boundary — are confirmed landed
+in the current source (`host-bridge.ts`'s `BRIDGE_PATH_CAPABILITIES`/`filterByCapabilities`,
+`in-sandbox-bootstrap.ts`'s per-capability context deletion, `common/plugins/permissions.ts`'s
+`parsePluginPermissions`), per `SANDBOX-CAPABILITY-AUDIT-PLAN.md`'s own correction note.
+
+## Verdict on the token mechanism itself
+
+**No circumvention found.** `getOrCreateTemplatingDbAuthToken()`/`isValidTemplatingDbAuthToken()`
+(`templating-worker-database-auth.ts`) is a per-process random 32-byte secret, compared with
+`crypto.timingSafeEqual` after a length pre-check (standard, non-exploitable pattern — the length
+pre-check can't be used to learn anything about the fixed-length real token). It is handed out only
+over IPC channels that check `event.sender` against `getMainWindow()?.webContents` or
+`getPluginWindow()?.webContents` (`ipc/templating-db-auth.ts`), mirroring the existing
+`plugin-window.ts` sender-check pattern. The protocol scheme is registered app-wide-privileged
+(`secure/standard/supportFetchAPI`, no `corsEnabled`) so it's reachable by any renderer/webview in
+the session — but reachability without the token now yields 401 before any handler runs, closing
+the original F1 gap. Every entry point that legitimately needs the token (main window, plugin
+window, and the templating Web Worker, which cannot reach `window.main` itself) fetches or forwards
+it before making any protocol call; ordering is safe because each fetch happens via a blocking
+top-level `await` in that realm's entry module before other code in that realm runs.
+
+Traced and ruled out: header-casing bypass (the Fetch `Headers` API is case-insensitive by spec),
+a `resolveDbByKey` caller that skips the check (single choke point — `protocol.handle` registers
+only this one function; grepped for all other `insomnia-templating-worker-database://` references,
+found none outside this file and the trusted callers), a startup race where a legitimate call fires
+before the token is set (fails closed — `fetchFromTemplateWorkerDatabase` omits the header entirely
+if the token isn't set yet, which the server-side check rejects, rather than silently succeeding
+unauthenticated), and the CLI/node-runtime path (`network-adapter.node.ts` calls
+`runRequestHookInSandbox` as a direct function call, never through the protocol, so it has nothing
+to authenticate and isn't affected by or a bypass of this control).
+
+## Existing capabilities / callers: none found broken
+
+Every caller of `fetchFromTemplateWorkerDatabase` was enumerated (`liquid-extension-worker.ts`,
+`invoke-method.ts`, `plugins/index.ts`, `ui/templating/worker.ts`) and each runs in a JS realm that
+now calls `setTemplatingDbAuthToken` before making a protocol call. The one pre-existing unit test
+that called `resolveDbByKey` directly without a token (`templating-worker-database.test.ts`'s
+`app.prompt` case) was already fixed in this branch (c28382d81). Re-ran the full local suite
+(`templating/sandbox`, `plugin-window-ipc-authorization`, `templating-worker-database*`): 186/186
+passing, no regressions.
+
+## Finding 1 — Caller-supplied `permissions` bypasses the trusted registry, unlike `directory` (Low/Medium)
+
+**Files:** `packages/insomnia/src/main/templating-worker-database.ts:738-763` (the
+`plugin.discoverUserPluginExports` / `plugin.runUserRequestHook` entries in `pluginToMainAPI`).
+
+**Verified:** yes — reproduced with a passing regression test (see below), not just read.
+
+F2' fixed exactly one of the two trust-relevant fields these handlers take from the request body:
+`directory` is now resolved server-side by `resolveTrustedPluginDirectory(name)` against the
+registry (`getPlugins()`). `permissions` is not — it's still read straight off the body
+(`body.permissions` / `body.plugin.permissions`) and passed to
+`resolveTemplateTagModules`/`resolveTemplateTagCapabilities` unchanged. Since C1/C2/C3 are landed,
+`insomnia.permissions` is a live enforcement boundary today (not the "already-planned, not yet a
+real control" state the remediation plan's own scoping note assumed when it explicitly excluded the
+"capability half" from F2's fix) — so this is the same class of bug F2' patched for `directory`,
+just left half-done.
+
+**Reproduced:** a plugin registered with `permissions: {}` (no capabilities, per `getPlugins()`,
+the trusted registry) has a request hook that reports whether `context.network` was granted
+(deleted from context unless the `network` capability is present — `in-sandbox-bootstrap.ts`'s
+`__hasCap`). Calling `plugin.runUserRequestHook` over the (now correctly authenticated) protocol
+with a forged `plugin.permissions.capabilities: ['network']` in the body causes the hook to observe
+`context.network` as granted, contradicting the registry's own record for that plugin.
+
+**Consequence:** any caller that can reach the protocol with a valid token (the trusted main/plugin
+window realm itself, or, per the plan's own execution-surface table, a **user plugin's action** —
+still un-sandboxed/full-Node until A1 lands) can force a *different*, already-installed plugin's
+hook to run with elevated capabilities beyond what that plugin's own manifest declares — up to the
+`TEMPLATE_TAG_PROFILE` ceiling (`network`/`storage`/`fs-read`/`app`, every registry module; `render`
+capability set-relevant, `credentials` excluded). This is not a sandbox escape (the profile ceiling
+still caps it, so it grants nothing a plugin couldn't already grant *itself* by declaring it), but
+it is a real violation of manifest integrity/least-privilege for the *targeted* plugin, and — same
+as F2' — the exact bug class this branch was in the middle of closing.
+
+**Fix:** mirror F2' — in `resolveTrustedPluginDirectory` (or a sibling helper), also return the
+resolved plugin's own `permissions` from the registry, and use that instead of trusting
+`body.permissions`/`body.plugin.permissions` in both handlers.
+
+**Test:**
+`packages/insomnia/src/main/__tests__/templating-worker-database-protocol-authorization.test.ts`,
+describe block `protocol-dispatch handlers trust caller-supplied 'permissions', not the registry
+(residual gap from F2')` — two cases: a baseline call (no forged permissions) correctly gets no
+`network` capability per the registry, and a forged-permissions call gets it anyway. Both pass
+today (the second passing is the bug — it documents current, not desired, behavior; flipping the
+handler to consult the registry should turn it into a real regression guard).
+
+## Why the branch's own dynamic tests didn't catch this
+
+The new `templating-worker-database-protocol-authorization.test.ts` iterates the live
+`pluginToMainAPI` map for the *token* axis (every path/token combination) and has two focused
+`directory`-forgery regression cases for F2' — but no equivalent case for the `permissions` field.
+The H1 remediation plan's own scoping note is the direct cause: it explicitly filed
+`body.plugin.permissions` as "the gist's already-planned manifest work — excluded," so nobody wrote
+a permissions-forgery test alongside the directory one. That exclusion was accurate at the time the
+*original* sandbox plan was written (capability grants were aspirational), but by the time this PR
+landed, C1/C2/C3 had already shipped and made `permissions` a real, load-bearing control — the
+scoping note wasn't updated to reflect that, and the test suite inherited the stale premise. This is
+the same failure mode `SANDBOX-CAPABILITY-AUDIT-PLAN.md` already flagged once (a prior-art doc's
+"deferred" framing going stale as later PRs landed) — recorded here as a second instance so a future
+reviewer knows to double check plan-scoping notes for a PR against current `develop`, not just
+against the plan doc's original framing.
+
+## Excluded from this review
+
+- **Plugin actions still executing un-sandboxed/full-Node for user plugins** — explicitly ticket A1
+  (PR 11), not yet landed; the plan's own execution-surface table already tracks this as the
+  mechanism by which Finding 1 above would be reached by genuinely untrusted code today. Not
+  reported as a new gap of this PR.
+- **`services.invoke` generic RPC gateway / cross-tenant DB access findings** — already recorded in
+  `CROSS-TENANT-DB-ACCESS-FINDINGS.md`; unrelated to the auth-token mechanism this review targeted.
+- **Bridge-dispatch prototype-object smell (`handlers[path]` against a plain object)** — already
+  recorded as F3 in `M2-STDLIB-SECURITY-REVIEW.md`; `resolveDbByKey`'s own lookup already has the
+  own-property guard this PR added (`Object.prototype.hasOwnProperty.call(withLowercasedKeys, ...)`
+  at `templating-worker-database.ts:52`), so that specific instance is resolved, but the general
+  finding in the other file stands as previously recorded, not re-reported here.
+
+## Hypotheses chased down and ruled out
+
+- Header-name casing used to smuggle a missing/forged token past the check — ruled out, Fetch
+  `Headers` are case-insensitive.
+- A second, unauthenticated call site to `resolveDbByKey`/the protocol scheme — ruled out by
+  grep; `protocol.handle(templatingWorkerDatabaseInterface, resolveDbByKey)` is the only
+  registration, and `fetchFromTemplateWorkerDatabase` is the only caller of the scheme in source.
+  distinguish it from the two build artifacts `entry.main.min.js`/`entry.plugin-window.min.js`
+  found by the same grep — pre-existing generated bundles, not source, and not part of this diff.
+- Startup race where a real caller fires before `setTemplatingDbAuthToken` runs — ruled out; each
+  entry module's fetch/forward is a blocking step before any other code in that realm runs, and a
+  missing token fails closed (401) rather than silently succeeding.
+- `getPluginWindow()`/`getMainWindow()` sender check racing against window (re)creation — ruled out
+  by reading `createPluginWindow()`: `pluginWindow` is assigned synchronously before `loadFile`, so
+  by the time the loaded page's JS runs and requests the token, the module-level reference already
+  points at it.
+- Plugin-related IPC channels registered outside `plugin-window.ts` that the static
+  "no bare `ipcMain` call" guardrail (scoped to that one file) wouldn't catch — found two
+  (`createPlugin`, `installPlugin` in `main/ipc/main.ts`) but they're pre-existing, unrelated to the
+  `plugins.*`/hook-dispatch surface this PR's guardrail is about, and out of scope for this review.
+
+## Verification
+
+```
+npm test -w packages/insomnia -- templating-worker-database-protocol-authorization
+npm test -w packages/insomnia -- templating/sandbox plugin-window-ipc-authorization templating-worker-database
+npx eslint packages/insomnia/src/main/__tests__/templating-worker-database-protocol-authorization.test.ts
+npx tsc --noEmit
+```
+
+All green as of this review (186/186 tests across the touched suites; lint and typecheck clean).

--- a/packages/insomnia/src/templating/sandbox/__snapshots__/sandbox-surface.test.ts.snap
+++ b/packages/insomnia/src/templating/sandbox/__snapshots__/sandbox-surface.test.ts.snap
@@ -267,6 +267,8 @@ exports[`sandbox surface > matches surface snapshot 1`] = `
   "globalThis.__describeExports.prototype: object",
   "globalThis.__invoke: function(0)",
   "globalThis.__invoke.prototype: object",
+  "globalThis.__invokeHook: function(0)",
+  "globalThis.__invokeHook.prototype: object",
   "globalThis.__loadPluginEntry: function(0)",
   "globalThis.__loadPluginEntry.prototype: object",
   "globalThis.__require: function(1)",

--- a/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
+++ b/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
@@ -324,6 +324,125 @@ export const IN_SANDBOX_BOOTSTRAP = [
   '    return ctx;',
   '  };',
 
+  // --- request-hook API rebuilt in-sandbox over the copied-in renderedRequest (`req`) ---
+  // Mirrors packages/insomnia/src/plugins/context/request.ts. Getters always present; mutators
+  // present only when !readOnly (matching request.ts's delete list, lines 221-258). Header matching
+  // is CASE-INSENSITIVE (misc.filterHeaders, misc.ts:21); parameter matching is CASE-SENSITIVE
+  // (filterParameters, request.ts:11). No host/bridge calls: every method is a sync read/write on req.
+  '  function __buildRequestApi(req, readOnly) {',
+  '    if (!req) { throw new Error("contexts.request initialized without request"); }',
+  '    if (!(req.headers instanceof Array)) { req.headers = []; }',
+  '    if (!(req.parameters instanceof Array)) { req.parameters = []; }',
+  '    if (!(req.cookies instanceof Array)) { req.cookies = []; }',
+  '    if (!req.authentication || typeof req.authentication !== "object") { req.authentication = {}; }',
+  '    if (!req.body || typeof req.body !== "object") { req.body = {}; }',
+  '    function __filterHeaders(name) {',
+  '      if (!(req.headers instanceof Array) || !name || typeof name !== "string") { return []; }',
+  '      var out = [];',
+  '      for (var i = 0; i < req.headers.length; i++) {',
+  '        var h = req.headers[i];',
+  '        if (!h || !h.name || typeof h.name !== "string") { continue; }',
+  '        if (h.name.toLowerCase() === name.toLowerCase()) { out.push(h); }',
+  '      }',
+  '      return out;',
+  '    }',
+  '    function __filterParameters(name) {',
+  '      if (!(req.parameters instanceof Array) || !name) { return []; }',
+  '      var out = [];',
+  '      for (var i = 0; i < req.parameters.length; i++) {',
+  '        var p = req.parameters[i];',
+  '        if (!p || !p.name) { continue; }',
+  '        if (p.name === name) { out.push(p); }',
+  '      }',
+  '      return out;',
+  '    }',
+  '    var api = {',
+  '      getId: function () { return req._id; },',
+  '      getName: function () { return req.name; },',
+  '      getUrl: function () { return req.url; },',
+  '      getMethod: function () { return req.method; },',
+  '      setMethod: function (method) { req.method = method; },',
+  '      setUrl: function (url) { req.url = url; },',
+  '      setCookie: function (name, value) {',
+  '        var cookie = null;',
+  '        for (var i = 0; i < req.cookies.length; i++) { if (req.cookies[i] && req.cookies[i].name === name) { cookie = req.cookies[i]; break; } }',
+  '        if (cookie) { cookie.value = value; } else { req.cookies.push({ name: name, value: value }); }',
+  '      },',
+  '      getEnvironmentVariable: function (name) { return __env.context[name]; },',
+  '      getEnvironment: function () { return __env.context; },',
+  '      settingSendCookies: function (enabled) { req.settingSendCookies = enabled; },',
+  '      settingStoreCookies: function (enabled) { req.settingStoreCookies = enabled; },',
+  '      settingEncodeUrl: function (enabled) { req.settingEncodeUrl = enabled; },',
+  '      settingDisableRenderRequestBody: function (enabled) { req.settingDisableRenderRequestBody = enabled; },',
+  '      settingFollowRedirects: function (enabled) { req.settingFollowRedirects = enabled; },',
+  '      getHeader: function (name) {',
+  '        var headers = __filterHeaders(name);',
+  '        if (headers.length) { var header = headers[headers.length - 1]; return header.value || ""; }',
+  '        return null;',
+  '      },',
+  '      getHeaders: function () {',
+  '        var out = [];',
+  '        for (var i = 0; i < req.headers.length; i++) { out.push({ name: req.headers[i].name, value: req.headers[i].value }); }',
+  '        return out;',
+  '      },',
+  '      hasHeader: function (name) { return this.getHeader(name) !== null; },',
+  '      removeHeader: function (name) {',
+  '        var headers = __filterHeaders(name);',
+  '        var out = [];',
+  '        for (var i = 0; i < req.headers.length; i++) { if (__arrIndexOf(headers, req.headers[i]) === -1) { out.push(req.headers[i]); } }',
+  '        req.headers = out;',
+  '      },',
+  '      setHeader: function (name, value) {',
+  '        var header = __filterHeaders(name)[0];',
+  '        if (header) { header.value = value; } else { this.addHeader(name, value); }',
+  '      },',
+  '      addHeader: function (name, value) {',
+  '        var header = __filterHeaders(name)[0];',
+  '        if (!header) { req.headers.push({ name: name, value: value }); }',
+  '      },',
+  '      getParameter: function (name) {',
+  '        var parameters = __filterParameters(name);',
+  '        if (parameters.length) { var parameter = parameters[parameters.length - 1]; return parameter.value || ""; }',
+  '        return null;',
+  '      },',
+  '      getParameters: function () {',
+  '        var out = [];',
+  '        for (var i = 0; i < req.parameters.length; i++) { out.push({ name: req.parameters[i].name, value: req.parameters[i].value }); }',
+  '        return out;',
+  '      },',
+  '      hasParameter: function (name) { return this.getParameter(name) !== null; },',
+  '      removeParameter: function (name) {',
+  '        var parameters = __filterParameters(name);',
+  '        var out = [];',
+  '        for (var i = 0; i < req.parameters.length; i++) { if (__arrIndexOf(parameters, req.parameters[i]) === -1) { out.push(req.parameters[i]); } }',
+  '        req.parameters = out;',
+  '      },',
+  '      setParameter: function (name, value) {',
+  '        var parameter = __filterParameters(name)[0];',
+  '        if (parameter) { parameter.value = value; } else { this.addParameter(name, value); }',
+  '      },',
+  '      addParameter: function (name, value) {',
+  '        var parameter = __filterParameters(name)[0];',
+  '        if (!parameter) { req.parameters.push({ name: name, value: value }); }',
+  '      },',
+  '      setAuthenticationParameter: function (name, value) { req.authentication[name] = value; },',
+  '      getAuthentication: function () { return req.authentication; },',
+  '      getBody: function () { return req.body; },',
+  '      setBody: function (body) { req.body = body; },',
+  '      getBodyText: function () { console.warn("request.getBodyText() is deprecated. Use request.getBody() instead."); return req.body.text || ""; },',
+  '      setBodyText: function (text) { console.warn("request.setBodyText() is deprecated. Use request.setBody() instead."); req.body.text = text; }',
+  '    };',
+  '    if (readOnly) {',
+  '      delete api.setUrl; delete api.setMethod; delete api.setBodyText; delete api.setCookie;',
+  '      delete api.settingSendCookies; delete api.settingStoreCookies; delete api.settingEncodeUrl;',
+  '      delete api.settingDisableRenderRequestBody; delete api.settingFollowRedirects;',
+  '      delete api.removeHeader; delete api.setHeader; delete api.addHeader;',
+  '      delete api.removeParameter; delete api.setParameter; delete api.addParameter;',
+  '      delete api.setAuthenticationParameter; delete api.setBody;',
+  '    }',
+  '    return api;',
+  '  }',
+
   // --- load the plugin (its entry module, resolving any relative requires) and run the tag ---
   '  globalThis.__invoke = function () {',
   '    var env = __env;',
@@ -335,6 +454,24 @@ export const IN_SANDBOX_BOOTSTRAP = [
   '    if (!tag) { throw new Error("Template tag \'" + __tag + "\' not found in plugin module"); }',
   '    var args = [ctx].concat(env.args || []);',
   '    return Promise.resolve(tag.run.apply(null, args)).then(function (r) { return r == null ? "" : String(r); });',
+  '  };',
+
+  // --- run a request/response hook (H1) and marshal the mutated request/response back out ---
+  // The hook mutates context.request (and context.response) in place, exactly like the in-process
+  // path; we rebuild those APIs over the copied-in envelope data and JSON-return the mutated data so
+  // the host can merge it. The side-effecting surfaces (app/store/network/util) come from
+  // __buildContext and stay capability-gated.
+  '  globalThis.__invokeHook = function () {',
+  '    var env = __env;',
+  '    var ctx = globalThis.__buildContext(env);',
+  '    var mod = globalThis.__loadPluginEntry();',
+  '    var isResponse = env.hookKind === "response";',
+  '    var hooks = (isResponse ? (mod && mod.responseHooks) : (mod && mod.requestHooks)) || [];',
+  '    var hook = hooks[env.hookIndex];',
+  '    if (typeof hook !== "function") { throw new Error("Plugin " + (isResponse ? "response" : "request") + " hook not found at index " + env.hookIndex); }',
+  // Response hooks get a read-only request view (matches pluginRequest.init(..., true)).
+  '    ctx.request = __buildRequestApi(env.hookRequest || {}, isResponse);',
+  '    return Promise.resolve(hook(ctx)).then(function () { return JSON.stringify({ request: env.hookRequest }); });',
   '  };',
 
   // --- describe the plugin's exports without running any of them (L1 load-time discovery) ---
@@ -373,7 +510,7 @@ export const IN_SANDBOX_BOOTSTRAP = [
   // context/invocation entry points. __registerModule is intentionally left mutable — the module
   // registry source deletes it once the registry is populated.
   '  var __lock = function (n) { Object.defineProperty(globalThis, n, { value: globalThis[n], writable: false, configurable: false }); };',
-  '  __lock("__require"); __lock("__buildContext"); __lock("__invoke"); __lock("__loadPluginEntry"); __lock("__describeExports");',
+  '  __lock("__require"); __lock("__buildContext"); __lock("__invoke"); __lock("__loadPluginEntry"); __lock("__describeExports"); __lock("__invokeHook");',
   '})();',
 ].join('\n');
 
@@ -385,3 +522,9 @@ export const RUNNER = 'globalThis.__task = globalThis.__invoke();';
  * Used at plugin load instead of {@link RUNNER} to enumerate exports without invoking any of them.
  */
 export const DESCRIBE_RUNNER = 'globalThis.__task = Promise.resolve(globalThis.__describeExports());';
+
+/**
+ * Hook runner (H1): parks a resolved promise of the mutated request/response (JSON string) on
+ * `globalThis.__task`. Used instead of {@link RUNNER} to run a request/response hook.
+ */
+export const HOOK_RUNNER = 'globalThis.__task = globalThis.__invokeHook();';

--- a/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
+++ b/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
@@ -470,7 +470,9 @@ export const IN_SANDBOX_BOOTSTRAP = [
   '    var hook = hooks[env.hookIndex];',
   '    if (typeof hook !== "function") { throw new Error("Plugin " + (isResponse ? "response" : "request") + " hook not found at index " + env.hookIndex); }',
   // Response hooks get a read-only request view (matches pluginRequest.init(..., true)).
-  '    ctx.request = __buildRequestApi(env.hookRequest || {}, isResponse);',
+  // Pass hookRequest through directly (no `|| {}`): __buildRequestApi throws on a missing request,
+  // matching the in-process pluginRequest.init(), and keeps the marshaled-back object === the mutated one.
+  '    ctx.request = __buildRequestApi(env.hookRequest, isResponse);',
   '    return Promise.resolve(hook(ctx)).then(function () { return JSON.stringify({ request: env.hookRequest }); });',
   '  };',
 

--- a/packages/insomnia/src/templating/sandbox/marshal.test.ts
+++ b/packages/insomnia/src/templating/sandbox/marshal.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import { type HostBridge } from './host-bridge';
+import { type ContextEnvelope, HOOK_REQUEST_FIELDS, type HookResult, mergeHookRequestMutation, stripDangerousKeysReviver } from './marshal';
+import { runTagInSandbox } from './plugin-tag-sandbox';
+
+// Tests that a request hook can't plant an own `__proto__`/`constructor`/`prototype` key on
+// nested request data. `DANGEROUS_KEY_SCENARIOS` covers where a hook can plant such a key, and
+// `findDangerousOwnKeyPaths` searches the entire result for survivors, so a new scenario is one
+// array entry rather than a bespoke assertion.
+
+const noBridge: HostBridge = async path => {
+  throw new Error(`unexpected bridge call: ${path}`);
+};
+
+const DANGEROUS_KEYS = ['__proto__', 'constructor', 'prototype'];
+
+/** Recursively lists every "$.path.to.key" where an *own* dangerous key was found. */
+function findDangerousOwnKeyPaths(value: unknown, path = '$', seen = new Set<unknown>()): string[] {
+  if (value === null || typeof value !== 'object') {
+    return [];
+  }
+  if (seen.has(value)) {
+    return [];
+  }
+  seen.add(value);
+
+  const found: string[] = [];
+  for (const key of Object.getOwnPropertyNames(value)) {
+    const childPath = `${path}.${key}`;
+    if (DANGEROUS_KEYS.includes(key)) {
+      found.push(childPath);
+    }
+    found.push(...findDangerousOwnKeyPaths((value as Record<string, unknown>)[key], childPath, seen));
+  }
+  return found;
+}
+
+const runRequestHookRaw = async (
+  hookSource: string,
+  request: Record<string, unknown>,
+): Promise<string> => {
+  const envelope: ContextEnvelope = {
+    args: [],
+    context: {},
+    meta: {},
+    renderPurpose: 'send',
+    appInfo: { version: '0.0.0', platform: 'linux', arch: 'x64' },
+    pluginName: 'test-plugin',
+    renderDepth: 0,
+    grantedModules: [],
+    grantedCapabilities: [],
+    moduleFiles: { 'index.js': `module.exports.requestHooks = [${hookSource}];` },
+    entryModuleKey: 'index.js',
+    hookKind: 'request',
+    hookIndex: 0,
+    hookRequest: request,
+  };
+  return runTagInSandbox({ tagName: '', envelope, bridge: noBridge });
+};
+
+describe('stripDangerousKeysReviver + mergeHookRequestMutation (defense-in-depth on the hook marshal boundary)', () => {
+  const DANGEROUS_KEY_SCENARIOS = DANGEROUS_KEYS.flatMap(key => [
+    {
+      name: `${key} nested inside a hook-supplied body`,
+      hookSource: `function (context) {
+        context.request.setBody(JSON.parse('{"${key}":{"polluted":true},"text":"hi"}'));
+      }`,
+      request: { body: {} },
+    },
+    {
+      name: `${key} nested inside a hook-supplied authentication value`,
+      hookSource: `function (context) {
+        context.request.setAuthenticationParameter('token', JSON.parse('{"${key}":{"polluted":true}}'));
+      }`,
+      request: { authentication: {} },
+    },
+    {
+      name: `${key} nested two levels deep inside a hook-supplied body`,
+      hookSource: `function (context) {
+        context.request.setBody(JSON.parse('{"nested":{"deeper":{"${key}":{"polluted":true}}}}'));
+      }`,
+      request: { body: {} },
+    },
+  ]);
+
+  // Confirms the naive parse is actually vulnerable, then that the reviver and allowlisted merge both end up clean.
+  it.each(DANGEROUS_KEY_SCENARIOS)('$name: does not survive the fixed parse into the merged request', async ({ hookSource, request }) => {
+    const json = await runRequestHookRaw(hookSource, request);
+
+    const naive = JSON.parse(json) as HookResult;
+    expect(findDangerousOwnKeyPaths(naive.request)).not.toEqual([]);
+
+    const sanitized = JSON.parse(json, stripDangerousKeysReviver) as HookResult;
+    expect(findDangerousOwnKeyPaths(sanitized.request)).toEqual([]);
+
+    const target: Record<string, unknown> = { _id: 'req_1' };
+    mergeHookRequestMutation(target, sanitized.request ?? {});
+    expect(findDangerousOwnKeyPaths(target)).toEqual([]);
+  });
+
+  // Parsed from JSON, so the computed-key "__proto__" here is a genuine own property, not the object-literal prototype setter.
+  it('mergeHookRequestMutation only ever copies fields from the HOOK_REQUEST_FIELDS allowlist', () => {
+    const target: Record<string, unknown> = {};
+    const mutated = JSON.parse(
+      '{"url":"https://rewritten.example","unexpectedNewField":"should not appear","__proto__":{"polluted":true}}',
+    ) as Record<string, unknown>;
+
+    mergeHookRequestMutation(target, mutated);
+
+    expect(target.url).toBe('https://rewritten.example');
+    expect(target).not.toHaveProperty('unexpectedNewField');
+    expect(Object.getOwnPropertyNames(target)).not.toContain('__proto__');
+    expect(Object.getOwnPropertyNames(target).every(key => (HOOK_REQUEST_FIELDS as readonly string[]).includes(key))).toBe(true);
+  });
+});

--- a/packages/insomnia/src/templating/sandbox/marshal.ts
+++ b/packages/insomnia/src/templating/sandbox/marshal.ts
@@ -65,6 +65,44 @@ export interface HookResult {
   response?: Record<string, unknown>;
 }
 
+// The serializable RenderedRequest fields a request hook may read or mutate, marshaled into and
+// out of the sandbox. Shared by the main-process and plugin-window merge call sites so both
+// enforce the same allowlist instead of duplicating it.
+export const HOOK_REQUEST_FIELDS = [
+  '_id',
+  'name',
+  'url',
+  'method',
+  'headers',
+  'parameters',
+  'authentication',
+  'body',
+  'cookies',
+  'settingSendCookies',
+  'settingStoreCookies',
+  'settingEncodeUrl',
+  'settingDisableRenderRequestBody',
+  'settingFollowRedirects',
+] as const;
+
+// A hook can plant one of these as an own key on a nested value via computed-key JSON
+// construction (e.g. `JSON.parse('{"__proto__":{...}}')`), which survives a plain `JSON.parse`
+// as a real own property. `stripDangerousKeysReviver` drops any of them at any depth.
+const DANGEROUS_JSON_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/** `JSON.parse` reviver that drops `__proto__`/`constructor`/`prototype` own-keys at any depth. */
+export const stripDangerousKeysReviver = (key: string, value: unknown): unknown =>
+  DANGEROUS_JSON_KEYS.has(key) ? undefined : value;
+
+/** Merges a hook's mutated request fields back onto the live request, one allowlisted field at a time. */
+export const mergeHookRequestMutation = (target: Record<string, any>, mutated: Record<string, any>): void => {
+  for (const key of HOOK_REQUEST_FIELDS) {
+    if (Object.prototype.hasOwnProperty.call(mutated, key)) {
+      target[key] = mutated[key];
+    }
+  }
+};
+
 /** A discovered template-tag's serializable metadata (no `run`, no other function members). */
 export interface TemplateTagDescriptor {
   name?: string;

--- a/packages/insomnia/src/templating/sandbox/marshal.ts
+++ b/packages/insomnia/src/templating/sandbox/marshal.ts
@@ -43,6 +43,26 @@ export interface ContextEnvelope {
   moduleFiles?: Record<string, string>;
   /** Key into `moduleFiles` for the plugin's entry module (from package.json `main`). */
   entryModuleKey?: string;
+  /**
+   * Request/response hook invocation (H1). When set, the sandbox runs the plugin's hook at
+   * `hookIndex` in `requestHooks`/`responseHooks` (per `hookKind`) instead of a template tag,
+   * rebuilding `context.request` (and `context.response`) over the copied-in `hookRequest`/
+   * `hookResponse` data. The hook mutates that data in place; the sandbox marshals the mutated
+   * object back out (see `HookResult`) and the host merges it onto the request/response it returns.
+   */
+  hookKind?: 'request' | 'response';
+  /** Index of the hook within the plugin's `requestHooks`/`responseHooks` array. */
+  hookIndex?: number;
+  /** The `RenderedRequest` fields a hook may read/mutate (headers/url/method/params/auth/body/settings). */
+  hookRequest?: Record<string, unknown>;
+  /** The response patch a response hook may read (getters only; `setBody` bridges to the host). */
+  hookResponse?: Record<string, unknown>;
+}
+
+/** What a hook invocation marshals back out of the sandbox: the mutated request/response data. */
+export interface HookResult {
+  request?: Record<string, unknown>;
+  response?: Record<string, unknown>;
 }
 
 /** A discovered template-tag's serializable metadata (no `run`, no other function members). */

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
@@ -1,7 +1,7 @@
 import type { QuickJSContext, QuickJSHandle } from 'quickjs-emscripten';
 
 import type { HostBridge } from './host-bridge';
-import { DESCRIBE_RUNNER, IN_SANDBOX_BOOTSTRAP, RUNNER } from './in-sandbox-bootstrap';
+import { DESCRIBE_RUNNER, HOOK_RUNNER, IN_SANDBOX_BOOTSTRAP, RUNNER } from './in-sandbox-bootstrap';
 import { type ContextEnvelope, encodeBridgeFailure, encodeBridgeSuccess } from './marshal';
 import { buildModuleRegistrySource } from './module-registry';
 import { SANDBOX_GLOBALS_SOURCE } from './sandbox-globals';
@@ -96,8 +96,9 @@ export const runTagInSandbox = async (opts: RunTagInSandboxOptions): Promise<str
     // Only register heavy vendored libs the plugin was granted, so unrelated renders don't parse them.
     evalOrThrow(ctx, buildModuleRegistrySource(fullEnvelope.grantedModules), '<sandbox-modules>');
     // Plugin source travels as envelope DATA (moduleFiles) and is compiled by the in-sandbox loader
-    // when __invoke()/__describeExports() loads the entry — no host-side eval of plugin code.
-    evalOrThrow(ctx, discover ? DESCRIBE_RUNNER : RUNNER, '<runner>');
+    // when __invoke()/__describeExports()/__invokeHook() loads the entry — no host-side eval.
+    const runner = envelope.hookKind ? HOOK_RUNNER : discover ? DESCRIBE_RUNNER : RUNNER;
+    evalOrThrow(ctx, runner, '<runner>');
 
     return await drivePromiseToString(ctx, timeoutMs);
   } finally {

--- a/packages/insomnia/src/templating/sandbox/sandbox-hooks.test.ts
+++ b/packages/insomnia/src/templating/sandbox/sandbox-hooks.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import { type HostBridge } from './host-bridge';
+import { type ContextEnvelope, type HookResult } from './marshal';
+import { runTagInSandbox } from './plugin-tag-sandbox';
+
+// H1: request/response hooks run inside the sandbox. The hook mutates context.request in place; the
+// sandbox marshals the mutated request back out as JSON so the host can merge it. These tests drive
+// the hook path directly with a hand-built envelope.
+
+const noBridge: HostBridge = async path => {
+  throw new Error(`unexpected bridge call: ${path}`);
+};
+
+const runRequestHook = async (
+  hookSource: string,
+  request: Record<string, unknown>,
+  grantedCapabilities: string[] = [],
+): Promise<Record<string, unknown>> => {
+  const envelope: ContextEnvelope = {
+    args: [],
+    context: { BASE_URL: 'https://env.example' },
+    meta: {},
+    renderPurpose: 'send',
+    appInfo: { version: '0.0.0', platform: 'linux', arch: 'x64' },
+    pluginName: 'test-plugin',
+    renderDepth: 0,
+    grantedModules: ['path', 'crypto'],
+    grantedCapabilities,
+    moduleFiles: { 'index.js': `module.exports.requestHooks = [${hookSource}];` },
+    entryModuleKey: 'index.js',
+    hookKind: 'request',
+    hookIndex: 0,
+    hookRequest: request,
+  };
+  const json = await runTagInSandbox({ tagName: '', envelope, bridge: noBridge });
+  return (JSON.parse(json) as HookResult).request ?? {};
+};
+
+describe('request hooks in the sandbox (H1)', () => {
+  it('marshals header/url/method/body mutations back out to the host', async () => {
+    const request = await runRequestHook(
+      `function (context) {
+        context.request.addHeader('X-Injected', 'from-hook');
+        context.request.setHeader('X-Existing', 'updated');
+        context.request.setUrl('https://rewritten.example/path');
+        context.request.setMethod('POST');
+        context.request.setBody({ text: 'new-body' });
+      }`,
+      {
+        _id: 'req_1',
+        url: 'https://original.example',
+        method: 'GET',
+        headers: [{ name: 'X-Existing', value: 'original' }],
+        body: {},
+      },
+    );
+
+    expect(request.url).toBe('https://rewritten.example/path');
+    expect(request.method).toBe('POST');
+    expect(request.body).toEqual({ text: 'new-body' });
+    expect(request.headers).toContainEqual({ name: 'X-Injected', value: 'from-hook' });
+    // setHeader updates the existing header in place (case-insensitive match), not a duplicate.
+    expect(request.headers).toContainEqual({ name: 'X-Existing', value: 'updated' });
+    expect((request.headers as unknown[]).length).toBe(2);
+  });
+
+  it('matches headers case-insensitively (parity with misc.filterHeaders)', async () => {
+    const request = await runRequestHook(
+      `function (context) { context.request.setHeader('content-TYPE', 'application/json'); }`,
+      { headers: [{ name: 'Content-Type', value: 'text/plain' }] },
+    );
+    // Updated in place, not appended, because the lookup is case-insensitive.
+    expect(request.headers).toEqual([{ name: 'Content-Type', value: 'application/json' }]);
+  });
+
+  it('reads environment variables from the render context', async () => {
+    const request = await runRequestHook(
+      `function (context) { context.request.setHeader('X-Base', context.request.getEnvironmentVariable('BASE_URL')); }`,
+      { headers: [] },
+    );
+    expect(request.headers).toContainEqual({ name: 'X-Base', value: 'https://env.example' });
+  });
+
+  it('denies an ungranted host capability from inside a hook (context.network absent)', async () => {
+    // No 'network' capability granted → context.network is undefined (C2), so reaching for it throws
+    // at the property access — the hook cannot make network calls it didn't declare.
+    await expect(
+      runRequestHook(`async function (context) { await context.network.sendRequest({}); }`, { headers: [] }, []),
+    ).rejects.toThrow(/sendRequest/i);
+  });
+
+  it('allows a granted capability: context.network is present when the manifest grants network', async () => {
+    // With 'network' granted the branch exists; feature-detecting it as an object proves C2 attaches
+    // the branch (the actual call would bridge to the host, which the unit test bridge rejects).
+    const request = await runRequestHook(
+      `function (context) { context.request.setHeader('X-Net', typeof context.network); }`,
+      { headers: [] },
+      ['network'],
+    );
+    expect(request.headers).toContainEqual({ name: 'X-Net', value: 'object' });
+  });
+});

--- a/packages/insomnia/src/templating/sandbox/sandbox-surface.ts
+++ b/packages/insomnia/src/templating/sandbox/sandbox-surface.ts
@@ -215,8 +215,19 @@ export const findLeakedGatedReferences = (entries: SurfaceEntry[]): string[] =>
  * in particular returns a context wired to the real host bridge; discovery-time safety comes from
  * `runTagInSandbox` substituting a rejecting bridge when `discover: true`, not from hiding this
  * global. Adding a new one here forces a human to re-check that story still holds.
+ *
+ * `__invokeHook` (H1) is in this set: like `__invoke`, it wires a context to the real bridge, but
+ * during discovery the rejecting bridge is installed AND no hook is present to run (hookKind/hookIndex
+ * are unset), so a discovery-time call reaches nothing — re-checked and safe.
  */
-export const SANDBOX_INTERNAL_GLOBALS = ['__buildContext', '__describeExports', '__invoke', '__loadPluginEntry', '__require'];
+export const SANDBOX_INTERNAL_GLOBALS = [
+  '__buildContext',
+  '__describeExports',
+  '__invoke',
+  '__invokeHook',
+  '__loadPluginEntry',
+  '__require',
+];
 
 /** Filters sandbox surface entries down to the bare `globalThis.__*` internals (excluding the `.prototype` sibling lines already in the snapshot). */
 export const findSandboxInternalGlobals = (entries: SurfaceEntry[]): string[] =>

--- a/packages/insomnia/src/ui/worker/templating-handler.ts
+++ b/packages/insomnia/src/ui/worker/templating-handler.ts
@@ -11,12 +11,23 @@ worker.addEventListener('error', event => {
   console.error('Error from worker:', event.message);
 });
 
-export function renderInWorker({ input, context, path, ignoreUndefinedEnvVariable }: RenderInputType): Promise<string> {
+// The Worker has no window.main access, so this module fetches the auth token once and forwards
+// it in on every postMessage instead.
+let authTokenPromise: Promise<string> | null = null;
+function getTemplatingDbAuthToken(): Promise<string> {
+  if (!authTokenPromise) {
+    authTokenPromise = window.main.templatingDb.getAuthToken();
+  }
+  return authTokenPromise;
+}
+
+export async function renderInWorker({ input, context, path, ignoreUndefinedEnvVariable }: RenderInputType): Promise<string> {
   const newContext = serializeRenderContext(context);
+  const authToken = await getTemplatingDbAuthToken();
 
   // Id to avoid race conditions
   const id = window.crypto.randomUUID();
-  const payloadWithHash = JSON.stringify({ id, input, context: newContext, path, ignoreUndefinedEnvVariable });
+  const payloadWithHash = JSON.stringify({ id, input, context: newContext, path, ignoreUndefinedEnvVariable, authToken });
   worker.postMessage(payloadWithHash);
   return new Promise((resolve, reject) => {
     const messageHandler = (event: MessageEvent) => {

--- a/packages/insomnia/src/ui/worker/templating.worker.ts
+++ b/packages/insomnia/src/ui/worker/templating.worker.ts
@@ -1,3 +1,4 @@
+import { setTemplatingDbAuthToken } from '~/common/templating/liquid-extension-worker';
 import { deserializeRenderContext } from '~/common/templating/render-context-serialization';
 import * as templating from '~/ui/templating/worker';
 
@@ -16,7 +17,9 @@ async function performJob(input: {
 
 // Listen for messages from the main thread
 self.onmessage = async event => {
-  const { id, input, context, path, ignoreUndefinedEnvVariable } = JSON.parse(event.data);
+  const { id, input, context, path, ignoreUndefinedEnvVariable, authToken } = JSON.parse(event.data);
+  // This Worker has its own copy of the module-scoped auth token, set from the message.
+  setTemplatingDbAuthToken(authToken ?? null);
   try {
     const result = await performJob({
       input,


### PR DESCRIPTION
## Summary

Phase 2, **PR 10a — H1 (request hooks).** Routes a **user** plugin's request hooks through the QuickJS sandbox instead of running them in-process, so a request hook can still rewrite headers/URL/body/params/auth but can no longer reach the host beyond its declared capabilities. Bundle plugins stay in-process; gated on `templateTagSandboxEnabled`. Stacked on #10276 (L1).

Response hooks (which involve the disk-writing `response.setBody`) follow as **PR 10b**.

## How it works

A request hook mutates `context.request` **in place** (pure in-memory field writes — no host calls), and the mutated request is read back by the send pipeline. So:

- **`__buildRequestApi` (in-sandbox):** a faithful ES5 rebuild of `plugins/context/request.ts` — all getters/mutators, **case-insensitive header** vs **case-sensitive parameter** matching, and the exact `readOnly` deletions — operating on the copied-in request. Built against `request.ts` line-by-line for parity.
- **`__invokeHook` + `HOOK_RUNNER`:** run the hook at `hookIndex` in the capability-gated context (`app`/`store`/`network` from `__buildContext`, C1/C2 gating intact) and marshal the mutated request back out as JSON.
- **Host `runRequestHookInSandbox`:** reuses the tag bridge/grants/crypto; returns the mutated field subset.
- **Both execution paths wired:** `network-adapter.node.ts` (main/CLI) calls the runner directly; `invoke-method.ts` (plugin window) reaches it over the `insomnia-templating-worker-database` protocol. A per-plugin counter recovers each hook's index; mutations merge back and **chain** hook-to-hook.

## Tests

- **Unit** (`sandbox-hooks.test.ts`): header/url/method/body mutation round-trip, case-insensitive header parity, env-var reads, capability gating (`context.network` absent when ungranted, present when granted).
- **E2E** (`sandbox-hook-collection.yaml`): a user-plugin request hook injects headers; the echo server reflects them. Flag **off** the hook reports `main-process` (control); flag **on** it reports `sandbox` and the injected header reaches the wire.

Local: 22 sandbox/worker-db unit tests + type-check + lint (incl. smoke workspace) green. Electron smoke runs in CI.
