### PR TITLE
feat(templating): (H1) route user-plugin response hooks through the sandbox (PR 10b)

### DIFF
--- a/packages/insomnia-data/node-src/services/response.ts
+++ b/packages/insomnia-data/node-src/services/response.ts
@@ -11,6 +11,11 @@ export function getById(id: string) {
   return db.findOne<Response>(type, { _id: id });
 }
 
+// Finds whichever response already owns a given on-disk body file, to verify ownership before overwrite.
+export function getByBodyPath(bodyPath: string) {
+  return db.findOne<Response>(type, { bodyPath });
+}
+
 export function findByParentId(parentId: string) {
   return db.find<Response>(type, { parentId: parentId });
 }

--- a/packages/insomnia-smoke-test/tests/smoke/response-bodypath-read-scope.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/response-bodypath-read-scope.test.ts
@@ -1,0 +1,123 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { expect, type Page } from '@playwright/test';
+
+import { loadFixture } from '../../playwright/paths';
+import { test } from '../../playwright/test';
+
+// response.getBodyBuffer sits behind the models.read capability, which is granted to every template
+// tag at baseline with no manifest declaration. This restricts it (via assertResponseBodyPathReadOwnership)
+// to bodyPaths that belong to an already-persisted response.
+
+const PLUGIN_NAME = 'insomnia-plugin-bodypath-read-scope';
+const OUTSIDE_CONTENTS = 'sandbox-bodypath-read-scope-check-9f3c1a';
+
+// Installs a template tag with no manifest permissions that reads a path via the baseline-granted
+// context.util.models.response.getBodyBuffer bridge call.
+const installReadPathPlugin = (dataPath: string) => {
+  const pluginDir = path.join(dataPath, 'plugins', PLUGIN_NAME);
+  fs.mkdirSync(pluginDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pluginDir, 'package.json'),
+    JSON.stringify({ name: PLUGIN_NAME, version: '1.0.0', main: 'index.js', insomnia: {} }),
+  );
+  fs.writeFileSync(
+    path.join(pluginDir, 'index.js'),
+    `
+      module.exports.templateTags = [
+        {
+          name: 'readpath',
+          displayName: 'Read Path',
+          description: 'Reads a path via response.getBodyBuffer with no declared permissions',
+          args: [{ displayName: 'Path', type: 'string', defaultValue: '' }],
+          async run(context, filePath) {
+            var raw = await context.util.models.response.getBodyBuffer({ bodyPath: filePath });
+            var bytes = (raw && raw.data) || [];
+            var out = '';
+            for (var i = 0; i < bytes.length; i++) { out += String.fromCharCode(bytes[i]); }
+            return out;
+          },
+        },
+      ];
+    `,
+  );
+};
+
+const clearPluginToast = async (page: Page) => {
+  await page.getByLabel('Import').waitFor();
+  await page.evaluate(() => localStorage.setItem('plugin-system-changes-toast-shown', 'true'));
+  const dismissButtons = page.getByRole('button', { name: 'Dismiss' });
+  await dismissButtons
+    .first()
+    .waitFor({ timeout: 3000 })
+    .catch(() => {});
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline && (await dismissButtons.count()) > 0) {
+    await dismissButtons.first().click({ force: true, timeout: 500 }).catch(() => {});
+  }
+};
+
+// Enables the sandbox via the real Preferences → Scripting UI toggle, not a pre-set settings object.
+const enableSandbox = async (page: Page) => {
+  await page.getByTestId('settings-button').click();
+  const sandboxToggle = page.getByTestId('toggle-template-tag-sandbox');
+  await page.getByRole('tab', { name: 'Scripting' }).click();
+  await sandboxToggle.getByRole('switch').waitFor();
+  await sandboxToggle.click();
+  await expect.soft(sandboxToggle.getByRole('switch')).toBeChecked();
+  await page.locator('.app').press('Escape');
+  await expect.soft(page.getByTestId('toggle-template-tag-sandbox')).toBeHidden();
+};
+
+test('response.getBodyBuffer restricts a zero-permission template tag to known response bodyPaths', async ({
+  page,
+  app,
+  dataPath,
+  insomnia,
+}) => {
+  // A file outside the Insomnia data directory, unrelated to any response.
+  const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'insomnia-outside-app-data-'));
+  const outsidePath = path.join(outsideDir, 'file.txt');
+  fs.writeFileSync(outsidePath, OUTSIDE_CONTENTS);
+
+  try {
+    installReadPathPlugin(dataPath);
+    await clearPluginToast(page);
+
+    const fixture = (await loadFixture('sandbox-probe-collection.yaml')).replace(
+      /\{% sandboxprobe 'e2e' %\}[\s\S]*/,
+      `{% readpath '${outsidePath.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}' %}\n`,
+    );
+    await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), fixture);
+    await page.getByLabel('Import').click();
+    await page.locator('[data-test-id="import-from-clipboard"]').click();
+    await page.getByRole('button', { name: 'Scan' }).click();
+    await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+
+    await page.evaluate(() => (window as any).main.plugins.reloadPlugins());
+
+    await insomnia.navigationSidebar.clickRequestOrFolder('Sandbox Probe');
+    await page.getByText('Body', { exact: true }).click();
+
+    await enableSandbox(page);
+
+    const readTagPreview = async (tagPrefix: string): Promise<string> => {
+      await page.locator(`[data-template^="${tagPrefix}"]`).click();
+      const modal = page.getByRole('dialog');
+      const preview = modal.getByLabel('Live Preview');
+      await expect.soft(preview).not.toHaveValue('rendering...');
+      const value = (await preview.inputValue()).trim();
+      await modal.getByRole('button', { name: 'Done' }).click();
+      await expect.soft(modal).toBeHidden();
+      return value;
+    };
+
+    // The just-toggled setting needs a moment to propagate to the main process before the tag runs
+    // in the sandbox — poll until it does, then assert the read is refused.
+    await expect.poll(() => readTagPreview('{% readpath'), { timeout: 20_000 }).toContain('does not belong to any known response');
+  } finally {
+    fs.rmSync(outsideDir, { recursive: true, force: true });
+  }
+});

--- a/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
@@ -760,3 +760,56 @@ test('Request hook sandbox (H1): a user plugin request hook runs in the sandbox 
   // The second header mutation also round-tripped through the sandbox and reached the wire.
   await expect.soft(responsePane).toContainText('hook-marker-9k2x');
 });
+
+test('Response hook sandbox (H1): a user plugin response hook runs in the sandbox and rewrites the body', async ({
+  page,
+  app,
+  dataPath,
+  insomnia,
+}) => {
+  // The response hook overwrites the response body with a canary that reports where it ran (the
+  // sandbox sets INSOMNIA_TEMPLATE_SANDBOX). setBody goes through the host bridge (base64) to the
+  // response's body file, so the rewritten body shows in the response pane.
+  writePlugin(
+    dataPath,
+    'insomnia-plugin-resp-hook-probe',
+    {},
+    `
+      module.exports.responseHooks = [
+        function (context) {
+          var ranIn = typeof INSOMNIA_TEMPLATE_SANDBOX !== 'undefined' ? 'ranin-sandboxed' : 'ranin-mainprocess';
+          context.response.setBody('resphook-rewrote-body:' + ranIn + ':status-' + context.response.getStatusCode());
+        },
+      ];
+    `,
+  );
+
+  const fixture = await loadFixture('sandbox-hook-collection.yaml');
+  await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), fixture);
+  await clearPluginToast(page);
+  await page.getByLabel('Import').click();
+  await page.locator('[data-test-id="import-from-clipboard"]').click();
+  await page.getByRole('button', { name: 'Scan' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+  await page.evaluate(() => (window as any).main.plugins.reloadPlugins());
+
+  await insomnia.navigationSidebar.clickRequestOrFolder('Hook Request');
+  const responsePane = page.getByTestId('response-pane');
+
+  // Flag OFF (default): the response hook runs in-process (control) and rewrites the body.
+  await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
+  await expect.soft(page.locator('[data-testid="response-status-tag"]:visible')).toContainText('200');
+  await expect.soft(responsePane).toContainText('resphook-rewrote-body:ranin-mainprocess');
+
+  // Flag ON: the same hook now runs in the QuickJS sandbox; setBody bridges the new body to disk.
+  await enableSandbox(page);
+  await expect
+    .poll(
+      async () => {
+        await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
+        return (await responsePane.textContent()) || '';
+      },
+      { timeout: 25_000 },
+    )
+    .toContain('resphook-rewrote-body:ranin-sandboxed');
+});

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -42,7 +42,9 @@
     "sandbox:vendored:upgrade": "esr ./scripts/upgrade-sandbox-vendored.ts",
     "sandbox:vendored:test-regression": "vitest run --config vitest.sandbox-vendored-regression.config.ts",
     "sandbox:surface": "vitest run src/templating/sandbox/print-sandbox-surface.test.ts",
