### PR TITLE
fix(templating): authenticate plugin IPC dispatch and sanitize hook marshal boundary

### DIFF
--- a/packages/insomnia-smoke-test/fixtures/sandbox-hook-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/sandbox-hook-collection.yaml
@@ -1,0 +1,20 @@
+type: collection.insomnia.rest/5.0
+schema_version: "5.1"
+name: Sandbox Hook Collection
+meta:
+  id: wrk_5a4h100000000000000000000000001
+  created: 1751800000000
+  modified: 1751800000000
+collection:
+  - url: http://127.0.0.1:4010/echo
+    name: Hook Request
+    meta:
+      id: req_5a4h100000000000000000000000002
+      created: 1751800000001
+      modified: 1751800000001
+      isPrivate: false
+      sortKey: -1751800000001
+    method: GET
+    headers:
+      - name: Content-Type
+        value: text/plain

--- a/packages/insomnia-smoke-test/fixtures/sandbox-l1-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/sandbox-l1-collection.yaml
@@ -1,0 +1,24 @@
+type: collection.insomnia.rest/5.0
+schema_version: "5.1"
+name: Sandbox L1 Collection
+meta:
+  id: wrk_5a4l100000000000000000000000001
+  created: 1751800000000
+  modified: 1751800000000
+collection:
+  - url: http://127.0.0.1:4010/echo
+    name: L1 Probe
+    meta:
+      id: req_5a4l100000000000000000000000002
+      created: 1751800000001
+      modified: 1751800000001
+      isPrivate: false
+      sortKey: -1751800000001
+    method: GET
+    body:
+      mimeType: text/plain
+      text: |
+        {% l1probe %}
+    headers:
+      - name: Content-Type
+        value: text/plain

--- a/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
@@ -709,3 +709,62 @@ test('Plugin sandbox (L1): installing a user plugin no longer runs its top-level
   };
   await expect.poll(() => readTagPreview('{% l1probe'), { timeout: 20_000 }).toContain('l1-tag-ran');
 });
+
+test('Request hook sandbox (H1): a user plugin request hook runs in the sandbox and mutates the request', async ({
+  page,
+  app,
+  dataPath,
+  insomnia,
+}) => {
+  // The hook injects two headers: X-Ran-In reports its execution environment (the canary — the
+  // sandbox sets INSOMNIA_TEMPLATE_SANDBOX; the legacy in-process path does not), and X-Sandbox-Hook
+  // is a fixed marker. The request targets the echo server, which reflects request headers into the
+  // response body, so both headers appear there.
+  writePlugin(
+    dataPath,
+    'insomnia-plugin-hook-probe',
+    {},
+    `
+      module.exports.requestHooks = [
+        function (context) {
+          var ranIn = typeof INSOMNIA_TEMPLATE_SANDBOX !== 'undefined' ? 'sandbox' : 'main-process';
+          context.request.setHeader('X-Ran-In', ranIn);
+          context.request.setHeader('X-Sandbox-Hook', 'sandbox-hook-value');
+        },
+      ];
+    `,
+  );
+
+  const fixture = await loadFixture('sandbox-hook-collection.yaml');
+  await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), fixture);
+  await clearPluginToast(page);
+  await page.getByLabel('Import').click();
+  await page.locator('[data-test-id="import-from-clipboard"]').click();
+  await page.getByRole('button', { name: 'Scan' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+  await page.evaluate(() => (window as any).main.plugins.reloadPlugins());
+
+  await insomnia.navigationSidebar.clickRequestOrFolder('Hook Request');
+  const responsePane = page.getByTestId('response-pane');
+
+  // Flag OFF (default): the hook runs in-process (control).
+  await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
+  await expect.soft(page.locator('[data-testid="response-status-tag"]:visible')).toContainText('200');
+  await expect.soft(responsePane).toContainText('main-process');
+
+  // Flag ON: the same hook now runs in the QuickJS sandbox, still mutating the request. Poll the send
+  // so the just-toggled setting has propagated before we assert the sandbox canary.
+  await enableSandbox(page);
+  await expect
+    .poll(
+      async () => {
+        await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
+        return (await responsePane.textContent()) || '';
+      },
+      { timeout: 25_000 },
+    )
+    .toContain('sandbox');
+  // The header mutation round-tripped through the sandbox and reached the wire.
+  await expect.soft(responsePane).toContainText('X-Sandbox-Hook');
+  await expect.soft(responsePane).toContainText('sandbox-hook-value');
+});

--- a/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
@@ -716,10 +716,11 @@ test('Request hook sandbox (H1): a user plugin request hook runs in the sandbox 
   dataPath,
   insomnia,
 }) => {
-  // The hook injects two headers: X-Ran-In reports its execution environment (the canary — the
-  // sandbox sets INSOMNIA_TEMPLATE_SANDBOX; the legacy in-process path does not), and X-Sandbox-Hook
-  // is a fixed marker. The request targets the echo server, which reflects request headers into the
-  // response body, so both headers appear there.
+  // The hook injects two headers, and the request targets the echo server, which reflects request
+  // headers into the response body. We assert on the header *values* (not names) because the echo
+  // lowercases header names but preserves values. X-Ran-In's value is the canary — the sandbox sets
+  // INSOMNIA_TEMPLATE_SANDBOX, the legacy in-process path does not — and the values are chosen so
+  // neither is a substring of the other (or of the marker), keeping the assertions unambiguous.
   writePlugin(
     dataPath,
     'insomnia-plugin-hook-probe',
@@ -727,9 +728,9 @@ test('Request hook sandbox (H1): a user plugin request hook runs in the sandbox 
     `
       module.exports.requestHooks = [
         function (context) {
-          var ranIn = typeof INSOMNIA_TEMPLATE_SANDBOX !== 'undefined' ? 'sandbox' : 'main-process';
+          var ranIn = typeof INSOMNIA_TEMPLATE_SANDBOX !== 'undefined' ? 'ranin-sandboxed' : 'ranin-mainprocess';
           context.request.setHeader('X-Ran-In', ranIn);
-          context.request.setHeader('X-Sandbox-Hook', 'sandbox-hook-value');
+          context.request.setHeader('X-Hook-Marker', 'hook-marker-9k2x');
         },
       ];
     `,
@@ -750,7 +751,7 @@ test('Request hook sandbox (H1): a user plugin request hook runs in the sandbox 
   // Flag OFF (default): the hook runs in-process (control).
   await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
   await expect.soft(page.locator('[data-testid="response-status-tag"]:visible')).toContainText('200');
-  await expect.soft(responsePane).toContainText('main-process');
+  await expect.soft(responsePane).toContainText('ranin-mainprocess');
 
   // Flag ON: the same hook now runs in the QuickJS sandbox, still mutating the request. Poll the send
   // so the just-toggled setting has propagated before we assert the sandbox canary.
@@ -763,8 +764,7 @@ test('Request hook sandbox (H1): a user plugin request hook runs in the sandbox 
       },
       { timeout: 25_000 },
     )
-    .toContain('sandbox');
-  // The header mutation round-tripped through the sandbox and reached the wire.
-  await expect.soft(responsePane).toContainText('X-Sandbox-Hook');
-  await expect.soft(responsePane).toContainText('sandbox-hook-value');
+    .toContain('ranin-sandboxed');
+  // The second header mutation also round-tripped through the sandbox and reached the wire.
+  await expect.soft(responsePane).toContainText('hook-marker-9k2x');
 });

--- a/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
@@ -640,3 +640,72 @@ test('Template tag sandbox: multi-file plugins resolve relative requires and ign
   // The plugin's own node_modules/uuid ('evil') is never consulted — the real vetted uuid runs.
   await assertTagPreview('{% poisonprobe', 'poison-real');
 });
+
+test('Plugin sandbox (L1): installing a user plugin no longer runs its top-level code on the host', async ({
+  page,
+  app,
+  dataPath,
+  insomnia,
+}) => {
+  const SENTINEL_PLUGIN = 'insomnia-plugin-l1-sentinel';
+  const sentinelPath = path.join(dataPath, 'plugins', SENTINEL_PLUGIN, 'sentinel.txt');
+
+  // The plugin's TOP-LEVEL code tries to write a file via a Node built-in. With the sandbox off, the
+  // loader nodeRequire()s the module on the host, so require('fs') works and the sentinel appears.
+  // With the sandbox on, exports are discovered by evaluating the source INSIDE the sandbox, where
+  // require('fs') is default-denied — so the write never happens, yet the tag still enumerates + runs.
+  // The try/catch keeps discovery from failing on the denied require, so the plugin still loads.
+  writePlugin(
+    dataPath,
+    SENTINEL_PLUGIN,
+    {},
+    `
+      try { require('fs').writeFileSync(__dirname + '/sentinel.txt', 'top-level-ran-on-host'); } catch (e) {}
+      module.exports.templateTags = [{
+        name: 'l1probe', displayName: 'L1 Probe', description: 'discovery marker', args: [],
+        async run() { return 'l1-tag-ran'; },
+      }];
+    `,
+  );
+
+  const fixture = await loadFixture('sandbox-l1-collection.yaml');
+  await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), fixture);
+  await clearPluginToast(page);
+  await page.getByLabel('Import').click();
+  await page.locator('[data-test-id="import-from-clipboard"]').click();
+  await page.getByRole('button', { name: 'Scan' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+
+  // Flag OFF (default): the loader runs the plugin's top-level code on the host (control).
+  await page.evaluate(() => (window as any).main.plugins.reloadPlugins());
+  expect.soft(fs.existsSync(sentinelPath), 'sandbox off: top-level code runs on the host').toBe(true);
+
+  // Flag ON: re-discover via the sandbox. Poll delete→reload→check so the just-toggled setting has
+  // time to propagate to the main process before we conclude the write did not recur.
+  await enableSandbox(page);
+  await expect
+    .poll(
+      async () => {
+        fs.rmSync(sentinelPath, { force: true });
+        await page.evaluate(() => (window as any).main.plugins.reloadPlugins());
+        return fs.existsSync(sentinelPath);
+      },
+      { timeout: 20_000 },
+    )
+    .toBe(false);
+
+  // Discovery still worked without host execution: the tag enumerates and runs in the sandbox.
+  await insomnia.navigationSidebar.clickRequestOrFolder('L1 Probe');
+  await page.getByText('Body', { exact: true }).click();
+  const readTagPreview = async (tagPrefix: string): Promise<string> => {
+    await page.locator(`[data-template^="${tagPrefix}"]`).click();
+    const modal = page.getByRole('dialog');
+    const preview = modal.getByLabel('Live Preview');
+    await expect.soft(preview).not.toHaveValue('rendering...');
+    const value = (await preview.inputValue()).trim();
+    await modal.getByRole('button', { name: 'Done' }).click();
+    await expect.soft(modal).toBeHidden();
+    return value;
+  };
+  await expect.poll(() => readTagPreview('{% l1probe'), { timeout: 20_000 }).toContain('l1-tag-ran');
+});

--- a/packages/insomnia/src/common/templating/types.ts
+++ b/packages/insomnia/src/common/templating/types.ts
@@ -95,6 +95,7 @@ export type PluginToMainAPIPaths =
   | 'plugin.getUserPluginTemplateTags'
   | 'plugin.executeUserPluginTag'
   | 'plugin.discoverUserPluginExports'
+  | 'plugin.runUserRequestHook'
   | 'app.alert'
   | 'app.dialog'
   | 'app.prompt'

--- a/packages/insomnia/src/common/templating/types.ts
+++ b/packages/insomnia/src/common/templating/types.ts
@@ -94,6 +94,7 @@ export type PluginToMainAPIPaths =
   | 'plugin.executeBundlePluginMainAction'
   | 'plugin.getUserPluginTemplateTags'
   | 'plugin.executeUserPluginTag'
+  | 'plugin.discoverUserPluginExports'
   | 'app.alert'
   | 'app.dialog'
   | 'app.prompt'

--- a/packages/insomnia/src/main/__tests__/plugin-window-ipc-authorization.test.ts
+++ b/packages/insomnia/src/main/__tests__/plugin-window-ipc-authorization.test.ts
@@ -1,0 +1,206 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// PR #10279 (H1) makes user-plugin request hooks capability-gated *inside* the QuickJS
+// sandbox, but the sandbox is only ever reached via IPC dispatchers in `plugin-window.ts`
+// (`plugins.applyRequestHooks` and its siblings). Those dispatchers used to accept a request
+// from *any* sender — no capability gating inside the sandbox matters if the dispatch that
+// reaches it never checks who's asking, with what data. See
+// `templating/sandbox/H1-HOOK-SANDBOX-SECURITY-REVIEW.md`, finding 1.
+//
+// The fix routes every `ipcMain.handle`/`ipcMain.on` registration in `plugin-window.ts`
+// through one of three sender-checked wrapper functions (`handleFromMainWindow`,
+// `onFromPluginWindow`, `handleFromPluginWindow`). This file has two guardrails, not one:
+//
+//   1. A STATIC test that the source of `plugin-window.ts` contains no bare `ipcMain.handle(`/
+//      `ipcMain.on(` call outside those three wrapper bodies — so a future engineer literally
+//      cannot add a new unauthenticated channel to this file without the wrapper (protected
+//      automatically) or the build failing (bypassed the wrapper).
+//   2. A DYNAMIC/behavioral test that iterates over every channel *actually registered* by
+//      `registerPluginIpcHandlers()` at runtime — not a hardcoded list of channel names — and
+//      proves each one rejects a forged sender. Because the loop reads the live registration
+//      map, a newly added `plugins.*` channel is exercised automatically the next time this
+//      suite runs, with no per-channel test to remember to add.
+//
+// Do not "fix" a failing test here by loosening an assertion or adding a name to an allowlist
+// without a one-line justification — that defeats the point of both guardrails.
+
+const registeredHandlers = new Map<string, (...args: any[]) => any>();
+const registeredListeners = new Map<string, (...args: any[]) => any>();
+
+const fakePluginWebContents = {
+  send: vi.fn(),
+  on: vi.fn(),
+  once: vi.fn(),
+  off: vi.fn(),
+};
+
+const fakePluginWindow = {
+  isDestroyed: () => false,
+  webContents: fakePluginWebContents,
+  on: vi.fn(),
+  loadFile: vi.fn(),
+};
+
+const fakeMainWebContents = { send: vi.fn() };
+const fakeMainWindow = { webContents: fakeMainWebContents };
+
+// A sender that is neither the real plugin window nor the real main window — the forged
+// caller identity an attacker (or an unrelated compromised/renderer context) would present.
+const forgedSender = { id: 'attacker-controlled-webcontents' };
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => '/fake/userData') },
+  BrowserWindow: vi.fn(() => fakePluginWindow),
+  ipcMain: {
+    handle: vi.fn((channel: string, fn: (...args: any[]) => any) => registeredHandlers.set(channel, fn)),
+    on: vi.fn((channel: string, fn: (...args: any[]) => any) => registeredListeners.set(channel, fn)),
+  },
+}));
+
+vi.mock('../window-utils', () => ({
+  getMainWindow: vi.fn(() => fakeMainWindow),
+}));
+
+vi.mock('../prompt-bridge', () => ({
+  requestPromptFromRenderer: vi.fn(),
+}));
+
+describe('plugin-window.ts IPC dispatch: sender authorization', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    registeredHandlers.clear();
+    registeredListeners.clear();
+    fakePluginWebContents.send.mockClear();
+    fakeMainWebContents.send.mockClear();
+  });
+
+  it('[static guardrail] every ipcMain.handle/.on call is confined to the three sender-checked wrappers', () => {
+    const source = readFileSync(path.join(__dirname, '..', 'plugin-window.ts'), 'utf8');
+
+    // Isolate the three wrapper *definitions* (the only place a raw `ipcMain.` call may
+    // appear) from the rest of the file.
+    const wrapperNames = ['handleFromMainWindow', 'onFromPluginWindow', 'handleFromPluginWindow'];
+    let withoutWrapperBodies = source;
+    for (const name of wrapperNames) {
+      const start = source.indexOf(`function ${name}`);
+      expect(start, `expected to find the ${name} wrapper definition`).toBeGreaterThan(-1);
+      // Each wrapper is a small, single-purpose function; its closing brace is the first
+      // top-level "}\n" after the opening one. Locating the matching brace by depth avoids
+      // assuming a fixed line count that would silently stop covering the real body if the
+      // wrapper grows.
+      let depth = 0;
+      let end = -1;
+      for (let i = source.indexOf('{', start); i < source.length; i++) {
+        if (source[i] === '{') depth++;
+        if (source[i] === '}') {
+          depth--;
+          if (depth === 0) {
+            end = i + 1;
+            break;
+          }
+        }
+      }
+      expect(end, `expected to find the end of the ${name} wrapper body`).toBeGreaterThan(start);
+      withoutWrapperBodies = withoutWrapperBodies.replace(source.slice(start, end), '');
+    }
+
+    expect(withoutWrapperBodies).not.toMatch(/\bipcMain\.handle\(/);
+    expect(withoutWrapperBodies).not.toMatch(/\bipcMain\.on\(/);
+  });
+
+  it('[dynamic] every channel registered by registerPluginIpcHandlers() rejects a forged sender', async () => {
+    const { registerPluginIpcHandlers } = await import('../plugin-window');
+    registerPluginIpcHandlers();
+
+    // Read whatever is *actually* registered at runtime, not a hardcoded name list — a new
+    // `plugins.*` channel added to `registerPluginIpcHandlers()` in the future is covered by
+    // this loop automatically.
+    expect(registeredHandlers.size).toBeGreaterThan(0);
+    for (const [channel, handler] of registeredHandlers) {
+      expect(
+        () => handler({ sender: forgedSender }, {}),
+        `expected plugins channel "${channel}" to reject a forged sender`,
+      ).toThrow(/sender is not the main app window/);
+    }
+  });
+
+  it('[dynamic] every channel registered by registerPluginIpcHandlers() accepts the real main window', async () => {
+    const { registerPluginIpcHandlers } = await import('../plugin-window');
+    registerPluginIpcHandlers();
+
+    for (const [channel, handler] of registeredHandlers) {
+      expect(
+        () => handler({ sender: fakeMainWebContents }, {}),
+        `expected plugins channel "${channel}" to accept the real main window sender`,
+      ).not.toThrow();
+    }
+  });
+
+  it('demonstrates the original vulnerability is fixed: plugins.applyRequestHooks now rejects a forged sender carrying attacker data', async () => {
+    const { registerPluginIpcHandlers } = await import('../plugin-window');
+    registerPluginIpcHandlers();
+
+    const applyRequestHooksHandler = registeredHandlers.get('plugins.applyRequestHooks');
+    expect(applyRequestHooksHandler).toBeTypeOf('function');
+
+    const forgedArgs = {
+      renderedRequest: { _id: 'req_forged', url: 'https://internal.example/secret', headers: [] },
+      projectId: 'proj_not_mine',
+      environment: { BASE_URL: 'https://attacker.example' },
+    };
+
+    expect(() => applyRequestHooksHandler!({ sender: forgedSender }, forgedArgs)).toThrow(
+      /sender is not the main app window/,
+    );
+    // The forged payload never reached the plugin window at all.
+    expect(fakePluginWebContents.send).not.toHaveBeenCalled();
+  });
+
+  it('plugins.uiAlert (a plugin-window -> host callback) still ignores a forged sender', async () => {
+    const { registerPluginIpcHandlers, createPluginWindow } = await import('../plugin-window');
+    registerPluginIpcHandlers();
+    // `ensureIpcListeners()` (which registers `plugins.uiAlert`) only runs inside
+    // `createPluginWindow()`.
+    createPluginWindow();
+
+    const uiAlertListener = registeredListeners.get('plugins.uiAlert');
+    expect(uiAlertListener).toBeTypeOf('function');
+
+    uiAlertListener!({ sender: forgedSender }, { message: 'hi' });
+
+    expect(fakeMainWebContents.send).not.toHaveBeenCalled();
+  });
+
+  it('end-to-end: a legitimate main-window call to plugins.applyRequestHooks still dispatches to the plugin window', async () => {
+    const { registerPluginIpcHandlers } = await import('../plugin-window');
+    registerPluginIpcHandlers();
+
+    const applyRequestHooksHandler = registeredHandlers.get('plugins.applyRequestHooks')!;
+    const legitimateArgs = {
+      renderedRequest: { _id: 'req_1', url: 'https://example.com', headers: [] },
+      projectId: 'proj_1',
+      environment: {},
+    };
+
+    const invokePromise = applyRequestHooksHandler({ sender: fakeMainWebContents }, legitimateArgs);
+
+    await vi.advanceTimersByTimeAsync(0);
+    const windowReadyListener = registeredListeners.get('plugins.windowReady');
+    windowReadyListener!({ sender: fakePluginWebContents });
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(fakePluginWebContents.send).toHaveBeenCalledWith(
+      'plugins.invoke',
+      expect.objectContaining({ method: 'applyRequestHooks', args: legitimateArgs }),
+    );
+
+    const [, { id }] = fakePluginWebContents.send.mock.calls[0];
+    const invokeResultListener = registeredListeners.get('plugins.invokeResult');
+    invokeResultListener!({ sender: fakePluginWebContents }, { id, result: {} });
+    await expect(invokePromise).resolves.toEqual({});
+  });
+});

