### PR TITLE
fix: workspace import targeting

### DIFF
--- a/packages/insomnia/src/common/__tests__/import.test.ts
+++ b/packages/insomnia/src/common/__tests__/import.test.ts
@@ -777,3 +777,70 @@ describe('MCP run deep-link import', () => {
     expect(match).toBeUndefined();
   });
 });
+
+describe('requiresNewWorkspace()', () => {
+  const base = { errors: [] as string[] };
+
+  it('returns false for collection-only imports', () => {
+    expect(
+      importUtil.requiresNewWorkspace({
+        ...base,
+        workspaces: [{ scope: 'collection' } as any],
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false for request-only imports without workspaces', () => {
+    expect(
+      importUtil.requiresNewWorkspace({
+        ...base,
+        requests: [{ _id: 'req_1' } as any],
+      }),
+    ).toBe(false);
+  });
+
+  it.each(['mock-server', 'environment', 'design', 'mcp'] as const)(
+    'returns true when a %s workspace is present',
+    scope => {
+      expect(
+        importUtil.requiresNewWorkspace({
+          ...base,
+          workspaces: [{ scope } as any],
+        }),
+      ).toBe(true);
+    },
+  );
+
+  it('returns true when any non-collection workspace is mixed with collections', () => {
+    expect(
+      importUtil.requiresNewWorkspace({
+        ...base,
+        workspaces: [{ scope: 'collection' } as any, { scope: 'environment' } as any],
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true for OpenAPI / Swagger scan results', () => {
+    expect(
+      importUtil.requiresNewWorkspace({
+        ...base,
+        type: { id: 'openapi3' } as any,
+      }),
+    ).toBe(true);
+    expect(
+      importUtil.requiresNewWorkspace({
+        ...base,
+        apiSpecs: [{ _id: 'spc_1' } as any],
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true when mcpRequests are present', () => {
+    expect(
+      importUtil.requiresNewWorkspace({
+        ...base,
+        mcpRequests: [{ _id: 'mcp_1' } as any],
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/insomnia/src/common/__tests__/import.test.ts
+++ b/packages/insomnia/src/common/__tests__/import.test.ts
@@ -288,7 +288,7 @@ describe('importRaw()', () => {
     const fixturePath = path.join(__dirname, '..', '__fixtures__', 'openapi', 'endpoint-security-input.yaml');
     const content = fs.readFileSync(fixturePath, 'utf8').toString();
     const disableLogs = console.log;
-    console.log = () => {};
+    console.log = () => { };
     const scanResult = await importUtil.scanResources([
       {
         contentStr: content,
@@ -840,6 +840,16 @@ describe('requiresNewWorkspace()', () => {
       importUtil.requiresNewWorkspace({
         ...base,
         mcpRequests: [{ _id: 'mcp_1' } as any],
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true for Postman environment scan results', () => {
+    expect(
+      importUtil.requiresNewWorkspace({
+        ...base,
+        type: { id: 'postman-environment' } as any,
+        environments: [{ _id: '__ENV_1__' } as any],
       }),
     ).toBe(true);
   });

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -137,6 +137,20 @@ export interface ScanResult {
   errors: string[];
 }
 
+export function isApiSpecScanResult(scanResult: ScanResult) {
+  return (
+    (scanResult.apiSpecs?.length ?? 0) > 0 || scanResult.type?.id === 'openapi3' || scanResult.type?.id === 'swagger2'
+  );
+}
+
+export function requiresNewWorkspace(scanResult: ScanResult) {
+  return (
+    isApiSpecScanResult(scanResult) ||
+    (scanResult.mcpRequests?.length ?? 0) > 0 ||
+    !!scanResult.workspaces?.some(w => w.scope !== 'collection')
+  );
+}
+
 interface ResourceCacheType {
   content: string;
   resources: BaseModel[];

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -146,6 +146,7 @@ export function isApiSpecScanResult(scanResult: ScanResult) {
 export function requiresNewWorkspace(scanResult: ScanResult) {
   return (
     isApiSpecScanResult(scanResult) ||
+    scanResult.type?.id === postmanEnvImporterId ||
     (scanResult.mcpRequests?.length ?? 0) > 0 ||
     !!scanResult.workspaces?.some(w => w.scope !== 'collection')
   );

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -19,6 +19,8 @@ import {
   findExistingImportedWorkspace,
   findRequestInExistingWorkspace,
   type ImportSourceType,
+  isApiSpecScanResult,
+  requiresNewWorkspace,
   type ScanResult,
 } from '../../../../common/import';
 import {
@@ -33,14 +35,7 @@ import { ModalHeader } from '../../base/modal-header';
 import { HelpTooltip } from '../../help-tooltip';
 import { Icon } from '../../icon';
 import { Button } from '../../themed-button';
-import {
-  CurlIcon,
-  isApiSpecScanResult,
-  requiresNewWorkspace,
-  ScanResultsTable,
-  SupportedFormats,
-  validImportExtensions,
-} from './shared';
+import { CurlIcon, ScanResultsTable, SupportedFormats, validImportExtensions } from './shared';
 
 export const Radio: FC<{
   name: string;
@@ -383,7 +378,6 @@ export const ImportModal: FC<ImportModalProps> = ({
             errors={importErrors}
             loading={importFetcher.state !== 'idle'}
             disabled={importErrors.length > 0}
-            autoScan={autoScan}
             isImportingBaseEnvironmentToWorkspace={!!isImportingBaseEnvironmentToWorkspace}
             onImport={async (
               overrideBaseEnvironmentData: boolean,
@@ -640,7 +634,6 @@ const ImportResourcesForm = ({
   errors,
   disabled,
   loading,
-  autoScan,
   isImportingBaseEnvironmentToWorkspace,
 }: {
   scanResults: ScanResult[];
@@ -653,17 +646,15 @@ const ImportResourcesForm = ({
   ) => void;
   disabled: boolean;
   loading: boolean;
-  autoScan: boolean;
   isImportingBaseEnvironmentToWorkspace: boolean;
 }) => {
-  const { organizationId, projectId, workspaceId } = useParams() as {
+  const { organizationId, projectId } = useParams() as {
     organizationId: string;
     projectId: string;
-    workspaceId: string;
   };
   const [overrideBaseEnvironmentData, setOverrideBaseEnvironmentData] = useState(true);
   const workspacesFetcher = useProjectListWorkspacesLoaderFetcher();
-  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState(autoScan ? '' : workspaceId || '');
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState('');
   const [selectedProjectId, setSelectedProjectId] = useState(projectId || '');
   const [newProjectName, setNewProjectName] = useState(() => {
     for (const result of scanResults) {

--- a/packages/insomnia/src/ui/components/modals/import-modal/shared.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/shared.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import React, { type FC, Fragment, type PropsWithChildren, useMemo } from 'react';
 
 import { type ProjectScopeKeys, scopeToLabelMap } from '~/common/get-workspace-label';
-import type { ScanResult } from '~/common/import';
+import { isApiSpecScanResult, type ScanResult } from '~/common/import';
 
 export const validImportExtensions = [
   'sh',
@@ -181,20 +181,6 @@ export const SupportedFormats = () => {
     </div>
   );
 };
-
-export function isApiSpecScanResult(scanResult: ScanResult) {
-  return (
-    (scanResult.apiSpecs?.length ?? 0) > 0 || scanResult.type?.id === 'openapi3' || scanResult.type?.id === 'swagger2'
-  );
-}
-
-export function requiresNewWorkspace(scanResult: ScanResult) {
-  return (
-    isApiSpecScanResult(scanResult) ||
-    (scanResult.mcpRequests?.length ?? 0) > 0 ||
-    !!scanResult.workspaces?.some(w => w.scope === 'design' || w.scope === 'mcp')
-  );
-}
 
 function getWorkspaceCountsByScope(workspaces: { scope?: string }[], scanResult: ScanResult) {
   const defaultScope = isApiSpecScanResult(scanResult) ? 'design' : 'collection';

--- a/packages/insomnia/src/ui/components/settings/import-export.tsx
+++ b/packages/insomnia/src/ui/components/settings/import-export.tsx
@@ -92,7 +92,7 @@ const showSaveExportedFileDialog = async ({
   exportedFileNamePrefix: string;
   selectedFormat: SelectedFormat;
 }) => {
-  const date = format(Date.now(), 'yyyy-MM-dd');
+  const date = format(Date.now(), 'yyyy-MM-dd-HH-mm-ss');
   const name = exportedFileNamePrefix.replace(/ /g, '-');
   const lastDir = window.localStorage.getItem('insomnia.lastExportPath');
   const dir = lastDir || window.app.getPath('desktop');


### PR DESCRIPTION

- Export default filenames now include `HH-mm-ss`, so back-to-back exports get unique names
- Manual imports with any non-Collection workspace (Mock, MCP, Environment, Document, etc.) hide the Collection picker and always create new workspaces; project selection remains available
- Collection imports default to `-- New Collection --` instead of the current workspace, so importing the same Collection twice creates two Collections
- Move `isApiSpecScanResult` / `requiresNewWorkspace` into `common/import.ts` and cover them with unit tests

