### PR TITLE
chore: hide 'generate-docs' command and skip hidden commands in documentation generation

### DIFF
--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -1041,7 +1041,7 @@ export const go = (args?: string[]) => {
       program.parseAsync(scriptArgs).catch(logErrorAndExit);
     });
 
-  program.command('generate-docs').action(() => {
+  program.command('generate-docs', { hidden: true }).action(() => {
     generateDocumentation(program);
     return process.exit(1);
   });

--- a/packages/insomnia-inso/src/scripts/docs.ts
+++ b/packages/insomnia-inso/src/scripts/docs.ts
@@ -90,7 +90,8 @@ export function generateDocumentation(program: commander.Command): void {
 
   const allCommands: any[] = [];
 
-  program.commands.forEach(command => {
+  program.commands.forEach((command: commander.Command & { _hidden?: boolean }) => {
+    if (command._hidden) return; // Skip hidden commands
     const commandData = generateCommandMarkdown(command, program.options, '');
 
     allCommands.push({


### PR DESCRIPTION
Avoid `generate-docs` from showing in `https://developer.konghq.com/inso-cli/reference/generate-docs/`