-    "sandbox:surface:test": "vitest run src/templating/sandbox/sandbox-surface.test.ts"
+    "sandbox:surface:test": "vitest run src/templating/sandbox/sandbox-surface.test.ts",
+    "sandbox:bridge-trust": "vitest run src/main/__tests__/print-templating-worker-database-surface.test.ts",
+    "sandbox:bridge-trust:test": "vitest run src/main/__tests__/templating-worker-database-surface.test.ts"
   },
   "dependencies": {
     "@apideck/better-ajv-errors": "^0.3.6",

--- a/packages/insomnia/src/common/templating/types.ts
+++ b/packages/insomnia/src/common/templating/types.ts
@@ -96,6 +96,8 @@ export type PluginToMainAPIPaths =
   | 'plugin.executeUserPluginTag'
   | 'plugin.discoverUserPluginExports'
   | 'plugin.runUserRequestHook'
+  | 'plugin.runUserResponseHook'
+  | 'response.setBody'
   | 'app.alert'
   | 'app.dialog'
   | 'app.prompt'

--- a/packages/insomnia/src/main/__tests__/print-templating-worker-database-surface.test.ts
+++ b/packages/insomnia/src/main/__tests__/print-templating-worker-database-surface.test.ts
@@ -1,0 +1,50 @@
+import { expect, it, vi } from 'vitest';
+
+import { describeHandlerSurface, formatHandlerSurfaceEntries } from '../templating-worker-database-surface';
+
+vi.mock('electron', () => ({
+  app: { getVersion: () => '1.0.0', getPath: () => '/fake/userData' },
+  clipboard: { readText: vi.fn(), writeText: vi.fn(), clear: vi.fn() },
+  dialog: { showMessageBox: vi.fn() },
+  shell: { openExternal: vi.fn() },
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+vi.mock('insomnia-data', () => ({
+  services: {
+    request: { getById: vi.fn() },
+    workspace: { getById: vi.fn() },
+    oAuth2Token: { getByParentId: vi.fn() },
+    cookieJar: { getOrCreateForParentId: vi.fn() },
+    response: { getLatestForRequestId: vi.fn(), getByBodyPath: vi.fn() },
+    helpers: { getResponseBodyBuffer: vi.fn() },
+    pluginData: { getByKey: vi.fn(), upsertByKey: vi.fn(), removeByKey: vi.fn(), removeAll: vi.fn(), all: vi.fn() },
+    cloudCredential: { getById: vi.fn(), update: vi.fn() },
+    settings: { get: vi.fn().mockResolvedValue({}) },
+  },
+}));
+vi.mock('~/plugins', () => ({
+  getPluginCommonContext: vi.fn(),
+  getTemplateTags: vi.fn().mockResolvedValue([]),
+  getPlugins: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('~/common/cookies', () => ({ jarFromCookies: vi.fn() }));
+vi.mock('../common/database', () => ({ database: {} }));
+vi.mock('../network/network', () => ({
+  fetchRequestData: vi.fn(),
+  sendCurlAndWriteTimeline: vi.fn(),
+  tryToInterpolateRequest: vi.fn(),
+}));
+vi.mock('../network/libcurl-promise', () => ({ curlRequest: vi.fn() }));
+vi.mock('../prompt-bridge', () => ({ requestPromptFromRenderer: vi.fn() }));
+vi.mock('../secure-read-file', () => ({ secureReadFile: vi.fn() }));
+
+// Not a regression check — prints the bridge-trust surface for eyeballing. Run via
+// `npm run sandbox:bridge-trust`.
+it('prints the protocol-dispatch bridge-trust surface', async () => {
+  const { pluginToMainAPI } = await import('../templating-worker-database');
+  const entries = describeHandlerSurface(pluginToMainAPI);
+  const lines = formatHandlerSurfaceEntries(entries);
+  console.log(lines.join('\n'));
+  console.log(`\n${lines.length} handlers`);
+  expect(lines.length).toBeGreaterThan(0);
+});

--- a/packages/insomnia/src/main/__tests__/templating-worker-database-bodypath-read.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database-bodypath-read.test.ts
@@ -1,0 +1,130 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+// response.getBodyBuffer is response.setBody's read-side sibling; #10294 added an ownership check
+// (assertResponseBodyPathOwnership) only to the write side. assertResponseBodyPathReadOwnership
+// covers the read side: it restricts response.getBodyBuffer to bodyPaths that belong to an
+// already-persisted response.
+
+vi.mock('electron', () => ({
+  app: { getVersion: () => '1.0.0', getPath: () => '/fake/userData' },
+  clipboard: { readText: vi.fn(), writeText: vi.fn(), clear: vi.fn() },
+  dialog: { showMessageBox: vi.fn() },
+  shell: { openExternal: vi.fn() },
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+vi.mock('insomnia-data', async () => {
+  // Delegate to the real implementation so this test exercises an actual file read, not a mock.
+  const nodeReal = await vi.importActual<{ servicesNodeImpl: { helpers: { getResponseBodyBuffer: (...args: any[]) => any } } }>('insomnia-data/node');
+  return {
+    services: {
+      request: { getById: vi.fn() },
+      workspace: { getById: vi.fn() },
+      oAuth2Token: { getByParentId: vi.fn() },
+      cookieJar: { getOrCreateForParentId: vi.fn() },
+      response: { getLatestForRequestId: vi.fn(), getByBodyPath: vi.fn() },
+      helpers: { getResponseBodyBuffer: nodeReal.servicesNodeImpl.helpers.getResponseBodyBuffer },
+      pluginData: { getByKey: vi.fn(), upsertByKey: vi.fn(), removeByKey: vi.fn(), removeAll: vi.fn(), all: vi.fn() },
+      cloudCredential: { getById: vi.fn(), update: vi.fn() },
+      settings: { get: vi.fn().mockResolvedValue({}) },
+    },
+  };
+});
+vi.mock('~/plugins', () => ({
+  getPluginCommonContext: vi.fn(),
+  getTemplateTags: vi.fn().mockResolvedValue([]),
+  getPlugins: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('~/common/cookies', () => ({ jarFromCookies: vi.fn() }));
+vi.mock('../common/database', () => ({ database: {} }));
+vi.mock('../network/network', () => ({
+  fetchRequestData: vi.fn(),
+  sendCurlAndWriteTimeline: vi.fn(),
+  tryToInterpolateRequest: vi.fn(),
+}));
+vi.mock('../network/libcurl-promise', () => ({ curlRequest: vi.fn() }));
+vi.mock('../prompt-bridge', () => ({ requestPromptFromRenderer: vi.fn() }));
+vi.mock('../secure-read-file', () => ({ secureReadFile: vi.fn() }));
+
+describe('response.getBodyBuffer restricts reads to bodyPaths owned by a known response', () => {
+  let outsidePath: string;
+  const OUTSIDE_CONTENTS = 'unrelated-file-contents';
+
+  const writeOutsideFile = () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'insomnia-outside-responses-'));
+    const file = path.join(dir, 'file.txt');
+    fs.writeFileSync(file, OUTSIDE_CONTENTS);
+    return file;
+  };
+
+  it('rejects a bodyPath that belongs to no known response', async () => {
+    outsidePath = writeOutsideFile();
+    const { pluginToMainAPI } = await import('../templating-worker-database');
+    await expect(
+      pluginToMainAPI['response.getBodyBuffer']({ response: { bodyPath: outsidePath } }),
+    ).rejects.toThrow(/does not belong to any known response/);
+  });
+
+  it('allows reading the body of a response that owns its bodyPath', async () => {
+    outsidePath = writeOutsideFile();
+    const { services } = await import('insomnia-data');
+    // mockResolvedValueOnce: must not leak into later tests, which rely on getByBodyPath's default
+    // (unconfigured -> undefined) to prove the check rejects an unrecognized bodyPath.
+    (services.response.getByBodyPath as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      _id: 'res_own', parentId: 'req_1', bodyPath: outsidePath,
+    });
+    const { pluginToMainAPI } = await import('../templating-worker-database');
+    const result = await pluginToMainAPI['response.getBodyBuffer']({
+      response: { bodyPath: outsidePath },
+    });
+    expect(result.toString('utf8')).toBe(OUTSIDE_CONTENTS);
+  });
+
+  it('restricts a template tag with only default (no-manifest) baseline capabilities from reading outside a known response, end to end through the real sandbox', async () => {
+    outsidePath = writeOutsideFile();
+
+    const { pluginToMainAPI } = await import('../templating-worker-database');
+    const { createMapBridge, TEMPLATE_TAG_BASELINE_CAPABILITIES } = await import('../../templating/sandbox/host-bridge');
+    const { TEMPLATE_TAG_BASELINE_MODULES } = await import('../../templating/sandbox/module-registry');
+    const { runTagInSandbox } = await import('../../templating/sandbox/plugin-tag-sandbox');
+
+    // The real production bridge, wired to the real production handler map — no reimplementation.
+    const bridge = createMapBridge(pluginToMainAPI);
+
+    // A plugin declaring no permissions; models.read (and so response.getBodyBuffer) is baseline.
+    const pluginSource = `
+      module.exports.templateTags = [{
+        name: 'readPath',
+        run: function (context, filePath) {
+          return context.util.models.response.getBodyBuffer({ bodyPath: filePath }).then(function (raw) {
+            var bytes = (raw && raw.data) || [];
+            var out = '';
+            for (var i = 0; i < bytes.length; i++) { out += String.fromCharCode(bytes[i]); }
+            return out;
+          });
+        }
+      }];`;
+
+    await expect(
+      runTagInSandbox({
+        pluginSource,
+        tagName: 'readPath',
+        bridge,
+        envelope: {
+          args: [outsidePath],
+          context: {},
+          meta: {},
+          renderPurpose: 'preview',
+          appInfo: { version: '0.0.0', platform: 'linux', arch: 'arm64' },
+          pluginName: 'no-manifest-plugin',
+          renderDepth: 0,
+          grantedModules: TEMPLATE_TAG_BASELINE_MODULES,
+          grantedCapabilities: TEMPLATE_TAG_BASELINE_CAPABILITIES,
+        },
+      }),
+    ).rejects.toThrow(/does not belong to any known response/);
+  });
+});

--- a/packages/insomnia/src/main/__tests__/templating-worker-database-protocol-authorization.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database-protocol-authorization.test.ts
@@ -22,7 +22,7 @@ vi.mock('insomnia-data', () => ({
     workspace: { getById: vi.fn() },
     oAuth2Token: { getByParentId: vi.fn() },
     cookieJar: { getOrCreateForParentId: vi.fn() },
-    response: { getLatestForRequestId: vi.fn() },
+    response: { getLatestForRequestId: vi.fn(), getByBodyPath: vi.fn() },
     helpers: { getResponseBodyBuffer: vi.fn() },
     pluginData: { getByKey: vi.fn(), upsertByKey: vi.fn(), removeByKey: vi.fn(), removeAll: vi.fn(), all: vi.fn() },
     cloudCredential: { getById: vi.fn(), update: vi.fn() },
@@ -207,12 +207,9 @@ describe('protocol-dispatch handlers resolve `directory` from the trusted regist
   });
 });
 
-// H1-followup finding (fixed): F2' resolved `directory` server-side from the trusted registry
-// (getPlugins()), but originally left `permissions` as a caller-supplied field on the request body
-// for both `plugin.runUserRequestHook` and `plugin.discoverUserPluginExports`. Now both handlers
-// resolve `permissions` from the trusted registry the same way they resolve `directory`, so a
-// forged `permissions` in the request body no longer grants a broader capability set than the
-// plugin's own registered manifest declares.
+// Both handlers resolve `permissions` from the trusted registry (getPlugins()), the same way they
+// resolve `directory`, so a `permissions` field on the request body doesn't grant a broader
+// capability set than the plugin's own registered manifest declares.
 describe('protocol-dispatch handlers resolve `permissions` from the trusted registry, not the request body', () => {
   let pluginDir: string;
 
@@ -266,23 +263,18 @@ describe('protocol-dispatch handlers resolve `permissions` from the trusted regi
     expect(hasNetwork).toBe(false);
   });
 
-  // The plugin's *registered* manifest (mocked above) declares no capabilities. A forged
-  // `permissions.capabilities: ['network']` in the request body must not grant `network` — the
-  // handler resolves `permissions` from `getPlugins()` by name, the same trusted-registry pattern
-  // F2' applies to `directory`, rather than trusting the request body.
-  it('a forged `permissions.capabilities` in the request body is ignored; the registry still denies network', async () => {
+  // The plugin's registered manifest (mocked above) declares no capabilities, so a
+  // `permissions.capabilities: ['network']` field on the request body must not grant `network` —
+  // the handler resolves `permissions` from `getPlugins()` by name, not the request body.
+  it('a `permissions.capabilities` field on the request body is ignored; the registry still denies network', async () => {
     const { hasNetwork } = await runHook({ capabilities: ['network'] });
     expect(hasNetwork).toBe(false);
   });
 });
 
-// Symmetric coverage for the other handler that resolves `permissions`: the describe block above
-// only exercises `plugin.runUserRequestHook`. `plugin.discoverUserPluginExports` takes the same
-// `resolveTrustedPlugin(...).permissions` value but on the *module* grant, not the capability grant
-// (discovery evaluates the plugin's top-level code, which can only reach gated `require(...)`, not
-// hook-time `context.*`). Exercising both fields on both handlers is the point: the permissions gap
-// this branch fixed existed specifically because the `directory` fix was verified per-handler but
-// `permissions` wasn't checked on every handler that resolves it.
+// Symmetric coverage: `plugin.discoverUserPluginExports` takes the same
+// `resolveTrustedPlugin(...).permissions` value as `plugin.runUserRequestHook` above, but applies it
+// to the module grant rather than the capability grant.
 describe('plugin.discoverUserPluginExports resolves `permissions.modules` from the trusted registry, not the request body', () => {
   let pluginDir: string;
 
@@ -325,6 +317,196 @@ describe('plugin.discoverUserPluginExports resolves `permissions.modules` from t
     expect(res.status).toBe(500);
     const json = await res.json();
     expect(json.error).toMatch(/not permitted by manifest/);
+  });
+});
+
+// A response hook's setBody() writes to a caller-supplied bodyPath with no persisted _id to reload
+// by, so assertResponseBodyPathOwnership instead rejects the call if that bodyPath already belongs
+// to a different, already-persisted response's parentId.
+describe('plugin.runUserResponseHook: setBody cannot redirect its write onto a different response', () => {
+  let pluginDir: string;
+  let responsesDir: string;
+  let ownBodyPath: string;
+  let otherBodyPath: string;
+  let previousDataPath: string | undefined;
+
+  beforeEach(async () => {
+    _testOnlyResetTemplatingDbAuthToken();
+    pluginDir = fs.mkdtempSync(path.join(os.tmpdir(), 'insomnia-plugin-resphook-'));
+    fs.writeFileSync(path.join(pluginDir, 'package.json'), JSON.stringify({ main: 'index.js' }));
+    fs.writeFileSync(
+      path.join(pluginDir, 'index.js'),
+      `module.exports.responseHooks = [function (context) {
+        context.response.setBody('replacement-body');
+      }];`,
+    );
+
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'insomnia-data-'));
+    responsesDir = path.join(dataDir, 'responses');
+    fs.mkdirSync(responsesDir);
+    ownBodyPath = path.join(responsesDir, 'own-response-body.txt');
+    otherBodyPath = path.join(responsesDir, 'other-response-body.txt');
+    fs.writeFileSync(ownBodyPath, 'own-original-body');
+    fs.writeFileSync(otherBodyPath, 'other-original-body');
+
+    previousDataPath = process.env['INSOMNIA_DATA_PATH'];
+    process.env['INSOMNIA_DATA_PATH'] = dataDir;
+
+    // Default: neither bodyPath is owned yet; individual tests override to simulate a claimed one.
+    const { services } = await import('insomnia-data');
+    (services.response.getByBodyPath as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    if (previousDataPath === undefined) {
+      delete process.env['INSOMNIA_DATA_PATH'];
+    } else {
+      process.env['INSOMNIA_DATA_PATH'] = previousDataPath;
+    }
+    fs.rmSync(pluginDir, { recursive: true, force: true });
+    fs.rmSync(path.dirname(responsesDir), { recursive: true, force: true });
+  });
+
+  const runResponseHook = async (bodyPath: string, parentId = 'req_1') => {
+    const token = getOrCreateTemplatingDbAuthToken();
+    const { getPlugins } = await import('~/plugins');
+    (getPlugins as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { name: 'insomnia-plugin-resphook', directory: pluginDir, permissions: {} },
+    ]);
+    const { resolveDbByKey } = await import('../templating-worker-database');
+    const req = new Request('insomnia-templating-worker-database://plugin.runuserresponsehook', {
+      method: 'POST',
+      headers: { [TEMPLATING_DB_AUTH_HEADER]: token },
+      body: JSON.stringify({
+        plugin: { name: 'insomnia-plugin-resphook' },
+        hookIndex: 0,
+        response: { parentId, bodyPath },
+        renderedRequest: { url: 'https://example.com', headers: [] },
+        renderContext: {},
+      }),
+    });
+    return resolveDbByKey(req);
+  };
+
+  it('baseline: setBody writes to a not-yet-persisted response\'s own bodyPath as intended', async () => {
+    const res = await runResponseHook(ownBodyPath, 'req_1');
+    expect(res.status).toBe(200);
+    expect(fs.readFileSync(ownBodyPath, 'utf8')).toBe('replacement-body');
+    expect(fs.readFileSync(otherBodyPath, 'utf8')).toBe('other-original-body');
+  });
+
+  it('allows re-writing a bodyPath that legitimately already belongs to the same parentId', async () => {
+    const { services } = await import('insomnia-data');
+    (services.response.getByBodyPath as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      _id: 'res_own', parentId: 'req_1', bodyPath: ownBodyPath,
+    });
+    const res = await runResponseHook(ownBodyPath, 'req_1');
+    expect(res.status).toBe(200);
+    expect(fs.readFileSync(ownBodyPath, 'utf8')).toBe('replacement-body');
+  });
+
+  it('rejects a `response.bodyPath` that belongs to a different response, before the hook runs', async () => {
+    const { services } = await import('insomnia-data');
+    (services.response.getByBodyPath as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      _id: 'res_other', parentId: 'req_other', bodyPath: otherBodyPath,
+    });
+    // The call's parentId ('req_1') doesn't match otherBodyPath's real owner ('req_other').
+    const res = await runResponseHook(otherBodyPath, 'req_1');
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/belongs to a different response/);
+    expect(fs.readFileSync(otherBodyPath, 'utf8')).toBe('other-original-body');
+    expect(fs.readFileSync(ownBodyPath, 'utf8')).toBe('own-original-body');
+  });
+
+  it('still rejects a bodyPath that escapes the responses directory entirely', async () => {
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'insomnia-outside-'));
+    const outsidePath = path.join(outsideDir, 'not-a-response.txt');
+    fs.writeFileSync(outsidePath, 'untouched');
+    try {
+      // The plugin hook doesn't await setBody()'s returned promise (fire-and-forget), so a rejected
+      // bridge call never surfaces as a non-200 response here — but the containment check still runs
+      // before any write, so the file outside `responses/` is provably never touched either way.
+      await runResponseHook(outsidePath, 'req_1');
+      expect(fs.readFileSync(outsidePath, 'utf8')).toBe('untouched');
+    } finally {
+      fs.rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  // Regression: the ownership check was originally only in the plugin.runUserResponseHook wrapper,
+  // not in response.setBody itself, which is directly dispatchable without going through it.
+  it('rejects a forged bodyPath+parentId sent directly to response.setBody, bypassing the hook wrapper entirely', async () => {
+    const { services } = await import('insomnia-data');
+    (services.response.getByBodyPath as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      _id: 'res_other', parentId: 'req_other', bodyPath: otherBodyPath,
+    });
+    const token = getOrCreateTemplatingDbAuthToken();
+    const { resolveDbByKey } = await import('../templating-worker-database');
+    const req = new Request('insomnia-templating-worker-database://response.setbody', {
+      method: 'POST',
+      headers: { [TEMPLATING_DB_AUTH_HEADER]: token },
+      body: JSON.stringify({
+        bodyPath: otherBodyPath,
+        bodyBase64: Buffer.from('replacement-body', 'utf8').toString('base64'),
+        parentId: 'req_1',
+      }),
+    });
+    const res = await resolveDbByKey(req);
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/belongs to a different response/);
+    expect(fs.readFileSync(otherBodyPath, 'utf8')).toBe('other-original-body');
+  });
+
+  // assertResponseBodyPathOwnership resolves the bodyPath before querying, so a textually different
+  // path that resolves to the same absolute file is recognized by the exact-match lookup.
+  it('rejects a path-normalization variant of another response\'s bodyPath via the hook wrapper', async () => {
+    const { services } = await import('insomnia-data');
+    // Real NeDB does exact-string field matching (`db.findOne(type, { bodyPath })`) -- mirror that
+    // here with `mockImplementation` instead of the input-independent `mockResolvedValue` used by
+    // the other tests in this block, so this test can't pass by accident regardless of what bodyPath
+    // string the code under test actually queries with.
+    (services.response.getByBodyPath as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (bodyPath: string) =>
+        bodyPath === otherBodyPath ? { _id: 'res_other', parentId: 'req_other', bodyPath: otherBodyPath } : null,
+    );
+    const pathVariant = `${responsesDir}${path.sep}zzz${path.sep}..${path.sep}other-response-body.txt`;
+    expect(pathVariant).not.toBe(otherBodyPath);
+    expect(path.resolve(pathVariant)).toBe(path.resolve(otherBodyPath));
+
+    const res = await runResponseHook(pathVariant, 'req_second');
+
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/belongs to a different response/);
+    expect(fs.readFileSync(otherBodyPath, 'utf8')).toBe('other-original-body');
+  });
+
+  // Same check, reached by sending the path-normalization variant directly to response.setBody.
+  it('rejects a path-normalization variant sent directly to response.setBody', async () => {
+    const { services } = await import('insomnia-data');
+    (services.response.getByBodyPath as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (bodyPath: string) =>
+        bodyPath === otherBodyPath ? { _id: 'res_other', parentId: 'req_other', bodyPath: otherBodyPath } : null,
+    );
+    const pathVariant = `${responsesDir}${path.sep}zzz${path.sep}..${path.sep}other-response-body.txt`;
+    const token = getOrCreateTemplatingDbAuthToken();
+    const { resolveDbByKey } = await import('../templating-worker-database');
+    const req = new Request('insomnia-templating-worker-database://response.setbody', {
+      method: 'POST',
+      headers: { [TEMPLATING_DB_AUTH_HEADER]: token },
+      body: JSON.stringify({
+        bodyPath: pathVariant,
+        bodyBase64: Buffer.from('replacement-body', 'utf8').toString('base64'),
+        parentId: 'req_second',
+      }),
+    });
+    const res = await resolveDbByKey(req);
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/belongs to a different response/);
+    expect(fs.readFileSync(otherBodyPath, 'utf8')).toBe('other-original-body');
   });
 });
 

--- a/packages/insomnia/src/main/__tests__/templating-worker-database-surface.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database-surface.test.ts
@@ -1,0 +1,289 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildPathNormalizationVariant, findHandlersThatBypassBodyPathOwnership, findHandlersThatLeakArbitraryBodyPathReads, findUnguardedBodyPathWrites } from '../templating-worker-database-surface';
+
+vi.mock('electron', () => ({
+  app: { getVersion: () => '1.0.0', getPath: () => '/fake/userData' },
+  clipboard: { readText: vi.fn(), writeText: vi.fn(), clear: vi.fn() },
+  dialog: { showMessageBox: vi.fn() },
+  shell: { openExternal: vi.fn() },
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+vi.mock('insomnia-data', () => ({
+  services: {
+    request: { getById: vi.fn() },
+    workspace: { getById: vi.fn() },
+    oAuth2Token: { getByParentId: vi.fn() },
+    cookieJar: { getOrCreateForParentId: vi.fn() },
+    response: { getLatestForRequestId: vi.fn(), getByBodyPath: vi.fn() },
+    helpers: { getResponseBodyBuffer: vi.fn() },
+    pluginData: { getByKey: vi.fn(), upsertByKey: vi.fn(), removeByKey: vi.fn(), removeAll: vi.fn(), all: vi.fn() },
+    cloudCredential: { getById: vi.fn(), update: vi.fn() },
+    settings: { get: vi.fn().mockResolvedValue({}) },
+  },
+}));
+vi.mock('~/plugins', () => ({
+  getPluginCommonContext: vi.fn(),
+  getTemplateTags: vi.fn().mockResolvedValue([]),
+  getPlugins: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('~/common/cookies', () => ({ jarFromCookies: vi.fn() }));
+vi.mock('../common/database', () => ({ database: {} }));
+vi.mock('../network/network', () => ({
+  fetchRequestData: vi.fn(),
+  sendCurlAndWriteTimeline: vi.fn(),
+  tryToInterpolateRequest: vi.fn(),
+}));
+vi.mock('../network/libcurl-promise', () => ({ curlRequest: vi.fn() }));
+vi.mock('../prompt-bridge', () => ({ requestPromptFromRenderer: vi.fn() }));
+vi.mock('../secure-read-file', () => ({ secureReadFile: vi.fn() }));
+
+describe('findUnguardedBodyPathWrites', () => {
+  // Enforced gate: the real handler map must never regress to an unguarded write choke point.
+  it('flags nothing in the real pluginToMainAPI handler map', async () => {
+    const { pluginToMainAPI } = await import('../templating-worker-database');
+    expect(findUnguardedBodyPathWrites(pluginToMainAPI)).toEqual([]);
+  });
+
+  // Positive control: an unguarded fake handler must be flagged.
+  it('flags a fake handler that writes to a body-path-derived location with no trust check', () => {
+    const fakeHandlers = {
+      'fake.unguardedWrite': (body: { bodyPath: string; data: string }) => {
+        fs.writeFileSync(body.bodyPath, body.data);
+        return Promise.resolve(null);
+      },
+      'fake.guardedWrite': (body: { bodyPath: string; data: string }) => {
+        assertFakeOwnership(body);
+        fs.writeFileSync(body.bodyPath, body.data);
+        return Promise.resolve(null);
+      },
+      'fake.readOnly': (body: { bodyPath: string }) => {
+        return Promise.resolve(fs.readFileSync(body.bodyPath));
+      },
+    };
+    const flagged = findUnguardedBodyPathWrites(fakeHandlers);
+    expect(flagged.map(f => f.path)).toEqual(['fake.unguardedWrite']);
+  });
+});
+
+function assertFakeOwnership(body: { bodyPath: string }) {
+  if (!body.bodyPath) {
+    throw new Error('missing bodyPath');
+  }
+}
+
+// Dynamic counterpart: findUnguardedBodyPathWrites can only see whether a trust-check call is
+// textually present in a handler's source, not whether it's actually awaited before the write it's
+// meant to gate. These tests exercise the real handlers (and a deliberately tricky fake one) to
+// prove the regex scan has a blind spot the dynamic probe doesn't.
+describe('findHandlersThatBypassBodyPathOwnership (dynamic, non-regex)', () => {
+  let dataDir: string;
+  let otherBodyPath: string;
+  let previousDataPath: string | undefined;
+
+  beforeEach(async () => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'insomnia-data-'));
+    const responsesDir = path.join(dataDir, 'responses');
+    fs.mkdirSync(responsesDir);
+    otherBodyPath = path.join(responsesDir, 'other-response-body.txt');
+    fs.writeFileSync(otherBodyPath, 'other-original-body');
+
+    previousDataPath = process.env['INSOMNIA_DATA_PATH'];
+    process.env['INSOMNIA_DATA_PATH'] = dataDir;
+
+    const { services } = await import('insomnia-data');
+    (services.response.getByBodyPath as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (bodyPath: string) =>
+        bodyPath === otherBodyPath ? { _id: 'res_other', parentId: 'req_other', bodyPath: otherBodyPath } : null,
+    );
+  });
+
+  afterEach(() => {
+    if (previousDataPath === undefined) {
+      delete process.env['INSOMNIA_DATA_PATH'];
+    } else {
+      process.env['INSOMNIA_DATA_PATH'] = previousDataPath;
+    }
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  // Enforced gate: the real handler map's writes must actually be gated at runtime, not just look
+  // gated to the static scan.
+  it('flags nothing in the real pluginToMainAPI handler map', async () => {
+    const { pluginToMainAPI } = await import('../templating-worker-database');
+    const violations = await findHandlersThatBypassBodyPathOwnership(pluginToMainAPI, {
+      otherBodyPath,
+      otherParentId: 'req_other',
+      callerParentId: 'req_caller',
+    });
+    expect(violations).toEqual([]);
+  });
+
+  it('regex detector reads a write-before-check handler as guarded; the dynamic probe catches the real bypass', async () => {
+    const fakeHandlers = {
+      'fake.writeBeforeCheck': (body: { bodyPath: string; parentId: string; bodyBase64?: string }) => {
+        fs.writeFileSync(body.bodyPath, Buffer.from(body.bodyBase64 || '', 'base64'));
+        // A real-shaped, correctly-named ownership check -- but its rejection surfaces only after
+        // the write already landed, so it provides no actual protection.
+        return assertFakeOwnershipAsync(body).then(() => null);
+      },
+    };
+
+    // The static scan sees a file write, a body.bodyPath reference, and a correctly-named
+    // assert*Ownership call, so it reports this handler as safe.
+    expect(findUnguardedBodyPathWrites(fakeHandlers)).toEqual([]);
+
+    // The dynamic probe observes the actual write and is not fooled by call order.
+    const violations = await findHandlersThatBypassBodyPathOwnership(fakeHandlers, {
+      otherBodyPath,
+      otherParentId: 'req_other',
+      callerParentId: 'req_caller',
+    });
+    expect(violations).toEqual(['fake.writeBeforeCheck']);
+  });
+
+  // Negative control: a handler that awaits its ownership check before writing must not be flagged.
+  it('does not flag a fake handler whose ownership check is properly awaited before the write', async () => {
+    const fakeHandlers = {
+      'fake.properlyGuardedWrite': async (body: { bodyPath: string; parentId: string; bodyBase64?: string }) => {
+        await assertFakeOwnershipAsync(body);
+        fs.writeFileSync(body.bodyPath, Buffer.from(body.bodyBase64 || '', 'base64'));
+        return null;
+      },
+    };
+    const violations = await findHandlersThatBypassBodyPathOwnership(fakeHandlers, {
+      otherBodyPath,
+      otherParentId: 'req_other',
+      callerParentId: 'req_caller',
+    });
+    expect(violations).toEqual([]);
+  });
+
+  // An ownership check that exact-matches bodyPath (mirroring an NeDB `findOne({ bodyPath })`
+  // lookup) while the write itself resolves it first misses a textually different, same-file path.
+  it('detects a fake handler whose ownership check exact-matches bodyPath but writes to the resolved path', async () => {
+    const fakeHandlers = {
+      'fake.checkRawThenWriteResolved': async (body: { bodyPath: string; parentId: string; bodyBase64?: string }) => {
+        const existing = body.bodyPath === otherBodyPath ? { parentId: 'req_other' } : null;
+        if (existing && existing.parentId !== body.parentId) {
+          throw new Error('body.bodyPath belongs to a different response than the one being processed');
+        }
+        fs.writeFileSync(path.resolve(body.bodyPath), Buffer.from(body.bodyBase64 || '', 'base64'));
+        return null;
+      },
+    };
+    const violations = await findHandlersThatBypassBodyPathOwnership(fakeHandlers, {
+      otherBodyPath,
+      otherParentId: 'req_other',
+      callerParentId: 'req_caller',
+    });
+    expect(violations).toEqual(['fake.checkRawThenWriteResolved']);
+  });
+
+  // Negative control mirroring the fix: resolving the bodyPath before the ownership lookup (so the
+  // check and the write agree on which file they mean) closes the gap above.
+  it('does not flag a fake handler that resolves the bodyPath before checking ownership', async () => {
+    const fakeHandlers = {
+      'fake.resolveThenCheck': async (body: { bodyPath: string; parentId: string; bodyBase64?: string }) => {
+        const resolved = path.resolve(body.bodyPath);
+        const existing = resolved === otherBodyPath ? { parentId: 'req_other' } : null;
+        if (existing && existing.parentId !== body.parentId) {
+          throw new Error('body.bodyPath belongs to a different response than the one being processed');
+        }
+        fs.writeFileSync(resolved, Buffer.from(body.bodyBase64 || '', 'base64'));
+        return null;
+      },
+    };
+    const violations = await findHandlersThatBypassBodyPathOwnership(fakeHandlers, {
+      otherBodyPath,
+      otherParentId: 'req_other',
+      callerParentId: 'req_caller',
+    });
+    expect(violations).toEqual([]);
+  });
+
+  it('buildPathNormalizationVariant produces a distinct string that resolves to the same absolute path', () => {
+    const variant = buildPathNormalizationVariant(otherBodyPath);
+    expect(variant).not.toBe(otherBodyPath);
+    expect(path.resolve(variant)).toBe(path.resolve(otherBodyPath));
+  });
+});
+
+function assertFakeOwnershipAsync(body: { parentId: string }) {
+  return Promise.resolve().then(() => {
+    if (body.parentId !== 'req_other') {
+      throw new Error('body.bodyPath belongs to a different response than the one being processed');
+    }
+  });
+}
+
+// Read-side counterpart of findHandlersThatBypassBodyPathOwnership: judges each handler by whether its return value discloses a path's contents.
+describe('findHandlersThatLeakArbitraryBodyPathReads (dynamic, non-regex)', () => {
+  let outsideDir: string;
+  let outsidePath: string;
+  const outsideContents = 'unrelated-file-contents';
+
+  beforeEach(async () => {
+    outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'insomnia-outside-responses-'));
+    outsidePath = path.join(outsideDir, 'file.txt');
+    fs.writeFileSync(outsidePath, outsideContents);
+
+    const { services } = await import('insomnia-data');
+    (services.helpers.getResponseBodyBuffer as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (response: { bodyPath?: string }) => (response?.bodyPath ? fs.promises.readFile(response.bodyPath) : Buffer.alloc(0)),
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(outsideDir, { recursive: true, force: true });
+  });
+
+  // Enforced gate: real reads are restricted at runtime by assertResponseBodyPathReadOwnership.
+  it('flags nothing in the real pluginToMainAPI handler map', async () => {
+    const { pluginToMainAPI } = await import('../templating-worker-database');
+    const violations = await findHandlersThatLeakArbitraryBodyPathReads(pluginToMainAPI, {
+      outsidePath,
+      outsideContents,
+    });
+    expect(violations).toEqual([]);
+  });
+
+  // Positive control: an unrestricted fake handler must be flagged.
+  it('flags a fake handler that returns the raw contents of a caller-supplied bodyPath', async () => {
+    const fakeHandlers = {
+      'fake.unrestrictedRead': async (body: { response?: { bodyPath?: string } }) =>
+        body.response?.bodyPath ? fs.promises.readFile(body.response.bodyPath) : Buffer.alloc(0),
+    };
+    const violations = await findHandlersThatLeakArbitraryBodyPathReads(fakeHandlers, { outsidePath, outsideContents });
+    expect(violations).toEqual(['fake.unrestrictedRead']);
+  });
+
+  // Negative control: a handler that never touches the caller-supplied bodyPath must not be flagged.
+  it('does not flag a fake handler that only reads a caller-independent, pre-resolved path', async () => {
+    const fakeHandlers = {
+      'fake.guardedRead': async () => Buffer.from('unrelated-owned-content'),
+    };
+    const violations = await findHandlersThatLeakArbitraryBodyPathReads(fakeHandlers, { outsidePath, outsideContents });
+    expect(violations).toEqual([]);
+  });
+
+  // Negative control: a handler with its own containment check must not be flagged.
+  it('does not flag a fake handler that enforces containment before reading', async () => {
+    const fakeHandlers = {
+      'fake.containedRead': async (body: { response?: { bodyPath?: string } }) => {
+        const bodyPath = body.response?.bodyPath;
+        const responsesDir = path.join(os.tmpdir(), 'insomnia-fake-responses');
+        if (!bodyPath || !path.resolve(bodyPath).startsWith(path.resolve(responsesDir) + path.sep)) {
+          throw new Error('bodyPath escapes the responses directory');
+        }
+        return fs.promises.readFile(bodyPath);
+      },
+    };
+    const violations = await findHandlersThatLeakArbitraryBodyPathReads(fakeHandlers, { outsidePath, outsideContents });
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/insomnia/src/main/templating-worker-database-surface.ts
+++ b/packages/insomnia/src/main/templating-worker-database-surface.ts
@@ -1,0 +1,186 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Static detector for the protocol-dispatch/bridge layer (pluginToMainAPI), mirroring
+// sandbox-surface.ts's structured-entry + findX() + formatter pattern but scanning handler source
+// text instead of probing a live VM. Covers both writes (findUnguardedBodyPathWrites /
+// findHandlersThatBypassBodyPathOwnership) and reads (findHandlersThatLeakArbitraryBodyPathReads).
+
+/** One protocol-dispatch handler, describing whether it writes to a body-path-derived location without an inline trust check. */
+export interface HandlerSurfaceEntry {
+  path: string;
+  hasFileWriteCall: boolean;
+  hasBodyPathReference: boolean;
+  hasTrustCheckCall: boolean;
+}
+
+// Matched on method name alone: build/test transforms rewrite `fs.writeFileSync` call sites to an
+// aliased import (e.g. `__vite_ssr_import_N__.default.writeFileSync`), so a literal `fs.` prefix
+// would silently stop matching under this detector's own test tooling.
+const FILE_WRITE_CALL_PATTERN =
+  /\.(writeFileSync|appendFileSync|unlinkSync|rmSync|renameSync|copyFileSync|writeFile|unlink|rm|rename|copyFile)\s*\(/;
+
+const BODY_PATH_REFERENCE_PATTERN = /body\.(bodyPath|path|filePath|directory|targetPath)\b/;
+
+// Trust checks must be named `resolveTrusted*` or `assert*Ownership`/`assert*Trust` to be recognized.
+const TRUST_CHECK_CALL_PATTERN = /\b(resolveTrusted\w*|assert\w*(?:Ownership|Trust)\w*)\s*\(/;
+
+/** Describes every handler in a pluginToMainAPI-shaped map by regexing its compiled source. */
+export const describeHandlerSurface = (handlers: Record<string, (...args: any[]) => any>): HandlerSurfaceEntry[] =>
+  Object.entries(handlers).map(([path, handler]) => {
+    const source = handler.toString();
+    return {
+      path,
+      hasFileWriteCall: FILE_WRITE_CALL_PATTERN.test(source),
+      hasBodyPathReference: BODY_PATH_REFERENCE_PATTERN.test(source),
+      hasTrustCheckCall: TRUST_CHECK_CALL_PATTERN.test(source),
+    };
+  });
+
+/** Flags handlers that write to a body-path-derived location with no inline trust check. */
+export const findUnguardedBodyPathWrites = (
+  handlers: Record<string, (...args: any[]) => any>,
+): { path: string; reason: string }[] =>
+  describeHandlerSurface(handlers)
+    .filter(e => e.hasFileWriteCall && e.hasBodyPathReference && !e.hasTrustCheckCall)
+    .map(e => ({
+      path: e.path,
+      reason: `writes to a body-path-derived location with no resolveTrusted*/assert*Ownership/assert*Trust call in its own source`,
+    }));
+
+/** Renders one HandlerSurfaceEntry back to readable text, for the diagnostic-print script only. */
+export const formatHandlerSurfaceEntry = (e: HandlerSurfaceEntry): string =>
+  `${e.path}: write=${e.hasFileWriteCall} bodyPathRef=${e.hasBodyPathReference} trustCheck=${e.hasTrustCheckCall}`;
+
+export const formatHandlerSurfaceEntries = (entries: HandlerSurfaceEntry[]): string[] =>
+  entries.map(formatHandlerSurfaceEntry);
+
+// Dynamic counterpart to findUnguardedBodyPathWrites: exercises each handler for real with a
+// synthetic body-path write it should refuse, and judges by whether the file actually changed —
+// so a check that's present in source but not awaited (or ordered after the write) still gets caught.
+export interface BodyPathOwnershipScenario {
+  /** Path to a file that a response other than the caller's already owns. */
+  otherBodyPath: string;
+  /** The real owner's parentId, as `services.response.getByBodyPath` would report it. */
+  otherParentId: string;
+  /** The parentId the caller claims, distinct from otherParentId. */
+  callerParentId: string;
+}
+
+/** Builds a bodyPath string that is textually different from the input yet resolves to the same absolute file via `path.resolve()`, to probe for an ownership check that compares strings exactly instead of resolving first. */
+export const buildPathNormalizationVariant = (bodyPath: string): string => {
+  const dir = path.dirname(bodyPath);
+  const base = path.basename(bodyPath);
+  return `${dir}${path.sep}__insomnia_probe_dir__${path.sep}..${path.sep}${base}`;
+};
+
+const bodyPathWriteProbePayloads = (scenario: BodyPathOwnershipScenario): Record<string, unknown>[] => {
+  const normalizationVariant = buildPathNormalizationVariant(scenario.otherBodyPath);
+  return [
+    // Shape used by response.setBody.
+    {
+      bodyPath: scenario.otherBodyPath,
+      parentId: scenario.callerParentId,
+      bodyBase64: Buffer.from('dynamic-probe-overwrite', 'utf8').toString('base64'),
+    },
+    // Shape used by plugin.runUserResponseHook (bodyPath/parentId nested under `response`).
+    {
+      plugin: { name: '__dynamic-probe-plugin__' },
+      hookIndex: 0,
+      response: { bodyPath: scenario.otherBodyPath, parentId: scenario.callerParentId },
+      renderedRequest: { url: 'https://example.com', headers: [] },
+      renderContext: {},
+    },
+    // Path-normalization variant of each shape above: same absolute file, different raw string.
+    {
+      bodyPath: normalizationVariant,
+      parentId: scenario.callerParentId,
+      bodyBase64: Buffer.from('dynamic-probe-overwrite-variant', 'utf8').toString('base64'),
+    },
+    {
+      plugin: { name: '__dynamic-probe-plugin__' },
+      hookIndex: 0,
+      response: { bodyPath: normalizationVariant, parentId: scenario.callerParentId },
+      renderedRequest: { url: 'https://example.com', headers: [] },
+      renderContext: {},
+    },
+  ];
+};
+
+/** Calls every handler with a payload that claims ownership of `scenario.otherBodyPath`; returns the path of every handler whose write actually changed that file's on-disk contents. */
+export const findHandlersThatBypassBodyPathOwnership = async (
+  handlers: Record<string, (...args: any[]) => any>,
+  scenario: BodyPathOwnershipScenario,
+): Promise<string[]> => {
+  const violations: string[] = [];
+  for (const [path, handler] of Object.entries(handlers)) {
+    for (const payload of bodyPathWriteProbePayloads(scenario)) {
+      const before = fs.readFileSync(scenario.otherBodyPath);
+      try {
+        await handler(payload);
+      } catch {
+        // Expected for handlers that reject the shape, or correctly enforce ownership.
+      }
+      const after = fs.readFileSync(scenario.otherBodyPath);
+      if (!before.equals(after)) {
+        violations.push(path);
+        fs.writeFileSync(scenario.otherBodyPath, before);
+      }
+    }
+  }
+  return [...new Set(violations)];
+};
+
+// Read-side counterpart: judges each handler by whether its *return value* discloses the contents of a path the caller has no claim to, rather than by whether a file changed.
+export interface BodyPathReadLeakScenario {
+  /** Path to a file whose contents the caller has no ownership claim over. */
+  outsidePath: string;
+  /** The real contents of `outsidePath`, used to detect disclosure in a handler's return value. */
+  outsideContents: string;
+}
+
+const bodyPathReadProbePayloads = (scenario: BodyPathReadLeakScenario): Record<string, unknown>[] => [
+  // Shape used by response.getBodyBuffer.
+  { response: { bodyPath: scenario.outsidePath } },
+  // Flat shape, in case a future handler takes bodyPath directly on the body rather than nested.
+  { bodyPath: scenario.outsidePath },
+];
+
+/** Best-effort stringify of a handler's return value (Buffer, Buffer-shaped JSON, or plain string) for a substring check. */
+const stringifyHandlerResult = (result: unknown): string => {
+  if (typeof result === 'string') {
+    return result;
+  }
+  if (Buffer.isBuffer(result)) {
+    return result.toString('utf8');
+  }
+  if (result && typeof result === 'object' && (result as { type?: string }).type === 'Buffer' && Array.isArray((result as { data?: unknown[] }).data)) {
+    return Buffer.from((result as { data: number[] }).data).toString('utf8');
+  }
+  try {
+    return JSON.stringify(result);
+  } catch {
+    return '';
+  }
+};
+
+/** Calls every handler with a payload pointing at a path the caller has no claim over; returns the path of every handler whose return value discloses its contents. */
+export const findHandlersThatLeakArbitraryBodyPathReads = async (
+  handlers: Record<string, (...args: any[]) => any>,
+  scenario: BodyPathReadLeakScenario,
+): Promise<string[]> => {
+  const violations: string[] = [];
+  for (const [path, handler] of Object.entries(handlers)) {
+    for (const payload of bodyPathReadProbePayloads(scenario)) {
+      try {
+        const result = await handler(payload);
+        if (stringifyHandlerResult(result).includes(scenario.outsideContents)) {
+          violations.push(path);
+        }
+      } catch {
+        // Expected for handlers that reject the shape, or correctly refuse to read it.
+      }
+    }
+  }
+  return [...new Set(violations)];
+};

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -34,7 +34,7 @@ import { isValidTemplatingDbAuthToken, TEMPLATING_DB_AUTH_HEADER } from './templ
 const bundlePluginModuleMap: Record<string, Plugin['module']> = {};
 
 export const resolveDbByKey = async (request: Request) => {
-  // Reject before parsing the body, so a forged call never reaches a handler with attacker-supplied data.
+  // Reject before parsing the body, so an unauthenticated call never reaches a handler.
   if (!isValidTemplatingDbAuthToken(request.headers.get(TEMPLATING_DB_AUTH_HEADER))) {
     return new Response(JSON.stringify({ error: 'Unauthorized: missing or invalid templating database auth token' }), {
       status: 401,
@@ -79,6 +79,32 @@ const resolveTrustedPlugin = async (
     throw new Error(`Unknown plugin: ${pluginName}`);
   }
   return { directory: plugin.directory, permissions: plugin.permissions };
+};
+
+// The response isn't persisted yet at hook time (no _id to reload by), so instead reject if the
+// claimed bodyPath already belongs to a different, already-persisted response's parentId.
+const assertResponseBodyPathOwnership = async (response: Record<string, any>): Promise<void> => {
+  const bodyPath = response?.bodyPath;
+  if (!bodyPath) {
+    return;
+  }
+  // Resolve before the ownership lookup so it agrees with the resolved path the write itself uses,
+  // otherwise a textually different bodyPath resolving to the same file misses this exact-string lookup.
+  const existing = await services.response.getByBodyPath(path.resolve(bodyPath));
+  if (existing && existing.parentId !== response.parentId) {
+    throw new Error('response.bodyPath belongs to a different response than the one being processed');
+  }
+};
+
+// Read-side counterpart of assertResponseBodyPathOwnership: rejects a bodyPath that isn't the stored bodyPath of an already-persisted response.
+const assertResponseBodyPathReadOwnership = async (bodyPath: string | undefined): Promise<void> => {
+  if (!bodyPath) {
+    return;
+  }
+  const existing = await services.response.getByBodyPath(path.resolve(bodyPath));
+  if (!existing) {
+    throw new Error('response.bodyPath does not belong to any known response');
+  }
 };
 
 const getBundlePluginModule = (pluginName: string): Plugin['module'] => {
@@ -603,12 +629,13 @@ export const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => P
     response?: { bodyPath?: string; bodyCompression?: any };
     readFailureValue?: string;
   }) => {
+    await assertResponseBodyPathReadOwnership(body.response?.bodyPath);
     return await services.helpers.getResponseBodyBuffer(body.response, body.readFailureValue);
   },
   // H1: a sandboxed response hook's context.response.setBody(). The body arrives base64-encoded (so
   // the bytes survive the JSON bridge). Contain the write to the responses directory as defense in
   // depth — bodyPath is host-set, but this handler must never write outside it even if that changes.
-  'response.setBody': async (body: { bodyPath?: string; bodyBase64?: string }) => {
+  'response.setBody': async (body: { bodyPath?: string; bodyBase64?: string; parentId?: string }) => {
     if (!body.bodyPath) {
       throw new Error('Could not set body without existing body path');
     }
@@ -617,6 +644,9 @@ export const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => P
     if (typeof body.bodyBase64 !== 'string') {
       throw new TypeError('response.setBody requires a base64-encoded body');
     }
+    // This handler is directly dispatchable, not only reachable via plugin.runUserResponseHook, so the
+    // ownership check must live at this actual write choke point (#10286 bypass).
+    await assertResponseBodyPathOwnership({ bodyPath: body.bodyPath, parentId: body.parentId });
     const responsesDir = path.resolve(process.env['INSOMNIA_DATA_PATH'] || app.getPath('userData'), 'responses');
     const target = path.resolve(body.bodyPath);
     const relative = path.relative(responsesDir, target);
@@ -870,6 +900,8 @@ export const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => P
   }) => {
     // Resolve directory/permissions from the trusted registry, never the caller-supplied body (#10290).
     const trusted = await resolveTrustedPlugin(body.plugin.name);
+    // Refuse to let setBody() redirect its write onto a different, already-persisted response (#10286).
+    await assertResponseBodyPathOwnership(body.response);
     return runResponseHookInSandbox(
       { ...body.plugin, directory: trusted.directory, permissions: trusted.permissions },
       body.hookIndex,

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -479,6 +479,80 @@ export const runRequestHookInSandbox = async (
   return result.request ?? hookRequest;
 };
 
+// The serializable ResponsePatch fields a response hook reads (the body itself lives on disk at
+// bodyPath and is read/written via the response.getBodyBuffer / response.setBody bridge paths).
+const HOOK_RESPONSE_FIELDS = [
+  'parentId',
+  'statusCode',
+  'statusMessage',
+  'bytesRead',
+  'bytesContent',
+  'elapsedTime',
+  'headers',
+  'bodyPath',
+  'bodyCompression',
+  'contentType',
+  'httpVersion',
+  'url',
+  'error',
+  'message',
+] as const;
+
+const pickHookResponseFields = (resp: Record<string, any>): Record<string, any> => {
+  const out: Record<string, any> = {};
+  for (const key of HOOK_RESPONSE_FIELDS) {
+    if (resp[key] !== undefined) {
+      out[key] = resp[key];
+    }
+  }
+  return out;
+};
+
+// H1: run a user plugin's response hook (at hookIndex) inside the sandbox, capability-gated. The hook
+// reads the response (and a read-only request) and may rewrite the body via the response.setBody
+// bridge; we marshal the mutated response fields back for the caller to merge.
+export const runResponseHookInSandbox = async (
+  plugin: { directory: string; name: string; permissions?: { modules?: string[]; capabilities?: string[] } },
+  hookIndex: number,
+  response: Record<string, any>,
+  renderedRequest: Record<string, any>,
+  renderContext: Record<string, any>,
+): Promise<Record<string, any>> => {
+  const { runTagInSandbox } = await import('../templating/sandbox/plugin-tag-sandbox');
+  const { resolveTemplateTagModules, resolveTemplateTagCapabilities } = await import(
+    '../templating/sandbox/surface-profiles'
+  );
+  const grantedCapabilities = resolveTemplateTagCapabilities(plugin.permissions?.capabilities);
+  const bridge = await buildSandboxBridge(grantedCapabilities);
+  const { moduleFiles, entryModuleKey } = readPluginModuleMap({ directory: plugin.directory, name: plugin.name });
+  const hookResponse = pickHookResponseFields(response);
+  const json = await runTagInSandbox({
+    tagName: '',
+    bridge,
+    hostCrypto: SANDBOX_HOST_CRYPTO,
+    envelope: {
+      args: [],
+      context: (renderContext as Record<string, any>) || {},
+      meta: {},
+      renderPurpose: 'send',
+      appInfo: { version: app.getVersion(), platform: process.platform, arch: process.arch },
+      pluginName: plugin.name,
+      renderDepth: 0,
+      grantedModules: resolveTemplateTagModules(plugin.permissions?.modules),
+      grantedCapabilities,
+      moduleFiles,
+      entryModuleKey,
+      hookKind: 'response',
+      hookIndex,
+      hookRequest: pickHookRequestFields(renderedRequest),
+      hookResponse,
+    },
+  });
+  // Sanitize untrusted sandbox output at the point it re-enters host memory (#10290).
+  const result = JSON.parse(json, stripDangerousKeysReviver) as { response?: Record<string, any> };
+  return result.response ?? hookResponse;
+};
+
 // These are exposed to the templating worker and can be used by plugins from context.util.
 // Exported so tests can enumerate every registered path.
 export const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<any>> = {
@@ -530,6 +604,22 @@ export const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => P
     readFailureValue?: string;
   }) => {
     return await services.helpers.getResponseBodyBuffer(body.response, body.readFailureValue);
+  },
+  // H1: a sandboxed response hook's context.response.setBody(). The body arrives base64-encoded (so
+  // the bytes survive the JSON bridge). Contain the write to the responses directory as defense in
+  // depth — bodyPath is host-set, but this handler must never write outside it even if that changes.
+  'response.setBody': async (body: { bodyPath?: string; bodyBase64?: string }) => {
+    if (!body.bodyPath) {
+      throw new Error('Could not set body without existing body path');
+    }
+    const responsesDir = path.resolve(process.env['INSOMNIA_DATA_PATH'] || app.getPath('userData'), 'responses');
+    const target = path.resolve(body.bodyPath);
+    const relative = path.relative(responsesDir, target);
+    if (relative.startsWith('..') || path.isAbsolute(relative)) {
+      throw new Error('response.setBody path escapes the responses directory');
+    }
+    fs.writeFileSync(target, Buffer.from(body.bodyBase64 || '', 'base64'));
+    return null;
   },
   'pluginData.hasItem': async (body: { pluginName: string; key: string }) => {
     const doc = await services.pluginData.getByKey(body.pluginName, body.key);
@@ -762,6 +852,23 @@ export const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => P
     return runRequestHookInSandbox(
       { ...body.plugin, directory: trusted.directory, permissions: trusted.permissions },
       body.hookIndex,
+      body.renderedRequest,
+      body.renderContext,
+    );
+  },
+  'plugin.runUserResponseHook': async (body: {
+    plugin: { directory: string; name: string; permissions?: { modules?: string[]; capabilities?: string[] } };
+    hookIndex: number;
+    response: Record<string, any>;
+    renderedRequest: Record<string, any>;
+    renderContext: Record<string, any>;
+  }) => {
+    // Resolve directory/permissions from the trusted registry, never the caller-supplied body (#10290).
+    const trusted = await resolveTrustedPlugin(body.plugin.name);
+    return runResponseHookInSandbox(
+      { ...body.plugin, directory: trusted.directory, permissions: trusted.permissions },
+      body.hookIndex,
+      body.response,
       body.renderedRequest,
       body.renderContext,
     );

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -612,13 +612,18 @@ export const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => P
     if (!body.bodyPath) {
       throw new Error('Could not set body without existing body path');
     }
+    // A write primitive must never silently truncate: reject a missing/non-string bodyBase64 rather
+    // than defaulting to '' (which would zero the body). An empty string is a valid empty body.
+    if (typeof body.bodyBase64 !== 'string') {
+      throw new TypeError('response.setBody requires a base64-encoded body');
+    }
     const responsesDir = path.resolve(process.env['INSOMNIA_DATA_PATH'] || app.getPath('userData'), 'responses');
     const target = path.resolve(body.bodyPath);
     const relative = path.relative(responsesDir, target);
     if (relative.startsWith('..') || path.isAbsolute(relative)) {
       throw new Error('response.setBody path escapes the responses directory');
     }
-    fs.writeFileSync(target, Buffer.from(body.bodyBase64 || '', 'base64'));
+    fs.writeFileSync(target, Buffer.from(body.bodyBase64, 'base64'));
     return null;
   },
   'pluginData.hasItem': async (body: { pluginName: string; key: string }) => {

--- a/packages/insomnia/src/plugins/invoke-method.ts
+++ b/packages/insomnia/src/plugins/invoke-method.ts
@@ -238,17 +238,34 @@ export async function invokePluginMethod(method: PluginInvokeMethod, args?: unkn
       const newResponse = { ...response };
       const newRequest = { ...renderedRequest };
       const renderedContext = deserializeRenderContext(environment);
+      // H1: with the sandbox on, a user plugin's response hook runs in the main-process sandbox over
+      // the templating-worker-database protocol; bundle plugins and the flag-off path run in-process.
+      const settings = await fetchFromTemplateWorkerDatabase('settings.get', {});
+      const sandboxEnabled = !!settings?.templateTagSandboxEnabled;
+      const hookIndexByPlugin: Record<string, number> = {};
 
       for (const { plugin, hook } of await getResponseHooks()) {
-        const context = {
-          ...pluginApp.init(),
-          ...pluginData.init(projectId),
-          ...(pluginStore.init(plugin) as Record<string, any>),
-          ...(pluginResponse.init(newResponse) as Record<string, any>),
-          ...(pluginRequest.init(newRequest as any, renderedContext, true) as Record<string, any>),
-          ...(pluginNetwork.init() as Record<string, any>),
-        };
+        const hookIndex = (hookIndexByPlugin[plugin.name] = (hookIndexByPlugin[plugin.name] ?? -1) + 1);
         try {
+          if (sandboxEnabled && plugin.directory !== '') {
+            const mutated = await fetchFromTemplateWorkerDatabase('plugin.runUserResponseHook', {
+              plugin: { directory: plugin.directory, name: plugin.name, permissions: plugin.permissions },
+              hookIndex,
+              response: newResponse,
+              renderedRequest: newRequest,
+              renderContext: renderedContext,
+            });
+            Object.assign(newResponse, mutated);
+            continue;
+          }
+          const context = {
+            ...pluginApp.init(),
+            ...pluginData.init(projectId),
+            ...(pluginStore.init(plugin) as Record<string, any>),
+            ...(pluginResponse.init(newResponse) as Record<string, any>),
+            ...(pluginRequest.init(newRequest as any, renderedContext, true) as Record<string, any>),
+            ...(pluginNetwork.init() as Record<string, any>),
+          };
           await hook(context);
         } catch (err) {
           const error = err instanceof Error ? err : new Error(String(err));

--- a/packages/insomnia/src/runtimes/network/network-adapter.node.ts
+++ b/packages/insomnia/src/runtimes/network/network-adapter.node.ts
@@ -127,16 +127,32 @@ export async function applyResponseHooks(
   const newResponse = clone(response);
   const newRequest = clone(renderedRequest);
   const pluginIndex = await import('../../plugins/index');
+  const { services } = await import('insomnia-data');
+  // The sandbox host (templating-worker-database) statically imports `electron`, so it's reachable
+  // only from an Electron process. This node runtime also backs the pure-Node inso CLI (no electron),
+  // where the sandbox is unavailable and hooks run in-process — gate on process.type accordingly.
+  const canSandbox = !!process.type;
+  const sandboxEnabled = canSandbox && (await services.settings.get()).templateTagSandboxEnabled;
+  const hookIndexByPlugin: Record<string, number> = {};
   for (const { plugin, hook } of await pluginIndex.getResponseHooks()) {
-    const context = {
-      ...(pluginApp.init() as Record<string, any>),
-      ...pluginData.init(renderedContext.getProjectId()),
-      ...(pluginStore.init(plugin) as Record<string, any>),
-      ...(pluginResponse.init(newResponse) as Record<string, any>),
-      ...(pluginRequest.init(newRequest, renderedContext, true) as Record<string, any>),
-      ...(pluginNetwork.init() as Record<string, any>),
-    };
+    const hookIndex = (hookIndexByPlugin[plugin.name] = (hookIndexByPlugin[plugin.name] ?? -1) + 1);
     try {
+      if (sandboxEnabled && plugin.directory !== '') {
+        const { runResponseHookInSandbox } = await import('../../main/templating-worker-database');
+        // The hook rewrites the body via the response.setBody bridge (on-disk) and returns the
+        // mutated response fields (e.g. bytesContent); merge them so downstream sees the change.
+        const mutated = await runResponseHookInSandbox(plugin, hookIndex, newResponse, newRequest, renderedContext);
+        Object.assign(newResponse, mutated);
+        continue;
+      }
+      const context = {
+        ...(pluginApp.init() as Record<string, any>),
+        ...pluginData.init(renderedContext.getProjectId()),
+        ...(pluginStore.init(plugin) as Record<string, any>),
+        ...(pluginResponse.init(newResponse) as Record<string, any>),
+        ...(pluginRequest.init(newRequest, renderedContext, true) as Record<string, any>),
+        ...(pluginNetwork.init() as Record<string, any>),
+      };
       await hook(context);
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));

--- a/packages/insomnia/src/templating/sandbox/host-bridge.ts
+++ b/packages/insomnia/src/templating/sandbox/host-bridge.ts
@@ -60,6 +60,11 @@ export const BRIDGE_PATH_CAPABILITIES: Record<string, Capability> = {
   'cookieJar.getCookiesForUrl': 'models.read',
   'response.getLatestForRequestId': 'models.read',
   'response.getBodyBuffer': 'models.read',
+  // A response hook rewriting its own response body (context.response.setBody). Grouped with the
+  // other response operations at baseline: it's a bounded write — the plugin supplies only bytes,
+  // never the path (bodyPath is host-set and can't be redirected), matching the ungated in-process
+  // response-hook behavior. Not a general fs write (there is no fs-write capability).
+  'response.setBody': 'models.read',
   'settings.get': 'models.read',
 
   'nodeOS': 'util',

--- a/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
+++ b/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
@@ -465,7 +465,7 @@ export const IN_SANDBOX_BOOTSTRAP = [
   '        if (!resp.bodyPath) { throw new Error("Could not set body without existing body path"); }',
   '        resp.bytesContent = (body && body.length) || 0;',
   '        var b64 = (typeof body === "string") ? Buffer.from(body, "utf8").toString("base64") : Buffer.from(body || []).toString("base64");',
-  '        return __bridge("response.setBody", { bodyPath: resp.bodyPath, bodyBase64: b64 });',
+  '        return __bridge("response.setBody", { bodyPath: resp.bodyPath, bodyBase64: b64, parentId: resp.parentId });',
   '      },',
   '      getHeader: function (name) {',
   '        var headers = resp.headers || [];',

--- a/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
+++ b/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
@@ -457,7 +457,9 @@ export const IN_SANDBOX_BOOTSTRAP = [
   '      getStatusMessage: function () { return resp.statusMessage || ""; },',
   '      getBytesRead: function () { return resp.bytesRead || 0; },',
   '      getTime: function () { return resp.elapsedTime || 0; },',
-  '      getBody: function () { return __bridge("response.getBodyBuffer", { response: { bodyPath: resp.bodyPath, bodyCompression: resp.bodyCompression } }); },',
+  // The host returns a Buffer; the JSON bridge marshals it as { type: "Buffer", data: [...] }. Revive
+  // it to a real (shimmed) Buffer so hooks consume getBody() the same as the in-process response API.
+  '      getBody: function () { return __bridge("response.getBodyBuffer", { response: { bodyPath: resp.bodyPath, bodyCompression: resp.bodyCompression } }).then(function (raw) { if (raw && typeof raw === "object" && raw.type === "Buffer" && raw.data) { return Buffer.from(raw.data); } return raw; }); },',
   '      getBodyStream: function () { throw new Error("response.getBodyStream() is not available in the sandbox; use getBody()"); },',
   '      setBody: function (body) {',
   '        if (!resp.bodyPath) { throw new Error("Could not set body without existing body path"); }',

--- a/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
+++ b/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
@@ -443,6 +443,47 @@ export const IN_SANDBOX_BOOTSTRAP = [
   '    return api;',
   '  }',
 
+  // --- response-hook API rebuilt in-sandbox over the copied-in response object (`resp`) ---
+  // Mirrors packages/insomnia/src/plugins/context/response.ts. No readOnly variant (response.ts has
+  // none). Header matching is CASE-INSENSITIVE and hand-rolled (NOT misc.filterHeaders); getHeader
+  // returns string | string[] | null exactly as response.ts:91-101. Sync field reads never touch the
+  // host; getBody/setBody route through __bridge (no fs in the sandbox). setBody sends the body as
+  // base64 so the bytes survive the JSON bridge; the host decodes and writes the file.
+  '  function __buildResponseApi(resp) {',
+  '    if (!resp) { throw new Error("contexts.response initialized without response"); }',
+  '    var api = {',
+  '      getRequestId: function () { return resp.parentId || ""; },',
+  '      getStatusCode: function () { return resp.statusCode || 0; },',
+  '      getStatusMessage: function () { return resp.statusMessage || ""; },',
+  '      getBytesRead: function () { return resp.bytesRead || 0; },',
+  '      getTime: function () { return resp.elapsedTime || 0; },',
+  '      getBody: function () { return __bridge("response.getBodyBuffer", { response: { bodyPath: resp.bodyPath, bodyCompression: resp.bodyCompression } }); },',
+  '      getBodyStream: function () { throw new Error("response.getBodyStream() is not available in the sandbox; use getBody()"); },',
+  '      setBody: function (body) {',
+  '        if (!resp.bodyPath) { throw new Error("Could not set body without existing body path"); }',
+  '        resp.bytesContent = (body && body.length) || 0;',
+  '        var b64 = (typeof body === "string") ? Buffer.from(body, "utf8").toString("base64") : Buffer.from(body || []).toString("base64");',
+  '        return __bridge("response.setBody", { bodyPath: resp.bodyPath, bodyBase64: b64 });',
+  '      },',
+  '      getHeader: function (name) {',
+  '        var headers = resp.headers || [];',
+  '        var matched = [];',
+  '        for (var i = 0; i < headers.length; i++) { if (headers[i].name.toLowerCase() === name.toLowerCase()) { matched.push(headers[i]); } }',
+  '        if (matched.length > 1) { var vals = []; for (var j = 0; j < matched.length; j++) { vals.push(matched[j].value); } return vals; }',
+  '        if (matched.length === 1) { return matched[0].value; }',
+  '        return null;',
+  '      },',
+  '      getHeaders: function () {',
+  '        if (!resp.headers) { return undefined; }',
+  '        var out = [];',
+  '        for (var i = 0; i < resp.headers.length; i++) { out.push({ name: resp.headers[i].name, value: resp.headers[i].value }); }',
+  '        return out;',
+  '      },',
+  '      hasHeader: function (name) { return this.getHeader(name) !== null; }',
+  '    };',
+  '    return api;',
+  '  }',
+
   // --- load the plugin (its entry module, resolving any relative requires) and run the tag ---
   '  globalThis.__invoke = function () {',
   '    var env = __env;',
@@ -469,11 +510,14 @@ export const IN_SANDBOX_BOOTSTRAP = [
   '    var hooks = (isResponse ? (mod && mod.responseHooks) : (mod && mod.requestHooks)) || [];',
   '    var hook = hooks[env.hookIndex];',
   '    if (typeof hook !== "function") { throw new Error("Plugin " + (isResponse ? "response" : "request") + " hook not found at index " + env.hookIndex); }',
-  // Response hooks get a read-only request view (matches pluginRequest.init(..., true)).
-  // Pass hookRequest through directly (no `|| {}`): __buildRequestApi throws on a missing request,
-  // matching the in-process pluginRequest.init(), and keeps the marshaled-back object === the mutated one.
+  // Response hooks get a read-only request view (matches pluginRequest.init(..., true)) plus the
+  // response API; request hooks get a mutable request only. Pass hookRequest/hookResponse through
+  // directly (no `|| {}`): __buildRequestApi/__buildResponseApi throw on missing data, matching the
+  // in-process pluginRequest.init()/pluginResponse.init(), and keep the marshaled-back objects === the
+  // ones the hook mutated.
   '    ctx.request = __buildRequestApi(env.hookRequest, isResponse);',
-  '    return Promise.resolve(hook(ctx)).then(function () { return JSON.stringify({ request: env.hookRequest }); });',
+  '    if (isResponse) { ctx.response = __buildResponseApi(env.hookResponse); }',
+  '    return Promise.resolve(hook(ctx)).then(function () { return JSON.stringify({ request: env.hookRequest, response: env.hookResponse }); });',
   '  };',
 
   // --- describe the plugin's exports without running any of them (L1 load-time discovery) ---

--- a/packages/insomnia/src/templating/sandbox/sandbox-hooks.test.ts
+++ b/packages/insomnia/src/templating/sandbox/sandbox-hooks.test.ts
@@ -95,7 +95,10 @@ describe('request hooks in the sandbox (H1)', () => {
     const bridge: HostBridge = async (path, body) => {
       bridgeCalls.push({ path, body });
       if (path === 'response.getBodyBuffer') {
-        return 'ORIGINAL';
+        // The real host returns a Node Buffer, which the JSON bridge marshals as
+        // { type: 'Buffer', data: [...] }. Return that exact shape (not a bare string) so the
+        // sandbox getBody() Buffer-revive is actually exercised.
+        return { type: 'Buffer', data: Array.from(Buffer.from('ORIGINAL', 'utf8')) };
       }
       if (path === 'response.setBody') {
         return null;
@@ -118,7 +121,8 @@ describe('request hooks in the sandbox (H1)', () => {
           if (typeof context.request.setHeader !== 'undefined') { throw new Error('request should be read-only in a response hook'); }
           var status = context.response.getStatusCode();
           var ctype = context.response.getHeader('content-type');
-          var original = await context.response.getBody();
+          // getBody() resolves to a (revived) Buffer, exactly like the in-process response API; decode it.
+          var original = (await context.response.getBody()).toString('utf8');
           context.response.setBody('rewritten:' + status + ':' + ctype + ':' + original);
         }];`,
       },

--- a/packages/insomnia/src/templating/sandbox/sandbox-hooks.test.ts
+++ b/packages/insomnia/src/templating/sandbox/sandbox-hooks.test.ts
@@ -90,6 +90,62 @@ describe('request hooks in the sandbox (H1)', () => {
     ).rejects.toThrow(/sendRequest/i);
   });
 
+  it('runs a response hook: reads response, rewrites the body via the host bridge (base64), request is read-only', async () => {
+    const bridgeCalls: { path: string; body: any }[] = [];
+    const bridge: HostBridge = async (path, body) => {
+      bridgeCalls.push({ path, body });
+      if (path === 'response.getBodyBuffer') {
+        return 'ORIGINAL';
+      }
+      if (path === 'response.setBody') {
+        return null;
+      }
+      throw new Error(`unexpected bridge call: ${path}`);
+    };
+    const envelope: ContextEnvelope = {
+      args: [],
+      context: {},
+      meta: {},
+      renderPurpose: 'send',
+      appInfo: { version: '0.0.0', platform: 'linux', arch: 'x64' },
+      pluginName: 'test-plugin',
+      renderDepth: 0,
+      grantedModules: ['path', 'crypto'],
+      grantedCapabilities: [],
+      moduleFiles: {
+        'index.js': `module.exports.responseHooks = [async function (context) {
+          // read-only request view: mutators are absent, getters work
+          if (typeof context.request.setHeader !== 'undefined') { throw new Error('request should be read-only in a response hook'); }
+          var status = context.response.getStatusCode();
+          var ctype = context.response.getHeader('content-type');
+          var original = await context.response.getBody();
+          context.response.setBody('rewritten:' + status + ':' + ctype + ':' + original);
+        }];`,
+      },
+      entryModuleKey: 'index.js',
+      hookKind: 'response',
+      hookIndex: 0,
+      hookRequest: { url: 'https://x', method: 'GET', headers: [] },
+      hookResponse: {
+        parentId: 'req_1',
+        statusCode: 201,
+        headers: [{ name: 'Content-Type', value: 'text/plain' }],
+        bodyPath: '/tmp/body-1',
+      },
+    };
+    const json = await runTagInSandbox({ tagName: '', envelope, bridge });
+    const result = JSON.parse(json) as HookResult;
+
+    // getBody read went through the existing models.read bridge path.
+    expect(bridgeCalls.some(c => c.path === 'response.getBodyBuffer')).toBe(true);
+    // setBody wrote via the new host path, base64-encoded so the bytes survive the JSON bridge.
+    const setCall = bridgeCalls.find(c => c.path === 'response.setBody');
+    expect(setCall?.body.bodyPath).toBe('/tmp/body-1');
+    expect(Buffer.from(setCall!.body.bodyBase64, 'base64').toString('utf8')).toBe('rewritten:201:text/plain:ORIGINAL');
+    // bytesContent is updated on the response marshaled back to the host.
+    expect((result.response as any)?.bytesContent).toBe('rewritten:201:text/plain:ORIGINAL'.length);
+  });
+
   it('allows a granted capability: context.network is present when the manifest grants network', async () => {
     // With 'network' granted the branch exists; feature-detecting it as an object proves C2 attaches
     // the branch (the actual call would bridge to the host, which the unit test bridge rejects).


### PR DESCRIPTION
## Summary

Phase 2, **PR 10b — H1 (response hooks)**, completing H1 (request hooks landed in #10279). Routes a **user** plugin's response hooks through the QuickJS sandbox: the hook reads the response and can rewrite its body, but reaches the host only through capability-gated bridges. Bundle plugins stay in-process; gated on `templateTagSandboxEnabled`. Stacked on #10279.

## How it works

- **`__buildResponseApi` (in-sandbox):** faithful ES5 rebuild of `plugins/context/response.ts` — getters (status/headers/time; `getHeader` returns `string | string[] | null`, case-insensitive). `getBody()` bridges to the existing `response.getBodyBuffer` path. `getBodyStream()` throws (a Node `Readable` can't cross the sandbox). `setBody()` base64-encodes the bytes over a **new `response.setBody` bridge** and updates `bytesContent`.
- **`__invokeHook`:** for response hooks, attaches `context.response` + a **read-only** `context.request` (matches `pluginRequest.init(..., true)`), and marshals both back out.
- **`response.setBody` host handler:** base64-decode → `fs.writeFileSync`, **contained to the responses directory** as defense in depth (`bodyPath` is host-set, never plugin-chosen). Mapped at **baseline** (`models.read`, grouped with the other response ops) — a bounded write matching the ungated in-process behavior; not a general fs write.
- **Both paths wired:** `network-adapter.node.ts` (main/CLI) calls `runResponseHookInSandbox` directly; `invoke-method.ts` (plugin window) over the protocol. Per-plugin hook-index recovery; the returned response fields merge onto `newResponse` and the body change persists via the on-disk write.

## Tests

- **Unit** (`sandbox-hooks.test.ts`): a response hook reads status/headers, reads the body via the bridge, and rewrites it via `setBody` — asserting the base64 round-trip, `bytesContent`, and that the request view is read-only.
- **E2E** (`sandbox-hook-collection.yaml`): a response hook rewrites the body; the echo response pane shows it. Flag **off** reports `ranin-mainprocess` (control); flag **on** reports `ranin-sandboxed`.

Local: 23 sandbox/worker-db unit tests + type-check + lint (incl. smoke workspace) green. Electron smoke runs in CI.

## Note on scope
`getBodyStream()` intentionally throws in the sandbox (a Node stream is unmarshalable) — response hooks should use `getBody()`. This is the one deliberate behavior difference from the in-process path.
