### PR TITLE
fix: prevent Git credential overwrite when authorizing a second account of the same provider [INS-3035]

### DIFF
--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -3177,7 +3177,13 @@ async function listGitProviders() {
   return providers;
 }
 
-async function initSignInToGitProvider({ provider }: { provider: GitRemoteProviderType }) {
+async function initSignInToGitProvider({
+  provider,
+  credentialId,
+}: {
+  provider: GitRemoteProviderType;
+  credentialId?: string;
+}) {
   const gitProvider = gitRemoteProviderRegistry.get(provider);
 
   invariant(gitProvider, `Git provider ${provider} not found`);
@@ -3185,7 +3191,7 @@ async function initSignInToGitProvider({ provider }: { provider: GitRemoteProvid
   invariant(gitProvider.initiateOAuth, `Git provider ${provider} does not support OAuth`);
 
   try {
-    await gitProvider.initiateOAuth();
+    await gitProvider.initiateOAuth(credentialId);
 
     return {};
   } catch (error) {

--- a/packages/insomnia/src/routes/git-credentials.init-sign-in.tsx
+++ b/packages/insomnia/src/routes/git-credentials.init-sign-in.tsx
@@ -7,12 +7,15 @@ import type { Route } from './+types/git-credentials.init-sign-in';
 
 interface InitSignInData {
   provider: GitRemoteProviderType;
+  /** When reauthorizing an existing credential, its ID — so completion updates that exact credential instead of creating a new one. */
+  credentialId?: string;
 }
 
 export async function clientAction({ request }: Route.ClientActionArgs) {
-  const { provider } = (await request.json()) as InitSignInData;
+  const { provider, credentialId } = (await request.json()) as InitSignInData;
   return await window.main.git.initSignInToGitProvider({
     provider,
+    credentialId,
   });
 }
 

--- a/packages/insomnia/src/sync/git/providers/__tests__/github.test.ts
+++ b/packages/insomnia/src/sync/git/providers/__tests__/github.test.ts
@@ -1,0 +1,164 @@
+import type * as insomniaData from 'insomnia-data';
+import { services } from 'insomnia-data';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GitHubProvider } from '../github';
+
+// vitest.config.ts aliases 'electron/main' to 'electron', so both `import { shell }
+// from 'electron'` and `import { net } from 'electron/main'` resolve to this one mock.
+vi.mock('electron', () => ({
+  shell: { openExternal: vi.fn(() => Promise.resolve()) },
+  net: { fetch: vi.fn() },
+}));
+
+vi.mock('insomnia-data', async importOriginal => {
+  const actual = await importOriginal<typeof insomniaData>();
+  return {
+    ...actual,
+    services: {
+      ...actual.services,
+      gitCredentials: {
+        getById: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+      },
+    },
+  };
+});
+
+const jsonResponse = (body: unknown) => Promise.resolve({ ok: true, json: () => Promise.resolve(body) } as Response);
+
+function mockGithubApi(email = 'user@example.com') {
+  return vi.fn((input: unknown) => {
+    const url = String(input);
+
+    if (url.includes('/v1/oauth/github-app')) {
+      return jsonResponse({ access_token: 'access-token' });
+    }
+    if (url.endsWith('/user/emails')) {
+      return jsonResponse([{ email, primary: true, verified: true }]);
+    }
+    if (url.endsWith('/user')) {
+      return jsonResponse({ id: 1, login: 'octocat', name: 'Octo Cat', email: null, avatar_url: 'avatar-url' });
+    }
+
+    return Promise.resolve({ ok: false, statusText: 'not found' } as Response);
+  });
+}
+
+function makeProvider() {
+  return new GitHubProvider({
+    type: 'github',
+    displayName: 'GitHub',
+    apiUrl: 'https://api.github.com',
+    webUrl: 'https://github.com',
+  });
+}
+
+describe('GitHubProvider OAuth create-vs-update', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { net } = await import('electron');
+    vi.mocked(net.fetch).mockImplementation(mockGithubApi());
+  });
+
+  it('creates a new credential when "Add Credential" is used, without looking up any existing one', async () => {
+    const provider = makeProvider();
+    const { state } = await provider.initiateOAuth();
+
+    const result = await provider.completeOAuth('some-code', state);
+
+    expect(result.success).toBe(true);
+    expect(services.gitCredentials.getById).not.toHaveBeenCalled();
+    expect(services.gitCredentials.create).toHaveBeenCalledTimes(1);
+    expect(services.gitCredentials.create).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: 'github' }),
+    );
+    expect(services.gitCredentials.update).not.toHaveBeenCalled();
+  });
+
+  it('creates a second, distinct credential when a different account is authorized via "Add Credential"', async () => {
+    const provider = makeProvider();
+    const { net } = await import('electron');
+
+    vi.mocked(net.fetch).mockImplementation(mockGithubApi('account-a@example.com'));
+    const { state: stateA } = await provider.initiateOAuth();
+    await provider.completeOAuth('code-a', stateA);
+
+    vi.mocked(net.fetch).mockImplementation(mockGithubApi('account-b@example.com'));
+    const { state: stateB } = await provider.initiateOAuth();
+    await provider.completeOAuth('code-b', stateB);
+
+    expect(services.gitCredentials.create).toHaveBeenCalledTimes(2);
+    expect(services.gitCredentials.update).not.toHaveBeenCalled();
+  });
+
+  it('updates the exact credential being reauthorized when a credentialId is supplied', async () => {
+    const provider = makeProvider();
+    const existing = {
+      _id: 'git_creds_existing',
+      type: 'GitCredentials',
+      provider: 'github',
+      name: 'GitHub Credential',
+      author: { email: 'old@example.com', name: 'Old', avatarUrl: '' },
+      credentials: { token: 'old-token', emails: [], selectedEmail: 'old@example.com' },
+    };
+    vi.mocked(services.gitCredentials.getById).mockResolvedValue(existing as never);
+
+    const { state } = await provider.initiateOAuth(existing._id);
+    const result = await provider.completeOAuth('some-code', state);
+
+    expect(result.success).toBe(true);
+    expect(services.gitCredentials.getById).toHaveBeenCalledWith(existing._id);
+    expect(services.gitCredentials.update).toHaveBeenCalledTimes(1);
+    expect(services.gitCredentials.update).toHaveBeenCalledWith(
+      existing,
+      expect.objectContaining({
+        credentials: expect.objectContaining({ token: 'access-token' }),
+      }),
+    );
+    expect(services.gitCredentials.create).not.toHaveBeenCalled();
+  });
+
+  it('falls back to creating a new credential if the reauthorized credentialId no longer exists', async () => {
+    const provider = makeProvider();
+    vi.mocked(services.gitCredentials.getById).mockResolvedValue(null);
+
+    const { state } = await provider.initiateOAuth('git_creds_deleted');
+    await provider.completeOAuth('some-code', state);
+
+    expect(services.gitCredentials.getById).toHaveBeenCalledWith('git_creds_deleted');
+    expect(services.gitCredentials.create).toHaveBeenCalledTimes(1);
+    expect(services.gitCredentials.update).not.toHaveBeenCalled();
+  });
+
+  it('falls back to creating a new credential if the reauthorized id belongs to a different provider', async () => {
+    const provider = makeProvider();
+    const gitlabCredential = {
+      _id: 'git_creds_gitlab',
+      type: 'GitCredentials',
+      provider: 'gitlab',
+      name: 'GitLab Credential',
+      author: { email: 'gl@example.com', name: 'GL', avatarUrl: '' },
+      credentials: { token: 'gl-token' },
+    };
+    vi.mocked(services.gitCredentials.getById).mockResolvedValue(gitlabCredential as never);
+
+    const { state } = await provider.initiateOAuth(gitlabCredential._id);
+    await provider.completeOAuth('some-code', state);
+
+    expect(services.gitCredentials.create).toHaveBeenCalledTimes(1);
+    expect(services.gitCredentials.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects completion with an unrecognized state and does not touch the database', async () => {
+    const provider = makeProvider();
+
+    const result = await provider.completeOAuth('some-code', 'unknown-state');
+
+    expect(result.success).toBe(false);
+    expect(services.gitCredentials.getById).not.toHaveBeenCalled();
+    expect(services.gitCredentials.create).not.toHaveBeenCalled();
+    expect(services.gitCredentials.update).not.toHaveBeenCalled();
+  });
+});