--- a/packages/insomnia/src/main/plugin-window.ts
+++ b/packages/insomnia/src/main/plugin-window.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow, ipcMain, type IpcMainEvent, type IpcMainInvokeEvent } from 'electron';
 
 import { requestPromptFromRenderer } from './prompt-bridge';
 import { getMainWindow } from './window-utils';
@@ -69,6 +69,65 @@ export function getBridgeMetricsSnapshot() {
   };
 }
 
+// --- Sender-checked IPC registration wrappers -------------------------------------------
+//
+// Every `ipcMain.handle`/`ipcMain.on` call in this file MUST go through one of the three
+// wrappers below rather than the raw `ipcMain` API. Each wrapper enforces which window is
+// allowed to be the caller for its direction of traffic; a channel registered any other way
+// has no caller-identity check at all, which is exactly the gap documented as finding 1 in
+// `templating/sandbox/H1-HOOK-SANDBOX-SECURITY-REVIEW.md` (`plugins.applyRequestHooks` used
+// to accept a request from *any* sender, letting anything reach the plugin-dispatch facility
+// with forged data regardless of what capability gating happens once inside it).
+//
+// `plugin-window-ipc-authorization.test.ts` has a static guardrail that fails the build if a
+// bare call to ipcMain's `handle`/`on` methods is ever added to this file outside these three
+// function bodies — so a future new channel is protected automatically, or the build breaks.
+
+/**
+ * Registers a channel that dispatches a plugin operation into the hidden plugin window
+ * (`getThemes`, `applyRequestHooks`, `executeAction`, etc.) — i.e. every channel that takes
+ * caller-supplied data and forwards it to `invokeInPluginWindow`. Restricted to the real main
+ * app window; any other sender gets a rejected promise instead of a result.
+ */
+function handleFromMainWindow<Args = unknown, R = unknown>(
+  channel: string,
+  handler: (args: Args) => R | Promise<R>,
+): void {
+  ipcMain.handle(channel, (event: IpcMainInvokeEvent, args: Args) => {
+    if (event.sender !== getMainWindow()?.webContents) {
+      throw new Error(`[plugin-bridge] rejected ${channel}: sender is not the main app window`);
+    }
+    return handler(args);
+  });
+}
+
+/**
+ * Registers a fire-and-forget callback that the hidden plugin window sends back to the host
+ * (a UI callback, an invoke result). Restricted to the plugin window itself; any other sender
+ * is silently ignored, matching how these "reverse direction" messages already behaved.
+ */
+function onFromPluginWindow<Args = unknown>(channel: string, handler: (args: Args) => void): void {
+  ipcMain.on(channel, (event: IpcMainEvent, args: Args) => {
+    if (event.sender !== pluginWindow?.webContents) {
+      return;
+    }
+    handler(args);
+  });
+}
+
+/** Like {@link onFromPluginWindow}, but for the one plugin-window callback that replies (`plugins.uiPrompt`). */
+function handleFromPluginWindow<Args = unknown, R = unknown>(
+  channel: string,
+  handler: (args: Args) => R | Promise<R>,
+): void {
+  ipcMain.handle(channel, (event: IpcMainInvokeEvent, args: Args) => {
+    if (event.sender !== pluginWindow?.webContents) {
+      return null;
+    }
+    return handler(args);
+  });
+}
+
 // Registered once so that persistent `ipcMain.on` handlers don't accumulate across window recreations.
 let ipcListenersRegistered = false;
 
@@ -78,10 +137,7 @@ function ensureIpcListeners() {
   }
   ipcListenersRegistered = true;
 
