### PR TITLE
fix(smoke-test): add missing /v3/users/me/onboarding mock endpoint

### DIFF
--- a/packages/insomnia-smoke-test/server/insomnia-api.ts
+++ b/packages/insomnia-smoke-test/server/insomnia-api.ts
@@ -492,6 +492,11 @@ export default function setup(app: Application) {
     });
   });
 
+  // GET /v3/users/me/onboarding
+  app.get('/v3/users/me/onboarding', (_req, res) => {
+    res.status(200).send({ is_new_signup: false, first_request_treatment: null });
+  });
+
   app.get('/v1/organizations/:orgId/features', (_req, res) => {
     res.status(200).send(organizationFeatures);
   });


### PR DESCRIPTION
E2E smoke tests log a lot of error "Failed to load onboarding state CODE-404: Not Found" because the mock API server had no handler for GET /v3/users/me/onboarding, which the app calls via getOnboardingState() on startup.