--- a/packages/insomnia/src/sync/git/providers/__tests__/gitlab.test.ts
+++ b/packages/insomnia/src/sync/git/providers/__tests__/gitlab.test.ts
@@ -1,0 +1,174 @@
+import type * as insomniaData from 'insomnia-data';
+import { services } from 'insomnia-data';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GitLabProvider } from '../gitlab';
+
+// vitest.config.ts aliases 'electron/main' to 'electron', so both `import { shell }
+// from 'electron'` and `import { net } from 'electron/main'` resolve to this one mock.
+vi.mock('electron', () => ({
+  shell: { openExternal: vi.fn(() => Promise.resolve()) },
+  net: { fetch: vi.fn() },
+}));
+
+vi.mock('insomnia-data', async importOriginal => {
+  const actual = await importOriginal<typeof insomniaData>();
+  return {
+    ...actual,
+    services: {
+      ...actual.services,
+      gitCredentials: {
+        getById: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+      },
+    },
+  };
+});
+
+const jsonResponse = (body: unknown) => Promise.resolve({ ok: true, json: () => Promise.resolve(body) } as Response);
+
+function mockGitlabApi(email = 'user@example.com') {
+  return vi.fn((input: unknown) => {
+    const url = String(input);
+
+    if (url.includes('/v1/oauth/gitlab/config')) {
+      return jsonResponse({ applicationId: 'client-id', redirectUri: 'https://app.insomnia.rest/oauth/gitlab' });
+    }
+    if (url.includes('/oauth/token')) {
+      return jsonResponse({ access_token: 'access-token', refresh_token: 'refresh-token' });
+    }
+    if (url.endsWith('/user/emails')) {
+      return jsonResponse([{ email }]);
+    }
+    if (url.endsWith('/user')) {
+      return jsonResponse({ id: 1, username: 'octocat', name: 'Octo Cat', avatar_url: 'avatar-url', email });
+    }
+
+    return Promise.resolve({ ok: false, statusText: 'not found' } as Response);
+  });
+}
+
+function makeProvider() {
+  return new GitLabProvider({
+    type: 'gitlab',
+    displayName: 'GitLab',
+    instanceUrl: 'https://gitlab.com',
+    apiUrl: 'https://gitlab.com/api/v4',
+  });
+}
+
+describe('GitLabProvider OAuth create-vs-update', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { net } = await import('electron');
+    vi.mocked(net.fetch).mockImplementation(mockGitlabApi());
+    // completeOAuth reads `._id` off whatever create()/update() resolve to
+    // (to reset renewal tracking), regardless of which branch ran.
+    vi.mocked(services.gitCredentials.create).mockResolvedValue({ _id: 'git_creds_created' } as never);
+    vi.mocked(services.gitCredentials.update).mockResolvedValue({ _id: 'git_creds_updated' } as never);
+  });
+
+  it('creates a new credential when "Add Credential" is used, without looking up any existing one', async () => {
+    const provider = makeProvider();
+    const { state } = await provider.initiateOAuth();
+
+    const result = await provider.completeOAuth('some-code', state);
+
+    expect(result.success).toBe(true);
+    expect(services.gitCredentials.getById).not.toHaveBeenCalled();
+    expect(services.gitCredentials.create).toHaveBeenCalledTimes(1);
+    expect(services.gitCredentials.create).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: 'gitlab' }),
+    );
+    expect(services.gitCredentials.update).not.toHaveBeenCalled();
+  });
+
+  it('creates a second, distinct credential when a different account is authorized via "Add Credential"', async () => {
+    const provider = makeProvider();
+    const { net } = await import('electron');
+
+    vi.mocked(net.fetch).mockImplementation(mockGitlabApi('account-a@example.com'));
+    const { state: stateA } = await provider.initiateOAuth();
+    await provider.completeOAuth('code-a', stateA);
+
+    vi.mocked(net.fetch).mockImplementation(mockGitlabApi('account-b@example.com'));
+    const { state: stateB } = await provider.initiateOAuth();
+    await provider.completeOAuth('code-b', stateB);
+
+    expect(services.gitCredentials.create).toHaveBeenCalledTimes(2);
+    expect(services.gitCredentials.update).not.toHaveBeenCalled();
+  });
+
+  it('updates the exact credential being reauthorized when a credentialId is supplied', async () => {
+    const provider = makeProvider();
+    const existing = {
+      _id: 'git_creds_existing',
+      type: 'GitCredentials',
+      provider: 'gitlab',
+      name: 'GitLab Credential',
+      author: { email: 'old@example.com', name: 'Old', avatarUrl: '' },
+      credentials: { token: 'old-token', refreshToken: 'old-refresh', emails: [], selectedEmail: 'old@example.com' },
+    };
+    vi.mocked(services.gitCredentials.getById).mockResolvedValue(existing as never);
+    vi.mocked(services.gitCredentials.update).mockResolvedValue(existing as never);
+
+    const { state } = await provider.initiateOAuth(existing._id);
+    const result = await provider.completeOAuth('some-code', state);
+
+    expect(result.success).toBe(true);
+    expect(services.gitCredentials.getById).toHaveBeenCalledWith(existing._id);
+    expect(services.gitCredentials.update).toHaveBeenCalledTimes(1);
+    expect(services.gitCredentials.update).toHaveBeenCalledWith(
+      existing,
+      expect.objectContaining({
+        credentials: expect.objectContaining({ token: 'access-token', refreshToken: 'refresh-token' }),
+      }),
+    );
+    expect(services.gitCredentials.create).not.toHaveBeenCalled();
+  });
+
+  it('falls back to creating a new credential if the reauthorized credentialId no longer exists', async () => {
+    const provider = makeProvider();
+    vi.mocked(services.gitCredentials.getById).mockResolvedValue(null);
+    vi.mocked(services.gitCredentials.create).mockResolvedValue({ _id: 'git_creds_new' } as never);
+
+    const { state } = await provider.initiateOAuth('git_creds_deleted');
+    await provider.completeOAuth('some-code', state);
+
+    expect(services.gitCredentials.getById).toHaveBeenCalledWith('git_creds_deleted');
+    expect(services.gitCredentials.create).toHaveBeenCalledTimes(1);
+    expect(services.gitCredentials.update).not.toHaveBeenCalled();
+  });
+
+  it('falls back to creating a new credential if the reauthorized id belongs to a different provider', async () => {
+    const provider = makeProvider();
+    const githubCredential = {
+      _id: 'git_creds_github',
+      type: 'GitCredentials',
+      provider: 'github',
+      name: 'GitHub Credential',
+      author: { email: 'gh@example.com', name: 'GH', avatarUrl: '' },
+      credentials: { token: 'gh-token' },
+    };
+    vi.mocked(services.gitCredentials.getById).mockResolvedValue(githubCredential as never);
+    vi.mocked(services.gitCredentials.create).mockResolvedValue({ _id: 'git_creds_new' } as never);
+
+    const { state } = await provider.initiateOAuth(githubCredential._id);
+    await provider.completeOAuth('some-code', state);
+
+    expect(services.gitCredentials.create).toHaveBeenCalledTimes(1);
+    expect(services.gitCredentials.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects completion with an unrecognized state and does not touch the database', async () => {
+    const provider = makeProvider();
+
+    const result = await provider.completeOAuth('some-code', 'unknown-state');
+
+    expect(result.success).toBe(false);
+    expect(services.gitCredentials.getById).not.toHaveBeenCalled();
+    expect(services.gitCredentials.create).not.toHaveBeenCalled();
+    expect(services.gitCredentials.update).not.toHaveBeenCalled();
+  });
+});

