### PR TITLE
fix: consolidate user-agent disable logic

### DIFF
--- a/packages/insomnia/src/common/render.ts
+++ b/packages/insomnia/src/common/render.ts
@@ -27,7 +27,7 @@ import type {
 import * as templatingUtils from '~/common/templating/utils';
 import { setDefaultProtocol } from '~/common/utils/url/protocol';
 
-import { getOrInheritAuthentication, getOrInheritHeaders } from '../network/network';
+import { getOrInheritAuthentication, getOrInheritHeaders, shouldSuppressUserAgent } from '../network/network';
 import { getRuntime } from '../runtimes';
 import { CONTENT_TYPE_GRAPHQL, JSON_ORDER_SEPARATOR } from './constants';
 import { database as db } from './database';
@@ -581,6 +581,7 @@ export async function getRenderedRequestAndContext({
   const description = request.description;
   request.description = '';
 
+  const suppressUserAgent = shouldSuppressUserAgent({ request, requestGroups });
   request.headers = getOrInheritHeaders({ request, requestGroups });
   request.authentication = getOrInheritAuthentication({ request, requestGroups });
   // Render all request properties
@@ -599,12 +600,6 @@ export async function getRenderedRequestAndContext({
   const renderedRequest = renderResult._request;
   const renderedCookieJar = renderResult._cookieJar;
   renderedRequest.description = await render(description, renderContext, null, 'keep');
-  const userAgentHeaders = request.headers.filter(h => h.name.toLowerCase() === 'user-agent');
-  const hasUserAgentHeader = userAgentHeaders.length > 0;
-  const allUserAgentHeadersDisabled = hasUserAgentHeader && userAgentHeaders.every(h => h.disabled === true);
-  // Suppress the default User-Agent when the request opts out via disableUserAgentHeader,
-  // or when the user added their own User-Agent header(s) and disabled all of them.
-  const suppressUserAgent = request.disableUserAgentHeader || allUserAgentHeadersDisabled;
   // Remove disabled params
   renderedRequest.parameters = renderedRequest.parameters.filter(p => !p.disabled);
   // Remove disabled headers

--- a/packages/insomnia/src/network/__tests__/network.test.ts
+++ b/packages/insomnia/src/network/__tests__/network.test.ts
@@ -1170,7 +1170,7 @@ describe('getOrInheritHeaders', () => {
   });
 });
 
-describe('getRenderedRequestAndContext suppressUserAgent', () => {
+describe('getRenderedRequest suppressUserAgent', () => {
   it('suppresses default user-agent when a custom user-agent header is disabled', async () => {
     const workspace = await services.workspace.create();
     const request = Object.assign(models.request.init(), {
@@ -1178,6 +1178,24 @@ describe('getRenderedRequestAndContext suppressUserAgent', () => {
       parentId: workspace._id,
       url: 'http://localhost',
       headers: [{ name: 'User-Agent', value: 'custom-xx', disabled: true }],
+    });
+
+    expect((await getRenderedRequest({ request })).suppressUserAgent).toBe(true);
+  });
+
+  it('suppresses default user-agent when all inherited user-agent headers are disabled', async () => {
+    const workspace = await services.workspace.create();
+    const folder = await services.requestGroup.create({
+      _id: 'fld_disabled_ua',
+      name: 'Disabled UA Folder',
+      parentId: workspace._id,
+      metaSortKey: 0,
+      headers: [{ name: 'User-Agent', value: 'custom-xx', disabled: true }],
+    });
+    const request = Object.assign(models.request.init(), {
+      _id: 'req_inherited_disabled_ua',
+      parentId: folder._id,
+      url: 'http://localhost',
     });
 
     expect((await getRenderedRequest({ request })).suppressUserAgent).toBe(true);

--- a/packages/insomnia/src/network/__tests__/network.test.ts
+++ b/packages/insomnia/src/network/__tests__/network.test.ts
@@ -1169,3 +1169,17 @@ describe('getOrInheritHeaders', () => {
     expect(networkUtils.getOrInheritHeaders({ request, requestGroups })).toEqual([]);
   });
 });
+
+describe('getRenderedRequestAndContext suppressUserAgent', () => {
+  it('suppresses default user-agent when a custom user-agent header is disabled', async () => {
+    const workspace = await services.workspace.create();
+    const request = Object.assign(models.request.init(), {
+      _id: 'req_disabled_ua',
+      parentId: workspace._id,
+      url: 'http://localhost',
+      headers: [{ name: 'User-Agent', value: 'custom-xx', disabled: true }],
+    });
+
+    expect((await getRenderedRequest({ request })).suppressUserAgent).toBe(true);
+  });
+});

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -111,6 +111,24 @@ export function getOrInheritHeaders({
     .sort(ascendingFirstIndexStringSort)
     .map(([name, value]) => ({ name: originalCaseMap.get(name)!, value }));
 }
+
+// determines if any user-agent header is disabled
+export function shouldSuppressUserAgent({
+  request,
+  requestGroups = [],
+}: {
+  request: Pick<Request | WebSocketRequest | SocketIORequest, 'headers' | 'disableUserAgentHeader'>;
+  requestGroups?: Pick<RequestGroup, 'headers'>[];
+}): boolean {
+  const userAgentHeaders = [...requestGroups, request]
+    .flatMap(doc => doc.headers || [])
+    .filter(h => h.name?.toLowerCase() === 'user-agent');
+  return (
+    Boolean(request.disableUserAgentHeader) ||
+    (userAgentHeaders.length > 0 && userAgentHeaders.every(h => h.disabled))
+  );
+}
+
 // (only used for getOAuth2 token) Intended to gather all required database objects and initialize ids
 export const fetchRequestGroupData = async (requestGroupId: string) => {
   const requestGroup = await services.requestGroup.getById(requestGroupId);
@@ -544,9 +562,9 @@ const tryToExecuteScript = async (context: RequestAndContextAndOptionalResponse)
         },
         iterationData: userUploadEnvironment
           ? {
-              name: userUploadEnvironment.name,
-              data: userUploadEnvironment.data || {},
-            }
+            name: userUploadEnvironment.name,
+            data: userUploadEnvironment.data || {},
+          }
           : undefined,
         execution: {
           ...execution, // keep some existing properties in the after-response script from the pre-request script

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -112,7 +112,7 @@ export function getOrInheritHeaders({
     .map(([name, value]) => ({ name: originalCaseMap.get(name)!, value }));
 }
 
-// determines if any user-agent header is disabled
+// Determine whether the default User-Agent should be suppressed (explicitly disabled, or when all custom User-Agent headers are disabled).
 export function shouldSuppressUserAgent({
   request,
   requestGroups = [],

--- a/packages/insomnia/src/ui/utils/render-realtime-connect.ts
+++ b/packages/insomnia/src/ui/utils/render-realtime-connect.ts
@@ -2,7 +2,7 @@ import type { CookieJar, Request, RequestAuthentication, RequestGroup, RequestHe
 import { models, services } from 'insomnia-data';
 
 import { database as db } from '../../common/database';
-import { getOrInheritAuthentication, getOrInheritHeaders } from '../../network/network';
+import { getOrInheritAuthentication, getOrInheritHeaders, shouldSuppressUserAgent } from '../../network/network';
 import { tryToInterpolateRequestOrShowRenderErrorModal } from './try-interpolate';
 
 const { applyPathParametersToUrl } = models.request;
@@ -52,12 +52,7 @@ export async function renderRealtimeConnectPayload({
     return undefined;
   }
 
-  // getOrInheritHeaders drops disabled headers, so disabled User-Agent headers are only visible on the raw request/folder headers
-  const userAgentHeaders = [...requestGroups, request]
-    .flatMap(doc => doc.headers || [])
-    .filter(h => h.name?.toLowerCase() === 'user-agent');
-  const suppressUserAgent =
-    Boolean(request.disableUserAgentHeader) || (userAgentHeaders.length > 0 && userAgentHeaders.every(h => h.disabled));
+  const suppressUserAgent = shouldSuppressUserAgent({ request, requestGroups });
 
   const url = applyPathParametersToUrl(rendered.url, rendered.pathParameters);
 


### PR DESCRIPTION
Disabled `user-agent` headers were being stripped via `getOrInheritHeaders` before it could be detected