### PR TITLE
fix: Add unique ids for cloud sync remote files

### DIFF
--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar-utils.ts
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar-utils.ts
@@ -18,6 +18,7 @@ import { fuzzyMatchAll } from 'insomnia-data/common';
 import { database } from '~/common/database';
 import { sortMethodMap } from '~/common/sorting';
 import type { Child } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
+import type { FlatItem } from '~/ui/components/sidebar/project-navigation-sidebar/types';
 import { dedupeCollectionItems } from '~/ui/utils/dedupe-collection-items';
 
 export interface SlimRequestDoc extends BaseModel {
@@ -54,6 +55,22 @@ export interface AllRequestsAndMetaInWorkspace {
 export type WorkspaceWithSyncStatus = Workspace & {
   hasUncommittedChanges?: boolean;
   hasUnpushedChanges?: boolean;
+};
+
+export const getSidebarGridListItemId = (item: FlatItem): string => {
+  const { kind, doc } = item;
+  const itemId = doc._id;
+  switch (kind) {
+    case 'pinnedRequest': {
+      return `pinned-request-${itemId}`;
+    }
+    case 'unsyncedWorkspace': {
+      return `project-${item.project._id}-unsynced-workspace-${itemId}`;
+    }
+    default: {
+      return itemId;
+    }
+  }
 };
 
 export async function getWorkspacesByProjectIds(projectIds: string[]) {

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
@@ -57,7 +57,6 @@ import { useLoaderDeferData } from '~/ui/hooks/use-loader-defer-data';
 import { useOrganizationPermissions } from '~/ui/hooks/use-organization-features';
 import insomniaLogo from '~/ui/images/insomnia-logo.svg';
 import { isPrimaryClickModifier } from '~/ui/utils';
-import { dedupeCollectionItems } from '~/ui/utils/dedupe-collection-items';
 import { getAllRemoteBackendProjectsOfOrg } from '~/ui/utils/remote-projects';
 
 import { Icon } from '../../icon';
@@ -66,6 +65,7 @@ import {
   filterCollection,
   flattenCollectionChildren,
   getAllRequestsAndMetaByWorkspace,
+  getSidebarGridListItemId,
   getWorkspacesByProjectIds,
   type WorkspaceWithSyncStatus,
 } from './project-navigation-sidebar-utils';
@@ -75,9 +75,6 @@ import type { FlatItem } from './types';
 import { useProjectNavigationSidebarNavigation } from './use-project-navigation-sidebar-navigation';
 import { useSidebarDragAndDrop } from './use-sidebar-drag-and-drop';
 import { WorkspaceNode } from './workspace-node';
-
-const getSidebarGridListItemId = (item: FlatItem): string =>
-  `${item.kind === 'pinnedRequest' ? 'pinned-request-' : ''}${item.doc._id}`;
 
 interface ProjectNavigationSidebarProps {
   storageRules: StorageRules;
@@ -1002,10 +999,7 @@ const ProjectNavigationSidebarInner = (
   const [isShortcutCreateOpen, setIsShortcutCreateOpen] = useState(false);
   // The item that the shortcut create dropdown is targeting by keyboard up and down arrow keys
   const [shortcutTargetItemId, setShortcutTargetItemId] = useState<string | null>(null);
-  const visibleFlatItems = useMemo(
-    () => dedupeCollectionItems(flatItems.filter(i => !i.hidden), getSidebarGridListItemId),
-    [flatItems],
-  );
+  const visibleFlatItems = useMemo(() => flatItems.filter(i => !i.hidden), [flatItems]);
   const virtualizer = useVirtualizer({
     getScrollElement: () => parentRef.current,
     count: visibleFlatItems.length,

--- a/packages/insomnia/src/ui/utils/dedupe-collection-items.ts
+++ b/packages/insomnia/src/ui/utils/dedupe-collection-items.ts
@@ -3,6 +3,7 @@ export function dedupeCollectionItems<T>(items: T[], getId: (item: T) => string)
   const uniqueItems = items.filter(item => {
     const id = getId(item);
     if (seenIds.has(id)) {
+      console.warn(`[Duplicate Item] Duplicate item found with id: ${id}`);
       return false;
     }
     seenIds.add(id);


### PR DESCRIPTION
# Changes:
For cloud sync workspace files, its document id will probably be the same as local workspace id.
Add unique prefix to avoid it


[INS-3132](https://konghq.atlassian.net/browse/INS-3132)

[INS-3132]: https://konghq.atlassian.net/browse/INS-3132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