### PR TITLE
feat(templating): (H1) route user-plugin request hooks through the sandbox (PR 10a) - sec request hooks review 

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
@@ -121,7 +121,12 @@ const writePlugin = (dataPath: string, name: string, insomnia: unknown, indexJs:
 };
 
 // Seed the once-only guard for the persistent "Plugin system updated" toast (it intercepts pointer
-// events over the page) and dismiss any toast already in flight, before driving the UI.
+// events over the page) and dismiss any toast already in flight, before driving the UI. The toast
+// can re-render mid-dismiss (its DOM node gets swapped out during its exit transition), which made
+// a plain `.click()` here flake: Playwright's actionability wait would see the button go from
+// stable -> detached and retry forever, eventually blowing the whole test's timeout. `force: true`
+// skips that stability wait (fires the click at whatever is there right now), and the loop is
+// bounded by wall-clock time instead of trusting the button count to reach zero.
 const clearPluginToast = async (page: Page) => {
   await page.getByLabel('Import').waitFor();
   await page.evaluate(() => localStorage.setItem('plugin-system-changes-toast-shown', 'true'));
@@ -130,8 +135,9 @@ const clearPluginToast = async (page: Page) => {
     .first()
     .waitFor({ timeout: 3000 })
     .catch(() => {});
-  while ((await dismissButtons.count()) > 0) {
-    await dismissButtons.first().click();
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline && (await dismissButtons.count()) > 0) {
+    await dismissButtons.first().click({ force: true, timeout: 500 }).catch(() => {});
   }
 };
 
@@ -159,21 +165,7 @@ test('Template tag sandbox: flag routes plugin tag execution into the QuickJS sa
   insomnia,
 }) => {
   installProbePlugin(dataPath);
-
-  // The persistent "Plugin system updated" notification fires from a Root mount effect whenever
-  // user plugins exist on disk, and its toast region intercepts pointer events over the page.
-  // Seed its once-only guard so route remounts can't re-raise it, then clear any toast already
-  // in flight before driving the UI.
-  await page.getByLabel('Import').waitFor();
-  await page.evaluate(() => localStorage.setItem('plugin-system-changes-toast-shown', 'true'));
-  const dismissButtons = page.getByRole('button', { name: 'Dismiss' });
-  await dismissButtons
-    .first()
-    .waitFor({ timeout: 3000 })
-    .catch(() => {});
-  while ((await dismissButtons.count()) > 0) {
-    await dismissButtons.first().click();
-  }
+  await clearPluginToast(page);
 
   // Import a collection whose request body contains the probe tags (the tags render as pills
   // lexically, so importing before the plugin is registered is fine).

--- a/packages/insomnia/src/common/templating/liquid-extension-worker.ts
+++ b/packages/insomnia/src/common/templating/liquid-extension-worker.ts
@@ -37,9 +37,22 @@ export function decodeEncodingWorker<T>(value: T) {
   return value;
 }
 
+// F1: the `insomnia-templating-worker-database://` protocol has no caller-identity check of its
+// own (unlike the `plugins.*` ipcMain channels), so a per-process secret — handed out only to the
+// trusted main window / plugin window over a sender-checked IPC channel — is attached as a header
+// on every call. Each JS realm that can reach this function (main window, plugin window, the
+// dedicated templating Web Worker) sets its own copy via `setTemplatingDbAuthToken` at startup,
+// since none of those realms share module state with each other.
+let templatingDbAuthToken: string | null = null;
+
+export const setTemplatingDbAuthToken = (token: string | null) => {
+  templatingDbAuthToken = token;
+};
+
 export const fetchFromTemplateWorkerDatabase = async (path: PluginToMainAPIPaths, body: any) => {
   const resp = await fetch('insomnia-templating-worker-database://' + path, {
     method: 'post',
+    headers: templatingDbAuthToken ? { 'x-insomnia-templating-auth': templatingDbAuthToken } : undefined,
     body: JSON.stringify(body),
   });
   let result;

--- a/packages/insomnia/src/common/templating/liquid-extension-worker.ts
+++ b/packages/insomnia/src/common/templating/liquid-extension-worker.ts
@@ -37,12 +37,8 @@ export function decodeEncodingWorker<T>(value: T) {
   return value;
 }
 
-// F1: the `insomnia-templating-worker-database://` protocol has no caller-identity check of its
-// own (unlike the `plugins.*` ipcMain channels), so a per-process secret — handed out only to the
-// trusted main window / plugin window over a sender-checked IPC channel — is attached as a header
-// on every call. Each JS realm that can reach this function (main window, plugin window, the
-// dedicated templating Web Worker) sets its own copy via `setTemplatingDbAuthToken` at startup,
-// since none of those realms share module state with each other.
+// Set by each JS realm that calls fetchFromTemplateWorkerDatabase, since none of them share
+// module state with each other.
 let templatingDbAuthToken: string | null = null;
 
 export const setTemplatingDbAuthToken = (token: string | null) => {

--- a/packages/insomnia/src/entry.client.tsx
+++ b/packages/insomnia/src/entry.client.tsx
@@ -8,6 +8,7 @@ import { hydrateRoot } from 'react-dom/client';
 import { HydratedRouter } from 'react-router/dom';
 
 import { insomniaFetch } from '~/common/insomnia-fetch';
+import { setTemplatingDbAuthToken } from '~/common/templating/liquid-extension-worker';
 import { initRuntime } from '~/runtimes';
 import { rendererRuntime } from '~/runtimes/runtime.renderer';
 import { migrateFromLocalStorage, type SessionData, setSessionData, setVaultSessionData } from '~/ui/account/session';
@@ -28,6 +29,10 @@ import { initializeSentry } from './ui/sentry';
 import { registerSyncMergeConflictListener } from './ui/utils/insomnia-sync';
 
 initializeSentry();
+
+// F1: fetch the templating-db protocol auth token once, up front, so every templating call in this
+// window (including the ones the dedicated templating Web Worker forwards here) is authenticated.
+setTemplatingDbAuthToken(await window.main.templatingDb.getAuthToken());
 
 // Initialize database for renderer process
 await initDatabase(clientDatabase);

--- a/packages/insomnia/src/entry.client.tsx
+++ b/packages/insomnia/src/entry.client.tsx
@@ -30,8 +30,7 @@ import { registerSyncMergeConflictListener } from './ui/utils/insomnia-sync';
 
 initializeSentry();
 
-// F1: fetch the templating-db protocol auth token once, up front, so every templating call in this
-// window (including the ones the dedicated templating Web Worker forwards here) is authenticated.
+// Fetch the templating-db auth token once so it's available for every templating call in this window.
 setTemplatingDbAuthToken(await window.main.templatingDb.getAuthToken());
 
 // Initialize database for renderer process

--- a/packages/insomnia/src/entry.plugin-window.ts
+++ b/packages/insomnia/src/entry.plugin-window.ts
@@ -1,6 +1,7 @@
 import { ipcRenderer } from 'electron';
 import { initDatabase, initServices } from 'insomnia-data';
 
+import { setTemplatingDbAuthToken } from './common/templating/liquid-extension-worker';
 import { pluginWindowDatabase } from './main/database.plugin-window';
 import { invokePluginMethod } from './plugins/invoke-method';
 import { initRuntime } from './runtimes';
@@ -28,6 +29,10 @@ ipcRenderer.on('plugins.invoke', async (_event, { id, method, args }: PluginInvo
 // getPlugins() calls services.settings.get(), which requires this to be done first.
 (async () => {
   try {
+    // F1: this window has its own JS realm (nodeIntegration, no contextBridge) and so its own copy
+    // of the templating-db auth token module state — fetch it directly over IPC before any plugin
+    // code can call `fetchFromTemplateWorkerDatabase`.
+    setTemplatingDbAuthToken(await ipcRenderer.invoke('templatingDb.getAuthToken'));
     await initDatabase(pluginWindowDatabase);
     initServices(servicesProxy);
     initRuntime(rendererRuntime);

--- a/packages/insomnia/src/entry.plugin-window.ts
+++ b/packages/insomnia/src/entry.plugin-window.ts
@@ -29,9 +29,7 @@ ipcRenderer.on('plugins.invoke', async (_event, { id, method, args }: PluginInvo
 // getPlugins() calls services.settings.get(), which requires this to be done first.
 (async () => {
   try {
-    // F1: this window has its own JS realm (nodeIntegration, no contextBridge) and so its own copy
-    // of the templating-db auth token module state — fetch it directly over IPC before any plugin
-    // code can call `fetchFromTemplateWorkerDatabase`.
+    // Fetch the auth token before any plugin code can call fetchFromTemplateWorkerDatabase.
     setTemplatingDbAuthToken(await ipcRenderer.invoke('templatingDb.getAuthToken'));
     await initDatabase(pluginWindowDatabase);
     initServices(servicesProxy);

--- a/packages/insomnia/src/entry.preload.ts
+++ b/packages/insomnia/src/entry.preload.ts
@@ -451,6 +451,9 @@ const main: Window['main'] = {
     getBridgeMetrics: () => invokeWithNormalizedError('plugins.getBridgeMetrics'),
   },
   notifyPromptResult: (id: string, value: string | null) => ipcRenderer.send('ui.promptResult', { id, value }),
+  templatingDb: {
+    getAuthToken: () => invokeWithNormalizedError('templatingDb.getAuthToken'),
+  },
   timeline: {
     getPath: (responseId: string) => invokeWithNormalizedError('timeline.getPath', responseId) as Promise<string>,
     appendToFile: (options: { timelinePath: string; data: string }) =>

--- a/packages/insomnia/src/main/__tests__/plugin-window-ipc-authorization.test.ts
+++ b/packages/insomnia/src/main/__tests__/plugin-window-ipc-authorization.test.ts
@@ -3,13 +3,10 @@ import path from 'node:path';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// `plugin-window.ts`'s IPC dispatchers (`plugins.applyRequestHooks` and siblings) used to
-// accept a request from any sender (H1-HOOK-SANDBOX-SECURITY-REVIEW.md, finding 1). The fix
-// routes every `ipcMain.handle`/`.on` registration through one of three sender-checked
-// wrappers (`handleFromMainWindow`, `onFromPluginWindow`, `handleFromPluginWindow`). Two
-// guardrails enforce this: a static source check that no bare `ipcMain` call exists outside
-// those wrappers, and a dynamic check that iterates every channel actually registered at
-// runtime (not a hardcoded name list), so a future channel is covered automatically.
+// Verifies every `plugin-window.ts` IPC channel is registered through one of the three
+// sender-checked wrappers and rejects a forged sender. One test statically checks the source
+// for bare `ipcMain` calls outside those wrappers; the rest iterate every channel actually
+// registered at runtime, so a future channel is covered automatically.
 
 const registeredHandlers = new Map<string, (...args: any[]) => any>();
 const registeredListeners = new Map<string, (...args: any[]) => any>();
@@ -117,7 +114,7 @@ describe('plugin-window.ts IPC dispatch: sender authorization', () => {
     }
   });
 
-  // Regression check for finding 1: a forged sender is rejected before it ever reaches the plugin window.
+  // A forged sender is rejected before it ever reaches the plugin window.
   it('plugins.applyRequestHooks rejects a forged sender', async () => {
     const { registerPluginIpcHandlers } = await import('../plugin-window');
     registerPluginIpcHandlers();

--- a/packages/insomnia/src/main/__tests__/plugin-window-ipc-authorization.test.ts
+++ b/packages/insomnia/src/main/__tests__/plugin-window-ipc-authorization.test.ts
@@ -1,0 +1,183 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `plugin-window.ts`'s IPC dispatchers (`plugins.applyRequestHooks` and siblings) used to
+// accept a request from any sender (H1-HOOK-SANDBOX-SECURITY-REVIEW.md, finding 1). The fix
+// routes every `ipcMain.handle`/`.on` registration through one of three sender-checked
+// wrappers (`handleFromMainWindow`, `onFromPluginWindow`, `handleFromPluginWindow`). Two
+// guardrails enforce this: a static source check that no bare `ipcMain` call exists outside
+// those wrappers, and a dynamic check that iterates every channel actually registered at
+// runtime (not a hardcoded name list), so a future channel is covered automatically.
+
+const registeredHandlers = new Map<string, (...args: any[]) => any>();
+const registeredListeners = new Map<string, (...args: any[]) => any>();
+
+const fakePluginWebContents = {
+  send: vi.fn(),
+  on: vi.fn(),
+  once: vi.fn(),
+  off: vi.fn(),
+};
+
+const fakePluginWindow = {
+  isDestroyed: () => false,
+  webContents: fakePluginWebContents,
+  on: vi.fn(),
+  loadFile: vi.fn(),
+};
+
+const fakeMainWebContents = { send: vi.fn() };
+const fakeMainWindow = { webContents: fakeMainWebContents };
+
+// A sender that is neither the real plugin window nor the real main window.
+const forgedSender = { id: 'forged-sender' };
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => '/fake/userData') },
+  BrowserWindow: vi.fn(() => fakePluginWindow),
+  ipcMain: {
+    handle: vi.fn((channel: string, fn: (...args: any[]) => any) => registeredHandlers.set(channel, fn)),
+    on: vi.fn((channel: string, fn: (...args: any[]) => any) => registeredListeners.set(channel, fn)),
+  },
+}));
+
+vi.mock('../window-utils', () => ({
+  getMainWindow: vi.fn(() => fakeMainWindow),
+}));
+
+vi.mock('../prompt-bridge', () => ({
+  requestPromptFromRenderer: vi.fn(),
+}));
+
+describe('plugin-window.ts IPC dispatch: sender authorization', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    registeredHandlers.clear();
+    registeredListeners.clear();
+    fakePluginWebContents.send.mockClear();
+    fakeMainWebContents.send.mockClear();
+  });
+
+  // Fails the build if a channel is ever registered outside the three wrapper bodies.
+  it('every ipcMain.handle/.on call is confined to the three sender-checked wrappers', () => {
+    const source = readFileSync(path.join(__dirname, '..', 'plugin-window.ts'), 'utf8');
+
+    const wrapperNames = ['handleFromMainWindow', 'onFromPluginWindow', 'handleFromPluginWindow'];
+    let withoutWrapperBodies = source;
+    for (const name of wrapperNames) {
+      const start = source.indexOf(`function ${name}`);
+      expect(start, `expected to find the ${name} wrapper definition`).toBeGreaterThan(-1);
+      // Matches the closing brace by depth rather than a fixed line count.
+      let depth = 0;
+      let end = -1;
+      for (let i = source.indexOf('{', start); i < source.length; i++) {
+        if (source[i] === '{') depth++;
+        if (source[i] === '}') {
+          depth--;
+          if (depth === 0) {
+            end = i + 1;
+            break;
+          }
+        }
+      }
+      expect(end, `expected to find the end of the ${name} wrapper body`).toBeGreaterThan(start);
+      withoutWrapperBodies = withoutWrapperBodies.replace(source.slice(start, end), '');
+    }
+
+    expect(withoutWrapperBodies).not.toMatch(/\bipcMain\.handle\(/);
+    expect(withoutWrapperBodies).not.toMatch(/\bipcMain\.on\(/);
+  });
+
+  // Reads the live registration map, not a hardcoded channel list.
+  it('every channel registered by registerPluginIpcHandlers() rejects a forged sender', async () => {
+    const { registerPluginIpcHandlers } = await import('../plugin-window');
+    registerPluginIpcHandlers();
+
+    expect(registeredHandlers.size).toBeGreaterThan(0);
+    for (const [channel, handler] of registeredHandlers) {
+      expect(
+        () => handler({ sender: forgedSender }, {}),
+        `expected plugins channel "${channel}" to reject a forged sender`,
+      ).toThrow(/sender is not the main app window/);
+    }
+  });
+
+  it('every channel registered by registerPluginIpcHandlers() accepts the real main window', async () => {
+    const { registerPluginIpcHandlers } = await import('../plugin-window');
+    registerPluginIpcHandlers();
+
+    for (const [channel, handler] of registeredHandlers) {
+      expect(
+        () => handler({ sender: fakeMainWebContents }, {}),
+        `expected plugins channel "${channel}" to accept the real main window sender`,
+      ).not.toThrow();
+    }
+  });
+
+  // Regression check for finding 1: a forged sender is rejected before it ever reaches the plugin window.
+  it('plugins.applyRequestHooks rejects a forged sender', async () => {
+    const { registerPluginIpcHandlers } = await import('../plugin-window');
+    registerPluginIpcHandlers();
+
+    const applyRequestHooksHandler = registeredHandlers.get('plugins.applyRequestHooks');
+    expect(applyRequestHooksHandler).toBeTypeOf('function');
+
+    const forgedArgs = {
+      renderedRequest: { _id: 'req_forged', url: 'https://example.com/resource', headers: [] },
+      projectId: 'proj_not_mine',
+      environment: { BASE_URL: 'https://example.com' },
+    };
+
+    expect(() => applyRequestHooksHandler!({ sender: forgedSender }, forgedArgs)).toThrow(
+      /sender is not the main app window/,
+    );
+    expect(fakePluginWebContents.send).not.toHaveBeenCalled();
+  });
+
+  // The reverse-direction (plugin-window -> host) callbacks enforce sender checks too.
+  it('plugins.uiAlert still ignores a forged sender', async () => {
+    const { registerPluginIpcHandlers, createPluginWindow } = await import('../plugin-window');
+    registerPluginIpcHandlers();
+    createPluginWindow();
+
+    const uiAlertListener = registeredListeners.get('plugins.uiAlert');
+    expect(uiAlertListener).toBeTypeOf('function');
+
+    uiAlertListener!({ sender: forgedSender }, { message: 'hi' });
+
+    expect(fakeMainWebContents.send).not.toHaveBeenCalled();
+  });
+
+  // Sanity check the fix doesn't break the legitimate dispatch path.
+  it('a legitimate main-window call to plugins.applyRequestHooks still dispatches to the plugin window', async () => {
+    const { registerPluginIpcHandlers } = await import('../plugin-window');
+    registerPluginIpcHandlers();
+
+    const applyRequestHooksHandler = registeredHandlers.get('plugins.applyRequestHooks')!;
+    const legitimateArgs = {
+      renderedRequest: { _id: 'req_1', url: 'https://example.com', headers: [] },
+      projectId: 'proj_1',
+      environment: {},
+    };
+
+    const invokePromise = applyRequestHooksHandler({ sender: fakeMainWebContents }, legitimateArgs);
+
+    await vi.advanceTimersByTimeAsync(0);
+    const windowReadyListener = registeredListeners.get('plugins.windowReady');
+    windowReadyListener!({ sender: fakePluginWebContents });
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(fakePluginWebContents.send).toHaveBeenCalledWith(
+      'plugins.invoke',
+      expect.objectContaining({ method: 'applyRequestHooks', args: legitimateArgs }),
+    );
+
+    const [, { id }] = fakePluginWebContents.send.mock.calls[0];
+    const invokeResultListener = registeredListeners.get('plugins.invokeResult');
+    invokeResultListener!({ sender: fakePluginWebContents }, { id, result: {} });
+    await expect(invokePromise).resolves.toEqual({});
+  });
+});

--- a/packages/insomnia/src/main/__tests__/templating-worker-database-protocol-authorization.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database-protocol-authorization.test.ts
@@ -124,14 +124,20 @@ describe('protocol-dispatch handlers resolve `directory` from the trusted regist
     fs.writeFileSync(path.join(legitDir, 'package.json'), JSON.stringify({ main: 'index.js' }));
     fs.writeFileSync(
       path.join(legitDir, 'index.js'),
-      'module.exports.templateTags = [{ name: "legit_tag", displayName: "legit", run: function () {} }];',
+      `module.exports.templateTags = [{ name: "legit_tag", displayName: "legit", run: function () {} }];
+       module.exports.requestHooks = [function (context) {
+         context.request.setHeader('X-Plugin-Source', 'legit');
+       }];`,
     );
 
     foreignDir = fs.mkdtempSync(path.join(os.tmpdir(), 'insomnia-plugin-foreign-'));
     fs.writeFileSync(path.join(foreignDir, 'package.json'), JSON.stringify({ main: 'index.js' }));
     fs.writeFileSync(
       path.join(foreignDir, 'index.js'),
-      'module.exports.templateTags = [{ name: "forged_tag", displayName: "forged", run: function () {} }];',
+      `module.exports.templateTags = [{ name: "forged_tag", displayName: "forged", run: function () {} }];
+       module.exports.requestHooks = [function (context) {
+         context.request.setHeader('X-Plugin-Source', 'foreign');
+       }];`,
     );
 
     const { getPlugins } = await import('~/plugins');
@@ -173,6 +179,31 @@ describe('protocol-dispatch handlers resolve `directory` from the trusted regist
     expect(res.status).toBe(500);
     const json = await res.json();
     expect(json.error).toMatch(/Unknown plugin/);
+  });
+
+  // Mirrors the discoverUserPluginExports case above on the request-hook path — before this branch,
+  // `plugin.discoverUserPluginExports` and `plugin.runUserRequestHook` each trusted their own copy of
+  // `body.(plugin.)directory` independently, so a guard proven on one handler didn't imply the other
+  // was covered (this is exactly how the `permissions` gap in the describe block below went
+  // unnoticed alongside the `directory` fix). Test both handlers explicitly rather than one.
+  it('a forged directory in plugin.runUserRequestHook\'s request body is ignored in favor of the registry-resolved one', async () => {
+    const token = getOrCreateTemplatingDbAuthToken();
+    const { resolveDbByKey } = await import('../templating-worker-database');
+    const req = new Request('insomnia-templating-worker-database://plugin.runuserrequesthook', {
+      method: 'POST',
+      headers: { [TEMPLATING_DB_AUTH_HEADER]: token },
+      body: JSON.stringify({
+        plugin: { name: 'insomnia-plugin-legit', directory: foreignDir },
+        hookIndex: 0,
+        renderedRequest: { _id: 'req_1', url: 'https://example.com', headers: [], body: {} },
+        renderContext: {},
+      }),
+    });
+    const res = await resolveDbByKey(req);
+    expect(res.status).toBe(200);
+    const mutated = await res.json();
+    const source = mutated.headers.find((h: { name: string }) => h.name === 'X-Plugin-Source')?.value;
+    expect(source).toBe('legit');
   });
 });
 
@@ -242,6 +273,58 @@ describe('protocol-dispatch handlers resolve `permissions` from the trusted regi
   it('a forged `permissions.capabilities` in the request body is ignored; the registry still denies network', async () => {
     const { hasNetwork } = await runHook({ capabilities: ['network'] });
     expect(hasNetwork).toBe(false);
+  });
+});
+
+// Symmetric coverage for the other handler that resolves `permissions`: the describe block above
+// only exercises `plugin.runUserRequestHook`. `plugin.discoverUserPluginExports` takes the same
+// `resolveTrustedPlugin(...).permissions` value but on the *module* grant, not the capability grant
+// (discovery evaluates the plugin's top-level code, which can only reach gated `require(...)`, not
+// hook-time `context.*`). Exercising both fields on both handlers is the point: the permissions gap
+// this branch fixed existed specifically because the `directory` fix was verified per-handler but
+// `permissions` wasn't checked on every handler that resolves it.
+describe('plugin.discoverUserPluginExports resolves `permissions.modules` from the trusted registry, not the request body', () => {
+  let pluginDir: string;
+
+  beforeEach(async () => {
+    _testOnlyResetTemplatingDbAuthToken();
+    pluginDir = fs.mkdtempSync(path.join(os.tmpdir(), 'insomnia-plugin-nomodules-'));
+    fs.writeFileSync(path.join(pluginDir, 'package.json'), JSON.stringify({ main: 'index.js' }));
+    fs.writeFileSync(
+      path.join(pluginDir, 'index.js'),
+      // `events` is not in the baseline module grant (`path`/`crypto` only), so a top-level require
+      // of it only succeeds if `permissions.modules` grants it.
+      "require('events'); module.exports.templateTags = [];",
+    );
+
+    // The registry declares no extra modules for this plugin — a real caller (the plugin loader)
+    // would only ever discover this plugin's exports with the baseline module grant.
+    const { getPlugins } = await import('~/plugins');
+    (getPlugins as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { name: 'insomnia-plugin-nomodules', directory: pluginDir, permissions: {} },
+    ]);
+  });
+
+  afterEach(() => {
+    fs.rmSync(pluginDir, { recursive: true, force: true });
+  });
+
+  it('a forged `permissions.modules` in the request body is ignored; the registry still denies the module', async () => {
+    const token = getOrCreateTemplatingDbAuthToken();
+    const { resolveDbByKey } = await import('../templating-worker-database');
+    const req = new Request('insomnia-templating-worker-database://plugin.discoveruserpluginexports', {
+      method: 'POST',
+      headers: { [TEMPLATING_DB_AUTH_HEADER]: token },
+      body: JSON.stringify({
+        name: 'insomnia-plugin-nomodules',
+        permissions: { modules: ['events'] },
+      }),
+    });
+    const res = await resolveDbByKey(req);
+    // Discovery surfaces a denied top-level require as a rejection, not a 200 with an empty manifest.
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/not permitted by manifest/);
   });
 });
 

--- a/packages/insomnia/src/main/__tests__/templating-worker-database-protocol-authorization.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database-protocol-authorization.test.ts
@@ -4,13 +4,10 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// The sender-authenticated `plugins.*` ipcMain channels (plugin-window-ipc-authorization.test.ts)
-// only cover one transport. `resolveDbByKey` dispatches the exact same plugin-execution surface
-// (plus the whole DB bridge) over the `insomnia-templating-worker-database://` protocol, and used to
-// have no caller check of its own, resolved a caller-supplied `directory` for hook/discovery dispatch
-// instead of a trusted registry lookup, and applied `stripDangerousKeysReviver` asymmetrically. These
-// guardrails mirror the dynamic-map shape of the ipcMain test: iterate the live `pluginToMainAPI` map
-// so a future path is covered automatically, rather than a hardcoded channel list.
+// Verifies every path in `resolveDbByKey`'s `pluginToMainAPI` map requires a valid auth token,
+// resolves plugin directories from the trusted registry rather than the request body, and
+// strips dangerous keys from sandbox output consistently. Iterates the live map so a future
+// path is covered automatically.
 
 vi.mock('electron', () => ({
   app: { getVersion: () => '1.0.0', getPath: () => '/fake/userData' },
@@ -101,8 +98,6 @@ describe('resolveDbByKey requires a valid protocol auth token', () => {
     }
   });
 
-  // Regression for the specific attack this guards against: the hook-dispatch path, forged, over the
-  // second transport that `plugins.applyRequestHooks`'s ipcMain sender check doesn't cover.
   it('plugin.runUserRequestHook rejects a forged, tokenless call before any hook runs', async () => {
     const { resolveDbByKey } = await import('../templating-worker-database');
     const req = new Request('insomnia-templating-worker-database://plugin.runuserrequesthook', {
@@ -184,9 +179,8 @@ describe('protocol-dispatch handlers resolve `directory` from the trusted regist
 describe('discoverPluginExportsInSandbox strips dangerous JSON keys, symmetric with the hook path', () => {
   it('a plugin export that plants a __proto__ own-key does not survive into the manifest', async () => {
     const { discoverPluginExportsInSandbox } = await import('../templating-worker-database');
-    // `themeDesc` in the in-sandbox bootstrap passes `theme: t.theme` through verbatim (unlike
-    // `actionDesc`, which rebuilds a clean {label, icon} object), the same kind of untrusted,
-    // sandbox-authored nested object the hook-result path already guards.
+    // `themeDesc` passes `theme: t.theme` through verbatim, a nested object that needs the same
+    // dangerous-key stripping as the hook-result path.
     const source = `
       var evilTheme = JSON.parse('{"__proto__": {"polluted": true}, "safe": 1}');
       module.exports.themes = [{ name: "t", displayName: "T", theme: evilTheme }];

--- a/packages/insomnia/src/main/__tests__/templating-worker-database-protocol-authorization.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database-protocol-authorization.test.ts
@@ -1,0 +1,204 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The sender-authenticated `plugins.*` ipcMain channels (plugin-window-ipc-authorization.test.ts)
+// only cover one transport. `resolveDbByKey` dispatches the exact same plugin-execution surface
+// (plus the whole DB bridge) over the `insomnia-templating-worker-database://` protocol, and used to
+// have no caller check of its own, resolved a caller-supplied `directory` for hook/discovery dispatch
+// instead of a trusted registry lookup, and applied `stripDangerousKeysReviver` asymmetrically. These
+// guardrails mirror the dynamic-map shape of the ipcMain test: iterate the live `pluginToMainAPI` map
+// so a future path is covered automatically, rather than a hardcoded channel list.
+
+vi.mock('electron', () => ({
+  app: { getVersion: () => '1.0.0', getPath: () => '/fake/userData' },
+  clipboard: { readText: vi.fn(), writeText: vi.fn(), clear: vi.fn() },
+  dialog: { showMessageBox: vi.fn() },
+  shell: { openExternal: vi.fn() },
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+vi.mock('insomnia-data', () => ({
+  services: {
+    request: { getById: vi.fn() },
+    workspace: { getById: vi.fn() },
+    oAuth2Token: { getByParentId: vi.fn() },
+    cookieJar: { getOrCreateForParentId: vi.fn() },
+    response: { getLatestForRequestId: vi.fn() },
+    helpers: { getResponseBodyBuffer: vi.fn() },
+    pluginData: { getByKey: vi.fn(), upsertByKey: vi.fn(), removeByKey: vi.fn(), removeAll: vi.fn(), all: vi.fn() },
+    cloudCredential: { getById: vi.fn(), update: vi.fn() },
+    settings: { get: vi.fn().mockResolvedValue({}) },
+  },
+}));
+vi.mock('~/plugins', () => ({
+  getPluginCommonContext: vi.fn(),
+  getTemplateTags: vi.fn().mockResolvedValue([]),
+  getPlugins: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('~/common/cookies', () => ({ jarFromCookies: vi.fn() }));
+vi.mock('../common/database', () => ({ database: {} }));
+vi.mock('../network/network', () => ({
+  fetchRequestData: vi.fn(),
+  sendCurlAndWriteTimeline: vi.fn(),
+  tryToInterpolateRequest: vi.fn(),
+}));
+vi.mock('../network/libcurl-promise', () => ({ curlRequest: vi.fn() }));
+vi.mock('../prompt-bridge', () => ({ requestPromptFromRenderer: vi.fn() }));
+vi.mock('../secure-read-file', () => ({ secureReadFile: vi.fn() }));
+
+import {
+  _testOnlyResetTemplatingDbAuthToken,
+  getOrCreateTemplatingDbAuthToken,
+  TEMPLATING_DB_AUTH_HEADER,
+} from '../templating-worker-database-auth';
+
+describe('resolveDbByKey requires a valid protocol auth token', () => {
+  beforeEach(() => {
+    _testOnlyResetTemplatingDbAuthToken();
+  });
+
+  it('every registered path rejects a request with no auth token at all', async () => {
+    const { resolveDbByKey, pluginToMainAPI } = await import('../templating-worker-database');
+    const paths = Object.keys(pluginToMainAPI);
+    expect(paths.length).toBeGreaterThan(0);
+    for (const p of paths) {
+      const req = new Request(`insomnia-templating-worker-database://${p.toLowerCase()}`, {
+        method: 'POST',
+        body: '{}',
+      });
+      const res = await resolveDbByKey(req);
+      expect(res.status, `expected path "${p}" to reject a request with no auth token`).toBe(401);
+    }
+  });
+
+  it('every registered path rejects a forged/invalid auth token', async () => {
+    getOrCreateTemplatingDbAuthToken();
+    const { resolveDbByKey, pluginToMainAPI } = await import('../templating-worker-database');
+    for (const p of Object.keys(pluginToMainAPI)) {
+      const req = new Request(`insomnia-templating-worker-database://${p.toLowerCase()}`, {
+        method: 'POST',
+        headers: { [TEMPLATING_DB_AUTH_HEADER]: 'deadbeef-not-the-real-token' },
+        body: '{}',
+      });
+      const res = await resolveDbByKey(req);
+      expect(res.status, `expected path "${p}" to reject a forged auth token`).toBe(401);
+    }
+  });
+
+  it('every registered path is dispatched (not rejected as unauthorized) given the real token', async () => {
+    const token = getOrCreateTemplatingDbAuthToken();
+    const { resolveDbByKey, pluginToMainAPI } = await import('../templating-worker-database');
+    for (const p of Object.keys(pluginToMainAPI)) {
+      const req = new Request(`insomnia-templating-worker-database://${p.toLowerCase()}`, {
+        method: 'POST',
+        headers: { [TEMPLATING_DB_AUTH_HEADER]: token },
+        body: '{}',
+      });
+      const res = await resolveDbByKey(req);
+      expect(res.status, `expected path "${p}" not to be rejected as unauthorized with a valid token`).not.toBe(401);
+    }
+  });
+
+  // Regression for the specific attack this guards against: the hook-dispatch path, forged, over the
+  // second transport that `plugins.applyRequestHooks`'s ipcMain sender check doesn't cover.
+  it('plugin.runUserRequestHook rejects a forged, tokenless call before any hook runs', async () => {
+    const { resolveDbByKey } = await import('../templating-worker-database');
+    const req = new Request('insomnia-templating-worker-database://plugin.runuserrequesthook', {
+      method: 'POST',
+      body: JSON.stringify({
+        plugin: { directory: '/tmp/anything', name: 'insomnia-plugin-forged' },
+        hookIndex: 0,
+        renderedRequest: { url: 'https://example.com', headers: [] },
+        renderContext: {},
+      }),
+    });
+    const res = await resolveDbByKey(req);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('protocol-dispatch handlers resolve `directory` from the trusted registry, not the request body', () => {
+  let legitDir: string;
+  let foreignDir: string;
+
+  beforeEach(async () => {
+    _testOnlyResetTemplatingDbAuthToken();
+    legitDir = fs.mkdtempSync(path.join(os.tmpdir(), 'insomnia-plugin-legit-'));
+    fs.writeFileSync(path.join(legitDir, 'package.json'), JSON.stringify({ main: 'index.js' }));
+    fs.writeFileSync(
+      path.join(legitDir, 'index.js'),
+      'module.exports.templateTags = [{ name: "legit_tag", displayName: "legit", run: function () {} }];',
+    );
+
+    foreignDir = fs.mkdtempSync(path.join(os.tmpdir(), 'insomnia-plugin-foreign-'));
+    fs.writeFileSync(path.join(foreignDir, 'package.json'), JSON.stringify({ main: 'index.js' }));
+    fs.writeFileSync(
+      path.join(foreignDir, 'index.js'),
+      'module.exports.templateTags = [{ name: "forged_tag", displayName: "forged", run: function () {} }];',
+    );
+
+    const { getPlugins } = await import('~/plugins');
+    (getPlugins as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { name: 'insomnia-plugin-legit', directory: legitDir, permissions: {} },
+    ]);
+  });
+
+  afterEach(() => {
+    fs.rmSync(legitDir, { recursive: true, force: true });
+    fs.rmSync(foreignDir, { recursive: true, force: true });
+  });
+
+  it('a forged directory in the request body is ignored in favor of the registry-resolved one', async () => {
+    const token = getOrCreateTemplatingDbAuthToken();
+    const { resolveDbByKey } = await import('../templating-worker-database');
+    const req = new Request('insomnia-templating-worker-database://plugin.discoveruserpluginexports', {
+      method: 'POST',
+      headers: { [TEMPLATING_DB_AUTH_HEADER]: token },
+      body: JSON.stringify({ directory: foreignDir, name: 'insomnia-plugin-legit' }),
+    });
+    const res = await resolveDbByKey(req);
+    expect(res.status).toBe(200);
+    const manifest = await res.json();
+    const tagNames = manifest.templateTags.map((t: { name: string }) => t.name);
+    expect(tagNames).toContain('legit_tag');
+    expect(tagNames).not.toContain('forged_tag');
+  });
+
+  it('rejects a plugin name that is not in the trusted registry, regardless of directory', async () => {
+    const token = getOrCreateTemplatingDbAuthToken();
+    const { resolveDbByKey } = await import('../templating-worker-database');
+    const req = new Request('insomnia-templating-worker-database://plugin.discoveruserpluginexports', {
+      method: 'POST',
+      headers: { [TEMPLATING_DB_AUTH_HEADER]: token },
+      body: JSON.stringify({ directory: foreignDir, name: 'insomnia-plugin-unregistered' }),
+    });
+    const res = await resolveDbByKey(req);
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/Unknown plugin/);
+  });
+});
+
+describe('discoverPluginExportsInSandbox strips dangerous JSON keys, symmetric with the hook path', () => {
+  it('a plugin export that plants a __proto__ own-key does not survive into the manifest', async () => {
+    const { discoverPluginExportsInSandbox } = await import('../templating-worker-database');
+    // `themeDesc` in the in-sandbox bootstrap passes `theme: t.theme` through verbatim (unlike
+    // `actionDesc`, which rebuilds a clean {label, icon} object), the same kind of untrusted,
+    // sandbox-authored nested object the hook-result path already guards.
+    const source = `
+      var evilTheme = JSON.parse('{"__proto__": {"polluted": true}, "safe": 1}');
+      module.exports.themes = [{ name: "t", displayName: "T", theme: evilTheme }];
+    `;
+    const manifest = await discoverPluginExportsInSandbox(source, {
+      pluginName: 'p',
+      grantedModules: [],
+      grantedCapabilities: [],
+    });
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    const theme = manifest.themes[0]?.theme as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(theme, '__proto__')).toBe(false);
+    expect(theme.safe).toBe(1);
+  });
+});

--- a/packages/insomnia/src/main/__tests__/templating-worker-database-protocol-authorization.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database-protocol-authorization.test.ts
@@ -176,6 +176,79 @@ describe('protocol-dispatch handlers resolve `directory` from the trusted regist
   });
 });
 
+// H1-followup finding: F2' resolved `directory` server-side from the trusted registry (getPlugins()),
+// but left `permissions` as a caller-supplied field on the request body for both
+// `plugin.runUserRequestHook` and `plugin.discoverUserPluginExports`. A plugin's *own* declared
+// manifest (what a legitimate caller — the plugin loader, or `invoke-method.ts`'s hook dispatch —
+// would send) is never consulted to cross-check the `permissions` the request body claims. So a
+// caller who can reach this protocol at all (has the auth token) can run any *registered* plugin's
+// hook with a broader capability grant than that plugin's own package.json declares, up to the
+// template-tag profile's ceiling (`surface-profiles.ts`). Not a sandbox escape — the profile ceiling
+// still caps it — but it is the same class of "trust a security-relevant field from the request body
+// instead of the registry" bug F2' fixed for `directory`, left unfixed for `permissions`.
+describe('protocol-dispatch handlers trust caller-supplied `permissions`, not the registry (residual gap from F2\')', () => {
+  let pluginDir: string;
+
+  beforeEach(async () => {
+    _testOnlyResetTemplatingDbAuthToken();
+    pluginDir = fs.mkdtempSync(path.join(os.tmpdir(), 'insomnia-plugin-restricted-'));
+    fs.writeFileSync(path.join(pluginDir, 'package.json'), JSON.stringify({ main: 'index.js' }));
+    fs.writeFileSync(
+      path.join(pluginDir, 'index.js'),
+      // Reports whether the `network` capability made it into the hook's context — deleted from
+      // `context` entirely unless granted (in-sandbox-bootstrap.ts `__hasCap`).
+      `module.exports.requestHooks = [function (context) {
+        context.request.setBody({ text: JSON.stringify({ hasNetwork: typeof context.network !== 'undefined' }) });
+      }];`,
+    );
+
+    // The registry's source of truth for this plugin declares NO capabilities (no manifest) —
+    // real callers (the plugin loader, invoke-method.ts) would only ever send this plugin's hook
+    // with baseline capabilities, which do not include `network`.
+    const { getPlugins } = await import('~/plugins');
+    (getPlugins as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { name: 'insomnia-plugin-restricted', directory: pluginDir, permissions: {} },
+    ]);
+  });
+
+  afterEach(() => {
+    fs.rmSync(pluginDir, { recursive: true, force: true });
+  });
+
+  const runHook = async (permissions?: { capabilities?: string[] }) => {
+    const token = getOrCreateTemplatingDbAuthToken();
+    const { resolveDbByKey } = await import('../templating-worker-database');
+    const req = new Request('insomnia-templating-worker-database://plugin.runuserrequesthook', {
+      method: 'POST',
+      headers: { [TEMPLATING_DB_AUTH_HEADER]: token },
+      body: JSON.stringify({
+        plugin: { name: 'insomnia-plugin-restricted', permissions },
+        hookIndex: 0,
+        renderedRequest: { _id: 'req_1', url: 'https://example.com', headers: [], body: {} },
+        renderContext: {},
+      }),
+    });
+    const res = await resolveDbByKey(req);
+    expect(res.status).toBe(200);
+    const mutated = await res.json();
+    return JSON.parse(mutated.body.text) as { hasNetwork: boolean };
+  };
+
+  it('baseline: a request that omits permissions gets the registry-appropriate (no-network) grant', async () => {
+    const { hasNetwork } = await runHook();
+    expect(hasNetwork).toBe(false);
+  });
+
+  // RED: this documents the bug. The plugin's *registered* manifest (mocked above) declares no
+  // capabilities, but the request body's `permissions.capabilities: ['network']` is trusted as-is,
+  // granting `network` anyway. A fix would look up `permissions` from `getPlugins()` by name — the
+  // same trusted-registry pattern F2' already applies to `directory` — rather than the request body.
+  it('a forged `permissions.capabilities` in the request body is granted despite the registry declaring none', async () => {
+    const { hasNetwork } = await runHook({ capabilities: ['network'] });
+    expect(hasNetwork).toBe(true);
+  });
+});
+
 describe('discoverPluginExportsInSandbox strips dangerous JSON keys, symmetric with the hook path', () => {
   it('a plugin export that plants a __proto__ own-key does not survive into the manifest', async () => {
     const { discoverPluginExportsInSandbox } = await import('../templating-worker-database');

--- a/packages/insomnia/src/main/__tests__/templating-worker-database-protocol-authorization.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database-protocol-authorization.test.ts
@@ -176,17 +176,13 @@ describe('protocol-dispatch handlers resolve `directory` from the trusted regist
   });
 });
 
-// H1-followup finding: F2' resolved `directory` server-side from the trusted registry (getPlugins()),
-// but left `permissions` as a caller-supplied field on the request body for both
-// `plugin.runUserRequestHook` and `plugin.discoverUserPluginExports`. A plugin's *own* declared
-// manifest (what a legitimate caller — the plugin loader, or `invoke-method.ts`'s hook dispatch —
-// would send) is never consulted to cross-check the `permissions` the request body claims. So a
-// caller who can reach this protocol at all (has the auth token) can run any *registered* plugin's
-// hook with a broader capability grant than that plugin's own package.json declares, up to the
-// template-tag profile's ceiling (`surface-profiles.ts`). Not a sandbox escape — the profile ceiling
-// still caps it — but it is the same class of "trust a security-relevant field from the request body
-// instead of the registry" bug F2' fixed for `directory`, left unfixed for `permissions`.
-describe('protocol-dispatch handlers trust caller-supplied `permissions`, not the registry (residual gap from F2\')', () => {
+// H1-followup finding (fixed): F2' resolved `directory` server-side from the trusted registry
+// (getPlugins()), but originally left `permissions` as a caller-supplied field on the request body
+// for both `plugin.runUserRequestHook` and `plugin.discoverUserPluginExports`. Now both handlers
+// resolve `permissions` from the trusted registry the same way they resolve `directory`, so a
+// forged `permissions` in the request body no longer grants a broader capability set than the
+// plugin's own registered manifest declares.
+describe('protocol-dispatch handlers resolve `permissions` from the trusted registry, not the request body', () => {
   let pluginDir: string;
 
   beforeEach(async () => {
@@ -239,13 +235,13 @@ describe('protocol-dispatch handlers trust caller-supplied `permissions`, not th
     expect(hasNetwork).toBe(false);
   });
 
-  // RED: this documents the bug. The plugin's *registered* manifest (mocked above) declares no
-  // capabilities, but the request body's `permissions.capabilities: ['network']` is trusted as-is,
-  // granting `network` anyway. A fix would look up `permissions` from `getPlugins()` by name — the
-  // same trusted-registry pattern F2' already applies to `directory` — rather than the request body.
-  it('a forged `permissions.capabilities` in the request body is granted despite the registry declaring none', async () => {
+  // The plugin's *registered* manifest (mocked above) declares no capabilities. A forged
+  // `permissions.capabilities: ['network']` in the request body must not grant `network` — the
+  // handler resolves `permissions` from `getPlugins()` by name, the same trusted-registry pattern
+  // F2' applies to `directory`, rather than trusting the request body.
+  it('a forged `permissions.capabilities` in the request body is ignored; the registry still denies network', async () => {
     const { hasNetwork } = await runHook({ capabilities: ['network'] });
-    expect(hasNetwork).toBe(true);
+    expect(hasNetwork).toBe(false);
   });
 });
 

--- a/packages/insomnia/src/main/__tests__/templating-worker-database.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database.test.ts
@@ -29,7 +29,11 @@ vi.mock('insomnia-data', () => ({
   },
   models: {},
 }));
-vi.mock('~/plugins', () => ({ getPluginCommonContext: vi.fn(), getTemplateTags: vi.fn().mockResolvedValue([]) }));
+vi.mock('~/plugins', () => ({
+  getPluginCommonContext: vi.fn(),
+  getTemplateTags: vi.fn().mockResolvedValue([]),
+  getPlugins: vi.fn().mockResolvedValue([]),
+}));
 vi.mock('~/common/cookies', () => ({ jarFromCookies: vi.fn() }));
 vi.mock('../common/database', () => ({ database: {} }));
 vi.mock('../network/network', () => ({

--- a/packages/insomnia/src/main/__tests__/templating-worker-database.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database.test.ts
@@ -56,6 +56,7 @@ import {
   resolveDbByKey,
   runPluginTagInSandbox,
 } from '../templating-worker-database';
+import { getOrCreateTemplatingDbAuthToken, TEMPLATING_DB_AUTH_HEADER } from '../templating-worker-database-auth';
 
 describe('readPluginModuleMap (M4 multi-file plugin reader)', () => {
   let dir: string;
@@ -257,10 +258,12 @@ describe('runPluginTagInSandbox — util.render escape', () => {
 describe('resolveDbByKey — app.prompt', () => {
   it('routes prompt requests to the renderer prompt bridge', async () => {
     vi.mocked(requestPromptFromRenderer).mockResolvedValueOnce('typed value');
+    const token = getOrCreateTemplatingDbAuthToken();
 
     const response = await resolveDbByKey(
       new Request('insomnia-templating-worker-database://app.prompt', {
         method: 'post',
+        headers: { [TEMPLATING_DB_AUTH_HEADER]: token },
         body: JSON.stringify({
           title: 'Title',
           options: { label: 'Label', defaultValue: 'cached value', inputType: 'password' },

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -177,6 +177,7 @@ export type HandleChannels =
   | 'syncNewWorkspaceIfNeeded'
   | 'sync.invoke'
   | 'sync.pullRemoteBackendProject'
+  | 'templatingDb.getAuthToken'
   | 'socketIO.open'
   | 'socketIO.readyState'
   | 'webSocket.event.findMany'

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -91,6 +91,7 @@ import type { electronStorageBridgeAPI } from './electron-storage';
 import extractPostmanDataDumpHandler from './extract-postman-data-dump';
 import type { gRPCBridgeAPI } from './grpc';
 import type { secretStorageBridgeAPI } from './secret-storage';
+import { registerTemplatingDbAuthIpcHandler } from './templating-db-auth';
 
 let lintProcess: Electron.UtilityProcess | null = null;
 
@@ -341,6 +342,9 @@ export interface RendererToMainBridgeAPI {
   >;
   syncNewWorkspaceIfNeeded: typeof syncNewWorkspaceIfNeeded;
   plugins: PluginsBridgeAPI;
+  templatingDb: {
+    getAuthToken: () => Promise<string>;
+  };
   notifyPromptResult: (id: string, value: string | null) => void;
   vault: {
     encryptSecretValue: (rawValue: string, symmetricKey: JsonWebKey) => Promise<string>;
@@ -948,4 +952,5 @@ export function registerMainHandlers() {
   });
 
   registerPluginIpcHandlers();
+  registerTemplatingDbAuthIpcHandler();
 }

--- a/packages/insomnia/src/main/ipc/templating-db-auth.ts
+++ b/packages/insomnia/src/main/ipc/templating-db-auth.ts
@@ -5,10 +5,7 @@ import { getOrCreateTemplatingDbAuthToken } from '../templating-worker-database-
 import { getMainWindow } from '../window-utils';
 import { ipcMainHandle } from './electron';
 
-// The templating-db auth token (F1) is only ever handed out to the two windows that legitimately
-// call the `insomnia-templating-worker-database://` protocol: the main app window and the hidden
-// plugin window. Any other sender (a compromised/forged renderer without the real window's
-// `webContents`) is rejected, mirroring the sender check `plugin-window.ts` uses for `plugins.*`.
+// Only hands the templating db auth token to the main app window or the hidden plugin window.
 export function registerTemplatingDbAuthIpcHandler() {
   ipcMainHandle('templatingDb.getAuthToken', (event: IpcMainInvokeEvent) => {
     const isMainWindow = event.sender === getMainWindow()?.webContents;

--- a/packages/insomnia/src/main/ipc/templating-db-auth.ts
+++ b/packages/insomnia/src/main/ipc/templating-db-auth.ts
@@ -1,0 +1,23 @@
+import type { IpcMainInvokeEvent } from 'electron';
+
+import { getPluginWindow } from '../plugin-window';
+import { getOrCreateTemplatingDbAuthToken } from '../templating-worker-database-auth';
+import { getMainWindow } from '../window-utils';
+import { ipcMainHandle } from './electron';
+
+// The templating-db auth token (F1) is only ever handed out to the two windows that legitimately
+// call the `insomnia-templating-worker-database://` protocol: the main app window and the hidden
+// plugin window. Any other sender (a compromised/forged renderer without the real window's
+// `webContents`) is rejected, mirroring the sender check `plugin-window.ts` uses for `plugins.*`.
+export function registerTemplatingDbAuthIpcHandler() {
+  ipcMainHandle('templatingDb.getAuthToken', (event: IpcMainInvokeEvent) => {
+    const isMainWindow = event.sender === getMainWindow()?.webContents;
+    const isPluginWindow = event.sender === getPluginWindow()?.webContents;
+    if (!isMainWindow && !isPluginWindow) {
+      throw new Error(
+        '[templating-db-auth] rejected templatingDb.getAuthToken: sender is neither the main app window nor the plugin window',
+      );
+    }
+    return getOrCreateTemplatingDbAuthToken();
+  });
+}

--- a/packages/insomnia/src/main/plugin-window.ts
+++ b/packages/insomnia/src/main/plugin-window.ts
@@ -71,23 +71,16 @@ export function getBridgeMetricsSnapshot() {
 
 // --- Sender-checked IPC registration wrappers -------------------------------------------
 //
-// Every `ipcMain.handle`/`ipcMain.on` call in this file MUST go through one of the three
-// wrappers below rather than the raw `ipcMain` API. Each wrapper enforces which window is
-// allowed to be the caller for its direction of traffic; a channel registered any other way
-// has no caller-identity check at all, which is exactly the gap documented as finding 1 in
-// `templating/sandbox/H1-HOOK-SANDBOX-SECURITY-REVIEW.md` (`plugins.applyRequestHooks` used
-// to accept a request from *any* sender, letting anything reach the plugin-dispatch facility
-// with forged data regardless of what capability gating happens once inside it).
-//
-// `plugin-window-ipc-authorization.test.ts` has a static guardrail that fails the build if a
-// bare call to ipcMain's `handle`/`on` methods is ever added to this file outside these three
-// function bodies — so a future new channel is protected automatically, or the build breaks.
+// Every `ipcMain.handle`/`ipcMain.on` call in this file must go through one of the three
+// wrappers below instead of the raw `ipcMain` API, so each channel enforces which window is
+// allowed to be its caller. `plugin-window-ipc-authorization.test.ts` fails the build if a bare
+// `ipcMain` call is added to this file outside these three function bodies.
 
 /**
  * Registers a channel that dispatches a plugin operation into the hidden plugin window
- * (`getThemes`, `applyRequestHooks`, `executeAction`, etc.) — i.e. every channel that takes
- * caller-supplied data and forwards it to `invokeInPluginWindow`. Restricted to the real main
- * app window; any other sender gets a rejected promise instead of a result.
+ * (`getThemes`, `applyRequestHooks`, `executeAction`, etc.), forwarding caller-supplied data to
+ * `invokeInPluginWindow`. Restricted to the real main app window; any other sender gets a
+ * rejected promise instead of a result.
  */
 function handleFromMainWindow<Args = unknown, R = unknown>(
   channel: string,

--- a/packages/insomnia/src/main/plugin-window.ts
+++ b/packages/insomnia/src/main/plugin-window.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow, ipcMain, type IpcMainEvent, type IpcMainInvokeEvent } from 'electron';
 
-import { type PromptRequestOptions, requestPromptFromRenderer } from './prompt-bridge';
+import { requestPromptFromRenderer } from './prompt-bridge';
 import { getMainWindow } from './window-utils';
 
 let pluginWindow: BrowserWindow | null = null;
@@ -69,6 +69,65 @@ export function getBridgeMetricsSnapshot() {
   };
 }
 
+// --- Sender-checked IPC registration wrappers -------------------------------------------
+//
+// Every `ipcMain.handle`/`ipcMain.on` call in this file MUST go through one of the three
+// wrappers below rather than the raw `ipcMain` API. Each wrapper enforces which window is
+// allowed to be the caller for its direction of traffic; a channel registered any other way
+// has no caller-identity check at all, which is exactly the gap documented as finding 1 in
+// `templating/sandbox/H1-HOOK-SANDBOX-SECURITY-REVIEW.md` (`plugins.applyRequestHooks` used
+// to accept a request from *any* sender, letting anything reach the plugin-dispatch facility
+// with forged data regardless of what capability gating happens once inside it).
+//
+// `plugin-window-ipc-authorization.test.ts` has a static guardrail that fails the build if a
+// bare call to ipcMain's `handle`/`on` methods is ever added to this file outside these three
+// function bodies — so a future new channel is protected automatically, or the build breaks.
+
+/**
+ * Registers a channel that dispatches a plugin operation into the hidden plugin window
+ * (`getThemes`, `applyRequestHooks`, `executeAction`, etc.) — i.e. every channel that takes
+ * caller-supplied data and forwards it to `invokeInPluginWindow`. Restricted to the real main
+ * app window; any other sender gets a rejected promise instead of a result.
+ */
+function handleFromMainWindow<Args = unknown, R = unknown>(
+  channel: string,
+  handler: (args: Args) => R | Promise<R>,
+): void {
+  ipcMain.handle(channel, (event: IpcMainInvokeEvent, args: Args) => {
+    if (event.sender !== getMainWindow()?.webContents) {
+      throw new Error(`[plugin-bridge] rejected ${channel}: sender is not the main app window`);
+    }
+    return handler(args);
+  });
+}
+
+/**
+ * Registers a fire-and-forget callback that the hidden plugin window sends back to the host
+ * (a UI callback, an invoke result). Restricted to the plugin window itself; any other sender
+ * is silently ignored, matching how these "reverse direction" messages already behaved.
+ */
+function onFromPluginWindow<Args = unknown>(channel: string, handler: (args: Args) => void): void {
+  ipcMain.on(channel, (event: IpcMainEvent, args: Args) => {
+    if (event.sender !== pluginWindow?.webContents) {
+      return;
+    }
+    handler(args);
+  });
+}
+
+/** Like {@link onFromPluginWindow}, but for the one plugin-window callback that replies (`plugins.uiPrompt`). */
+function handleFromPluginWindow<Args = unknown, R = unknown>(
+  channel: string,
+  handler: (args: Args) => R | Promise<R>,
+): void {
+  ipcMain.handle(channel, (event: IpcMainInvokeEvent, args: Args) => {
+    if (event.sender !== pluginWindow?.webContents) {
+      return null;
+    }
+    return handler(args);
+  });
+}
+
 // Registered once so that persistent `ipcMain.on` handlers don't accumulate across window recreations.
 let ipcListenersRegistered = false;
 
@@ -78,10 +137,7 @@ function ensureIpcListeners() {
   }
   ipcListenersRegistered = true;
 
-  ipcMain.on('plugins.windowReady', event => {
-    if (event.sender !== pluginWindow?.webContents) {
-      return;
-    }
+  onFromPluginWindow<void>('plugins.windowReady', () => {
     windowReady = true;
     const startedAt = bridgeMetrics.lastStartupAt;
     const startupMs = startedAt ? Date.now() - startedAt : 0;
@@ -89,33 +145,21 @@ function ensureIpcListeners() {
     console.log(`[plugin-bridge] window_ready startup_ms=${startupMs}`);
   });
 
-  ipcMain.on('plugins.uiAlert', (event, options: Record<string, unknown>) => {
-    if (event.sender !== pluginWindow?.webContents) {
-      return;
-    }
+  onFromPluginWindow<Record<string, unknown>>('plugins.uiAlert', options => {
     getMainWindow()?.webContents.send('plugins.uiAlert', options);
   });
 
-  ipcMain.on('plugins.uiDialog', (event, options: Record<string, unknown>) => {
-    if (event.sender !== pluginWindow?.webContents) {
-      return;
-    }
+  onFromPluginWindow<Record<string, unknown>>('plugins.uiDialog', options => {
     getMainWindow()?.webContents.send('plugins.uiDialog', options);
   });
 
-  ipcMain.handle('plugins.uiPrompt', async (event, options: Record<string, unknown>) => {
-    if (event.sender !== pluginWindow?.webContents) {
-      return null;
-    }
-    return requestPromptFromRenderer(options as unknown as PromptRequestOptions);
-  });
+  handleFromPluginWindow<{ title: string; label?: string; defaultValue?: string }>('plugins.uiPrompt', options =>
+    requestPromptFromRenderer(options),
+  );
 
-  ipcMain.on(
+  onFromPluginWindow<{ id: string; result?: unknown; error?: string }>(
     'plugins.invokeResult',
-    (event, { id, result, error }: { id: string; result?: unknown; error?: string }) => {
-      if (event.sender !== pluginWindow?.webContents) {
-        return;
-      }
+    ({ id, result, error }) => {
       const pending = pendingRequests.get(id);
       if (!pending) {
         return;
@@ -257,40 +301,38 @@ export function reloadPluginsInWindow() {
 }
 
 export function registerPluginIpcHandlers() {
-  ipcMain.handle('plugins.getThemes', () => invokeInPluginWindow('getThemes'));
-  ipcMain.handle('plugins.getPlugins', () => invokeInPluginWindow('getPlugins'));
-  ipcMain.handle('plugins.getActivePlugins', () => invokeInPluginWindow('getActivePlugins'));
-  ipcMain.handle('plugins.reloadPlugins', async () => {
+  handleFromMainWindow('plugins.getThemes', () => invokeInPluginWindow('getThemes'));
+  handleFromMainWindow('plugins.getPlugins', () => invokeInPluginWindow('getPlugins'));
+  handleFromMainWindow('plugins.getActivePlugins', () => invokeInPluginWindow('getActivePlugins'));
+  handleFromMainWindow('plugins.reloadPlugins', async () => {
     cachedHasRequestHooks = null;
     cachedHasResponseHooks = null;
     await invokeInPluginWindow('reloadPlugins');
   });
-  ipcMain.handle('plugins.getRequestActions', () => invokeInPluginWindow('getRequestActions'));
-  ipcMain.handle('plugins.getRequestGroupActions', () => invokeInPluginWindow('getRequestGroupActions'));
-  ipcMain.handle('plugins.getWorkspaceActions', () => invokeInPluginWindow('getWorkspaceActions'));
-  ipcMain.handle('plugins.getDocumentActions', () => invokeInPluginWindow('getDocumentActions'));
-  ipcMain.handle('plugins.executeAction', (_event, args) => invokeInPluginWindow('executeAction', args));
-  ipcMain.handle('plugins.getTemplateTags', () => invokeInPluginWindow('getTemplateTags'));
-  ipcMain.handle('plugins.runTemplateTagAction', (_event, args) => invokeInPluginWindow('runTemplateTagAction', args));
-  ipcMain.handle('plugins.getBundlePlugins', () => invokeInPluginWindow('getBundlePlugins'));
-  ipcMain.handle('plugins.executePluginMainAction', (_event, args) =>
-    invokeInPluginWindow('executePluginMainAction', args),
-  );
-  ipcMain.handle('plugins.hasRequestHooks', async () => {
+  handleFromMainWindow('plugins.getRequestActions', () => invokeInPluginWindow('getRequestActions'));
+  handleFromMainWindow('plugins.getRequestGroupActions', () => invokeInPluginWindow('getRequestGroupActions'));
+  handleFromMainWindow('plugins.getWorkspaceActions', () => invokeInPluginWindow('getWorkspaceActions'));
+  handleFromMainWindow('plugins.getDocumentActions', () => invokeInPluginWindow('getDocumentActions'));
+  handleFromMainWindow('plugins.executeAction', args => invokeInPluginWindow('executeAction', args));
+  handleFromMainWindow('plugins.getTemplateTags', () => invokeInPluginWindow('getTemplateTags'));
+  handleFromMainWindow('plugins.runTemplateTagAction', args => invokeInPluginWindow('runTemplateTagAction', args));
+  handleFromMainWindow('plugins.getBundlePlugins', () => invokeInPluginWindow('getBundlePlugins'));
+  handleFromMainWindow('plugins.executePluginMainAction', args => invokeInPluginWindow('executePluginMainAction', args));
+  handleFromMainWindow('plugins.hasRequestHooks', async () => {
     if (cachedHasRequestHooks === null) {
       cachedHasRequestHooks = (await invokeInPluginWindow('hasRequestHooks')) as boolean;
     }
     return cachedHasRequestHooks;
   });
-  ipcMain.handle('plugins.hasResponseHooks', async () => {
+  handleFromMainWindow('plugins.hasResponseHooks', async () => {
     if (cachedHasResponseHooks === null) {
       cachedHasResponseHooks = (await invokeInPluginWindow('hasResponseHooks')) as boolean;
     }
     return cachedHasResponseHooks;
   });
-  ipcMain.handle('plugins.applyRequestHooks', (_event, args) => invokeInPluginWindow('applyRequestHooks', args));
-  ipcMain.handle('plugins.applyResponseHooks', (_event, args) => invokeInPluginWindow('applyResponseHooks', args));
-  ipcMain.handle('plugins.getBridgeMetrics', () => getBridgeMetricsSnapshot());
+  handleFromMainWindow('plugins.applyRequestHooks', args => invokeInPluginWindow('applyRequestHooks', args));
+  handleFromMainWindow('plugins.applyResponseHooks', args => invokeInPluginWindow('applyResponseHooks', args));
+  handleFromMainWindow('plugins.getBridgeMetrics', () => getBridgeMetricsSnapshot());
 }
 
 export function getAppUserDataPath() {

--- a/packages/insomnia/src/main/templating-worker-database-auth.ts
+++ b/packages/insomnia/src/main/templating-worker-database-auth.ts
@@ -1,11 +1,7 @@
 import crypto from 'node:crypto';
 
-// F1: `resolveDbByKey` dispatches every `plugin.*`/db handler over the app-wide-privileged
-// `insomnia-templating-worker-database://` protocol, which — unlike the `plugins.*` ipcMain
-// channels — has no caller identity to check (a `protocol.handle` request carries no sender
-// reference). A per-process secret, known only to the trusted first-party renderer/plugin-window
-// (handed out over an IPC channel that itself checks the sender), closes that gap: anything that
-// can `fetch()` the scheme still reaches the handler, but can't produce a valid token.
+// Per-process secret required on every request to the templating db protocol, since that
+// protocol has no sender identity to check on its own.
 let token: string | null = null;
 
 export const getOrCreateTemplatingDbAuthToken = (): string => {

--- a/packages/insomnia/src/main/templating-worker-database-auth.ts
+++ b/packages/insomnia/src/main/templating-worker-database-auth.ts
@@ -1,0 +1,29 @@
+import crypto from 'node:crypto';
+
+// F1: `resolveDbByKey` dispatches every `plugin.*`/db handler over the app-wide-privileged
+// `insomnia-templating-worker-database://` protocol, which — unlike the `plugins.*` ipcMain
+// channels — has no caller identity to check (a `protocol.handle` request carries no sender
+// reference). A per-process secret, known only to the trusted first-party renderer/plugin-window
+// (handed out over an IPC channel that itself checks the sender), closes that gap: anything that
+// can `fetch()` the scheme still reaches the handler, but can't produce a valid token.
+let token: string | null = null;
+
+export const getOrCreateTemplatingDbAuthToken = (): string => {
+  if (!token) {
+    token = crypto.randomBytes(32).toString('hex');
+  }
+  return token;
+};
+
+export const TEMPLATING_DB_AUTH_HEADER = 'x-insomnia-templating-auth';
+
+export const isValidTemplatingDbAuthToken = (candidate: string | null | undefined): boolean => {
+  if (!token || !candidate || candidate.length !== token.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(Buffer.from(candidate), Buffer.from(token));
+};
+
+export const _testOnlyResetTemplatingDbAuthToken = () => {
+  token = null;
+};

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -18,7 +18,7 @@ import type {
   PluginTemplateTagContext,
   PluginToMainAPIPaths,
 } from '~/common/templating/types';
-import { getPluginCommonContext, getTemplateTags } from '~/plugins';
+import { getPluginCommonContext, getPlugins, getTemplateTags } from '~/plugins';
 import { HOOK_REQUEST_FIELDS, type PluginExportManifest, stripDangerousKeysReviver } from '~/templating/sandbox/marshal';
 import type { SandboxModuleDenialError } from '~/templating/sandbox/plugin-tag-sandbox';
 
@@ -29,15 +29,27 @@ import { fetchRequestData, sendCurlAndWriteTimeline, tryToInterpolateRequest } f
 import { curlRequest } from './network/libcurl-promise';
 import { requestPromptFromRenderer } from './prompt-bridge';
 import { secureReadFile } from './secure-read-file';
+import { isValidTemplatingDbAuthToken, TEMPLATING_DB_AUTH_HEADER } from './templating-worker-database-auth';
 
 const bundlePluginModuleMap: Record<string, Plugin['module']> = {};
 
 export const resolveDbByKey = async (request: Request) => {
+  // F1: `plugins.applyRequestHooks` and friends are gated to the real main window over ipcMain, but
+  // this protocol has no equivalent caller check of its own — anything able to `fetch()` the scheme
+  // reached every handler below unauthenticated. Reject before doing anything else, including body
+  // parsing, so a forged call never reaches a handler with attacker-supplied data.
+  if (!isValidTemplatingDbAuthToken(request.headers.get(TEMPLATING_DB_AUTH_HEADER))) {
+    return new Response(JSON.stringify({ error: 'Unauthorized: missing or invalid templating database auth token' }), {
+      status: 401,
+    });
+  }
   const url = new URL(request.url);
   let body;
   try {
+    // F3: strip `__proto__`/`constructor`/`prototype` own-keys at the exact point this untrusted
+    // request body re-enters host memory, not just on the sandbox's own hook-result output.
     // We expect this to throw if a db call returns undefined
-    body = await request.json();
+    body = JSON.parse(await request.text(), stripDangerousKeysReviver);
   } catch {}
   // url get normalized to lowercase, so we need to normalize the keys to lower case as well
   const withLowercasedKeys = Object.fromEntries(
@@ -58,6 +70,21 @@ export const resolveDbByKey = async (request: Request) => {
     console.error(`Error resolving db by key ${urlHostLowerCase}:`, err);
     return new Response(JSON.stringify({ error: err.message }), { status: 500 });
   }
+};
+
+// F2': resolve a plugin's on-disk directory server-side, from the trusted registry the plugin loader
+// itself already built (`getPlugins()`), keyed only by name — the caller-supplied `directory` in the
+// request body is never trusted for the two protocol-dispatch handlers below. Only reachable over the
+// protocol boundary (`plugin.discoverUserPluginExports` / `plugin.runUserRequestHook`); the loader's
+// own direct calls to `discoverUserPluginExportsForLoader`/`readPluginModuleMap` (during the registry
+// scan that populates this very registry) bypass this function entirely, so there's no recursion.
+const resolveTrustedPluginDirectory = async (pluginName: string): Promise<string> => {
+  const plugins = await getPlugins();
+  const plugin = plugins.find(p => p.name === pluginName);
+  if (!plugin) {
+    throw new Error(`Unknown plugin: ${pluginName}`);
+  }
+  return plugin.directory;
 };
 
 const getBundlePluginModule = (pluginName: string): Plugin['module'] => {
@@ -384,7 +411,9 @@ export const discoverPluginExportsInSandbox = async (
       entryModuleKey,
     },
   });
-  return JSON.parse(json);
+  // F3: this is the same untrusted-sandbox-output boundary `runRequestHookInSandbox` already guards
+  // with `stripDangerousKeysReviver` below — the manifest just hadn't been routed through it yet.
+  return JSON.parse(json, stripDangerousKeysReviver);
 };
 
 // Discover a user plugin's exports from its on-disk source, resolving the template-tag surface grant
@@ -458,8 +487,10 @@ export const runRequestHookInSandbox = async (
   return result.request ?? hookRequest;
 };
 
-// These are exposed to the templating worker and can be used by plugins from context.util
-const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<any>> = {
+// These are exposed to the templating worker and can be used by plugins from context.util.
+// Exported (read-only in practice) so tests can enumerate every registered path — see
+// `templating-worker-database-protocol-authorization.test.ts`.
+export const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<any>> = {
   'readFile': async (body: { path: string }) => {
     return secureReadFile(body.path);
   },
@@ -720,7 +751,14 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
     directory: string;
     name: string;
     permissions?: { modules?: string[]; capabilities?: string[] };
-  }) => discoverUserPluginExportsForLoader(body),
+  }) =>
+    discoverUserPluginExportsForLoader({
+      ...body,
+      // F2': the directory to read source from is resolved server-side from the trusted registry,
+      // never taken from the request body — a forged `directory` can no longer point discovery at
+      // an arbitrary folder with a package.json.
+      directory: await resolveTrustedPluginDirectory(body.name),
+    }),
   // H1: run a user plugin's request hook in the sandbox (plugin-window path reaches this over the
   // templating-worker-database protocol; the node runtime calls runRequestHookInSandbox directly).
   'plugin.runUserRequestHook': async (body: {
@@ -728,7 +766,14 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
     hookIndex: number;
     renderedRequest: Record<string, any>;
     renderContext: Record<string, any>;
-  }) => runRequestHookInSandbox(body.plugin, body.hookIndex, body.renderedRequest, body.renderContext),
+  }) =>
+    runRequestHookInSandbox(
+      // F2': same trusted-directory resolution as discovery, by name — see above.
+      { ...body.plugin, directory: await resolveTrustedPluginDirectory(body.plugin.name) },
+      body.hookIndex,
+      body.renderedRequest,
+      body.renderContext,
+    ),
   // execute a user-installed plugin tag with the given parameters, in the main process where
   // Node built-ins (e.g. crypto) the plugin requires are available.
   'plugin.executeUserPluginTag': async (body: {

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -34,10 +34,7 @@ import { isValidTemplatingDbAuthToken, TEMPLATING_DB_AUTH_HEADER } from './templ
 const bundlePluginModuleMap: Record<string, Plugin['module']> = {};
 
 export const resolveDbByKey = async (request: Request) => {
-  // F1: `plugins.applyRequestHooks` and friends are gated to the real main window over ipcMain, but
-  // this protocol has no equivalent caller check of its own — anything able to `fetch()` the scheme
-  // reached every handler below unauthenticated. Reject before doing anything else, including body
-  // parsing, so a forged call never reaches a handler with attacker-supplied data.
+  // Reject before parsing the body, so a forged call never reaches a handler with attacker-supplied data.
   if (!isValidTemplatingDbAuthToken(request.headers.get(TEMPLATING_DB_AUTH_HEADER))) {
     return new Response(JSON.stringify({ error: 'Unauthorized: missing or invalid templating database auth token' }), {
       status: 401,
@@ -46,8 +43,6 @@ export const resolveDbByKey = async (request: Request) => {
   const url = new URL(request.url);
   let body;
   try {
-    // F3: strip `__proto__`/`constructor`/`prototype` own-keys at the exact point this untrusted
-    // request body re-enters host memory, not just on the sandbox's own hook-result output.
     // We expect this to throw if a db call returns undefined
     body = JSON.parse(await request.text(), stripDangerousKeysReviver);
   } catch {}
@@ -72,12 +67,8 @@ export const resolveDbByKey = async (request: Request) => {
   }
 };
 
-// F2': resolve a plugin's on-disk directory server-side, from the trusted registry the plugin loader
-// itself already built (`getPlugins()`), keyed only by name — the caller-supplied `directory` in the
-// request body is never trusted for the two protocol-dispatch handlers below. Only reachable over the
-// protocol boundary (`plugin.discoverUserPluginExports` / `plugin.runUserRequestHook`); the loader's
-// own direct calls to `discoverUserPluginExportsForLoader`/`readPluginModuleMap` (during the registry
-// scan that populates this very registry) bypass this function entirely, so there's no recursion.
+// Resolves a plugin's on-disk directory from the trusted plugin registry by name, so the two
+// protocol-dispatch handlers below never trust a caller-supplied directory path.
 const resolveTrustedPluginDirectory = async (pluginName: string): Promise<string> => {
   const plugins = await getPlugins();
   const plugin = plugins.find(p => p.name === pluginName);
@@ -411,8 +402,6 @@ export const discoverPluginExportsInSandbox = async (
       entryModuleKey,
     },
   });
-  // F3: this is the same untrusted-sandbox-output boundary `runRequestHookInSandbox` already guards
-  // with `stripDangerousKeysReviver` below — the manifest just hadn't been routed through it yet.
   return JSON.parse(json, stripDangerousKeysReviver);
 };
 
@@ -488,8 +477,7 @@ export const runRequestHookInSandbox = async (
 };
 
 // These are exposed to the templating worker and can be used by plugins from context.util.
-// Exported (read-only in practice) so tests can enumerate every registered path — see
-// `templating-worker-database-protocol-authorization.test.ts`.
+// Exported so tests can enumerate every registered path.
 export const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<any>> = {
   'readFile': async (body: { path: string }) => {
     return secureReadFile(body.path);
@@ -754,9 +742,6 @@ export const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => P
   }) =>
     discoverUserPluginExportsForLoader({
       ...body,
-      // F2': the directory to read source from is resolved server-side from the trusted registry,
-      // never taken from the request body — a forged `directory` can no longer point discovery at
-      // an arbitrary folder with a package.json.
       directory: await resolveTrustedPluginDirectory(body.name),
     }),
   // H1: run a user plugin's request hook in the sandbox (plugin-window path reaches this over the
@@ -768,7 +753,6 @@ export const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => P
     renderContext: Record<string, any>;
   }) =>
     runRequestHookInSandbox(
-      // F2': same trusted-directory resolution as discovery, by name — see above.
       { ...body.plugin, directory: await resolveTrustedPluginDirectory(body.plugin.name) },
       body.hookIndex,
       body.renderedRequest,

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -67,15 +67,18 @@ export const resolveDbByKey = async (request: Request) => {
   }
 };
 
-// Resolves a plugin's on-disk directory from the trusted plugin registry by name, so the two
-// protocol-dispatch handlers below never trust a caller-supplied directory path.
-const resolveTrustedPluginDirectory = async (pluginName: string): Promise<string> => {
+// Resolves a plugin's on-disk directory and manifest-declared permissions from the trusted plugin
+// registry by name, so the two protocol-dispatch handlers below never trust a caller-supplied
+// directory path or permissions object.
+const resolveTrustedPlugin = async (
+  pluginName: string,
+): Promise<{ directory: string; permissions: { modules: string[]; capabilities: string[] } }> => {
   const plugins = await getPlugins();
   const plugin = plugins.find(p => p.name === pluginName);
   if (!plugin) {
     throw new Error(`Unknown plugin: ${pluginName}`);
   }
-  return plugin.directory;
+  return { directory: plugin.directory, permissions: plugin.permissions };
 };
 
 const getBundlePluginModule = (pluginName: string): Plugin['module'] => {
@@ -739,11 +742,14 @@ export const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => P
     directory: string;
     name: string;
     permissions?: { modules?: string[]; capabilities?: string[] };
-  }) =>
-    discoverUserPluginExportsForLoader({
+  }) => {
+    const trusted = await resolveTrustedPlugin(body.name);
+    return discoverUserPluginExportsForLoader({
       ...body,
-      directory: await resolveTrustedPluginDirectory(body.name),
-    }),
+      directory: trusted.directory,
+      permissions: trusted.permissions,
+    });
+  },
   // H1: run a user plugin's request hook in the sandbox (plugin-window path reaches this over the
   // templating-worker-database protocol; the node runtime calls runRequestHookInSandbox directly).
   'plugin.runUserRequestHook': async (body: {
@@ -751,13 +757,15 @@ export const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => P
     hookIndex: number;
     renderedRequest: Record<string, any>;
     renderContext: Record<string, any>;
-  }) =>
-    runRequestHookInSandbox(
-      { ...body.plugin, directory: await resolveTrustedPluginDirectory(body.plugin.name) },
+  }) => {
+    const trusted = await resolveTrustedPlugin(body.plugin.name);
+    return runRequestHookInSandbox(
+      { ...body.plugin, directory: trusted.directory, permissions: trusted.permissions },
       body.hookIndex,
       body.renderedRequest,
       body.renderContext,
-    ),
+    );
+  },
   // execute a user-installed plugin tag with the given parameters, in the main process where
   // Node built-ins (e.g. crypto) the plugin requires are available.
   'plugin.executeUserPluginTag': async (body: {

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -19,7 +19,7 @@ import type {
   PluginToMainAPIPaths,
 } from '~/common/templating/types';
 import { getPluginCommonContext, getTemplateTags } from '~/plugins';
-import type { PluginExportManifest } from '~/templating/sandbox/marshal';
+import { HOOK_REQUEST_FIELDS, type PluginExportManifest, stripDangerousKeysReviver } from '~/templating/sandbox/marshal';
 import type { SandboxModuleDenialError } from '~/templating/sandbox/plugin-tag-sandbox';
 
 import { getAppBundlePlugins, RESPONSE_CODE_REASONS } from '../common/constants';
@@ -406,25 +406,6 @@ export const discoverUserPluginExportsForLoader = async (body: {
   });
 };
 
-// The serializable RenderedRequest fields a request hook may read or mutate — the subset marshaled
-// into and out of the sandbox (mirrors what plugins/context/request.ts touches on the request).
-const HOOK_REQUEST_FIELDS = [
-  '_id',
-  'name',
-  'url',
-  'method',
-  'headers',
-  'parameters',
-  'authentication',
-  'body',
-  'cookies',
-  'settingSendCookies',
-  'settingStoreCookies',
-  'settingEncodeUrl',
-  'settingDisableRenderRequestBody',
-  'settingFollowRedirects',
-] as const;
-
 const pickHookRequestFields = (req: Record<string, any>): Record<string, any> => {
   const out: Record<string, any> = {};
   for (const key of HOOK_REQUEST_FIELDS) {
@@ -473,7 +454,7 @@ export const runRequestHookInSandbox = async (
       hookRequest,
     },
   });
-  const result = JSON.parse(json) as { request?: Record<string, any> };
+  const result = JSON.parse(json, stripDangerousKeysReviver) as { request?: Record<string, any> };
   return result.request ?? hookRequest;
 };
 

--- a/packages/insomnia/src/plugins/invoke-method.ts
+++ b/packages/insomnia/src/plugins/invoke-method.ts
@@ -212,9 +212,7 @@ export async function invokePluginMethod(method: PluginInvokeMethod, args?: unkn
               renderedRequest: newRenderedRequest,
               renderContext: renderedContext,
             });
-            // `mergeHookRequestMutation` only copies the allowlisted request fields a hook is
-            // permitted to touch, one at a time — never a blanket `Object.assign` of whatever
-            // keys happen to be in the parsed JSON.
+            // Only copies the allowlisted request fields a hook is permitted to touch.
             mergeHookRequestMutation(newRenderedRequest, mutated);
             continue;
           }

--- a/packages/insomnia/src/plugins/invoke-method.ts
+++ b/packages/insomnia/src/plugins/invoke-method.ts
@@ -8,6 +8,7 @@ import type {
 import type { Plugin } from '~/common/plugins/types';
 import { fetchFromTemplateWorkerDatabase } from '~/common/templating/liquid-extension-worker';
 import { deserializeRenderContext } from '~/common/templating/render-context-serialization';
+import { mergeHookRequestMutation } from '~/templating/sandbox/marshal';
 
 import * as pluginApp from './context/app';
 import * as pluginData from './context/data';
@@ -211,7 +212,10 @@ export async function invokePluginMethod(method: PluginInvokeMethod, args?: unkn
               renderedRequest: newRenderedRequest,
               renderContext: renderedContext,
             });
-            Object.assign(newRenderedRequest, mutated);
+            // `mergeHookRequestMutation` only copies the allowlisted request fields a hook is
+            // permitted to touch, one at a time — never a blanket `Object.assign` of whatever
+            // keys happen to be in the parsed JSON.
+            mergeHookRequestMutation(newRenderedRequest, mutated);
             continue;
           }
           const context = {

--- a/packages/insomnia/src/runtimes/network/network-adapter.node.ts
+++ b/packages/insomnia/src/runtimes/network/network-adapter.node.ts
@@ -90,10 +90,14 @@ export async function applyRequestHooks(
     try {
       if (sandboxEnabled && plugin.directory !== '') {
         const { runRequestHookInSandbox } = await import('../../main/templating-worker-database');
+        const { mergeHookRequestMutation } = await import('../../templating/sandbox/marshal');
         // The hook mutates the request in the sandbox; merge the returned fields back so the next
         // hook (and the send pipeline) sees the mutation, exactly like the in-place path below.
+        // `mergeHookRequestMutation` only copies the allowlisted request fields a hook is
+        // permitted to touch, one at a time — never a blanket `Object.assign` of whatever keys
+        // happen to be in the parsed JSON.
         const mutated = await runRequestHookInSandbox(plugin, hookIndex, newRenderedRequest, renderedContext);
-        Object.assign(newRenderedRequest, mutated);
+        mergeHookRequestMutation(newRenderedRequest, mutated);
         continue;
       }
       const context = {

--- a/packages/insomnia/src/runtimes/network/network-adapter.node.ts
+++ b/packages/insomnia/src/runtimes/network/network-adapter.node.ts
@@ -93,9 +93,7 @@ export async function applyRequestHooks(
         const { mergeHookRequestMutation } = await import('../../templating/sandbox/marshal');
         // The hook mutates the request in the sandbox; merge the returned fields back so the next
         // hook (and the send pipeline) sees the mutation, exactly like the in-place path below.
-        // `mergeHookRequestMutation` only copies the allowlisted request fields a hook is
-        // permitted to touch, one at a time — never a blanket `Object.assign` of whatever keys
-        // happen to be in the parsed JSON.
+        // Only copies the allowlisted request fields a hook is permitted to touch.
         const mutated = await runRequestHookInSandbox(plugin, hookIndex, newRenderedRequest, renderedContext);
         mergeHookRequestMutation(newRenderedRequest, mutated);
         continue;

--- a/packages/insomnia/src/templating/sandbox/H1-FOLLOWUP-PERMISSIONS-TRUST-SECURITY-REVIEW.md
+++ b/packages/insomnia/src/templating/sandbox/H1-FOLLOWUP-PERMISSIONS-TRUST-SECURITY-REVIEW.md
@@ -1,0 +1,164 @@
+# Security review — PR #10290 (H1, "route user-plugin request hooks through the sandbox (PR 10a) — sec request hooks review")
+
+## Context
+
+This PR (branch `review/pr10-hooks-security-fixes`) adds the templating-db protocol auth token
+(F1), server-side `directory` resolution (F2'), and symmetric `stripDangerousKeysReviver` coverage
+(F3) — closing the three findings recorded in
+[H1-HOOK-CONTROL-BYPASS-REMEDIATION-PLAN.md](H1-HOOK-CONTROL-BYPASS-REMEDIATION-PLAN.md). This
+review was scoped specifically to the authorization token added for `insomnia-templating-worker-
+database://` IPC/protocol dispatch: (1) whether the token check itself can be circumvented, (2)
+whether any existing caller doesn't correctly participate in it (breakage), and (3) if a gap is
+found, why the branch's own dynamic tests didn't catch it.
+
+Checked against the migration plan gist (fetched fresh this run): this PR is Phase 2, ticket H1,
+depending on L1 (PR 9, landed) and preceding A1 (PR 11, actions-via-bridge — not yet landed). C1
+(bridge capability gating), C2 (capability-aware context), and C3 (manifest schema/loader) — the
+Phase 1 tickets that make `insomnia.permissions` a live enforcement boundary — are confirmed landed
+in the current source (`host-bridge.ts`'s `BRIDGE_PATH_CAPABILITIES`/`filterByCapabilities`,
+`in-sandbox-bootstrap.ts`'s per-capability context deletion, `common/plugins/permissions.ts`'s
+`parsePluginPermissions`), per `SANDBOX-CAPABILITY-AUDIT-PLAN.md`'s own correction note.
+
+## Verdict on the token mechanism itself
+
+**No circumvention found.** `getOrCreateTemplatingDbAuthToken()`/`isValidTemplatingDbAuthToken()`
+(`templating-worker-database-auth.ts`) is a per-process random 32-byte secret, compared with
+`crypto.timingSafeEqual` after a length pre-check (standard, non-exploitable pattern — the length
+pre-check can't be used to learn anything about the fixed-length real token). It is handed out only
+over IPC channels that check `event.sender` against `getMainWindow()?.webContents` or
+`getPluginWindow()?.webContents` (`ipc/templating-db-auth.ts`), mirroring the existing
+`plugin-window.ts` sender-check pattern. The protocol scheme is registered app-wide-privileged
+(`secure/standard/supportFetchAPI`, no `corsEnabled`) so it's reachable by any renderer/webview in
+the session — but reachability without the token now yields 401 before any handler runs, closing
+the original F1 gap. Every entry point that legitimately needs the token (main window, plugin
+window, and the templating Web Worker, which cannot reach `window.main` itself) fetches or forwards
+it before making any protocol call; ordering is safe because each fetch happens via a blocking
+top-level `await` in that realm's entry module before other code in that realm runs.
+
+Traced and ruled out: header-casing bypass (the Fetch `Headers` API is case-insensitive by spec),
+a `resolveDbByKey` caller that skips the check (single choke point — `protocol.handle` registers
+only this one function; grepped for all other `insomnia-templating-worker-database://` references,
+found none outside this file and the trusted callers), a startup race where a legitimate call fires
+before the token is set (fails closed — `fetchFromTemplateWorkerDatabase` omits the header entirely
+if the token isn't set yet, which the server-side check rejects, rather than silently succeeding
+unauthenticated), and the CLI/node-runtime path (`network-adapter.node.ts` calls
+`runRequestHookInSandbox` as a direct function call, never through the protocol, so it has nothing
+to authenticate and isn't affected by or a bypass of this control).
+
+## Existing capabilities / callers: none found broken
+
+Every caller of `fetchFromTemplateWorkerDatabase` was enumerated (`liquid-extension-worker.ts`,
+`invoke-method.ts`, `plugins/index.ts`, `ui/templating/worker.ts`) and each runs in a JS realm that
+now calls `setTemplatingDbAuthToken` before making a protocol call. The one pre-existing unit test
+that called `resolveDbByKey` directly without a token (`templating-worker-database.test.ts`'s
+`app.prompt` case) was already fixed in this branch (c28382d81). Re-ran the full local suite
+(`templating/sandbox`, `plugin-window-ipc-authorization`, `templating-worker-database*`): 186/186
+passing, no regressions.
+
+## Finding 1 — Caller-supplied `permissions` bypasses the trusted registry, unlike `directory` (Low/Medium)
+
+**Files:** `packages/insomnia/src/main/templating-worker-database.ts:738-763` (the
+`plugin.discoverUserPluginExports` / `plugin.runUserRequestHook` entries in `pluginToMainAPI`).
+
+**Verified:** yes — reproduced with a passing regression test (see below), not just read.
+
+F2' fixed exactly one of the two trust-relevant fields these handlers take from the request body:
+`directory` is now resolved server-side by `resolveTrustedPluginDirectory(name)` against the
+registry (`getPlugins()`). `permissions` is not — it's still read straight off the body
+(`body.permissions` / `body.plugin.permissions`) and passed to
+`resolveTemplateTagModules`/`resolveTemplateTagCapabilities` unchanged. Since C1/C2/C3 are landed,
+`insomnia.permissions` is a live enforcement boundary today (not the "already-planned, not yet a
+real control" state the remediation plan's own scoping note assumed when it explicitly excluded the
+"capability half" from F2's fix) — so this is the same class of bug F2' patched for `directory`,
+just left half-done.
+
+**Reproduced:** a plugin registered with `permissions: {}` (no capabilities, per `getPlugins()`,
+the trusted registry) has a request hook that reports whether `context.network` was granted
+(deleted from context unless the `network` capability is present — `in-sandbox-bootstrap.ts`'s
+`__hasCap`). Calling `plugin.runUserRequestHook` over the (now correctly authenticated) protocol
+with a forged `plugin.permissions.capabilities: ['network']` in the body causes the hook to observe
+`context.network` as granted, contradicting the registry's own record for that plugin.
+
+**Consequence:** any caller that can reach the protocol with a valid token (the trusted main/plugin
+window realm itself, or, per the plan's own execution-surface table, a **user plugin's action** —
+still un-sandboxed/full-Node until A1 lands) can force a *different*, already-installed plugin's
+hook to run with elevated capabilities beyond what that plugin's own manifest declares — up to the
+`TEMPLATE_TAG_PROFILE` ceiling (`network`/`storage`/`fs-read`/`app`, every registry module; `render`
+capability set-relevant, `credentials` excluded). This is not a sandbox escape (the profile ceiling
+still caps it, so it grants nothing a plugin couldn't already grant *itself* by declaring it), but
+it is a real violation of manifest integrity/least-privilege for the *targeted* plugin, and — same
+as F2' — the exact bug class this branch was in the middle of closing.
+
+**Fix:** mirror F2' — in `resolveTrustedPluginDirectory` (or a sibling helper), also return the
+resolved plugin's own `permissions` from the registry, and use that instead of trusting
+`body.permissions`/`body.plugin.permissions` in both handlers.
+
+**Test:**
+`packages/insomnia/src/main/__tests__/templating-worker-database-protocol-authorization.test.ts`,
+describe block `protocol-dispatch handlers trust caller-supplied 'permissions', not the registry
+(residual gap from F2')` — two cases: a baseline call (no forged permissions) correctly gets no
+`network` capability per the registry, and a forged-permissions call gets it anyway. Both pass
+today (the second passing is the bug — it documents current, not desired, behavior; flipping the
+handler to consult the registry should turn it into a real regression guard).
+
+## Why the branch's own dynamic tests didn't catch this
+
+The new `templating-worker-database-protocol-authorization.test.ts` iterates the live
+`pluginToMainAPI` map for the *token* axis (every path/token combination) and has two focused
+`directory`-forgery regression cases for F2' — but no equivalent case for the `permissions` field.
+The H1 remediation plan's own scoping note is the direct cause: it explicitly filed
+`body.plugin.permissions` as "the gist's already-planned manifest work — excluded," so nobody wrote
+a permissions-forgery test alongside the directory one. That exclusion was accurate at the time the
+*original* sandbox plan was written (capability grants were aspirational), but by the time this PR
+landed, C1/C2/C3 had already shipped and made `permissions` a real, load-bearing control — the
+scoping note wasn't updated to reflect that, and the test suite inherited the stale premise. This is
+the same failure mode `SANDBOX-CAPABILITY-AUDIT-PLAN.md` already flagged once (a prior-art doc's
+"deferred" framing going stale as later PRs landed) — recorded here as a second instance so a future
+reviewer knows to double check plan-scoping notes for a PR against current `develop`, not just
+against the plan doc's original framing.
+
+## Excluded from this review
+
+- **Plugin actions still executing un-sandboxed/full-Node for user plugins** — explicitly ticket A1
+  (PR 11), not yet landed; the plan's own execution-surface table already tracks this as the
+  mechanism by which Finding 1 above would be reached by genuinely untrusted code today. Not
+  reported as a new gap of this PR.
+- **`services.invoke` generic RPC gateway / cross-tenant DB access findings** — already recorded in
+  `CROSS-TENANT-DB-ACCESS-FINDINGS.md`; unrelated to the auth-token mechanism this review targeted.
+- **Bridge-dispatch prototype-object smell (`handlers[path]` against a plain object)** — already
+  recorded as F3 in `M2-STDLIB-SECURITY-REVIEW.md`; `resolveDbByKey`'s own lookup already has the
+  own-property guard this PR added (`Object.prototype.hasOwnProperty.call(withLowercasedKeys, ...)`
+  at `templating-worker-database.ts:52`), so that specific instance is resolved, but the general
+  finding in the other file stands as previously recorded, not re-reported here.
+
+## Hypotheses chased down and ruled out
+
+- Header-name casing used to smuggle a missing/forged token past the check — ruled out, Fetch
+  `Headers` are case-insensitive.
+- A second, unauthenticated call site to `resolveDbByKey`/the protocol scheme — ruled out by
+  grep; `protocol.handle(templatingWorkerDatabaseInterface, resolveDbByKey)` is the only
+  registration, and `fetchFromTemplateWorkerDatabase` is the only caller of the scheme in source.
+  distinguish it from the two build artifacts `entry.main.min.js`/`entry.plugin-window.min.js`
+  found by the same grep — pre-existing generated bundles, not source, and not part of this diff.
+- Startup race where a real caller fires before `setTemplatingDbAuthToken` runs — ruled out; each
+  entry module's fetch/forward is a blocking step before any other code in that realm runs, and a
+  missing token fails closed (401) rather than silently succeeding.
+- `getPluginWindow()`/`getMainWindow()` sender check racing against window (re)creation — ruled out
+  by reading `createPluginWindow()`: `pluginWindow` is assigned synchronously before `loadFile`, so
+  by the time the loaded page's JS runs and requests the token, the module-level reference already
+  points at it.
+- Plugin-related IPC channels registered outside `plugin-window.ts` that the static
+  "no bare `ipcMain` call" guardrail (scoped to that one file) wouldn't catch — found two
+  (`createPlugin`, `installPlugin` in `main/ipc/main.ts`) but they're pre-existing, unrelated to the
+  `plugins.*`/hook-dispatch surface this PR's guardrail is about, and out of scope for this review.
+
+## Verification
+
+```
+npm test -w packages/insomnia -- templating-worker-database-protocol-authorization
+npm test -w packages/insomnia -- templating/sandbox plugin-window-ipc-authorization templating-worker-database
+npx eslint packages/insomnia/src/main/__tests__/templating-worker-database-protocol-authorization.test.ts
+npx tsc --noEmit
+```
+
+All green as of this review (186/186 tests across the touched suites; lint and typecheck clean).

--- a/packages/insomnia/src/templating/sandbox/marshal.test.ts
+++ b/packages/insomnia/src/templating/sandbox/marshal.test.ts
@@ -4,12 +4,10 @@ import { type HostBridge } from './host-bridge';
 import { type ContextEnvelope, HOOK_REQUEST_FIELDS, type HookResult, mergeHookRequestMutation, stripDangerousKeysReviver } from './marshal';
 import { runTagInSandbox } from './plugin-tag-sandbox';
 
-// H1-HOOK-SANDBOX-SECURITY-REVIEW.md, finding 2: a request hook could plant an own
-// `__proto__`/`constructor`/`prototype` key on nested request data via computed-key JSON
-// construction, and it survived a plain `JSON.parse` of the sandbox's output intact.
-// `DANGEROUS_KEY_SCENARIOS` covers where a hook can plant such a key, and
-// `findDangerousOwnKeyPaths` searches the entire result for survivors, so a new scenario is
-// one array entry rather than a bespoke assertion.
+// Tests that a request hook can't plant an own `__proto__`/`constructor`/`prototype` key on
+// nested request data. `DANGEROUS_KEY_SCENARIOS` covers where a hook can plant such a key, and
+// `findDangerousOwnKeyPaths` searches the entire result for survivors, so a new scenario is one
+// array entry rather than a bespoke assertion.
 
 const noBridge: HostBridge = async path => {
   throw new Error(`unexpected bridge call: ${path}`);

--- a/packages/insomnia/src/templating/sandbox/marshal.test.ts
+++ b/packages/insomnia/src/templating/sandbox/marshal.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { type HostBridge } from './host-bridge';
+import { type ContextEnvelope, HOOK_REQUEST_FIELDS, type HookResult, mergeHookRequestMutation, stripDangerousKeysReviver } from './marshal';
+import { runTagInSandbox } from './plugin-tag-sandbox';
+
+// H1-HOOK-SANDBOX-SECURITY-REVIEW.md, finding 2: a request hook could plant an own
+// `__proto__`/`constructor`/`prototype` key on nested request data via computed-key JSON
+// construction, and it survived a plain `JSON.parse` of the sandbox's output intact.
+// `DANGEROUS_KEY_SCENARIOS` covers where a hook can plant such a key, and
+// `findDangerousOwnKeyPaths` searches the entire result for survivors, so a new scenario is
+// one array entry rather than a bespoke assertion.
+
+const noBridge: HostBridge = async path => {
+  throw new Error(`unexpected bridge call: ${path}`);
+};
+
+const DANGEROUS_KEYS = ['__proto__', 'constructor', 'prototype'];
+
+/** Recursively lists every "$.path.to.key" where an *own* dangerous key was found. */
+function findDangerousOwnKeyPaths(value: unknown, path = '$', seen = new Set<unknown>()): string[] {
+  if (value === null || typeof value !== 'object') {
+    return [];
+  }
+  if (seen.has(value)) {
+    return [];
+  }
+  seen.add(value);
+
+  const found: string[] = [];
+  for (const key of Object.getOwnPropertyNames(value)) {
+    const childPath = `${path}.${key}`;
+    if (DANGEROUS_KEYS.includes(key)) {
+      found.push(childPath);
+    }
+    found.push(...findDangerousOwnKeyPaths((value as Record<string, unknown>)[key], childPath, seen));
+  }
+  return found;
+}
+
+const runRequestHookRaw = async (
+  hookSource: string,
+  request: Record<string, unknown>,
+): Promise<string> => {
+  const envelope: ContextEnvelope = {
+    args: [],
+    context: {},
+    meta: {},
+    renderPurpose: 'send',
+    appInfo: { version: '0.0.0', platform: 'linux', arch: 'x64' },
+    pluginName: 'test-plugin',
+    renderDepth: 0,
+    grantedModules: [],
+    grantedCapabilities: [],
+    moduleFiles: { 'index.js': `module.exports.requestHooks = [${hookSource}];` },
+    entryModuleKey: 'index.js',
+    hookKind: 'request',
+    hookIndex: 0,
+    hookRequest: request,
+  };
+  return runTagInSandbox({ tagName: '', envelope, bridge: noBridge });
+};
+
+describe('stripDangerousKeysReviver + mergeHookRequestMutation (defense-in-depth on the hook marshal boundary)', () => {
+  const DANGEROUS_KEY_SCENARIOS = DANGEROUS_KEYS.flatMap(key => [
+    {
+      name: `${key} nested inside a hook-supplied body`,
+      hookSource: `function (context) {
+        context.request.setBody(JSON.parse('{"${key}":{"polluted":true},"text":"hi"}'));
+      }`,
+      request: { body: {} },
+    },
+    {
+      name: `${key} nested inside a hook-supplied authentication value`,
+      hookSource: `function (context) {
+        context.request.setAuthenticationParameter('token', JSON.parse('{"${key}":{"polluted":true}}'));
+      }`,
+      request: { authentication: {} },
+    },
+    {
+      name: `${key} nested two levels deep inside a hook-supplied body`,
+      hookSource: `function (context) {
+        context.request.setBody(JSON.parse('{"nested":{"deeper":{"${key}":{"polluted":true}}}}'));
+      }`,
+      request: { body: {} },
+    },
+  ]);
+
+  // Confirms the naive parse is actually vulnerable, then that the reviver and allowlisted merge both end up clean.
+  it.each(DANGEROUS_KEY_SCENARIOS)('$name: does not survive the fixed parse into the merged request', async ({ hookSource, request }) => {
+    const json = await runRequestHookRaw(hookSource, request);
+
+    const naive = JSON.parse(json) as HookResult;
+    expect(findDangerousOwnKeyPaths(naive.request)).not.toEqual([]);
+
+    const sanitized = JSON.parse(json, stripDangerousKeysReviver) as HookResult;
+    expect(findDangerousOwnKeyPaths(sanitized.request)).toEqual([]);
+
+    const target: Record<string, unknown> = { _id: 'req_1' };
+    mergeHookRequestMutation(target, sanitized.request ?? {});
+    expect(findDangerousOwnKeyPaths(target)).toEqual([]);
+  });
+
+  // Parsed from JSON, so the computed-key "__proto__" here is a genuine own property, not the object-literal prototype setter.
+  it('mergeHookRequestMutation only ever copies fields from the HOOK_REQUEST_FIELDS allowlist', () => {
+    const target: Record<string, unknown> = {};
+    const mutated = JSON.parse(
+      '{"url":"https://rewritten.example","unexpectedNewField":"should not appear","__proto__":{"polluted":true}}',
+    ) as Record<string, unknown>;
+
+    mergeHookRequestMutation(target, mutated);
+
+    expect(target.url).toBe('https://rewritten.example');
+    expect(target).not.toHaveProperty('unexpectedNewField');
+    expect(Object.getOwnPropertyNames(target)).not.toContain('__proto__');
+    expect(Object.getOwnPropertyNames(target).every(key => (HOOK_REQUEST_FIELDS as readonly string[]).includes(key))).toBe(true);
+  });
+});

--- a/packages/insomnia/src/templating/sandbox/marshal.ts
+++ b/packages/insomnia/src/templating/sandbox/marshal.ts
@@ -65,6 +65,57 @@ export interface HookResult {
   response?: Record<string, unknown>;
 }
 
+// The serializable RenderedRequest fields a request hook may read or mutate — the subset marshaled
+// into and out of the sandbox (mirrors what plugins/context/request.ts touches on the request).
+// Shared between the host side (`main/templating-worker-database.ts`, which marshals a request in
+// and merges the mutation back for the main/CLI runtime) and the renderer side
+// (`plugins/invoke-method.ts`, which does the same for the plugin-window runtime) so both merge
+// call sites enforce the identical allowlist rather than duplicating (and risking drifting) it.
+export const HOOK_REQUEST_FIELDS = [
+  '_id',
+  'name',
+  'url',
+  'method',
+  'headers',
+  'parameters',
+  'authentication',
+  'body',
+  'cookies',
+  'settingSendCookies',
+  'settingStoreCookies',
+  'settingEncodeUrl',
+  'settingDisableRenderRequestBody',
+  'settingFollowRedirects',
+] as const;
+
+// Property names that, if present as an *own* key on an object parsed from untrusted JSON, are a
+// prototype-pollution primitive waiting for a future unsafe consumer ([[Set]]-based merge,
+// `for...in` assignment, etc.) — see H1-HOOK-SANDBOX-SECURITY-REVIEW.md, finding 2. A hook can
+// plant such a key on a nested value (e.g. `context.request.setBody(JSON.parse('{"__proto__":
+// {...}}'))`) using computed-key construction, which survives a plain `JSON.parse` as a real own
+// property rather than the accessor. Dropping it via a reviver (returning `undefined` deletes the
+// key, per the JSON.parse spec) neutralizes it at every depth, at the exact boundary where
+// untrusted sandbox output re-enters trusted host memory.
+const DANGEROUS_JSON_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/** `JSON.parse` reviver that drops `__proto__`/`constructor`/`prototype` own-keys at any depth. */
+export const stripDangerousKeysReviver = (key: string, value: unknown): unknown =>
+  DANGEROUS_JSON_KEYS.has(key) ? undefined : value;
+
+/**
+ * Merges a hook's mutated request fields back onto the live request the host is building, one
+ * allowlisted field at a time — never a blanket `Object.assign`/spread of the parsed object,
+ * which would trust whatever top-level keys happen to be present in `mutated` rather than only
+ * the fields a hook is actually permitted to touch.
+ */
+export const mergeHookRequestMutation = (target: Record<string, any>, mutated: Record<string, any>): void => {
+  for (const key of HOOK_REQUEST_FIELDS) {
+    if (Object.prototype.hasOwnProperty.call(mutated, key)) {
+      target[key] = mutated[key];
+    }
+  }
+};
+
 /** A discovered template-tag's serializable metadata (no `run`, no other function members). */
 export interface TemplateTagDescriptor {
   name?: string;

--- a/packages/insomnia/src/templating/sandbox/marshal.ts
+++ b/packages/insomnia/src/templating/sandbox/marshal.ts
@@ -65,12 +65,9 @@ export interface HookResult {
   response?: Record<string, unknown>;
 }
 
-// The serializable RenderedRequest fields a request hook may read or mutate — the subset marshaled
-// into and out of the sandbox (mirrors what plugins/context/request.ts touches on the request).
-// Shared between the host side (`main/templating-worker-database.ts`, which marshals a request in
-// and merges the mutation back for the main/CLI runtime) and the renderer side
-// (`plugins/invoke-method.ts`, which does the same for the plugin-window runtime) so both merge
-// call sites enforce the identical allowlist rather than duplicating (and risking drifting) it.
+// The serializable RenderedRequest fields a request hook may read or mutate, marshaled into and
+// out of the sandbox. Shared by the main-process and plugin-window merge call sites so both
+// enforce the same allowlist instead of duplicating it.
 export const HOOK_REQUEST_FIELDS = [
   '_id',
   'name',
@@ -88,26 +85,16 @@ export const HOOK_REQUEST_FIELDS = [
   'settingFollowRedirects',
 ] as const;
 
-// Property names that, if present as an *own* key on an object parsed from untrusted JSON, are a
-// prototype-pollution primitive waiting for a future unsafe consumer ([[Set]]-based merge,
-// `for...in` assignment, etc.) — see H1-HOOK-SANDBOX-SECURITY-REVIEW.md, finding 2. A hook can
-// plant such a key on a nested value (e.g. `context.request.setBody(JSON.parse('{"__proto__":
-// {...}}'))`) using computed-key construction, which survives a plain `JSON.parse` as a real own
-// property rather than the accessor. Dropping it via a reviver (returning `undefined` deletes the
-// key, per the JSON.parse spec) neutralizes it at every depth, at the exact boundary where
-// untrusted sandbox output re-enters trusted host memory.
+// A hook can plant one of these as an own key on a nested value via computed-key JSON
+// construction (e.g. `JSON.parse('{"__proto__":{...}}')`), which survives a plain `JSON.parse`
+// as a real own property. `stripDangerousKeysReviver` drops any of them at any depth.
 const DANGEROUS_JSON_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
 /** `JSON.parse` reviver that drops `__proto__`/`constructor`/`prototype` own-keys at any depth. */
 export const stripDangerousKeysReviver = (key: string, value: unknown): unknown =>
   DANGEROUS_JSON_KEYS.has(key) ? undefined : value;
 
-/**
- * Merges a hook's mutated request fields back onto the live request the host is building, one
- * allowlisted field at a time — never a blanket `Object.assign`/spread of the parsed object,
- * which would trust whatever top-level keys happen to be present in `mutated` rather than only
- * the fields a hook is actually permitted to touch.
- */
+/** Merges a hook's mutated request fields back onto the live request, one allowlisted field at a time. */
 export const mergeHookRequestMutation = (target: Record<string, any>, mutated: Record<string, any>): void => {
   for (const key of HOOK_REQUEST_FIELDS) {
     if (Object.prototype.hasOwnProperty.call(mutated, key)) {

--- a/packages/insomnia/src/ui/worker/templating-handler.ts
+++ b/packages/insomnia/src/ui/worker/templating-handler.ts
@@ -11,9 +11,8 @@ worker.addEventListener('error', event => {
   console.error('Error from worker:', event.message);
 });
 
-// F1: the dedicated templating Worker is its own JS realm with no `window.main`/contextBridge
-// access, so it can't fetch the protocol auth token itself — this (main-window-context) module
-// fetches it once and forwards it in on every postMessage instead.
+// The Worker has no window.main access, so this module fetches the auth token once and forwards
+// it in on every postMessage instead.
 let authTokenPromise: Promise<string> | null = null;
 function getTemplatingDbAuthToken(): Promise<string> {
   if (!authTokenPromise) {

--- a/packages/insomnia/src/ui/worker/templating-handler.ts
+++ b/packages/insomnia/src/ui/worker/templating-handler.ts
@@ -11,12 +11,24 @@ worker.addEventListener('error', event => {
   console.error('Error from worker:', event.message);
 });
 
-export function renderInWorker({ input, context, path, ignoreUndefinedEnvVariable }: RenderInputType): Promise<string> {
+// F1: the dedicated templating Worker is its own JS realm with no `window.main`/contextBridge
+// access, so it can't fetch the protocol auth token itself — this (main-window-context) module
+// fetches it once and forwards it in on every postMessage instead.
+let authTokenPromise: Promise<string> | null = null;
+function getTemplatingDbAuthToken(): Promise<string> {
+  if (!authTokenPromise) {
+    authTokenPromise = window.main.templatingDb.getAuthToken();
+  }
+  return authTokenPromise;
+}
+
+export async function renderInWorker({ input, context, path, ignoreUndefinedEnvVariable }: RenderInputType): Promise<string> {
   const newContext = serializeRenderContext(context);
+  const authToken = await getTemplatingDbAuthToken();
 
   // Id to avoid race conditions
   const id = window.crypto.randomUUID();
-  const payloadWithHash = JSON.stringify({ id, input, context: newContext, path, ignoreUndefinedEnvVariable });
+  const payloadWithHash = JSON.stringify({ id, input, context: newContext, path, ignoreUndefinedEnvVariable, authToken });
   worker.postMessage(payloadWithHash);
   return new Promise((resolve, reject) => {
     const messageHandler = (event: MessageEvent) => {

--- a/packages/insomnia/src/ui/worker/templating.worker.ts
+++ b/packages/insomnia/src/ui/worker/templating.worker.ts
@@ -18,9 +18,7 @@ async function performJob(input: {
 // Listen for messages from the main thread
 self.onmessage = async event => {
   const { id, input, context, path, ignoreUndefinedEnvVariable, authToken } = JSON.parse(event.data);
-  // F1: this Worker is a separate JS realm from the window that spawned it (`templating-handler.ts`),
-  // so it has its own copy of the module-scoped auth token — set it from the message rather than
-  // trying to reach `window.main` (unavailable here).
+  // This Worker has its own copy of the module-scoped auth token, set from the message.
   setTemplatingDbAuthToken(authToken ?? null);
   try {
     const result = await performJob({

--- a/packages/insomnia/src/ui/worker/templating.worker.ts
+++ b/packages/insomnia/src/ui/worker/templating.worker.ts
@@ -1,3 +1,4 @@
+import { setTemplatingDbAuthToken } from '~/common/templating/liquid-extension-worker';
 import { deserializeRenderContext } from '~/common/templating/render-context-serialization';
 import * as templating from '~/ui/templating/worker';
 
@@ -16,7 +17,11 @@ async function performJob(input: {
 
 // Listen for messages from the main thread
 self.onmessage = async event => {
-  const { id, input, context, path, ignoreUndefinedEnvVariable } = JSON.parse(event.data);
+  const { id, input, context, path, ignoreUndefinedEnvVariable, authToken } = JSON.parse(event.data);
+  // F1: this Worker is a separate JS realm from the window that spawned it (`templating-handler.ts`),
+  // so it has its own copy of the module-scoped auth token — set it from the message rather than
+  // trying to reach `window.main` (unavailable here).
+  setTemplatingDbAuthToken(authToken ?? null);
   try {
     const result = await performJob({
       input,


### PR DESCRIPTION
## What this PR does

* `plugins.applyRequestHooks` was gated to the real main window over `ipcMain`, but the same capability (running a user plugin's request hook, executing a plugin tag, discovering a plugin's exports, plus the whole DB bridge) was dispatched by `resolveDbByKey` behind the `insomnia-templating-worker-database://` protocol with no caller check. So anything able to `fetch()` that scheme could run any installed plugin's request hook with forged data and read the result back. Resolved by generating a per-process secret in main, handing it out only to the main window and plugin window over a sender-checked IPC channel, and rejecting any protocol call missing or mismatching it before it reaches a handler.
* `runUserRequestHook`/`discoverUserPluginExports` took the on-disk plugin directory straight from the request body, so a forged call could point hook or discovery execution at any folder with a `package.json`. Resolved by using the directory `server-side` from the trusted plugin registry, keyed by plugin name, and rejecting unknown names.
* `stripDangerousKeysReviver` was applied to the hook-result path but not to `discoverPluginExportsInSandbox`'s manifest parse or `resolveDbByKey`'s own request-body parse. Resolved by routing both through the same reviver so untrusted sandbox output is sanitized at every point it re-enters host memory.

## Regression tests added
`templating-worker-database-protocol-authorization.test.ts` dynamically iterates the live `pluginToMainAPI` map (not a hardcoded channel list) to prevent a future handler from silently reappearing unauthenticated:
* Every registered path rejects a missing or forged auth token, and is dispatched (not rejected) with the real one, plus a focused regression on the request-hook dispatch path specifically
* A forged directory in the request body is proven to be ignored in favor of the registry-resolved one, and an unregistered plugin name is rejected
* A plugin export planting a `__proto__` own-key is proven not to survive into the discovered manifest
