### PR TITLE
fix(first-request): add spacing below quick actions/examples row (treatment A)

### DIFF
--- a/packages/insomnia/src/ui/components/first-request-creation.tsx
+++ b/packages/insomnia/src/ui/components/first-request-creation.tsx
@@ -631,7 +631,7 @@ export const FirstRequestCreation = ({
           </div>
 
           {treatment === 'A' && (
-            <div className="mt-1 flex flex-wrap gap-x-10 gap-y-6">
+            <div className="mt-1 mb-3 flex flex-wrap gap-x-10 gap-y-6">
               <div>
                 <p className="text-sm font-semibold text-(--hl)">Quick actions</p>
                 <div className="mt-2 flex flex-wrap gap-2">{quickActions.map(renderQuickStartButton)}</div>


### PR DESCRIPTION
## Summary
- Treatment A's "Quick actions" / "Start with an example" row sat too close to the card's bottom edge. Added `mb-3` (12px) below that block so it has breathing room, scoped to treatment A only since treatment B doesn't render this section.

## Screenshot
<img width="2622" height="488" alt="image" src="https://github.com/user-attachments/assets/e31edeca-803b-43b0-9778-9496a0098e32" />