-  ipcMain.on('plugins.windowReady', event => {
-    if (event.sender !== pluginWindow?.webContents) {
-      return;
-    }
+  onFromPluginWindow<void>('plugins.windowReady', () => {
     windowReady = true;
     const startedAt = bridgeMetrics.lastStartupAt;
     const startupMs = startedAt ? Date.now() - startedAt : 0;
@@ -89,33 +145,21 @@ function ensureIpcListeners() {
     console.log(`[plugin-bridge] window_ready startup_ms=${startupMs}`);
   });
 
-  ipcMain.on('plugins.uiAlert', (event, options: Record<string, unknown>) => {
-    if (event.sender !== pluginWindow?.webContents) {
-      return;
-    }
+  onFromPluginWindow<Record<string, unknown>>('plugins.uiAlert', options => {
     getMainWindow()?.webContents.send('plugins.uiAlert', options);
   });
 
-  ipcMain.on('plugins.uiDialog', (event, options: Record<string, unknown>) => {
-    if (event.sender !== pluginWindow?.webContents) {
-      return;
-    }
+  onFromPluginWindow<Record<string, unknown>>('plugins.uiDialog', options => {
     getMainWindow()?.webContents.send('plugins.uiDialog', options);
   });
 
-  ipcMain.handle('plugins.uiPrompt', async (event, options: Record<string, unknown>) => {
-    if (event.sender !== pluginWindow?.webContents) {
-      return null;
-    }
-    return requestPromptFromRenderer(options as { title: string; label?: string; defaultValue?: string });
-  });
+  handleFromPluginWindow<{ title: string; label?: string; defaultValue?: string }>('plugins.uiPrompt', options =>
+    requestPromptFromRenderer(options),
+  );
 
-  ipcMain.on(
+  onFromPluginWindow<{ id: string; result?: unknown; error?: string }>(
     'plugins.invokeResult',
-    (event, { id, result, error }: { id: string; result?: unknown; error?: string }) => {
-      if (event.sender !== pluginWindow?.webContents) {
-        return;
-      }
+    ({ id, result, error }) => {
       const pending = pendingRequests.get(id);
       if (!pending) {
         return;
@@ -257,40 +301,38 @@ export function reloadPluginsInWindow() {
 }
 
 export function registerPluginIpcHandlers() {
-  ipcMain.handle('plugins.getThemes', () => invokeInPluginWindow('getThemes'));
-  ipcMain.handle('plugins.getPlugins', () => invokeInPluginWindow('getPlugins'));
-  ipcMain.handle('plugins.getActivePlugins', () => invokeInPluginWindow('getActivePlugins'));
-  ipcMain.handle('plugins.reloadPlugins', async () => {
+  handleFromMainWindow('plugins.getThemes', () => invokeInPluginWindow('getThemes'));
+  handleFromMainWindow('plugins.getPlugins', () => invokeInPluginWindow('getPlugins'));
+  handleFromMainWindow('plugins.getActivePlugins', () => invokeInPluginWindow('getActivePlugins'));
+  handleFromMainWindow('plugins.reloadPlugins', async () => {
     cachedHasRequestHooks = null;
     cachedHasResponseHooks = null;
     await invokeInPluginWindow('reloadPlugins');
   });
-  ipcMain.handle('plugins.getRequestActions', () => invokeInPluginWindow('getRequestActions'));
-  ipcMain.handle('plugins.getRequestGroupActions', () => invokeInPluginWindow('getRequestGroupActions'));
-  ipcMain.handle('plugins.getWorkspaceActions', () => invokeInPluginWindow('getWorkspaceActions'));
-  ipcMain.handle('plugins.getDocumentActions', () => invokeInPluginWindow('getDocumentActions'));
-  ipcMain.handle('plugins.executeAction', (_event, args) => invokeInPluginWindow('executeAction', args));
-  ipcMain.handle('plugins.getTemplateTags', () => invokeInPluginWindow('getTemplateTags'));
-  ipcMain.handle('plugins.runTemplateTagAction', (_event, args) => invokeInPluginWindow('runTemplateTagAction', args));
-  ipcMain.handle('plugins.getBundlePlugins', () => invokeInPluginWindow('getBundlePlugins'));
-  ipcMain.handle('plugins.executePluginMainAction', (_event, args) =>
-    invokeInPluginWindow('executePluginMainAction', args),
-  );
-  ipcMain.handle('plugins.hasRequestHooks', async () => {
+  handleFromMainWindow('plugins.getRequestActions', () => invokeInPluginWindow('getRequestActions'));
+  handleFromMainWindow('plugins.getRequestGroupActions', () => invokeInPluginWindow('getRequestGroupActions'));
+  handleFromMainWindow('plugins.getWorkspaceActions', () => invokeInPluginWindow('getWorkspaceActions'));
+  handleFromMainWindow('plugins.getDocumentActions', () => invokeInPluginWindow('getDocumentActions'));
+  handleFromMainWindow('plugins.executeAction', args => invokeInPluginWindow('executeAction', args));
+  handleFromMainWindow('plugins.getTemplateTags', () => invokeInPluginWindow('getTemplateTags'));
+  handleFromMainWindow('plugins.runTemplateTagAction', args => invokeInPluginWindow('runTemplateTagAction', args));
+  handleFromMainWindow('plugins.getBundlePlugins', () => invokeInPluginWindow('getBundlePlugins'));
+  handleFromMainWindow('plugins.executePluginMainAction', args => invokeInPluginWindow('executePluginMainAction', args));
+  handleFromMainWindow('plugins.hasRequestHooks', async () => {
     if (cachedHasRequestHooks === null) {
       cachedHasRequestHooks = (await invokeInPluginWindow('hasRequestHooks')) as boolean;
     }
     return cachedHasRequestHooks;
   });
-  ipcMain.handle('plugins.hasResponseHooks', async () => {
+  handleFromMainWindow('plugins.hasResponseHooks', async () => {
     if (cachedHasResponseHooks === null) {
       cachedHasResponseHooks = (await invokeInPluginWindow('hasResponseHooks')) as boolean;
     }
     return cachedHasResponseHooks;
   });
-  ipcMain.handle('plugins.applyRequestHooks', (_event, args) => invokeInPluginWindow('applyRequestHooks', args));
-  ipcMain.handle('plugins.applyResponseHooks', (_event, args) => invokeInPluginWindow('applyResponseHooks', args));
-  ipcMain.handle('plugins.getBridgeMetrics', () => getBridgeMetricsSnapshot());
+  handleFromMainWindow('plugins.applyRequestHooks', args => invokeInPluginWindow('applyRequestHooks', args));
+  handleFromMainWindow('plugins.applyResponseHooks', args => invokeInPluginWindow('applyResponseHooks', args));
+  handleFromMainWindow('plugins.getBridgeMetrics', () => getBridgeMetricsSnapshot());
 }
 
 export function getAppUserDataPath() {

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -401,6 +401,77 @@ export const discoverUserPluginExportsForLoader = async (body: {
   });
 };
 
+// The serializable RenderedRequest fields a request hook may read or mutate — the subset marshaled
+// into and out of the sandbox (mirrors what plugins/context/request.ts touches on the request).
+const HOOK_REQUEST_FIELDS = [
+  '_id',
+  'name',
+  'url',
+  'method',
+  'headers',
+  'parameters',
+  'authentication',
+  'body',
+  'cookies',
+  'settingSendCookies',
+  'settingStoreCookies',
+  'settingEncodeUrl',
+  'settingDisableRenderRequestBody',
+  'settingFollowRedirects',
+] as const;
+
+const pickHookRequestFields = (req: Record<string, any>): Record<string, any> => {
+  const out: Record<string, any> = {};
+  for (const key of HOOK_REQUEST_FIELDS) {
+    if (req[key] !== undefined) {
+      out[key] = req[key];
+    }
+  }
+  return out;
+};
+
+// H1: run a user plugin's request hook (at hookIndex) inside the sandbox, capability-gated. The hook
+// mutates the request in the sandbox; we marshal the mutated field subset back for the caller to
+// merge onto the request it is building. Reuses the same bridge/grants/crypto as tag execution.
+export const runRequestHookInSandbox = async (
+  plugin: { directory: string; name: string; permissions?: { modules?: string[]; capabilities?: string[] } },
+  hookIndex: number,
+  renderedRequest: Record<string, any>,
+  renderContext: Record<string, any>,
+): Promise<Record<string, any>> => {
+  const { runTagInSandbox } = await import('../templating/sandbox/plugin-tag-sandbox');
+  const { resolveTemplateTagModules, resolveTemplateTagCapabilities } = await import(
+    '../templating/sandbox/surface-profiles'
+  );
+  const grantedCapabilities = resolveTemplateTagCapabilities(plugin.permissions?.capabilities);
+  const bridge = await buildSandboxBridge(grantedCapabilities);
+  const { moduleFiles, entryModuleKey } = readPluginModuleMap({ directory: plugin.directory, name: plugin.name });
+  const hookRequest = pickHookRequestFields(renderedRequest);
+  const json = await runTagInSandbox({
+    tagName: '',
+    bridge,
+    hostCrypto: SANDBOX_HOST_CRYPTO,
+    envelope: {
+      args: [],
+      context: (renderContext as Record<string, any>) || {},
+      meta: {},
+      renderPurpose: 'send',
+      appInfo: { version: app.getVersion(), platform: process.platform, arch: process.arch },
+      pluginName: plugin.name,
+      renderDepth: 0,
+      grantedModules: resolveTemplateTagModules(plugin.permissions?.modules),
+      grantedCapabilities,
+      moduleFiles,
+      entryModuleKey,
+      hookKind: 'request',
+      hookIndex,
+      hookRequest,
+    },
+  });
+  const result = JSON.parse(json) as { request?: Record<string, any> };
+  return result.request ?? hookRequest;
+};
+
 // These are exposed to the templating worker and can be used by plugins from context.util
 const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<any>> = {
   'readFile': async (body: { path: string }) => {
@@ -664,6 +735,14 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
     name: string;
     permissions?: { modules?: string[]; capabilities?: string[] };
   }) => discoverUserPluginExportsForLoader(body),
+  // H1: run a user plugin's request hook in the sandbox (plugin-window path reaches this over the
+  // templating-worker-database protocol; the node runtime calls runRequestHookInSandbox directly).
+  'plugin.runUserRequestHook': async (body: {
+    plugin: { directory: string; name: string; permissions?: { modules?: string[]; capabilities?: string[] } };
+    hookIndex: number;
+    renderedRequest: Record<string, any>;
+    renderContext: Record<string, any>;
+  }) => runRequestHookInSandbox(body.plugin, body.hookIndex, body.renderedRequest, body.renderContext),
   // execute a user-installed plugin tag with the given parameters, in the main process where
   // Node built-ins (e.g. crypto) the plugin requires are available.
   'plugin.executeUserPluginTag': async (body: {

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -14,6 +14,7 @@ import { jarFromCookies } from '~/common/cookies';
 import { type Plugin, type TemplateTag } from '~/common/plugins/types';
 import type { PluginTemplateTag, PluginTemplateTagContext, PluginToMainAPIPaths } from '~/common/templating/types';
 import { getPluginCommonContext, getTemplateTags } from '~/plugins';
+import type { PluginExportManifest } from '~/templating/sandbox/marshal';
 import type { SandboxModuleDenialError } from '~/templating/sandbox/plugin-tag-sandbox';
 
 import { getAppBundlePlugins, RESPONSE_CODE_REASONS } from '../common/constants';
@@ -264,6 +265,44 @@ export const maybeWarnMissingManifest = (
 // module map read from disk (M4 multi-file plugins).
 type PluginModuleSource = string | { moduleFiles: Record<string, string>; entryModuleKey: string };
 
+// node:crypto is synchronous and available in main, so back the sandbox's require('crypto') shim with
+// it via sync host functions rather than the async bridge. Stateless, so shared across sandbox runs.
+const SANDBOX_HOST_CRYPTO = {
+  hash: (algo: string, data: string, inputEncoding: string, outputEncoding: string) =>
+    crypto
+      .createHash(algo)
+      .update(data, inputEncoding as crypto.Encoding)
+      .digest(outputEncoding as BinaryToTextEncoding),
+  hmac: (algo: string, key: string, data: string, outputEncoding: string) =>
+    crypto
+      .createHmac(algo, key)
+      .update(data, 'utf8')
+      .digest(outputEncoding as BinaryToTextEncoding),
+  randomBytes: (size: number) => crypto.randomBytes(size).toString('base64'),
+  randomUUID: () => crypto.randomUUID(),
+};
+
+// Build the capability-gated host bridge shared by tag execution and load-time discovery. The handler
+// map is filtered by capability first, so an ungranted path rejects at the bridge naming the missing
+// capability rather than silently running.
+const buildSandboxBridge = async (capabilities: string[]) => {
+  const { createMapBridge, filterByCapabilities } = await import('../templating/sandbox/host-bridge');
+  return createMapBridge(
+    filterByCapabilities(
+      {
+        ...(pluginToMainAPI as Record<string, (b: any) => Promise<any>>),
+        // allowTags: false so a sandboxed plugin can't invoke another tag's real, unsandboxed run()
+        // (including its own) by handing util.render a string containing "{% tagName %}".
+        'util.render': async (b: { str: string; context: Record<string, any> }) => {
+          const { render } = await import('../templating');
+          return render(b.str, { context: b.context, allowTags: false });
+        },
+      },
+      capabilities,
+    ),
+  );
+};
+
 export const runPluginTagInSandbox = async (
   pluginModule: PluginModuleSource,
   body: {
@@ -280,9 +319,7 @@ export const runPluginTagInSandbox = async (
   grantedCapabilities?: string[],
 ): Promise<string> => {
   const { runTagInSandbox } = await import('../templating/sandbox/plugin-tag-sandbox');
-  const { createMapBridge, filterByCapabilities, TEMPLATE_TAG_BASELINE_CAPABILITIES } = await import(
-    '../templating/sandbox/host-bridge'
-  );
+  const { TEMPLATE_TAG_BASELINE_CAPABILITIES } = await import('../templating/sandbox/host-bridge');
   const { TEMPLATE_TAG_BASELINE_MODULES } = await import('../templating/sandbox/module-registry');
   const { pluginName, tagName, args, context: originContext } = body;
   const { meta, renderPurpose, context } = originContext;
@@ -291,41 +328,11 @@ export const runPluginTagInSandbox = async (
     typeof pluginModule === 'string'
       ? { moduleFiles: { 'index.js': pluginModule }, entryModuleKey: 'index.js' }
       : pluginModule;
-  // Gate the handler map by capability before building the bridge: an ungranted path rejects at the
-  // bridge with a message naming the missing capability, rather than silently running.
-  const bridge = createMapBridge(
-    filterByCapabilities(
-      {
-        ...(pluginToMainAPI as Record<string, (b: any) => Promise<any>>),
-        // allowTags: false so a sandboxed plugin can't invoke another tag's real, unsandboxed run()
-        // (including its own) by handing util.render a string containing "{% tagName %}".
-        'util.render': async (b: { str: string; context: Record<string, any> }) => {
-          const { render } = await import('../templating');
-          return render(b.str, { context: b.context, allowTags: false });
-        },
-      },
-      capabilities,
-    ),
-  );
+  const bridge = await buildSandboxBridge(capabilities);
   return runTagInSandbox({
     tagName,
     bridge,
-    // node:crypto is synchronous and available in main, so back the sandbox's require('crypto')
-    // shim with it via sync host functions rather than the async bridge.
-    hostCrypto: {
-      hash: (algo, data, inputEncoding, outputEncoding) =>
-        crypto
-          .createHash(algo)
-          .update(data, inputEncoding as crypto.Encoding)
-          .digest(outputEncoding as BinaryToTextEncoding),
-      hmac: (algo, key, data, outputEncoding) =>
-        crypto
-          .createHmac(algo, key)
-          .update(data, 'utf8')
-          .digest(outputEncoding as BinaryToTextEncoding),
-      randomBytes: (size: number) => crypto.randomBytes(size).toString('base64'),
-      randomUUID: () => crypto.randomUUID(),
-    },
+    hostCrypto: SANDBOX_HOST_CRYPTO,
     envelope: {
       args: args || [],
       context: (context as Record<string, any>) || {},
@@ -340,6 +347,39 @@ export const runPluginTagInSandbox = async (
       entryModuleKey,
     },
   });
+};
+
+// L1 load-time discovery: evaluate a user plugin's source inside the sandbox and return a manifest of
+// its exports, instead of nodeRequire-ing it on the host. The plugin's top-level code runs in the
+// sandbox (default-deny require, no host reach), so installing/enabling it can't execute host code.
+export const discoverPluginExportsInSandbox = async (
+  pluginModule: PluginModuleSource,
+  opts: { pluginName: string; grantedModules: string[]; grantedCapabilities: string[] },
+): Promise<PluginExportManifest> => {
+  const { runTagInSandbox } = await import('../templating/sandbox/plugin-tag-sandbox');
+  const { moduleFiles, entryModuleKey } =
+    typeof pluginModule === 'string'
+      ? { moduleFiles: { 'index.js': pluginModule }, entryModuleKey: 'index.js' }
+      : pluginModule;
+  const bridge = await buildSandboxBridge(opts.grantedCapabilities);
+  const json = await runTagInSandbox({
+    tagName: '',
+    discover: true,
+    bridge,
+    hostCrypto: SANDBOX_HOST_CRYPTO,
+    envelope: {
+      args: [],
+      context: {},
+      appInfo: { version: app.getVersion(), platform: process.platform, arch: process.arch },
+      pluginName: opts.pluginName,
+      renderDepth: 0,
+      grantedModules: opts.grantedModules,
+      grantedCapabilities: opts.grantedCapabilities,
+      moduleFiles,
+      entryModuleKey,
+    },
+  });
+  return JSON.parse(json);
 };
 
 // These are exposed to the templating worker and can be used by plugins from context.util
@@ -596,6 +636,24 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
         },
         templateTag,
       }));
+  },
+  // L1: discover a user plugin's exports by evaluating its source in the sandbox (no host execution),
+  // returning a serializable manifest. The plugin loader (plugins/index.ts) calls this instead of
+  // nodeRequire-ing the module when the sandbox is enabled.
+  'plugin.discoverUserPluginExports': async (body: {
+    directory: string;
+    name: string;
+    permissions?: { modules?: string[]; capabilities?: string[] };
+  }) => {
+    const { directory, name, permissions } = body;
+    const { resolveTemplateTagModules, resolveTemplateTagCapabilities } = await import(
+      '../templating/sandbox/surface-profiles'
+    );
+    return discoverPluginExportsInSandbox(readPluginModuleMap({ directory, name }), {
+      pluginName: name,
+      grantedModules: resolveTemplateTagModules(permissions?.modules),
+      grantedCapabilities: resolveTemplateTagCapabilities(permissions?.capabilities),
+    });
   },
   // execute a user-installed plugin tag with the given parameters, in the main process where
   // Node built-ins (e.g. crypto) the plugin requires are available.

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -14,7 +14,7 @@ import { jarFromCookies } from '~/common/cookies';
 import { type Plugin, type TemplateTag } from '~/common/plugins/types';
 import type { PluginTemplateTag, PluginTemplateTagContext, PluginToMainAPIPaths } from '~/common/templating/types';
 import { getPluginCommonContext, getTemplateTags } from '~/plugins';
-import type { PluginExportManifest } from '~/templating/sandbox/marshal';
+import { HOOK_REQUEST_FIELDS, type PluginExportManifest, stripDangerousKeysReviver } from '~/templating/sandbox/marshal';
 import type { SandboxModuleDenialError } from '~/templating/sandbox/plugin-tag-sandbox';
 
 import { getAppBundlePlugins, RESPONSE_CODE_REASONS } from '../common/constants';
@@ -401,25 +401,6 @@ export const discoverUserPluginExportsForLoader = async (body: {
   });
 };
 
-// The serializable RenderedRequest fields a request hook may read or mutate — the subset marshaled
-// into and out of the sandbox (mirrors what plugins/context/request.ts touches on the request).
-const HOOK_REQUEST_FIELDS = [
-  '_id',
-  'name',
-  'url',
-  'method',
-  'headers',
-  'parameters',
-  'authentication',
-  'body',
-  'cookies',
-  'settingSendCookies',
-  'settingStoreCookies',
-  'settingEncodeUrl',
-  'settingDisableRenderRequestBody',
-  'settingFollowRedirects',
-] as const;
-
 const pickHookRequestFields = (req: Record<string, any>): Record<string, any> => {
   const out: Record<string, any> = {};
   for (const key of HOOK_REQUEST_FIELDS) {
@@ -468,7 +449,7 @@ export const runRequestHookInSandbox = async (
       hookRequest,
     },
   });
-  const result = JSON.parse(json) as { request?: Record<string, any> };
+  const result = JSON.parse(json, stripDangerousKeysReviver) as { request?: Record<string, any> };
   return result.request ?? hookRequest;
 };
 

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -382,6 +382,25 @@ export const discoverPluginExportsInSandbox = async (
   return JSON.parse(json);
 };
 
+// Discover a user plugin's exports from its on-disk source, resolving the template-tag surface grant
+// from its manifest. Shared by the plugin loader (plugins/index.ts calls this directly when it runs
+// in the main process) and the `plugin.discoverUserPluginExports` bridge handler (renderer path).
+export const discoverUserPluginExportsForLoader = async (body: {
+  directory: string;
+  name: string;
+  permissions?: { modules?: string[]; capabilities?: string[] };
+}): Promise<PluginExportManifest> => {
+  const { directory, name, permissions } = body;
+  const { resolveTemplateTagModules, resolveTemplateTagCapabilities } = await import(
+    '../templating/sandbox/surface-profiles'
+  );
+  return discoverPluginExportsInSandbox(readPluginModuleMap({ directory, name }), {
+    pluginName: name,
+    grantedModules: resolveTemplateTagModules(permissions?.modules),
+    grantedCapabilities: resolveTemplateTagCapabilities(permissions?.capabilities),
+  });
+};
+
 // These are exposed to the templating worker and can be used by plugins from context.util
 const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<any>> = {
   'readFile': async (body: { path: string }) => {
@@ -644,17 +663,7 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
     directory: string;
     name: string;
     permissions?: { modules?: string[]; capabilities?: string[] };
-  }) => {
-    const { directory, name, permissions } = body;
-    const { resolveTemplateTagModules, resolveTemplateTagCapabilities } = await import(
-      '../templating/sandbox/surface-profiles'
-    );
-    return discoverPluginExportsInSandbox(readPluginModuleMap({ directory, name }), {
-      pluginName: name,
-      grantedModules: resolveTemplateTagModules(permissions?.modules),
-      grantedCapabilities: resolveTemplateTagCapabilities(permissions?.capabilities),
-    });
-  },
+  }) => discoverUserPluginExportsForLoader(body),
   // execute a user-installed plugin tag with the given parameters, in the main process where
   // Node built-ins (e.g. crypto) the plugin requires are available.
   'plugin.executeUserPluginTag': async (body: {

--- a/packages/insomnia/src/plugins/__tests__/invoke-method.test.ts
+++ b/packages/insomnia/src/plugins/__tests__/invoke-method.test.ts
@@ -20,7 +20,12 @@ vi.mock('insomnia-data', () => ({
   },
 }));
 
+vi.mock('~/common/templating/liquid-extension-worker', () => ({
+  fetchFromTemplateWorkerDatabase: vi.fn(),
+}));
+
 import type { Plugin } from '~/common/plugins/types';
+import { fetchFromTemplateWorkerDatabase } from '~/common/templating/liquid-extension-worker';
 
 import { _testOnlySetPlugins } from '../index';
 import { invokePluginMethod } from '../invoke-method';
@@ -76,6 +81,8 @@ describe('invokePluginMethod', () => {
   it('preserves plugin-prefixed request hook errors', async () => {
     const hook = vi.fn().mockRejectedValue(new Error('boom'));
     _testOnlySetPlugins([makePlugin({ module: { requestHooks: [hook] } })]);
+
+    vi.mocked(fetchFromTemplateWorkerDatabase).mockResolvedValue({});
 
     await expect(
       invokePluginMethod('applyRequestHooks', {

--- a/packages/insomnia/src/plugins/index.ts
+++ b/packages/insomnia/src/plugins/index.ts
@@ -87,10 +87,17 @@ function buildUserPluginModuleFromManifest(pluginName: string, manifest: PluginE
     icon: a.icon,
     action: notRouted(surface),
   });
+  // The count comes from untrusted sandbox output; clamp to a finite, non-negative, bounded integer
+  // before allocating so a hostile manifest can't drive a huge Array.from allocation (the sandbox
+  // clamps too — this is defense in depth).
+  const hookStubs = (count: number, surface: string) =>
+    Array.from({ length: Number.isFinite(count) && count > 0 ? Math.min(Math.floor(count), 1000) : 0 }, () =>
+      notRouted(surface),
+    );
   return {
     templateTags: manifest.templateTags.map(t => ({ ...t, run: notRouted('template-tag run()') }) as PluginTemplateTag),
-    requestHooks: Array.from({ length: manifest.requestHooks }, () => notRouted('request hooks')),
-    responseHooks: Array.from({ length: manifest.responseHooks }, () => notRouted('response hooks')),
+    requestHooks: hookStubs(manifest.requestHooks, 'request hooks'),
+    responseHooks: hookStubs(manifest.responseHooks, 'response hooks'),
     requestActions: manifest.requestActions.map(toAction('request actions')),
     requestGroupActions: manifest.requestGroupActions.map(toAction('request group actions')),
     workspaceActions: manifest.workspaceActions.map(toAction('workspace actions')),

--- a/packages/insomnia/src/plugins/index.ts
+++ b/packages/insomnia/src/plugins/index.ts
@@ -19,7 +19,8 @@ import type {
   WorkspaceAction,
 } from '~/common/plugins/types';
 import { fetchFromTemplateWorkerDatabase } from '~/common/templating/liquid-extension-worker';
-import type { RenderPurpose } from '~/common/templating/types';
+import type { PluginTemplateTag, RenderPurpose } from '~/common/templating/types';
+import type { ActionDescriptor, PluginExportManifest } from '~/templating/sandbox/marshal';
 
 import { getAppBundlePlugins, isDevelopment } from '../common/constants';
 import * as pluginApp from '../plugins/context/app';
@@ -51,7 +52,41 @@ export async function init() {
   await reloadPlugins();
 }
 
-async function traversePluginPath(pluginMap: Record<string, Plugin>, allPaths: string[], allConfigs: PluginConfigMap) {
+// Build a user plugin's `module` from the sandbox-discovered export manifest (L1). Only descriptors
+// cross from the sandbox — no live functions. Execution is routed separately: a template tag's
+// `run()` goes through the sandbox bridge (`plugin.executeUserPluginTag`), so the stub `run` here is
+// never called while the sandbox is on. Hook/action invocation isn't sandbox-routed yet, so those
+// function members throw a clear error until that lands (PR 10/11); the plugin's tags/hooks/actions
+// still *enumerate* in the UI from these descriptors.
+function buildUserPluginModuleFromManifest(pluginName: string, manifest: PluginExportManifest): Plugin['module'] {
+  const notRouted = (surface: string) => () => {
+    throw new Error(
+      `Plugin "${pluginName}": sandboxed ${surface} are not supported yet. Disable "Run template tags in sandbox" to use them.`,
+    );
+  };
+  const toAction = (surface: string) => (a: ActionDescriptor) => ({
+    label: a.label ?? '',
+    icon: a.icon,
+    action: notRouted(surface),
+  });
+  return {
+    templateTags: manifest.templateTags.map(t => ({ ...t, run: notRouted('template-tag run()') }) as PluginTemplateTag),
+    requestHooks: Array.from({ length: manifest.requestHooks }, () => notRouted('request hooks')),
+    responseHooks: Array.from({ length: manifest.responseHooks }, () => notRouted('response hooks')),
+    requestActions: manifest.requestActions.map(toAction('request actions')),
+    requestGroupActions: manifest.requestGroupActions.map(toAction('request group actions')),
+    workspaceActions: manifest.workspaceActions.map(toAction('workspace actions')),
+    documentActions: manifest.documentActions.map(toAction('document actions')),
+    themes: manifest.themes,
+  } as Plugin['module'];
+}
+
+async function traversePluginPath(
+  pluginMap: Record<string, Plugin>,
+  allPaths: string[],
+  allConfigs: PluginConfigMap,
+  sandboxEnabled: boolean,
+) {
   for (const p of allPaths) {
     if (!fs.existsSync(p)) {
       continue;
@@ -71,7 +106,7 @@ async function traversePluginPath(pluginMap: Record<string, Plugin>, allPaths: s
 
         // Is it a scoped directory?
         if (filename.startsWith('@')) {
-          await traversePluginPath(pluginMap, [modulePath], allConfigs);
+          await traversePluginPath(pluginMap, [modulePath], allConfigs, sandboxEnabled);
         }
 
         // Is it a Node module?
@@ -100,6 +135,7 @@ async function traversePluginPath(pluginMap: Record<string, Plugin>, allPaths: s
           }
         }
 
+        // package.json is plain data — requiring it runs no plugin code (unlike the module below).
         const pluginJson = nodeRequire(packageJSONPath);
 
         // Not an Insomnia plugin because it doesn't have the package.json['insomnia']
@@ -107,13 +143,25 @@ async function traversePluginPath(pluginMap: Record<string, Plugin>, allPaths: s
           continue;
         }
 
-        // Delete require cache entry and re-require
-        const module = nodeRequire(modulePath);
-
         const parsedPermissions = parsePluginPermissions(pluginJson.insomnia);
         if (parsedPermissions.warnings.length > 0) {
           // Constant format string; interpolated values passed as args so a plugin name can't forge log output.
           console.warn('[plugin] %s has invalid insomnia.permissions: %o', pluginJson.name, parsedPermissions.warnings);
+        }
+
+        // L1: with the sandbox on, discover a user plugin's exports by evaluating its source *inside*
+        // the sandbox (main process) instead of nodeRequire-ing it here — so installing/enabling it
+        // never runs its top-level code with host (Node) privileges. Off → legacy in-process require.
+        let module: Plugin['module'];
+        if (sandboxEnabled) {
+          const manifest = (await fetchFromTemplateWorkerDatabase('plugin.discoverUserPluginExports', {
+            directory: modulePath,
+            name: pluginJson.name,
+            permissions: parsedPermissions.permissions,
+          })) as PluginExportManifest;
+          module = buildUserPluginModuleFromManifest(pluginJson.name, manifest);
+        } else {
+          module = nodeRequire(modulePath);
         }
 
         pluginMap[pluginJson.name] = {
@@ -166,7 +214,7 @@ export async function getPlugins(force = false): Promise<Plugin[]> {
 
     // Store plugins in a map so that plugins with the same name only get added once
     const pluginMap: Record<string, Plugin> = {};
-    await traversePluginPath(pluginMap, allPaths, allConfigs);
+    await traversePluginPath(pluginMap, allPaths, allConfigs, settings.templateTagSandboxEnabled);
     const bundlePluginMap = getBundlePluginMap();
     const fullPluginMap = { ...pluginMap, ...bundlePluginMap };
     plugins = Object.keys(fullPluginMap).map(name => fullPluginMap[name]);

--- a/packages/insomnia/src/plugins/index.ts
+++ b/packages/insomnia/src/plugins/index.ts
@@ -58,33 +58,22 @@ export async function init() {
 // never called while the sandbox is on. Hook/action invocation isn't sandbox-routed yet, so those
 // function members throw a clear error until that lands (PR 10/11); the plugin's tags/hooks/actions
 // still *enumerate* in the UI from these descriptors.
-// Run sandbox export discovery in the main process (templating worker DB). The call rides the
-// `insomnia-templating-worker-database://` protocol, which can briefly be unavailable while the app
-// re-renders around a settings change (the reload that flips the sandbox on is triggered by exactly
-// such a change), surfacing as a low-level "fetch failed". Retry a few times with a short backoff so
-// a transient readiness race doesn't drop the plugin; a persistent failure still throws to the
-// per-plugin catch below (that plugin logs a load error; others are unaffected).
+// Run sandbox export discovery for a user plugin. getPlugins/traversePluginPath runs in BOTH the
+// main process (via getTemplateTags in templating-worker-database) and the plugin window, so the
+// discovery has to reach the sandbox from either. In main we call the sandbox directly — the
+// `insomnia-templating-worker-database://` protocol is a renderer<->main channel and main's own
+// `fetch` can't resolve it. In a renderer (the plugin window) we go over that protocol.
 async function discoverUserPluginExports(
   directory: string,
   name: string,
   permissions: Plugin['permissions'],
 ): Promise<PluginExportManifest> {
   const body = { directory, name, permissions };
-  let lastErr: unknown;
-  for (let attempt = 0; attempt < 5; attempt++) {
-    try {
-      return (await fetchFromTemplateWorkerDatabase('plugin.discoverUserPluginExports', body)) as PluginExportManifest;
-    } catch (err) {
-      lastErr = err;
-      // Only a transport-level failure ("fetch failed") is worth retrying; a handler error (denied
-      // require, syntax error) comes back as a resolved 500 with a message and should surface at once.
-      if (!/fetch failed/i.test(err instanceof Error ? err.message : String(err))) {
-        throw err;
-      }
-      await new Promise(resolve => setTimeout(resolve, 100 * (attempt + 1)));
-    }
+  if (__IS_RENDERER__) {
+    return (await fetchFromTemplateWorkerDatabase('plugin.discoverUserPluginExports', body)) as PluginExportManifest;
   }
-  throw lastErr;
+  const { discoverUserPluginExportsForLoader } = await import('~/main/templating-worker-database');
+  return discoverUserPluginExportsForLoader(body);
 }
 
 function buildUserPluginModuleFromManifest(pluginName: string, manifest: PluginExportManifest): Plugin['module'] {

--- a/packages/insomnia/src/plugins/index.ts
+++ b/packages/insomnia/src/plugins/index.ts
@@ -58,6 +58,35 @@ export async function init() {
 // never called while the sandbox is on. Hook/action invocation isn't sandbox-routed yet, so those
 // function members throw a clear error until that lands (PR 10/11); the plugin's tags/hooks/actions
 // still *enumerate* in the UI from these descriptors.
+// Run sandbox export discovery in the main process (templating worker DB). The call rides the
+// `insomnia-templating-worker-database://` protocol, which can briefly be unavailable while the app
+// re-renders around a settings change (the reload that flips the sandbox on is triggered by exactly
+// such a change), surfacing as a low-level "fetch failed". Retry a few times with a short backoff so
+// a transient readiness race doesn't drop the plugin; a persistent failure still throws to the
+// per-plugin catch below (that plugin logs a load error; others are unaffected).
+async function discoverUserPluginExports(
+  directory: string,
+  name: string,
+  permissions: Plugin['permissions'],
+): Promise<PluginExportManifest> {
+  const body = { directory, name, permissions };
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      return (await fetchFromTemplateWorkerDatabase('plugin.discoverUserPluginExports', body)) as PluginExportManifest;
+    } catch (err) {
+      lastErr = err;
+      // Only a transport-level failure ("fetch failed") is worth retrying; a handler error (denied
+      // require, syntax error) comes back as a resolved 500 with a message and should surface at once.
+      if (!/fetch failed/i.test(err instanceof Error ? err.message : String(err))) {
+        throw err;
+      }
+      await new Promise(resolve => setTimeout(resolve, 100 * (attempt + 1)));
+    }
+  }
+  throw lastErr;
+}
+
 function buildUserPluginModuleFromManifest(pluginName: string, manifest: PluginExportManifest): Plugin['module'] {
   const notRouted = (surface: string) => () => {
     throw new Error(
@@ -154,11 +183,7 @@ async function traversePluginPath(
         // never runs its top-level code with host (Node) privileges. Off → legacy in-process require.
         let module: Plugin['module'];
         if (sandboxEnabled) {
-          const manifest = (await fetchFromTemplateWorkerDatabase('plugin.discoverUserPluginExports', {
-            directory: modulePath,
-            name: pluginJson.name,
-            permissions: parsedPermissions.permissions,
-          })) as PluginExportManifest;
+          const manifest = await discoverUserPluginExports(modulePath, pluginJson.name, parsedPermissions.permissions);
           module = buildUserPluginModuleFromManifest(pluginJson.name, manifest);
         } else {
           module = nodeRequire(modulePath);

--- a/packages/insomnia/src/plugins/invoke-method.ts
+++ b/packages/insomnia/src/plugins/invoke-method.ts
@@ -6,6 +6,7 @@ import type {
   RunTemplateTagActionArgs,
 } from '~/common/plugins/bridge-types';
 import type { Plugin } from '~/common/plugins/types';
+import { fetchFromTemplateWorkerDatabase } from '~/common/templating/liquid-extension-worker';
 import { deserializeRenderContext } from '~/common/templating/render-context-serialization';
 
 import * as pluginApp from './context/app';
@@ -193,16 +194,33 @@ export async function invokePluginMethod(method: PluginInvokeMethod, args?: unkn
       const { renderedRequest, projectId, environment } = args as ApplyRequestHooksArgs;
       const newRenderedRequest = { ...renderedRequest };
       const renderedContext = deserializeRenderContext(environment);
+      // H1: with the sandbox on, a user plugin's hook (a throw-stub here after discovery) runs in the
+      // main-process sandbox over the templating-worker-database protocol; bundle plugins and the
+      // flag-off path run in-process. Per-plugin counter recovers the hook's index within its array.
+      const settings = await fetchFromTemplateWorkerDatabase('settings.get', {});
+      const sandboxEnabled = !!settings?.templateTagSandboxEnabled;
+      const hookIndexByPlugin: Record<string, number> = {};
 
       for (const { plugin, hook } of await getRequestHooks()) {
-        const context = {
-          ...pluginApp.init(),
-          ...pluginData.init(projectId),
-          ...(pluginStore.init(plugin) as Record<string, any>),
-          ...(pluginRequest.init(newRenderedRequest as any, renderedContext) as Record<string, any>),
-          ...(pluginNetwork.init() as Record<string, any>),
-        };
+        const hookIndex = (hookIndexByPlugin[plugin.name] = (hookIndexByPlugin[plugin.name] ?? -1) + 1);
         try {
+          if (sandboxEnabled && plugin.directory !== '') {
+            const mutated = await fetchFromTemplateWorkerDatabase('plugin.runUserRequestHook', {
+              plugin: { directory: plugin.directory, name: plugin.name, permissions: plugin.permissions },
+              hookIndex,
+              renderedRequest: newRenderedRequest,
+              renderContext: renderedContext,
+            });
+            Object.assign(newRenderedRequest, mutated);
+            continue;
+          }
+          const context = {
+            ...pluginApp.init(),
+            ...pluginData.init(projectId),
+            ...(pluginStore.init(plugin) as Record<string, any>),
+            ...(pluginRequest.init(newRenderedRequest as any, renderedContext) as Record<string, any>),
+            ...(pluginNetwork.init() as Record<string, any>),
+          };
           await hook(context);
         } catch (err) {
           const error = err instanceof Error ? err : new Error(String(err));

--- a/packages/insomnia/src/plugins/invoke-method.ts
+++ b/packages/insomnia/src/plugins/invoke-method.ts
@@ -8,6 +8,7 @@ import type {
 import type { Plugin } from '~/common/plugins/types';
 import { fetchFromTemplateWorkerDatabase } from '~/common/templating/liquid-extension-worker';
 import { deserializeRenderContext } from '~/common/templating/render-context-serialization';
+import { mergeHookRequestMutation } from '~/templating/sandbox/marshal';
 
 import * as pluginApp from './context/app';
 import * as pluginData from './context/data';
@@ -211,7 +212,10 @@ export async function invokePluginMethod(method: PluginInvokeMethod, args?: unkn
               renderedRequest: newRenderedRequest,
               renderContext: renderedContext,
             });
-            Object.assign(newRenderedRequest, mutated);
+            // `mergeHookRequestMutation` only copies the allowlisted request fields a hook is
+            // permitted to touch, one at a time — never a blanket `Object.assign` of whatever
+            // keys happen to be in the parsed JSON.
+            mergeHookRequestMutation(newRenderedRequest, mutated);
             continue;
           }
           const context = {

--- a/packages/insomnia/src/runtimes/network/network-adapter.node.ts
+++ b/packages/insomnia/src/runtimes/network/network-adapter.node.ts
@@ -78,15 +78,31 @@ export async function applyRequestHooks(
 ): Promise<RenderedRequest> {
   const newRenderedRequest = applyDefaultHeaders(renderedRequest, renderedContext['DEFAULT_HEADERS']);
   const pluginIndex = await import('../../plugins/index');
+  const { services } = await import('insomnia-data');
+  // H1: with the sandbox on, a user plugin's hook runs in QuickJS (its `hook` here is a throw-stub
+  // from discovery); bundle plugins and the flag-off path run in-process as before.
+  const sandboxEnabled = (await services.settings.get()).templateTagSandboxEnabled;
+  // getRequestHooks flattens each plugin's requestHooks in order, so a per-plugin running counter
+  // recovers the hook's index within its own array (what the sandbox loads by).
+  const hookIndexByPlugin: Record<string, number> = {};
   for (const { plugin, hook } of await pluginIndex.getRequestHooks()) {
-    const context = {
-      ...(pluginApp.init() as Record<string, any>),
-      ...pluginData.init(renderedContext.getProjectId()),
-      ...(pluginStore.init(plugin) as Record<string, any>),
-      ...(pluginRequest.init(newRenderedRequest, renderedContext) as Record<string, any>),
-      ...(pluginNetwork.init() as Record<string, any>),
-    };
+    const hookIndex = (hookIndexByPlugin[plugin.name] = (hookIndexByPlugin[plugin.name] ?? -1) + 1);
     try {
+      if (sandboxEnabled && plugin.directory !== '') {
+        const { runRequestHookInSandbox } = await import('../../main/templating-worker-database');
+        // The hook mutates the request in the sandbox; merge the returned fields back so the next
+        // hook (and the send pipeline) sees the mutation, exactly like the in-place path below.
+        const mutated = await runRequestHookInSandbox(plugin, hookIndex, newRenderedRequest, renderedContext);
+        Object.assign(newRenderedRequest, mutated);
+        continue;
+      }
+      const context = {
+        ...(pluginApp.init() as Record<string, any>),
+        ...pluginData.init(renderedContext.getProjectId()),
+        ...(pluginStore.init(plugin) as Record<string, any>),
+        ...(pluginRequest.init(newRenderedRequest, renderedContext) as Record<string, any>),
+        ...(pluginNetwork.init() as Record<string, any>),
+      };
       await hook(context);
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));

--- a/packages/insomnia/src/runtimes/network/network-adapter.node.ts
+++ b/packages/insomnia/src/runtimes/network/network-adapter.node.ts
@@ -90,10 +90,14 @@ export async function applyRequestHooks(
     try {
       if (sandboxEnabled && plugin.directory !== '') {
         const { runRequestHookInSandbox } = await import('../../main/templating-worker-database');
+        const { mergeHookRequestMutation } = await import('../../templating/sandbox/marshal');
         // The hook mutates the request in the sandbox; merge the returned fields back so the next
         // hook (and the send pipeline) sees the mutation, exactly like the in-place path below.
+        // `mergeHookRequestMutation` only copies the allowlisted request fields a hook is
+        // permitted to touch, one at a time — never a blanket `Object.assign` of whatever keys
+        // happen to be in the parsed JSON.
         const mutated = await runRequestHookInSandbox(plugin, hookIndex, newRenderedRequest, renderedContext);
-        Object.assign(newRenderedRequest, mutated);
+        mergeHookRequestMutation(newRenderedRequest, mutated);
         continue;
       }
       const context = {

--- a/packages/insomnia/src/templating/sandbox/H1-HOOK-SANDBOX-SECURITY-REVIEW.md
+++ b/packages/insomnia/src/templating/sandbox/H1-HOOK-SANDBOX-SECURITY-REVIEW.md
@@ -1,0 +1,214 @@
+# Security review — PR #10279 (H1, "route user-plugin request hooks through the sandbox")
+
+## Status: both findings remediated
+
+- **Finding 1 (IPC dispatch accepts any sender): FIXED.** `plugin-window.ts` now routes every
+  `ipcMain.handle`/`ipcMain.on` registration through one of three sender-checked wrapper
+  functions (`handleFromMainWindow`, `onFromPluginWindow`, `handleFromPluginWindow`).
+  `plugins.applyRequestHooks` and its dispatch siblings now reject any caller that isn't the
+  real main app window. A **static** guardrail test asserts no bare `ipcMain.handle`/`.on` call
+  exists in the file outside those three wrapper bodies, so a future channel added any other
+  way fails the build automatically; a **dynamic** test iterates every channel actually
+  registered at runtime (not a hardcoded name list) and proves each one rejects a forged
+  sender and accepts the real main window. See "Remediation" below.
+- **Finding 2 (unsanitized JSON marshal): FIXED (defense-in-depth).** The hook-mutation parse
+  now uses a `JSON.parse` reviver that strips `__proto__`/`constructor`/`prototype` own-keys at
+  any depth, and the merge onto the live request object now copies only the
+  `HOOK_REQUEST_FIELDS` allowlist field-by-field instead of a blanket `Object.assign`. A
+  dynamic/parameterized test (`marshal.test.ts`) drives the real sandbox with several
+  differently-shaped attack payloads and asserts no dangerous key survives anywhere in the
+  final merged object.
+
+## Context
+
+PR #10279 (`claude/sandbox-pr10-hooks`, stacked on the merged L1 discovery/rejecting-bridge
+work) routes a **user** plugin's `requestHooks` through the QuickJS sandbox instead of
+running them in-process, so a hook can still rewrite headers/URL/body/params/auth but is
+claimed to "no longer reach the host beyond its declared capabilities" (PR description).
+This review source-audited that claim, plus the surrounding architecture it leans on
+(`__buildRequestApi`, capability resolution, plugin loading). Findings below are verified
+against the current source (read directly) unless noted; several plausible hypotheses were
+also chased down and ruled out — recorded for completeness so a future reviewer doesn't
+re-walk the same dead ends.
+
+## Finding 1 — `plugins.applyRequestHooks` (and siblings) accept a request from any sender
+
+**Files:**
+- `packages/insomnia/src/main/plugin-window.ts:291-292` (the dispatch handlers)
+- `packages/insomnia/src/main/plugin-window.ts:82-133` (the sibling handlers that *do* check)
+- `packages/insomnia/src/entry.preload.ts:449-450` (renderer exposure)
+- `packages/insomnia/src/plugins/invoke-method.ts:190-214` (`applyRequestHooks` case)
+
+**Verified:** yes, read directly, and demonstrated with an executable test (see below).
+
+`main/plugin-window.ts` registers two different kinds of IPC listener. The first group
+(lines 82-133: `plugins.uiAlert`, `plugins.uiDialog`, `plugins.uiPrompt`,
+`plugins.invokeResult`) explicitly checks the caller:
+
+```ts
+ipcMain.on('plugins.uiAlert', (event, options) => {
+  if (event.sender !== pluginWindow?.webContents) {
+    return;
+  }
+  getMainWindow()?.webContents.send('plugins.uiAlert', options);
+});
+```
+
+The second group (lines 260-293), registered by `registerPluginIpcHandlers()`, does not:
+
+```ts
+ipcMain.handle('plugins.applyRequestHooks', (_event, args) => invokeInPluginWindow('applyRequestHooks', args));
+ipcMain.handle('plugins.applyResponseHooks', (_event, args) => invokeInPluginWindow('applyResponseHooks', args));
+```
+
+`_event` is deliberately unused — there is no check that the caller is the main app window,
+no check that it's *any* particular window, nothing. This handler is exposed directly to the
+main renderer as `window.main.plugins.applyRequestHooks(args)`
+(`entry.preload.ts:449`, `invokePluginBridgeMethod('applyRequestHooks', args)`), which
+forwards straight into `invokePluginMethod('applyRequestHooks', {renderedRequest, projectId,
+environment})` (`plugins/invoke-method.ts:192`) — **all three fields fully caller-supplied**,
+with no check that they describe a request that is actually being sent, or that the caller
+is entitled to trigger hook execution for that `projectId`/`environment` at all.
+
+**Consequence:** whatever capability gating H1 enforces *once a hook is running inside the
+sandbox* is beside the point if the dispatch that reaches it never checks who's asking, with
+what data. Any code able to reach `window.main.plugins.applyRequestHooks(...)` (or the
+underlying `ipcMain.handle('plugins.applyRequestHooks', ...)` channel directly, e.g. from a
+plugin's own code running unsandboxed today — plugin *actions* are still in-process pending
+the later "A1" phase) can:
+- Trigger **every installed plugin's** request hooks (not just its own) against a fully
+  forged `renderedRequest`/`environment`, and read back the merged/mutated result directly
+  over the IPC response.
+- Use this as a confused-deputy exfiltration primitive: if any installed plugin's hook
+  conditionally attaches a secret/header based on URL or environment-variable matching (a
+  completely ordinary thing for an auth-helper plugin to do), craft a forged request that
+  satisfies the condition, invoke the handler directly, and read the injected secret back out
+  — without ever sending a real network request.
+
+**This gap predates PR #10279** — the PR's diff never touches `plugin-window.ts` or
+`entry.preload.ts`, and the asymmetry (checked vs. unchecked handler groups) already existed
+before this PR. It is recorded here, not as a regression introduced by #10279, but because it
+directly undermines the security property #10279 states it delivers: no amount of in-sandbox
+capability gating matters if the dispatch entry point in front of it has no notion of "who is
+allowed to ask for this, with what data." Recommend adding a sender check (mirroring the
+first handler group) to `plugins.applyRequestHooks`, `plugins.applyResponseHooks`,
+`plugins.executeAction`, `plugins.executePluginMainAction`, and `plugins.runTemplateTagAction`
+— restricting them to the legitimate first-party caller (the main app window), the same way
+the reverse-direction handlers already restrict themselves to the legitimate plugin window.
+
+**Remediation:** `plugin-window.ts` now defines three wrappers — `handleFromMainWindow`
+(restricts a channel to the real main app window; used by every channel
+`registerPluginIpcHandlers()` registers, including `applyRequestHooks`/`applyResponseHooks`),
+`onFromPluginWindow`, and `handleFromPluginWindow` (both restrict a channel to the real plugin
+window, matching the pre-existing checked group) — and every `ipcMain.handle`/`ipcMain.on`
+call in the file goes through one of them. A forged sender now gets a rejected promise
+(`handleFromMainWindow`) or is silently ignored (`onFromPluginWindow`/`handleFromPluginWindow`,
+matching prior behavior for that direction), never a result built from its data.
+
+**Test:** `packages/insomnia/src/main/__tests__/plugin-window-ipc-authorization.test.ts` —
+drives the real `plugin-window.ts` module (not a reimplementation). Two kinds of guardrail,
+per the "dynamic catching" goal (not one hardcoded per-channel test):
+
+- **Static**: reads the file's source and asserts no bare `ipcMain.handle(`/`ipcMain.on(` call
+  exists outside the three wrapper bodies — a future channel registered any other way fails
+  the build regardless of its name.
+- **Dynamic**: after calling `registerPluginIpcHandlers()`, iterates every channel *actually
+  registered* at runtime (reading the live registration map, not a hardcoded list of channel
+  names) and asserts each one rejects a forged sender and accepts the real main window — so a
+  newly added `plugins.*` channel is exercised automatically the next time the suite runs.
+- Plus two representative end-to-end/contrast checks: `plugins.applyRequestHooks` explicitly
+  with the original forged-payload scenario, and `plugins.uiAlert` to show the
+  plugin-window-direction check still works.
+
+## Finding 2 (minor, defense-in-depth only — not a regression) — unsanitized JSON marshal on the hook-mutation merge
+
+**Files (as originally found):**
+- `packages/insomnia/src/runtimes/network/network-adapter.node.ts` (`Object.assign(newRenderedRequest, mutated)`)
+- `packages/insomnia/src/plugins/invoke-method.ts` (same pattern)
+- `packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts` (`__buildRequestApi`)
+
+The host merged a hook's mutated request back with `Object.assign(newRenderedRequest,
+mutated)`, where `mutated = JSON.parse(json)` and `json` is whatever the sandbox returned. No
+key-name sanitization or type/shape validation happened at this boundary. A hook could plant
+an own `"__proto__"` property inside nested `body`/`authentication` objects (e.g.
+`context.request.setBody(JSON.parse('{"__proto__":{"x":1},"text":"hi"}'))`, using
+computed-key construction so the property is a real own key rather than triggering the
+prototype setter), and it survived the sandbox→host JSON round-trip intact.
+
+I traced every downstream consumer of `RenderedRequest.body`/`.authentication`/`.headers`
+(`network/network.ts` → `main/network/libcurl-promise.ts`/`curl.ts`, HAR export in
+`main/har.ts`, `network/apply-default-headers.ts`, `network/parse-header-strings.ts`) and
+found only safe copy patterns (`clone()`, object spread, direct property reads) — **no
+`Object.assign`/`for...in`-assignment/lodash-merge sink currently exists** that would turn
+this into live `Object.prototype` pollution. I also confirmed the identical risk already
+exists in the pre-existing **legacy in-process** hook path
+(`plugins/context/request.ts`'s `setBody`/`setAuthenticationParameter` accept the same
+unsanitized values by direct reference — no serialization needed to reach the same state) —
+so sandboxing neither introduced nor worsened this; it's an existing characteristic of the
+plugin-hook trust model, not a vulnerability attributable to this PR. Fixed anyway as cheap
+defense-in-depth, since a future unrelated change (a deep-merge/deep-clone added elsewhere)
+could turn this latent primitive into real pollution with no warning.
+
+**Remediation:** both moved to shared, boundary-neutral code in
+`packages/insomnia/src/templating/sandbox/marshal.ts` (importable from both the main-process
+call site in `network-adapter.node.ts` and the renderer/plugin-window call site in
+`invoke-method.ts`, avoiding a `main/`-into-`renderer` import):
+
+- `stripDangerousKeysReviver` — a `JSON.parse` reviver dropping `__proto__`/`constructor`/
+  `prototype` own-keys at any depth (returning `undefined` from a reviver deletes the key, per
+  spec). Used in `runRequestHookInSandbox`'s `JSON.parse(json, stripDangerousKeysReviver)`.
+- `mergeHookRequestMutation(target, mutated)` — replaces the blanket `Object.assign` with a
+  loop over the fixed `HOOK_REQUEST_FIELDS` allowlist, copying a field only if `mutated` has it
+  as an own property. Used at both call sites instead of `Object.assign(newRenderedRequest,
+  mutated)`.
+
+**Test:** `packages/insomnia/src/templating/sandbox/marshal.test.ts` — dynamic/parameterized
+rather than one hardcoded case: `DANGEROUS_KEY_SCENARIOS` describes several different places a
+hook can plant `__proto__`/`constructor`/`prototype` (inside a hook-supplied body, inside an
+authentication value, nested two levels deep), and a recursive `findDangerousOwnKeyPaths`
+walker searches the *entire* result structure for survivors rather than checking one specific
+path. Each scenario runs the real `runTagInSandbox` end-to-end, confirms the attack actually
+plants the key against a naive `JSON.parse` (so the test fails for the right reason if the
+attack stops working), then asserts the fixed parse and the fixed merge both come out clean. A
+separate test confirms `mergeHookRequestMutation` never copies a field outside
+`HOOK_REQUEST_FIELDS`, regardless of what the parsed object contains.
+
+## Hypotheses chased down and ruled out (recorded so a future pass doesn't repeat this work)
+
+- **Capability defaults for undeclared-permission plugins**: `resolveTemplateTagModules`/
+  `resolveTemplateTagCapabilities` (`templating/sandbox/surface-profiles.ts`) default missing
+  `modules`/`capabilities` to `[]` at every layer (parsing in `common/plugins/permissions.ts`,
+  the resolve functions, `host-bridge.ts`'s `filterByCapabilities`, and
+  `in-sandbox-bootstrap.ts`'s `__grantedCaps = (__env && __env.grantedCapabilities) || []`).
+  Fail-closed everywhere; a plugin never gets `network`/other elevated capabilities just by
+  omitting a manifest.
+- **`plugin.directory === ''` sandbox-bypass**: only bundle plugins (`plugins/index.ts:268`,
+  `main/templating-worker-database.ts:595,630`) and the themes loader ever get
+  `directory: ''`; disk-loaded plugins always get a real `path.resolve`d directory
+  (`plugins/index.ts:124,192`). The new `if (sandboxEnabled && plugin.directory !== '')` gate
+  can't be tricked into treating an untrusted disk plugin as a trusted bundle plugin.
+- **Plugin-name collision desyncing `hookIndexByPlugin`**: `pluginMap` in `plugins/index.ts`
+  is keyed by `pluginJson.name` and last-writer-wins, so `getPlugins()`/`getRequestHooks()`
+  can never yield two distinct `Plugin` objects with the same `name` simultaneously — the
+  index-recovery-by-name counter in the new hook-dispatch code can't desync this way (a name
+  collision causes silent plugin shadowing instead, a pre-existing, separate issue, not
+  explored further here).
+- **`__buildRequestApi` parity vs. real `plugins/context/request.ts`**: line-by-line
+  comparison confirms the ES5 rebuild in `in-sandbox-bootstrap.ts` matches getters/mutators,
+  case-insensitive header vs. case-sensitive parameter matching, and the exact `readOnly`
+  deletion list. No extra capability leaks through this rebuild.
+- **Shared `__buildContext` gating**: hooks and tags both go through the same
+  `__buildContext(env)`, so C1/C2 capability gating (`context.network` presence/absence)
+  applies identically; nothing hook-specific weakens it.
+
+## Verification
+
+- `plugin-window-ipc-authorization.test.ts` (6 tests) — static guardrail + dynamic per-channel
+  sender checks + the original forged-payload/contrast/end-to-end scenarios, all passing.
+- `marshal.test.ts` (10 tests) — parameterized dangerous-key scenarios + allowlist-merge test,
+  all passing.
+- Full package suite (`npx vitest run`): 132 test files, 2107 tests passed, 14 skipped, 0
+  failures — no regressions from either fix.
+- `npm run lint -w packages/insomnia`: 0 errors (2 pre-existing warnings in unrelated vendored
+  generated files).
+- `tsc --noEmit -p packages/insomnia`: 0 errors.

--- a/packages/insomnia/src/templating/sandbox/__snapshots__/sandbox-surface.test.ts.snap
+++ b/packages/insomnia/src/templating/sandbox/__snapshots__/sandbox-surface.test.ts.snap
@@ -263,6 +263,8 @@ exports[`sandbox surface > matches surface snapshot 1`] = `
   "globalThis.WeakSet.prototype: object",
   "globalThis.__buildContext: function(1)",
   "globalThis.__buildContext.prototype: object",
+  "globalThis.__describeExports: function(0)",
+  "globalThis.__describeExports.prototype: object",
   "globalThis.__invoke: function(0)",
   "globalThis.__invoke.prototype: object",
   "globalThis.__loadPluginEntry: function(0)",

--- a/packages/insomnia/src/templating/sandbox/__snapshots__/sandbox-surface.test.ts.snap
+++ b/packages/insomnia/src/templating/sandbox/__snapshots__/sandbox-surface.test.ts.snap
@@ -267,6 +267,8 @@ exports[`sandbox surface > matches surface snapshot 1`] = `
   "globalThis.__describeExports.prototype: object",
   "globalThis.__invoke: function(0)",
   "globalThis.__invoke.prototype: object",
+  "globalThis.__invokeHook: function(0)",
+  "globalThis.__invokeHook.prototype: object",
   "globalThis.__loadPluginEntry: function(0)",
   "globalThis.__loadPluginEntry.prototype: object",
   "globalThis.__require: function(1)",

--- a/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
+++ b/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
@@ -324,6 +324,125 @@ export const IN_SANDBOX_BOOTSTRAP = [
   '    return ctx;',
   '  };',
 
+  // --- request-hook API rebuilt in-sandbox over the copied-in renderedRequest (`req`) ---
+  // Mirrors packages/insomnia/src/plugins/context/request.ts. Getters always present; mutators
+  // present only when !readOnly (matching request.ts's delete list, lines 221-258). Header matching
+  // is CASE-INSENSITIVE (misc.filterHeaders, misc.ts:21); parameter matching is CASE-SENSITIVE
+  // (filterParameters, request.ts:11). No host/bridge calls: every method is a sync read/write on req.
+  '  function __buildRequestApi(req, readOnly) {',
+  '    if (!req) { throw new Error("contexts.request initialized without request"); }',
+  '    if (!(req.headers instanceof Array)) { req.headers = []; }',
+  '    if (!(req.parameters instanceof Array)) { req.parameters = []; }',
+  '    if (!(req.cookies instanceof Array)) { req.cookies = []; }',
+  '    if (!req.authentication || typeof req.authentication !== "object") { req.authentication = {}; }',
+  '    if (!req.body || typeof req.body !== "object") { req.body = {}; }',
+  '    function __filterHeaders(name) {',
+  '      if (!(req.headers instanceof Array) || !name || typeof name !== "string") { return []; }',
+  '      var out = [];',
+  '      for (var i = 0; i < req.headers.length; i++) {',
+  '        var h = req.headers[i];',
+  '        if (!h || !h.name || typeof h.name !== "string") { continue; }',
+  '        if (h.name.toLowerCase() === name.toLowerCase()) { out.push(h); }',
+  '      }',
+  '      return out;',
+  '    }',
+  '    function __filterParameters(name) {',
+  '      if (!(req.parameters instanceof Array) || !name) { return []; }',
+  '      var out = [];',
+  '      for (var i = 0; i < req.parameters.length; i++) {',
+  '        var p = req.parameters[i];',
+  '        if (!p || !p.name) { continue; }',
+  '        if (p.name === name) { out.push(p); }',
+  '      }',
+  '      return out;',
+  '    }',
+  '    var api = {',
+  '      getId: function () { return req._id; },',
+  '      getName: function () { return req.name; },',
+  '      getUrl: function () { return req.url; },',
+  '      getMethod: function () { return req.method; },',
+  '      setMethod: function (method) { req.method = method; },',
+  '      setUrl: function (url) { req.url = url; },',
+  '      setCookie: function (name, value) {',
+  '        var cookie = null;',
+  '        for (var i = 0; i < req.cookies.length; i++) { if (req.cookies[i] && req.cookies[i].name === name) { cookie = req.cookies[i]; break; } }',
+  '        if (cookie) { cookie.value = value; } else { req.cookies.push({ name: name, value: value }); }',
+  '      },',
+  '      getEnvironmentVariable: function (name) { return __env.context[name]; },',
+  '      getEnvironment: function () { return __env.context; },',
+  '      settingSendCookies: function (enabled) { req.settingSendCookies = enabled; },',
+  '      settingStoreCookies: function (enabled) { req.settingStoreCookies = enabled; },',
+  '      settingEncodeUrl: function (enabled) { req.settingEncodeUrl = enabled; },',
+  '      settingDisableRenderRequestBody: function (enabled) { req.settingDisableRenderRequestBody = enabled; },',
+  '      settingFollowRedirects: function (enabled) { req.settingFollowRedirects = enabled; },',
+  '      getHeader: function (name) {',
+  '        var headers = __filterHeaders(name);',
+  '        if (headers.length) { var header = headers[headers.length - 1]; return header.value || ""; }',
+  '        return null;',
+  '      },',
+  '      getHeaders: function () {',
+  '        var out = [];',
+  '        for (var i = 0; i < req.headers.length; i++) { out.push({ name: req.headers[i].name, value: req.headers[i].value }); }',
+  '        return out;',
+  '      },',
+  '      hasHeader: function (name) { return this.getHeader(name) !== null; },',
+  '      removeHeader: function (name) {',
+  '        var headers = __filterHeaders(name);',
+  '        var out = [];',
+  '        for (var i = 0; i < req.headers.length; i++) { if (__arrIndexOf(headers, req.headers[i]) === -1) { out.push(req.headers[i]); } }',
+  '        req.headers = out;',
+  '      },',
+  '      setHeader: function (name, value) {',
+  '        var header = __filterHeaders(name)[0];',
+  '        if (header) { header.value = value; } else { this.addHeader(name, value); }',
+  '      },',
+  '      addHeader: function (name, value) {',
+  '        var header = __filterHeaders(name)[0];',
+  '        if (!header) { req.headers.push({ name: name, value: value }); }',
+  '      },',
+  '      getParameter: function (name) {',
+  '        var parameters = __filterParameters(name);',
+  '        if (parameters.length) { var parameter = parameters[parameters.length - 1]; return parameter.value || ""; }',
+  '        return null;',
+  '      },',
+  '      getParameters: function () {',
+  '        var out = [];',
+  '        for (var i = 0; i < req.parameters.length; i++) { out.push({ name: req.parameters[i].name, value: req.parameters[i].value }); }',
+  '        return out;',
+  '      },',
+  '      hasParameter: function (name) { return this.getParameter(name) !== null; },',
+  '      removeParameter: function (name) {',
+  '        var parameters = __filterParameters(name);',
+  '        var out = [];',
+  '        for (var i = 0; i < req.parameters.length; i++) { if (__arrIndexOf(parameters, req.parameters[i]) === -1) { out.push(req.parameters[i]); } }',
+  '        req.parameters = out;',
+  '      },',
+  '      setParameter: function (name, value) {',
+  '        var parameter = __filterParameters(name)[0];',
+  '        if (parameter) { parameter.value = value; } else { this.addParameter(name, value); }',
+  '      },',
+  '      addParameter: function (name, value) {',
+  '        var parameter = __filterParameters(name)[0];',
+  '        if (!parameter) { req.parameters.push({ name: name, value: value }); }',
+  '      },',
+  '      setAuthenticationParameter: function (name, value) { req.authentication[name] = value; },',
+  '      getAuthentication: function () { return req.authentication; },',
+  '      getBody: function () { return req.body; },',
+  '      setBody: function (body) { req.body = body; },',
+  '      getBodyText: function () { console.warn("request.getBodyText() is deprecated. Use request.getBody() instead."); return req.body.text || ""; },',
+  '      setBodyText: function (text) { console.warn("request.setBodyText() is deprecated. Use request.setBody() instead."); req.body.text = text; }',
+  '    };',
+  '    if (readOnly) {',
+  '      delete api.setUrl; delete api.setMethod; delete api.setBodyText; delete api.setCookie;',
+  '      delete api.settingSendCookies; delete api.settingStoreCookies; delete api.settingEncodeUrl;',
+  '      delete api.settingDisableRenderRequestBody; delete api.settingFollowRedirects;',
+  '      delete api.removeHeader; delete api.setHeader; delete api.addHeader;',
+  '      delete api.removeParameter; delete api.setParameter; delete api.addParameter;',
+  '      delete api.setAuthenticationParameter; delete api.setBody;',
+  '    }',
+  '    return api;',
+  '  }',
+
   // --- load the plugin (its entry module, resolving any relative requires) and run the tag ---
   '  globalThis.__invoke = function () {',
   '    var env = __env;',
@@ -335,6 +454,24 @@ export const IN_SANDBOX_BOOTSTRAP = [
   '    if (!tag) { throw new Error("Template tag \'" + __tag + "\' not found in plugin module"); }',
   '    var args = [ctx].concat(env.args || []);',
   '    return Promise.resolve(tag.run.apply(null, args)).then(function (r) { return r == null ? "" : String(r); });',
+  '  };',
+
+  // --- run a request/response hook (H1) and marshal the mutated request/response back out ---
+  // The hook mutates context.request (and context.response) in place, exactly like the in-process
+  // path; we rebuild those APIs over the copied-in envelope data and JSON-return the mutated data so
+  // the host can merge it. The side-effecting surfaces (app/store/network/util) come from
+  // __buildContext and stay capability-gated.
+  '  globalThis.__invokeHook = function () {',
+  '    var env = __env;',
+  '    var ctx = globalThis.__buildContext(env);',
+  '    var mod = globalThis.__loadPluginEntry();',
+  '    var isResponse = env.hookKind === "response";',
+  '    var hooks = (isResponse ? (mod && mod.responseHooks) : (mod && mod.requestHooks)) || [];',
+  '    var hook = hooks[env.hookIndex];',
+  '    if (typeof hook !== "function") { throw new Error("Plugin " + (isResponse ? "response" : "request") + " hook not found at index " + env.hookIndex); }',
+  // Response hooks get a read-only request view (matches pluginRequest.init(..., true)).
+  '    ctx.request = __buildRequestApi(env.hookRequest || {}, isResponse);',
+  '    return Promise.resolve(hook(ctx)).then(function () { return JSON.stringify({ request: env.hookRequest }); });',
   '  };',
 
   // --- describe the plugin's exports without running any of them (L1 load-time discovery) ---
@@ -373,7 +510,7 @@ export const IN_SANDBOX_BOOTSTRAP = [
   // context/invocation entry points. __registerModule is intentionally left mutable — the module
   // registry source deletes it once the registry is populated.
   '  var __lock = function (n) { Object.defineProperty(globalThis, n, { value: globalThis[n], writable: false, configurable: false }); };',
-  '  __lock("__require"); __lock("__buildContext"); __lock("__invoke"); __lock("__loadPluginEntry"); __lock("__describeExports");',
+  '  __lock("__require"); __lock("__buildContext"); __lock("__invoke"); __lock("__loadPluginEntry"); __lock("__describeExports"); __lock("__invokeHook");',
   '})();',
 ].join('\n');
 
@@ -385,3 +522,9 @@ export const RUNNER = 'globalThis.__task = globalThis.__invoke();';
  * Used at plugin load instead of {@link RUNNER} to enumerate exports without invoking any of them.
  */
 export const DESCRIBE_RUNNER = 'globalThis.__task = Promise.resolve(globalThis.__describeExports());';
+
+/**
+ * Hook runner (H1): parks a resolved promise of the mutated request/response (JSON string) on
+ * `globalThis.__task`. Used instead of {@link RUNNER} to run a request/response hook.
+ */
+export const HOOK_RUNNER = 'globalThis.__task = globalThis.__invokeHook();';

--- a/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
+++ b/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
@@ -351,10 +351,14 @@ export const IN_SANDBOX_BOOTSTRAP = [
   '    var tagDesc = function (t) { return isObj(t) ? { name: t.name, displayName: t.displayName, description: t.description, args: t.args || [] } : null; };',
   '    var actionDesc = function (a) { return isObj(a) ? { label: a.label, icon: a.icon } : null; };',
   '    var themeDesc = function (t) { return isObj(t) ? { name: t.name, displayName: t.displayName, theme: t.theme } : null; };',
+  // Report a hook count, not the array itself — but a plugin could export a non-array with a huge
+  // `.length` to make the host allocate `Array.from({length})` (DoS). Coerce to a finite, non-negative
+  // integer and cap it; the host clamps again as defense in depth.
+  '    var hookCount = function (arr) { var n = arr && arr.length; n = (typeof n === "number" && isFinite(n)) ? Math.floor(n) : 0; if (n < 0) { n = 0; } return n > 1000 ? 1000 : n; };',
   '    var manifest = {',
   '      templateTags: mapArr(mod.templateTags, tagDesc),',
-  '      requestHooks: (mod.requestHooks && mod.requestHooks.length) || 0,',
-  '      responseHooks: (mod.responseHooks && mod.responseHooks.length) || 0,',
+  '      requestHooks: hookCount(mod.requestHooks),',
+  '      responseHooks: hookCount(mod.responseHooks),',
   '      requestActions: mapArr(mod.requestActions, actionDesc),',
   '      requestGroupActions: mapArr(mod.requestGroupActions, actionDesc),',
   '      workspaceActions: mapArr(mod.workspaceActions, actionDesc),',

--- a/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
+++ b/packages/insomnia/src/templating/sandbox/in-sandbox-bootstrap.ts
@@ -337,14 +337,47 @@ export const IN_SANDBOX_BOOTSTRAP = [
   '    return Promise.resolve(tag.run.apply(null, args)).then(function (r) { return r == null ? "" : String(r); });',
   '  };',
 
+  // --- describe the plugin's exports without running any of them (L1 load-time discovery) ---
+  // Evaluates the plugin entry (its top-level code runs here, in the sandbox — never on the host)
+  // and returns a JSON-serializable manifest of what it exports: template-tag metadata, hook counts,
+  // action labels/icons, and theme data. The host reads this instead of nodeRequire()ing the module,
+  // so installing/enabling a user plugin no longer executes its top-level code with Node privileges.
+  // Only DATA crosses back — function-valued members (tag.run, hook fns, action fns) are dropped;
+  // execution is routed separately (tags already go through __invoke; hooks/actions land in PR 10/11).
+  '  globalThis.__describeExports = function () {',
+  '    var mod = globalThis.__loadPluginEntry() || {};',
+  '    var isObj = function (x) { return !!x && typeof x === "object"; };',
+  '    var mapArr = function (arr, fn) { var out = []; if (arr && arr.length) { for (var i = 0; i < arr.length; i++) { var d = fn(arr[i]); if (d) { out.push(d); } } } return out; };',
+  '    var tagDesc = function (t) { return isObj(t) ? { name: t.name, displayName: t.displayName, description: t.description, args: t.args || [] } : null; };',
+  '    var actionDesc = function (a) { return isObj(a) ? { label: a.label, icon: a.icon } : null; };',
+  '    var themeDesc = function (t) { return isObj(t) ? { name: t.name, displayName: t.displayName, theme: t.theme } : null; };',
+  '    var manifest = {',
+  '      templateTags: mapArr(mod.templateTags, tagDesc),',
+  '      requestHooks: (mod.requestHooks && mod.requestHooks.length) || 0,',
+  '      responseHooks: (mod.responseHooks && mod.responseHooks.length) || 0,',
+  '      requestActions: mapArr(mod.requestActions, actionDesc),',
+  '      requestGroupActions: mapArr(mod.requestGroupActions, actionDesc),',
+  '      workspaceActions: mapArr(mod.workspaceActions, actionDesc),',
+  '      documentActions: mapArr(mod.documentActions, actionDesc),',
+  '      themes: mapArr(mod.themes, themeDesc)',
+  '    };',
+  '    return JSON.stringify(manifest);',
+  '  };',
+
   // --- lock the sandbox-internal globals ---
   // Plugin code runs after this bootstrap; pin these so it can't reassign the require gate or the
   // context/invocation entry points. __registerModule is intentionally left mutable — the module
   // registry source deletes it once the registry is populated.
   '  var __lock = function (n) { Object.defineProperty(globalThis, n, { value: globalThis[n], writable: false, configurable: false }); };',
-  '  __lock("__require"); __lock("__buildContext"); __lock("__invoke"); __lock("__loadPluginEntry");',
+  '  __lock("__require"); __lock("__buildContext"); __lock("__invoke"); __lock("__loadPluginEntry"); __lock("__describeExports");',
   '})();',
 ].join('\n');
 
 /** The runner: kicks off the async invocation and parks the VM promise on `globalThis.__task`. */
 export const RUNNER = 'globalThis.__task = globalThis.__invoke();';
+
+/**
+ * Discovery runner: parks a resolved promise of the export manifest (JSON string) on `globalThis.__task`.
+ * Used at plugin load instead of {@link RUNNER} to enumerate exports without invoking any of them.
+ */
+export const DESCRIBE_RUNNER = 'globalThis.__task = Promise.resolve(globalThis.__describeExports());';

--- a/packages/insomnia/src/templating/sandbox/marshal.test.ts
+++ b/packages/insomnia/src/templating/sandbox/marshal.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+
+import { type HostBridge } from './host-bridge';
+import { type ContextEnvelope, HOOK_REQUEST_FIELDS, type HookResult, mergeHookRequestMutation, stripDangerousKeysReviver } from './marshal';
+import { runTagInSandbox } from './plugin-tag-sandbox';
+
+// H1-HOOK-SANDBOX-SECURITY-REVIEW.md, finding 2: a request hook can plant an own `__proto__`/
+// `constructor`/`prototype` key on nested request data (`body`, `authentication`, individual
+// header/cookie entries) using computed-key JSON construction, and — before this fix — that key
+// survived a plain `JSON.parse` of the sandbox's output intact, landing on the live host request
+// object the merge produced. No live downstream sink was found for this at review time, but it's
+// exactly the kind of latent primitive a future unrelated change (a deep clone/merge added
+// elsewhere) could turn into real `Object.prototype` pollution — so it's neutralized at the
+// boundary instead of relying on every future consumer being careful.
+//
+// This suite is deliberately DYNAMIC rather than one hardcoded case: `DANGEROUS_KEY_SCENARIOS`
+// describes *where* a hook can plant a dangerous key, and `findDangerousOwnKeyPaths` searches the
+// entire result structure for survivors rather than checking one specific path — so a new
+// scenario is one array entry, and a regression anywhere in the structure is caught without
+// needing a matching new assertion.
+
+const noBridge: HostBridge = async path => {
+  throw new Error(`unexpected bridge call: ${path}`);
+};
+
+const DANGEROUS_KEYS = ['__proto__', 'constructor', 'prototype'];
+
+/** Recursively lists every "$.path.to.key" where an *own* dangerous key was found. */
+function findDangerousOwnKeyPaths(value: unknown, path = '$', seen = new Set<unknown>()): string[] {
+  if (value === null || typeof value !== 'object') {
+    return [];
+  }
+  if (seen.has(value)) {
+    return [];
+  }
+  seen.add(value);
+
+  const found: string[] = [];
+  for (const key of Object.getOwnPropertyNames(value)) {
+    const childPath = `${path}.${key}`;
+    if (DANGEROUS_KEYS.includes(key)) {
+      found.push(childPath);
+    }
+    found.push(...findDangerousOwnKeyPaths((value as Record<string, unknown>)[key], childPath, seen));
+  }
+  return found;
+}
+
+const runRequestHookRaw = async (
+  hookSource: string,
+  request: Record<string, unknown>,
+): Promise<string> => {
+  const envelope: ContextEnvelope = {
+    args: [],
+    context: {},
+    meta: {},
+    renderPurpose: 'send',
+    appInfo: { version: '0.0.0', platform: 'linux', arch: 'x64' },
+    pluginName: 'test-plugin',
+    renderDepth: 0,
+    grantedModules: [],
+    grantedCapabilities: [],
+    moduleFiles: { 'index.js': `module.exports.requestHooks = [${hookSource}];` },
+    entryModuleKey: 'index.js',
+    hookKind: 'request',
+    hookIndex: 0,
+    hookRequest: request,
+  };
+  return runTagInSandbox({ tagName: '', envelope, bridge: noBridge });
+};
+
+describe('stripDangerousKeysReviver + mergeHookRequestMutation (defense-in-depth on the hook marshal boundary)', () => {
+  // Each scenario is a hook body that plants a dangerous key somewhere different in the request
+  // it returns, via computed-key JSON construction (the technique that survives a plain
+  // JSON.parse as a real own property instead of triggering the `__proto__` accessor).
+  const DANGEROUS_KEY_SCENARIOS = DANGEROUS_KEYS.flatMap(key => [
+    {
+      name: `${key} nested inside a hook-supplied body`,
+      hookSource: `function (context) {
+        context.request.setBody(JSON.parse('{"${key}":{"polluted":true},"text":"hi"}'));
+      }`,
+      request: { body: {} },
+    },
+    {
+      name: `${key} nested inside a hook-supplied authentication value`,
+      hookSource: `function (context) {
+        context.request.setAuthenticationParameter('token', JSON.parse('{"${key}":{"polluted":true}}'));
+      }`,
+      request: { authentication: {} },
+    },
+    {
+      name: `${key} nested two levels deep inside a hook-supplied body`,
+      hookSource: `function (context) {
+        context.request.setBody(JSON.parse('{"nested":{"deeper":{"${key}":{"polluted":true}}}}'));
+      }`,
+      request: { body: {} },
+    },
+  ]);
+
+  it.each(DANGEROUS_KEY_SCENARIOS)('$name: does not survive the fixed parse into the merged request', async ({ hookSource, request }) => {
+    const json = await runRequestHookRaw(hookSource, request);
+
+    // Sanity check the attack actually works against a naive parse — otherwise this test would
+    // pass for the wrong reason (the hook failed to plant anything, not because the fix works).
+    const naive = JSON.parse(json) as HookResult;
+    expect(findDangerousOwnKeyPaths(naive.request)).not.toEqual([]);
+
+    // The fixed parse: a reviver strips the dangerous key at every depth as it's parsed.
+    const sanitized = JSON.parse(json, stripDangerousKeysReviver) as HookResult;
+    expect(findDangerousOwnKeyPaths(sanitized.request)).toEqual([]);
+
+    // And the fixed merge only copies allowlisted top-level fields onto the live request object
+    // the host is building — proving the *actual* code path used by both call sites
+    // (`network-adapter.node.ts`, `invoke-method.ts`) ends up clean, not just the parse step.
+    const target: Record<string, unknown> = { _id: 'req_1' };
+    mergeHookRequestMutation(target, sanitized.request ?? {});
+    expect(findDangerousOwnKeyPaths(target)).toEqual([]);
+  });
+
+  it('mergeHookRequestMutation only ever copies fields from the HOOK_REQUEST_FIELDS allowlist', () => {
+    const target: Record<string, unknown> = {};
+    // Parsed from JSON (as the real merge callers' input always is), so a computed-key
+    // "__proto__" is a genuine own property here, not the object-literal prototype-setter.
+    const mutated = JSON.parse(
+      '{"url":"https://rewritten.example","unexpectedNewField":"should not appear","__proto__":{"polluted":true}}',
+    ) as Record<string, unknown>;
+
+    mergeHookRequestMutation(target, mutated);
+
+    expect(target.url).toBe('https://rewritten.example');
+    expect(target).not.toHaveProperty('unexpectedNewField');
+    expect(Object.getOwnPropertyNames(target)).not.toContain('__proto__');
+    expect(Object.getOwnPropertyNames(target).every(key => (HOOK_REQUEST_FIELDS as readonly string[]).includes(key))).toBe(true);
+  });
+});

--- a/packages/insomnia/src/templating/sandbox/marshal.ts
+++ b/packages/insomnia/src/templating/sandbox/marshal.ts
@@ -65,6 +65,57 @@ export interface HookResult {
   response?: Record<string, unknown>;
 }
 
+// The serializable RenderedRequest fields a request hook may read or mutate — the subset marshaled
+// into and out of the sandbox (mirrors what plugins/context/request.ts touches on the request).
+// Shared between the host side (`main/templating-worker-database.ts`, which marshals a request in
+// and merges the mutation back for the main/CLI runtime) and the renderer side
+// (`plugins/invoke-method.ts`, which does the same for the plugin-window runtime) so both merge
+// call sites enforce the identical allowlist rather than duplicating (and risking drifting) it.
+export const HOOK_REQUEST_FIELDS = [
+  '_id',
+  'name',
+  'url',
+  'method',
+  'headers',
+  'parameters',
+  'authentication',
+  'body',
+  'cookies',
+  'settingSendCookies',
+  'settingStoreCookies',
+  'settingEncodeUrl',
+  'settingDisableRenderRequestBody',
+  'settingFollowRedirects',
+] as const;
+
+// Property names that, if present as an *own* key on an object parsed from untrusted JSON, are a
+// prototype-pollution primitive waiting for a future unsafe consumer ([[Set]]-based merge,
+// `for...in` assignment, etc.) — see H1-HOOK-SANDBOX-SECURITY-REVIEW.md, finding 2. A hook can
+// plant such a key on a nested value (e.g. `context.request.setBody(JSON.parse('{"__proto__":
+// {...}}'))`) using computed-key construction, which survives a plain `JSON.parse` as a real own
+// property rather than the accessor. Dropping it via a reviver (returning `undefined` deletes the
+// key, per the JSON.parse spec) neutralizes it at every depth, at the exact boundary where
+// untrusted sandbox output re-enters trusted host memory.
+const DANGEROUS_JSON_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/** `JSON.parse` reviver that drops `__proto__`/`constructor`/`prototype` own-keys at any depth. */
+export const stripDangerousKeysReviver = (key: string, value: unknown): unknown =>
+  DANGEROUS_JSON_KEYS.has(key) ? undefined : value;
+
+/**
+ * Merges a hook's mutated request fields back onto the live request the host is building, one
+ * allowlisted field at a time — never a blanket `Object.assign`/spread of the parsed object,
+ * which would trust whatever top-level keys happen to be present in `mutated` rather than only
+ * the fields a hook is actually permitted to touch.
+ */
+export const mergeHookRequestMutation = (target: Record<string, any>, mutated: Record<string, any>): void => {
+  for (const key of HOOK_REQUEST_FIELDS) {
+    if (Object.prototype.hasOwnProperty.call(mutated, key)) {
+      target[key] = mutated[key];
+    }
+  }
+};
+
 /** A discovered template-tag's serializable metadata (no `run`, no other function members). */
 export interface TemplateTagDescriptor {
   name?: string;

--- a/packages/insomnia/src/templating/sandbox/marshal.ts
+++ b/packages/insomnia/src/templating/sandbox/marshal.ts
@@ -45,6 +45,44 @@ export interface ContextEnvelope {
   entryModuleKey?: string;
 }
 
+/** A discovered template-tag's serializable metadata (no `run`, no other function members). */
+export interface TemplateTagDescriptor {
+  name?: string;
+  displayName?: string;
+  description?: string;
+  args?: unknown[];
+}
+
+/** A discovered action's serializable metadata (no `action`/`run`). */
+export interface ActionDescriptor {
+  label?: string;
+  icon?: string;
+}
+
+/** A discovered theme (plain data). */
+export interface ThemeDescriptor {
+  name?: string;
+  displayName?: string;
+  theme?: unknown;
+}
+
+/**
+ * What the sandbox returns for a plugin at load time (L1): the shapes of its exports, discovered by
+ * evaluating the entry inside the sandbox instead of `nodeRequire`-ing it on the host. Only data
+ * crosses back — hook/action function bodies never leave the sandbox (hooks are reported as a count;
+ * their execution is routed in a later PR).
+ */
+export interface PluginExportManifest {
+  templateTags: TemplateTagDescriptor[];
+  requestHooks: number;
+  responseHooks: number;
+  requestActions: ActionDescriptor[];
+  requestGroupActions: ActionDescriptor[];
+  workspaceActions: ActionDescriptor[];
+  documentActions: ActionDescriptor[];
+  themes: ThemeDescriptor[];
+}
+
 /**
  * The contract every host-bridge call resolves to. We resolve (never reject) the VM promise with
  * this so the sandbox side can rethrow a real Error without us juggling VM error handles. The

--- a/packages/insomnia/src/templating/sandbox/marshal.ts
+++ b/packages/insomnia/src/templating/sandbox/marshal.ts
@@ -43,6 +43,26 @@ export interface ContextEnvelope {
   moduleFiles?: Record<string, string>;
   /** Key into `moduleFiles` for the plugin's entry module (from package.json `main`). */
   entryModuleKey?: string;
+  /**
+   * Request/response hook invocation (H1). When set, the sandbox runs the plugin's hook at
+   * `hookIndex` in `requestHooks`/`responseHooks` (per `hookKind`) instead of a template tag,
+   * rebuilding `context.request` (and `context.response`) over the copied-in `hookRequest`/
+   * `hookResponse` data. The hook mutates that data in place; the sandbox marshals the mutated
+   * object back out (see `HookResult`) and the host merges it onto the request/response it returns.
+   */
+  hookKind?: 'request' | 'response';
+  /** Index of the hook within the plugin's `requestHooks`/`responseHooks` array. */
+  hookIndex?: number;
+  /** The `RenderedRequest` fields a hook may read/mutate (headers/url/method/params/auth/body/settings). */
+  hookRequest?: Record<string, unknown>;
+  /** The response patch a response hook may read (getters only; `setBody` bridges to the host). */
+  hookResponse?: Record<string, unknown>;
+}
+
+/** What a hook invocation marshals back out of the sandbox: the mutated request/response data. */
+export interface HookResult {
+  request?: Record<string, unknown>;
+  response?: Record<string, unknown>;
 }
 
 /** A discovered template-tag's serializable metadata (no `run`, no other function members). */

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
@@ -1,7 +1,7 @@
 import type { QuickJSContext, QuickJSHandle } from 'quickjs-emscripten';
 
 import type { HostBridge } from './host-bridge';
-import { IN_SANDBOX_BOOTSTRAP, RUNNER } from './in-sandbox-bootstrap';
+import { DESCRIBE_RUNNER, IN_SANDBOX_BOOTSTRAP, RUNNER } from './in-sandbox-bootstrap';
 import { type ContextEnvelope, encodeBridgeFailure, encodeBridgeSuccess } from './marshal';
 import { buildModuleRegistrySource } from './module-registry';
 import { SANDBOX_GLOBALS_SOURCE } from './sandbox-globals';
@@ -26,8 +26,14 @@ export interface RunTagInSandboxOptions {
    * a module map (multi-file plugins, M4).
    */
   pluginSource?: string;
-  /** Name of the tag within the module to execute. */
+  /** Name of the tag within the module to execute. Ignored (may be '') when `discover` is set. */
   tagName: string;
+  /**
+   * Discovery mode (L1): instead of running a tag, evaluate the plugin entry and return a JSON
+   * string manifest of its exports (template-tag metadata, hook counts, action labels, themes).
+   * The plugin's top-level code still runs — but inside the sandbox, never on the host.
+   */
+  discover?: boolean;
   /** Bulk-copied state passed to the rebuilt in-sandbox context. */
   envelope: ContextEnvelope;
   /** Host side of the async bridge — runs the real work for each `__hostBridge` call. */
@@ -46,7 +52,7 @@ export interface RunTagInSandboxOptions {
  * intermediate handles are reclaimed wholesale.
  */
 export const runTagInSandbox = async (opts: RunTagInSandboxOptions): Promise<string> => {
-  const { pluginSource, tagName, envelope, bridge, onConsole, timeoutMs = 10_000 } = opts;
+  const { pluginSource, tagName, envelope, bridge, onConsole, discover = false, timeoutMs = 10_000 } = opts;
   const { getQuickJSModule } = await import('./quickjs-runtime');
   const QuickJS = await getQuickJSModule();
   const ctx = QuickJS.newContext();
@@ -85,8 +91,8 @@ export const runTagInSandbox = async (opts: RunTagInSandboxOptions): Promise<str
     // Only register heavy vendored libs the plugin was granted, so unrelated renders don't parse them.
     evalOrThrow(ctx, buildModuleRegistrySource(fullEnvelope.grantedModules), '<sandbox-modules>');
     // Plugin source travels as envelope DATA (moduleFiles) and is compiled by the in-sandbox loader
-    // when __invoke() loads the entry — no host-side eval of plugin code.
-    evalOrThrow(ctx, RUNNER, '<runner>');
+    // when __invoke()/__describeExports() loads the entry — no host-side eval of plugin code.
+    evalOrThrow(ctx, discover ? DESCRIBE_RUNNER : RUNNER, '<runner>');
 
     return await drivePromiseToString(ctx, timeoutMs);
   } finally {

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
@@ -1,7 +1,7 @@
 import type { QuickJSContext, QuickJSHandle } from 'quickjs-emscripten';
 
 import type { HostBridge } from './host-bridge';
-import { DESCRIBE_RUNNER, IN_SANDBOX_BOOTSTRAP, RUNNER } from './in-sandbox-bootstrap';
+import { DESCRIBE_RUNNER, HOOK_RUNNER, IN_SANDBOX_BOOTSTRAP, RUNNER } from './in-sandbox-bootstrap';
 import { type ContextEnvelope, encodeBridgeFailure, encodeBridgeSuccess } from './marshal';
 import { buildModuleRegistrySource } from './module-registry';
 import { SANDBOX_GLOBALS_SOURCE } from './sandbox-globals';
@@ -96,8 +96,9 @@ export const runTagInSandbox = async (opts: RunTagInSandboxOptions): Promise<str
     // Only register heavy vendored libs the plugin was granted, so unrelated renders don't parse them.
     evalOrThrow(ctx, buildModuleRegistrySource(fullEnvelope.grantedModules), '<sandbox-modules>');
     // Plugin source travels as envelope DATA (moduleFiles) and is compiled by the in-sandbox loader
-    // when __invoke()/__describeExports() loads the entry — no host-side eval of plugin code.
-    evalOrThrow(ctx, discover ? DESCRIBE_RUNNER : RUNNER, '<runner>');
+    // when __invoke()/__describeExports()/__invokeHook() loads the entry — no host-side eval.
+    const runner = envelope.hookKind ? HOOK_RUNNER : discover ? DESCRIBE_RUNNER : RUNNER;
+    evalOrThrow(ctx, runner, '<runner>');
 
     return await drivePromiseToString(ctx, timeoutMs);
   } finally {

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
@@ -73,7 +73,12 @@ export const runTagInSandbox = async (opts: RunTagInSandboxOptions): Promise<str
     ctx.runtime.setInterruptHandler(() => Date.now() > deadline);
     // Caps the WASM heap so a plugin can't OOM the host by allocating without bound.
     ctx.runtime.setMemoryLimit(32 * 1024 * 1024);
-    installHostBridge(ctx, bridge);
+    // Discovery only ever evaluates plugin top-level code to read its exports — it must stay
+    // side-effect-free even though that same top-level code can reach `__buildContext` (a bare
+    // sandbox global, see SANDBOX_INTERNAL_GLOBALS) and wire up a context of its own. Swapping in a
+    // rejecting bridge here means any such attempt fails inside the sandbox instead of reaching the
+    // real host, no matter how it's invoked.
+    installHostBridge(ctx, discover ? rejectingBridge : bridge);
     installHostConsole(ctx, onConsole);
     installHostCrypto(ctx, opts.hostCrypto);
 
@@ -98,6 +103,11 @@ export const runTagInSandbox = async (opts: RunTagInSandboxOptions): Promise<str
   } finally {
     ctx.dispose();
   }
+};
+
+/** Installed instead of the real bridge during `discover: true` so a bridge call made from plugin top-level code fails inside the sandbox rather than reaching the host. */
+const rejectingBridge: HostBridge = async path => {
+  throw new Error(`Host bridge is unavailable during discovery (attempted call to "${path}")`);
 };
 
 /** Register `__hostBridge(path, bodyJson)` returning a VM promise resolved from async host work. */

--- a/packages/insomnia/src/templating/sandbox/sandbox-export-discovery.test.ts
+++ b/packages/insomnia/src/templating/sandbox/sandbox-export-discovery.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import { type HostBridge } from './host-bridge';
+import { type ContextEnvelope, type PluginExportManifest } from './marshal';
+import { runTagInSandbox } from './plugin-tag-sandbox';
+
+// L1 load-time discovery: evaluate a plugin's entry inside the sandbox and return a manifest of its
+// exports, instead of nodeRequire-ing it on the host. The plugin's top-level code runs — but in the
+// sandbox, so it can't touch the host. These tests drive the discovery path directly.
+
+const noBridge: HostBridge = async path => {
+  throw new Error(`unexpected bridge call: ${path}`);
+};
+
+const envelope = (moduleFiles: Record<string, string>, grantedModules: string[] = ['path', 'crypto']): ContextEnvelope => ({
+  args: [],
+  context: {},
+  meta: {},
+  renderPurpose: 'preview',
+  appInfo: { version: '0.0.0', platform: 'linux', arch: 'x64' },
+  pluginName: 'test-plugin',
+  renderDepth: 0,
+  grantedModules,
+  grantedCapabilities: [],
+  moduleFiles,
+  entryModuleKey: 'index.js',
+});
+
+const discover = async (moduleFiles: Record<string, string>, grantedModules?: string[]): Promise<PluginExportManifest> => {
+  const json = await runTagInSandbox({
+    tagName: '',
+    discover: true,
+    envelope: envelope(moduleFiles, grantedModules),
+    bridge: noBridge,
+  });
+  return JSON.parse(json) as PluginExportManifest;
+};
+
+describe('sandbox export discovery (L1)', () => {
+  it('returns a manifest of a multi-export plugin without running any export', async () => {
+    const manifest = await discover({
+      'index.js': `
+        module.exports.templateTags = [
+          { name: 'a', displayName: 'Tag A', description: 'first', args: [{ type: 'string' }], run: function () { return 'ran-a'; } },
+          { name: 'b', run: function () { return 'ran-b'; } },
+        ];
+        module.exports.requestHooks = [function () {}, function () {}];
+        module.exports.responseHooks = [function () {}];
+        module.exports.requestActions = [{ label: 'Do It', icon: 'fa-bolt', action: function () {} }];
+        module.exports.workspaceActions = [{ label: 'WS', action: function () {} }];
+        module.exports.themes = [{ name: 't', displayName: 'Theme', theme: { background: { default: '#000' } } }];`,
+    });
+
+    expect(manifest.templateTags).toEqual([
+      { name: 'a', displayName: 'Tag A', description: 'first', args: [{ type: 'string' }] },
+      { name: 'b', displayName: undefined, description: undefined, args: [] },
+    ]);
+    expect(manifest.requestHooks).toBe(2);
+    expect(manifest.responseHooks).toBe(1);
+    expect(manifest.requestActions).toEqual([{ label: 'Do It', icon: 'fa-bolt' }]);
+    expect(manifest.workspaceActions).toEqual([{ label: 'WS', icon: undefined }]);
+    expect(manifest.documentActions).toEqual([]);
+    expect(manifest.themes).toEqual([{ name: 't', displayName: 'Theme', theme: { background: { default: '#000' } } }]);
+  });
+
+  it('resolves relative requires while discovering (multi-file plugin)', async () => {
+    const manifest = await discover({
+      'index.js': "module.exports.templateTags = require('./tags');",
+      'tags.js': "module.exports = [{ name: 'fromlib', run: function () { return 'x'; } }];",
+    });
+    expect(manifest.templateTags).toEqual([{ name: 'fromlib', displayName: undefined, description: undefined, args: [] }]);
+  });
+
+  it('contains a throwing top-level (surfaced as a rejection, not a host crash)', async () => {
+    await expect(discover({ 'index.js': "throw new Error('boom at load');" })).rejects.toThrow(/boom at load/);
+  });
+
+  it('denies a top-level require of an ungranted module (proves discovery runs in the sandbox)', async () => {
+    // A plugin whose top-level does require('child_process') to spawn a process gets nothing: the
+    // sandbox require is default-deny, so discovery fails the same way tag execution would — the
+    // host is never reached.
+    await expect(discover({ 'index.js': "require('child_process'); module.exports.templateTags = [];" })).rejects.toThrow(
+      /not permitted by manifest/,
+    );
+  });
+});

--- a/packages/insomnia/src/templating/sandbox/sandbox-export-discovery.test.ts
+++ b/packages/insomnia/src/templating/sandbox/sandbox-export-discovery.test.ts
@@ -12,7 +12,10 @@ const noBridge: HostBridge = async path => {
   throw new Error(`unexpected bridge call: ${path}`);
 };
 
-const envelope = (moduleFiles: Record<string, string>, grantedModules: string[] = ['path', 'crypto']): ContextEnvelope => ({
+const envelope = (
+  moduleFiles: Record<string, string>,
+  grantedModules: string[] = ['path', 'crypto'],
+): ContextEnvelope => ({
   args: [],
   context: {},
   meta: {},
@@ -26,7 +29,10 @@ const envelope = (moduleFiles: Record<string, string>, grantedModules: string[] 
   entryModuleKey: 'index.js',
 });
 
-const discover = async (moduleFiles: Record<string, string>, grantedModules?: string[]): Promise<PluginExportManifest> => {
+const discover = async (
+  moduleFiles: Record<string, string>,
+  grantedModules?: string[],
+): Promise<PluginExportManifest> => {
   const json = await runTagInSandbox({
     tagName: '',
     discover: true,
@@ -68,7 +74,22 @@ describe('sandbox export discovery (L1)', () => {
       'index.js': "module.exports.templateTags = require('./tags');",
       'tags.js': "module.exports = [{ name: 'fromlib', run: function () { return 'x'; } }];",
     });
-    expect(manifest.templateTags).toEqual([{ name: 'fromlib', displayName: undefined, description: undefined, args: [] }]);
+    expect(manifest.templateTags).toEqual([
+      { name: 'fromlib', displayName: undefined, description: undefined, args: [] },
+    ]);
+  });
+
+  it('clamps a hostile hook count so the host cannot be driven into a huge allocation', async () => {
+    // A plugin exports a non-array with a giant `.length`; the manifest count must be clamped, not
+    // passed through, so the host's Array.from({ length }) can't be weaponized into an OOM.
+    const manifest = await discover({
+      'index.js': `
+        module.exports.requestHooks = { length: 1e12 };
+        module.exports.responseHooks = [function () {}, function () {}, function () {}];
+        module.exports.templateTags = [];`,
+    });
+    expect(manifest.requestHooks).toBe(1000);
+    expect(manifest.responseHooks).toBe(3);
   });
 
   it('contains a throwing top-level (surfaced as a rejection, not a host crash)', async () => {
@@ -79,8 +100,8 @@ describe('sandbox export discovery (L1)', () => {
     // A plugin whose top-level does require('child_process') to spawn a process gets nothing: the
     // sandbox require is default-deny, so discovery fails the same way tag execution would — the
     // host is never reached.
-    await expect(discover({ 'index.js': "require('child_process'); module.exports.templateTags = [];" })).rejects.toThrow(
-      /not permitted by manifest/,
-    );
+    await expect(
+      discover({ 'index.js': "require('child_process'); module.exports.templateTags = [];" }),
+    ).rejects.toThrow(/not permitted by manifest/);
   });
 });

--- a/packages/insomnia/src/templating/sandbox/sandbox-export-discovery.test.ts
+++ b/packages/insomnia/src/templating/sandbox/sandbox-export-discovery.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { type HostBridge } from './host-bridge';
 import { type ContextEnvelope, type PluginExportManifest } from './marshal';
 import { runTagInSandbox } from './plugin-tag-sandbox';
+import { buildReachabilityProbeSource } from './sandbox-surface';
 
 // L1 load-time discovery: evaluate a plugin's entry inside the sandbox and return a manifest of its
 // exports, instead of nodeRequire-ing it on the host. The plugin's top-level code runs — but in the
@@ -15,6 +16,7 @@ const noBridge: HostBridge = async path => {
 const envelope = (
   moduleFiles: Record<string, string>,
   grantedModules: string[] = ['path', 'crypto'],
+  grantedCapabilities: string[] = [],
 ): ContextEnvelope => ({
   args: [],
   context: {},
@@ -24,7 +26,7 @@ const envelope = (
   pluginName: 'test-plugin',
   renderDepth: 0,
   grantedModules,
-  grantedCapabilities: [],
+  grantedCapabilities,
   moduleFiles,
   entryModuleKey: 'index.js',
 });
@@ -104,4 +106,60 @@ describe('sandbox export discovery (L1)', () => {
       discover({ 'index.js': "require('child_process'); module.exports.templateTags = [];" }),
     ).rejects.toThrow(/not permitted by manifest/);
   });
+});
+
+describe('sandbox export discovery (L1) — bridge isolation', () => {
+  it('a discovery-time call to the internal context builder never reaches the host bridge', async () => {
+    const calls: { path: string; body: unknown }[] = [];
+    const recordingBridge: HostBridge = async (path, body) => {
+      calls.push({ path, body });
+      return {};
+    };
+
+    // Top-level code (runs during mere discovery, before any tag is ever invoked) reaches for the
+    // internal context builder directly and tries to use it — exactly what a plugin manifest never
+    // declaring anything would still be able to attempt.
+    await runTagInSandbox({
+      tagName: '',
+      discover: true,
+      envelope: envelope(
+        {
+          'index.js': `
+            var ctx = globalThis.__buildContext({ pluginName: 'x', context: {}, meta: {}, renderPurpose: 'preview', appInfo: {} });
+            ctx.app.alert('t', 'm');
+            module.exports.templateTags = [];`,
+        },
+        ['path', 'crypto'],
+        ['app'],
+      ),
+      bridge: recordingBridge,
+    });
+
+    expect(calls).toEqual([]);
+  });
+
+  // Stretch coverage: instead of one hand-picked exploit shape, recursively invoke every
+  // globalThis-reachable function (and whatever it returns) during discovery, watching for any
+  // bridge call anywhere in the tree.
+  it('no globalThis-reachable function reaches the host bridge during discovery, however invoked', async () => {
+    const calls: { path: string; body: unknown }[] = [];
+    const recordingBridge: HostBridge = async (path, body) => {
+      calls.push({ path, body });
+      return {};
+    };
+
+    await runTagInSandbox({
+      tagName: '',
+      discover: true,
+      envelope: envelope(
+        { 'index.js': buildReachabilityProbeSource() },
+        ['path', 'crypto'],
+        ['app', 'storage', 'network', 'fs-read', 'render', 'util', 'credentials', 'models.read'],
+      ),
+      bridge: recordingBridge,
+      timeoutMs: 30_000,
+    });
+
+    expect(calls).toEqual([]);
+  }, 40_000);
 });

--- a/packages/insomnia/src/templating/sandbox/sandbox-hooks.test.ts
+++ b/packages/insomnia/src/templating/sandbox/sandbox-hooks.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import { type HostBridge } from './host-bridge';
+import { type ContextEnvelope, type HookResult } from './marshal';
+import { runTagInSandbox } from './plugin-tag-sandbox';
+
+// H1: request/response hooks run inside the sandbox. The hook mutates context.request in place; the
+// sandbox marshals the mutated request back out as JSON so the host can merge it. These tests drive
+// the hook path directly with a hand-built envelope.
+
+const noBridge: HostBridge = async path => {
+  throw new Error(`unexpected bridge call: ${path}`);
+};
+
+const runRequestHook = async (
+  hookSource: string,
+  request: Record<string, unknown>,
+  grantedCapabilities: string[] = [],
+): Promise<Record<string, unknown>> => {
+  const envelope: ContextEnvelope = {
+    args: [],
+    context: { BASE_URL: 'https://env.example' },
+    meta: {},
+    renderPurpose: 'send',
+    appInfo: { version: '0.0.0', platform: 'linux', arch: 'x64' },
+    pluginName: 'test-plugin',
+    renderDepth: 0,
+    grantedModules: ['path', 'crypto'],
+    grantedCapabilities,
+    moduleFiles: { 'index.js': `module.exports.requestHooks = [${hookSource}];` },
+    entryModuleKey: 'index.js',
+    hookKind: 'request',
+    hookIndex: 0,
+    hookRequest: request,
+  };
+  const json = await runTagInSandbox({ tagName: '', envelope, bridge: noBridge });
+  return (JSON.parse(json) as HookResult).request ?? {};
+};
+
+describe('request hooks in the sandbox (H1)', () => {
+  it('marshals header/url/method/body mutations back out to the host', async () => {
+    const request = await runRequestHook(
+      `function (context) {
+        context.request.addHeader('X-Injected', 'from-hook');
+        context.request.setHeader('X-Existing', 'updated');
+        context.request.setUrl('https://rewritten.example/path');
+        context.request.setMethod('POST');
+        context.request.setBody({ text: 'new-body' });
+      }`,
+      {
+        _id: 'req_1',
+        url: 'https://original.example',
+        method: 'GET',
+        headers: [{ name: 'X-Existing', value: 'original' }],
+        body: {},
+      },
+    );
+
+    expect(request.url).toBe('https://rewritten.example/path');
+    expect(request.method).toBe('POST');
+    expect(request.body).toEqual({ text: 'new-body' });
+    expect(request.headers).toContainEqual({ name: 'X-Injected', value: 'from-hook' });
+    // setHeader updates the existing header in place (case-insensitive match), not a duplicate.
+    expect(request.headers).toContainEqual({ name: 'X-Existing', value: 'updated' });
+    expect((request.headers as unknown[]).length).toBe(2);
+  });
+
+  it('matches headers case-insensitively (parity with misc.filterHeaders)', async () => {
+    const request = await runRequestHook(
+      `function (context) { context.request.setHeader('content-TYPE', 'application/json'); }`,
+      { headers: [{ name: 'Content-Type', value: 'text/plain' }] },
+    );
+    // Updated in place, not appended, because the lookup is case-insensitive.
+    expect(request.headers).toEqual([{ name: 'Content-Type', value: 'application/json' }]);
+  });
+
+  it('reads environment variables from the render context', async () => {
+    const request = await runRequestHook(
+      `function (context) { context.request.setHeader('X-Base', context.request.getEnvironmentVariable('BASE_URL')); }`,
+      { headers: [] },
+    );
+    expect(request.headers).toContainEqual({ name: 'X-Base', value: 'https://env.example' });
+  });
+
+  it('denies an ungranted host capability from inside a hook (context.network absent)', async () => {
+    // No 'network' capability granted → context.network is undefined (C2), so reaching for it throws
+    // at the property access — the hook cannot make network calls it didn't declare.
+    await expect(
+      runRequestHook(`async function (context) { await context.network.sendRequest({}); }`, { headers: [] }, []),
+    ).rejects.toThrow(/sendRequest/i);
+  });
+
+  it('allows a granted capability: context.network is present when the manifest grants network', async () => {
+    // With 'network' granted the branch exists; feature-detecting it as an object proves C2 attaches
+    // the branch (the actual call would bridge to the host, which the unit test bridge rejects).
+    const request = await runRequestHook(
+      `function (context) { context.request.setHeader('X-Net', typeof context.network); }`,
+      { headers: [] },
+      ['network'],
+    );
+    expect(request.headers).toContainEqual({ name: 'X-Net', value: 'object' });
+  });
+});

--- a/packages/insomnia/src/templating/sandbox/sandbox-surface.test.ts
+++ b/packages/insomnia/src/templating/sandbox/sandbox-surface.test.ts
@@ -3,10 +3,12 @@ import { describe, expect, it } from 'vitest';
 import { ALL_SANDBOX_MODULES } from './module-registry';
 import {
   findLeakedGatedReferences,
+  findSandboxInternalGlobals,
   findUnaccountedHostNatives,
   formatSurfaceEntries,
   getSandboxEscapeProbe,
   getSandboxSurface,
+  SANDBOX_INTERNAL_GLOBALS,
 } from './sandbox-surface';
 
 describe('sandbox surface', () => {
@@ -74,5 +76,13 @@ describe('sandbox', () => {
   it('no gated reference leaks onto bare globalThis (alias resolver)', async () => {
     const entries = await getSandboxSurface();
     expect(findLeakedGatedReferences(entries)).toEqual([]);
+  }, 20_000);
+
+  // Completeness tripwire: any new sandbox-internal global must be added here deliberately, so its
+  // safety story (who can reach it, what it can do during discovery) gets reviewed rather than
+  // slipping in unnoticed.
+  it('exposes exactly the reviewed set of sandbox-internal globals', async () => {
+    const entries = await getSandboxSurface();
+    expect(findSandboxInternalGlobals(entries)).toEqual([...SANDBOX_INTERNAL_GLOBALS].sort());
   }, 20_000);
 });

--- a/packages/insomnia/src/templating/sandbox/sandbox-surface.ts
+++ b/packages/insomnia/src/templating/sandbox/sandbox-surface.ts
@@ -215,8 +215,19 @@ export const findLeakedGatedReferences = (entries: SurfaceEntry[]): string[] =>
  * in particular returns a context wired to the real host bridge; discovery-time safety comes from
  * `runTagInSandbox` substituting a rejecting bridge when `discover: true`, not from hiding this
  * global. Adding a new one here forces a human to re-check that story still holds.
+ *
+ * `__invokeHook` (H1) is in this set: like `__invoke`, it wires a context to the real bridge, but
+ * during discovery the rejecting bridge is installed AND no hook is present to run (hookKind/hookIndex
+ * are unset), so a discovery-time call reaches nothing — re-checked and safe.
  */
-export const SANDBOX_INTERNAL_GLOBALS = ['__buildContext', '__describeExports', '__invoke', '__loadPluginEntry', '__require'];
+export const SANDBOX_INTERNAL_GLOBALS = [
+  '__buildContext',
+  '__describeExports',
+  '__invoke',
+  '__invokeHook',
+  '__loadPluginEntry',
+  '__require',
+];
 
 /** Filters sandbox surface entries down to the bare `globalThis.__*` internals (excluding the `.prototype` sibling lines already in the snapshot). */
 export const findSandboxInternalGlobals = (entries: SurfaceEntry[]): string[] =>

--- a/packages/insomnia/src/templating/sandbox/sandbox-surface.ts
+++ b/packages/insomnia/src/templating/sandbox/sandbox-surface.ts
@@ -207,6 +207,69 @@ export const findLeakedGatedReferences = (entries: SurfaceEntry[]): string[] =>
     .filter(e => !!e.aliasOf && e.aliasOf.startsWith('globalThis.') && (e.root === 'context' || e.root.startsWith('require(')))
     .map(e => `${e.path} aliases ${e.aliasOf}`);
 
+/**
+ * The complete, reviewed set of sandbox-internal globals (`in-sandbox-bootstrap.ts`) exposed bare on
+ * `globalThis` so `RUNNER`/`DESCRIBE_RUNNER` — each a separate `ctx.evalCode` call, so they can only
+ * share state via `globalThis`, never lexical closure — can reach them. Locked against reassignment,
+ * but reachable (and callable) by plugin top-level code, same as any other global. `__buildContext`
+ * in particular returns a context wired to the real host bridge; discovery-time safety comes from
+ * `runTagInSandbox` substituting a rejecting bridge when `discover: true`, not from hiding this
+ * global. Adding a new one here forces a human to re-check that story still holds.
+ */
+export const SANDBOX_INTERNAL_GLOBALS = ['__buildContext', '__describeExports', '__invoke', '__loadPluginEntry', '__require'];
+
+/** Filters sandbox surface entries down to the bare `globalThis.__*` internals (excluding the `.prototype` sibling lines already in the snapshot). */
+export const findSandboxInternalGlobals = (entries: SurfaceEntry[]): string[] =>
+  entries
+    .filter(e => e.root === 'globalThis' && /^globalThis\.__[^.]+$/.test(e.path))
+    .map(e => e.path.slice('globalThis.'.length));
+
+/**
+ * Tier B-deep reachability probe (discovery-time bridge escape coverage): recursively walks every
+ * `globalThis`-reachable property (same walk/cycle-detection shape as `buildSurfaceProbeSource`) and
+ * additionally *invokes* every function found with a couple of generic argument shapes, then walks
+ * whatever it returns too — the real exploit shape is a bare `globalThis` function (`__buildContext`)
+ * whose return value exposes further bridge-backed functions several levels down. Meant to run as
+ * plugin top-level code during a `discover: true` run (no tag ever inserted). The authoritative check
+ * is the host-side recording bridge seeing zero calls; nothing here reports its own pass/fail — a
+ * bridge call from inside the sandbox is indistinguishable from any other promise-returning builtin.
+ */
+export const buildReachabilityProbeSource = (maxDepth = 2): string => `
+(function () {
+  var seen = [];
+  var genericArgs = [
+    [],
+    [{ pluginName: 'probe', context: {}, meta: {}, renderPurpose: 'preview', appInfo: {} }],
+  ];
+  function walk(obj, depth) {
+    if (depth > ${maxDepth}) { return; }
+    if (obj === null || (typeof obj !== 'object' && typeof obj !== 'function')) { return; }
+    if (seen.indexOf(obj) !== -1) { return; }
+    seen.push(obj);
+    var names;
+    try { names = Object.getOwnPropertyNames(obj).sort(); } catch (e) { return; }
+    for (var i = 0; i < names.length; i++) {
+      var name = names[i];
+      if (name === 'length' || name === 'name' || name === 'prototype') { continue; }
+      var val;
+      try { val = obj[name]; } catch (e) { continue; }
+      if (typeof val === 'function') {
+        for (var a = 0; a < genericArgs.length; a++) {
+          try {
+            var r = val.apply(null, genericArgs[a]);
+            if (r && typeof r.then === 'function') { r.then(function () {}, function () {}); }
+            walk(r, 0);
+          } catch (e) { /* probing only - a thrown arity/shape mismatch is not a finding */ }
+        }
+      }
+      walk(val, depth + 1);
+    }
+  }
+  walk(globalThis, 0);
+})();
+module.exports.templateTags = [];
+`;
+
 const ESCAPE_PROBE_TAG_NAME = 'escapeProbe';
 
 // Checks whether `this`, Function('return this')(), ambient globals, or the process shim ever


### PR DESCRIPTION
## What this PR does

- The protocol had no caller authentication. `plugins.applyRequestHooks` was gated to the real main window over ipcMain, but the same capability (running a user plugin's request hook, executing a plugin tag, discovering a plugin's exports, plus the whole DB bridge) was dispatched by resolveDbByKey behind the insomnia-templating-worker-database:// protocol with no caller check at all. Anything able to fetch() that scheme could run any installed plugin's request hook with forged data and read the result back. This is resolved by generating a per-process secret in main, handing it out only to the main window and plugin window over a sender-checked IPC channel, and rejecting any protocol call missing or mismatching it before it reaches a handler.
- Two of those handlers took the on-disk plugin directory straight from the request body, so a forged call could point hook or discovery execution at any folder with a package.json. This is resolved by resolving the directory server-side from the trusted plugin registry, keyed by plugin name, and rejecting unknown names.
- stripDangerousKeysReviver was applied to the hook-result path but not to the manifest-discovery parse or resolveDbByKey's own request-body parse, leaving an inconsistent guard against prototype pollution from untrusted sandbox output. This is resolved by routing both through the same reviver so sanitization happens at every point untrusted data re-enters host memory, not just one.

## Regression tests added

`templating-worker-database-protocol-authorization.test.ts` dynamically iterates the live plugin-to-handler map (not a hardcoded channel list) so a future handler can't silently reappear unauthenticated:
- every registered path rejects a missing or forged auth token, and is dispatched (not rejected) with the real one, plus a focused regression on the request-hook dispatch path specifically
- a forged directory in the request body is proven to be ignored in favor of the registry-resolved one, and an unregistered plugin name is rejected
- a plugin export planting a `__proto__` own-key is proven not to survive into the discovered manifest

Full test suite, type-check, lint, and the sandbox smoke suite (including the request-hook end-to-end test) all pass.