--- a/packages/insomnia/src/sync/git/providers/github.ts
+++ b/packages/insomnia/src/sync/git/providers/github.ts
@@ -23,9 +23,10 @@ const { isGitCredentialsV2 } = models.gitCredentials;
 
 /**
  * OAuth state cache for security validation
- * Stores states that are generated for the OAuth flow to verify callback legitimacy
+ * Stores states that are generated for the OAuth flow to verify callback legitimacy,
+ * mapped to the credential ID being reauthorized (undefined when adding a fresh credential).
  */
-const githubStatesCache = new Set<string>();
+const githubStatesCache = new Map<string, string | undefined>();
 
 type GitHubCredentialV2 = Extract<GitCredentialsV2, { provider: 'github' }>;
 
@@ -262,10 +263,10 @@ export class GitHubProvider implements GitRemoteProvider<GitHubProviderConfig> {
    * Initiate OAuth flow
    * Opens the browser to GitHub OAuth page and manages state for security
    */
-  async initiateOAuth(): Promise<OAuthInitResult> {
+  async initiateOAuth(credentialId?: string): Promise<OAuthInitResult> {
     try {
       const state = v4();
-      githubStatesCache.add(state);
+      githubStatesCache.set(state, credentialId);
       const url = new URL(getAppWebsiteBaseURL() + '/oauth/github-app');
 
       url.search = new URLSearchParams({
@@ -295,6 +296,7 @@ export class GitHubProvider implements GitRemoteProvider<GitHubProviderConfig> {
       if (!PLAYWRIGHT_TEST && !githubStatesCache.has(state)) {
         throw new Error('Invalid state parameter. It looks like the authorization flow was not initiated by the app.');
       }
+      const reauthorizingCredentialId = githubStatesCache.get(state);
 
       // Exchange code for access token via Insomnia backend
       const response = await net.fetch(getApiBaseURL() + '/v1/oauth/github-app', {
@@ -333,31 +335,22 @@ export class GitHubProvider implements GitRemoteProvider<GitHubProviderConfig> {
       const credentials = {
         token: data.access_token,
         emails,
-        // Ensure the credential has a selectedEmail for consistent matching later.
         selectedEmail: email || undefined,
         ...(accessTokenExpiresAt !== undefined ? { expiresAt: accessTokenExpiresAt } : {}),
       };
 
-      // Upsert: update the existing GitHub credential when we can reliably identify it.
-      // Otherwise, create a new credential to avoid overwriting a different account.
-      const existingGitHubCredentials = (await services.gitCredentials.all()).filter(
-        (c): c is GitHubCredentialV2 => isGitCredentialsV2(c) && c.provider === 'github',
-      );
-
-      const matchingByEmail = email
-        ? existingGitHubCredentials
-            .filter(c => {
-              return (
-                c.author.email === email ||
-                c.credentials.selectedEmail === email ||
-                c.credentials.emails?.some(e => e.email === email)
-              );
-            })
-            .sort((a, b) => (b.modified ?? 0) - (a.modified ?? 0))
-        : [];
-
-      const existing =
-        matchingByEmail[0] || (existingGitHubCredentials.length === 1 ? existingGitHubCredentials[0] : undefined);
+      // Update the credential this flow was explicitly reauthorizing (see
+      // GitEditProviderOAuthForm's "Reauthorize" button), if any. Otherwise this is
+      // an "Add Credential" flow, so always create a new credential — never guess
+      // at an existing one to update, or a second account for this provider could
+      // silently overwrite the first.
+      const existingCredential = reauthorizingCredentialId
+        ? await services.gitCredentials.getById(reauthorizingCredentialId)
+        : null;
+      const existing: GitHubCredentialV2 | undefined =
+        existingCredential && isGitCredentialsV2(existingCredential) && existingCredential.provider === 'github'
+          ? existingCredential
+          : undefined;
 
       await (existing
         ? services.gitCredentials.update(existing, {

--- a/packages/insomnia/src/sync/git/providers/gitlab.ts
+++ b/packages/insomnia/src/sync/git/providers/gitlab.ts
@@ -30,9 +30,10 @@ const { isGitCredentialsV2 } = models.gitCredentials;
 
 /**
  * OAuth state cache for security validation with PKCE verifiers
- * Maps state -> code_verifier for GitLab PKCE flow
+ * Maps state -> code_verifier (for GitLab PKCE flow) and the credential ID being
+ * reauthorized, if any (undefined when adding a fresh credential).
  */
-const gitlabStatesCache = new Map<string, string>();
+const gitlabStatesCache = new Map<string, { verifier: string; credentialId?: string }>();
 
 type GitLabCredentialV2 = Extract<GitCredentialsV2, { provider: 'gitlab' }>;
 
@@ -331,11 +332,11 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
    * Initiate OAuth flow with PKCE
    * Opens the browser to GitLab OAuth page and manages state for security
    */
-  async initiateOAuth(): Promise<OAuthInitResult> {
+  async initiateOAuth(credentialId?: string): Promise<OAuthInitResult> {
     try {
       const state = v4();
       const verifier = base64URLEncode(randomBytes(32));
-      gitlabStatesCache.set(state, verifier);
+      gitlabStatesCache.set(state, { verifier, credentialId });
 
       const scopes = [
         // Needed to read the user's email address, username and avatar_url from the /user GitLab API
@@ -380,7 +381,8 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
   async completeOAuth(code: string, state: string): Promise<OAuthCompleteResult> {
     try {
       // Validate state and get verifier for PKCE
-      let verifier = gitlabStatesCache.get(state);
+      let verifier = gitlabStatesCache.get(state)?.verifier;
+      const reauthorizingCredentialId = gitlabStatesCache.get(state)?.credentialId;
 
       if (PLAYWRIGHT_TEST) {
         verifier = 'test-verifier';
@@ -436,24 +438,18 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
         ...(accessTokenExpiresAt !== undefined ? { expiresAt: accessTokenExpiresAt } : {}),
       };
 
-      // Upsert: update the existing GitLab credential when we can reliably identify it.
-      // Otherwise, create a new credential to avoid overwriting a different account.
-      const existingGitLabCredentials = (await services.gitCredentials.all()).filter(
-        (c): c is GitLabCredentialV2 => isGitCredentialsV2(c) && c.provider === 'gitlab',
-      );
-
-      const matchingByEmail = existingGitLabCredentials
-        .filter(c => {
-          return (
-            c.author.email === email ||
-            c.credentials.selectedEmail === email ||
-            c.credentials.emails?.some(e => e.email === email)
-          );
-        })
-        .sort((a, b) => (b.modified ?? 0) - (a.modified ?? 0));
-
-      const existing =
-        matchingByEmail[0] || (existingGitLabCredentials.length === 1 ? existingGitLabCredentials[0] : undefined);
+      // Update the credential this flow was explicitly reauthorizing (see
+      // GitEditProviderOAuthForm's "Reauthorize" button), if any. Otherwise this is
+      // an "Add Credential" flow, so always create a new credential — never guess
+      // at an existing one to update, or a second account for this provider could
+      // silently overwrite the first.
+      const existingCredential = reauthorizingCredentialId
+        ? await services.gitCredentials.getById(reauthorizingCredentialId)
+        : null;
+      const existing: GitLabCredentialV2 | undefined =
+        existingCredential && isGitCredentialsV2(existingCredential) && existingCredential.provider === 'gitlab'
+          ? existingCredential
+          : undefined;
 
       const credential = await (existing
         ? services.gitCredentials.update(existing, {

--- a/packages/insomnia/src/sync/git/providers/types.ts
+++ b/packages/insomnia/src/sync/git/providers/types.ts
@@ -170,9 +170,12 @@ export interface GitRemoteProvider<TConfig extends BaseProviderConfig = BaseProv
 
   /**
    * Initiate OAuth flow
-   * Only for providers that support OAuth
+   * Only for providers that support OAuth. When `credentialId` is provided, the
+   * flow is reauthorizing that specific existing credential rather than adding a
+   * new one — completeOAuth uses it to update that exact credential instead of
+   * guessing which (if any) existing credential to update.
    */
-  initiateOAuth?(): Promise<OAuthInitResult>;
+  initiateOAuth?(credentialId?: string): Promise<OAuthInitResult>;
 
   /**
    * Complete OAuth flow

--- a/packages/insomnia/src/ui/components/settings/credentials.tsx
+++ b/packages/insomnia/src/ui/components/settings/credentials.tsx
@@ -158,7 +158,7 @@ const GitEditProviderOAuthForm = ({
               className="text-(--color-surprise)"
               onPress={() => {
                 setIsAuthenticating(true);
-                initSignInFetcher.submit({ provider: provider.type });
+                initSignInFetcher.submit({ provider: provider.type, credentialId: gitCredentialToEdit?._id });
               }}
             >
               Reauthorize


### PR DESCRIPTION
## Summary

Authorizing a second, different account for the same Git provider (e.g. a
second GitHub account) silently overwrote the first credential instead of
adding a new one, because `completeOAuth` picked an existing credential to
update by guessing — matching on email, or falling back to "the only existing
credential for this provider" if there was exactly one.

- Replaces that guesswork with an explicit `credentialId`, threaded through
  the OAuth flow (`initiateOAuth(credentialId)` → OAuth state cache →
  `completeOAuth`) so the update path only ever fires when the user explicitly
  clicked **Reauthorize** on an existing credential.
- "Add Credential" now always creates a new row, regardless of how many
  credentials already exist for that provider or what email the new account
  uses.
- Applies to both the GitHub and GitLab providers.
- Adds unit tests covering the create-vs-update branching (new credential,
  second distinct credential, reauthorize-by-id, stale/cross-provider id
  fallback, invalid OAuth state).

## Test plan

- [x] `npm test -w packages/insomnia -- src/sync/git/providers/__tests__/github.test.ts src/sync/git/providers/__tests__/gitlab.test.ts` — 12/12 passing
- [x] `npm run lint` on changed files — clean
- [x] `tsc --noEmit` on changed files — no errors
- [ ] Manual: Settings > Git Credentials > Add Credential > GitHub, authorize Account A → Add Credential > GitHub again, authorize Account B → verify two separate credential rows exist
- [ ] Manual: open an existing credential's edit view and click Reauthorize → verify it updates that same row instead of creating a new one

