### PR TITLE
feat(templating): (S1) capability & bridge-handler scoping audit

### DIFF
--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -44,7 +44,9 @@
     "sandbox:surface": "vitest run src/templating/sandbox/print-sandbox-surface.test.ts",
     "sandbox:surface:test": "vitest run src/templating/sandbox/sandbox-surface.test.ts",
     "sandbox:bridge-trust": "vitest run src/main/__tests__/print-templating-worker-database-surface.test.ts",
-    "sandbox:bridge-trust:test": "vitest run src/main/__tests__/templating-worker-database-surface.test.ts"
+    "sandbox:bridge-trust:test": "vitest run src/main/__tests__/templating-worker-database-surface.test.ts",
+    "sandbox:bridge-inventory": "vitest run src/main/__tests__/print-templating-worker-database-inventory.test.ts",
+    "sandbox:bridge-inventory:test": "vitest run src/main/__tests__/templating-worker-database-inventory.test.ts"
   },
   "dependencies": {
     "@apideck/better-ajv-errors": "^0.3.6",

--- a/packages/insomnia/src/main/__tests__/print-templating-worker-database-inventory.test.ts
+++ b/packages/insomnia/src/main/__tests__/print-templating-worker-database-inventory.test.ts
@@ -1,0 +1,15 @@
+import { expect, it } from 'vitest';
+
+import { formatInventory, hostOnlyInventory, pluginFacingInventory } from '../templating-worker-database-inventory';
+
+// Not a regression check — prints the handler scoping inventory as a table for eyeballing.
+// The authoritative gates live in templating-worker-database-inventory.test.ts.
+it('prints the bridge-handler scoping inventory', () => {
+  const lines = formatInventory();
+  console.log(`${'path'.padEnd(38)} ${'side-effect'.padEnd(22)} ${'capability'.padEnd(14)} guards`);
+  console.log(lines.join('\n'));
+  console.log(
+    `\n${pluginFacingInventory().length} plugin-facing (capability-gated), ${hostOnlyInventory().length} host-only (directly dispatchable)`,
+  );
+  expect(lines.length).toBeGreaterThan(0);
+});

--- a/packages/insomnia/src/main/__tests__/templating-worker-database-inventory.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database-inventory.test.ts
@@ -107,4 +107,32 @@ describe('S1: bridge-handler scoping inventory', () => {
       expect(e.guards, `${e.path} writes files but has no ownership guard`).toContain('body-path-ownership');
     }
   });
+
+  it('blast radius text names the concrete data each baseline (zero-manifest) handler discloses', () => {
+    // oAuth2Token.getByRequestId returns live bearer tokens (o-auth-2-token.ts's accessToken/
+    // refreshToken/identityToken fields) through the 'models.read' baseline capability, granted to
+    // every plugin with no manifest — its classification and wording should reflect a credential
+    // disclosure, not generic model metadata.
+    const oauth = HANDLER_INVENTORY.find(e => e.path === 'oAuth2Token.getByRequestId');
+    expect(oauth?.sideEffect).toBe('credential');
+    expect(oauth?.blastRadius.toLowerCase()).toMatch(/access.*token|refresh.*token/);
+
+    // nodeOS discloses real host-identifying state: hostname and os.userInfo() (username/homedir/shell).
+    const nodeOS = HANDLER_INVENTORY.find(e => e.path === 'nodeOS');
+    expect(nodeOS?.blastRadius.toLowerCase()).toMatch(/hostname/);
+    expect(nodeOS?.blastRadius.toLowerCase()).toMatch(/userinfo|username/);
+
+    // These three call a getOrCreate service function, so their wording should name the persisted
+    // write alongside the read.
+    for (const path of ['cookieJar.getOrCreateForParentId', 'cookieJar.getCookiesForUrl', 'settings.get']) {
+      const e = HANDLER_INVENTORY.find(x => x.path === path);
+      expect(e?.blastRadius.toLowerCase(), `${path} blastRadius should mention its get-or-create side effect`).toMatch(/creat/);
+    }
+
+    // response.getBodyBuffer's read-side ownership check is existence-only (no identity/parentId
+    // comparison), unlike response.setBody's write-side check — its wording should name both
+    // possibilities rather than implying the two guards are equivalent.
+    const getBodyBuffer = HANDLER_INVENTORY.find(e => e.path === 'response.getBodyBuffer');
+    expect(getBodyBuffer?.blastRadius.toLowerCase()).toMatch(/any known response|arbitrary file/);
+  });
 });

--- a/packages/insomnia/src/main/__tests__/templating-worker-database-inventory.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database-inventory.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { BRIDGE_PATH_CAPABILITIES } from '../../templating/sandbox/host-bridge';
+import { HANDLER_INVENTORY, NON_DB_BRIDGE_PATHS } from '../templating-worker-database-inventory';
+import { findUnguardedBodyPathWrites } from '../templating-worker-database-surface';
+
+// Same mock surface as templating-worker-database-surface.test.ts: importing pluginToMainAPI pulls in
+// electron + insomnia-data, which aren't available under vitest.
+vi.mock('electron', () => ({
+  app: { getVersion: () => '1.0.0', getPath: () => '/fake/userData' },
+  clipboard: { readText: vi.fn(), writeText: vi.fn(), clear: vi.fn() },
+  dialog: { showMessageBox: vi.fn() },
+  shell: { openExternal: vi.fn() },
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+vi.mock('insomnia-data', () => ({
+  services: {
+    request: { getById: vi.fn() },
+    workspace: { getById: vi.fn() },
+    oAuth2Token: { getByParentId: vi.fn() },
+    cookieJar: { getOrCreateForParentId: vi.fn() },
+    response: { getLatestForRequestId: vi.fn(), getByBodyPath: vi.fn() },
+    helpers: { getResponseBodyBuffer: vi.fn() },
+    pluginData: { getByKey: vi.fn(), upsertByKey: vi.fn(), removeByKey: vi.fn(), removeAll: vi.fn(), all: vi.fn() },
+    cloudCredential: { getById: vi.fn(), update: vi.fn() },
+    settings: { get: vi.fn().mockResolvedValue({}) },
+  },
+}));
+vi.mock('~/plugins', () => ({
+  getPluginCommonContext: vi.fn(),
+  getTemplateTags: vi.fn().mockResolvedValue([]),
+  getPlugins: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('~/common/cookies', () => ({ jarFromCookies: vi.fn() }));
+vi.mock('../common/database', () => ({ database: {} }));
+vi.mock('../network/network', () => ({
+  fetchRequestData: vi.fn(),
+  sendCurlAndWriteTimeline: vi.fn(),
+  tryToInterpolateRequest: vi.fn(),
+}));
+vi.mock('../network/libcurl-promise', () => ({ curlRequest: vi.fn() }));
+vi.mock('../prompt-bridge', () => ({ requestPromptFromRenderer: vi.fn() }));
+vi.mock('../secure-read-file', () => ({ secureReadFile: vi.fn() }));
+
+const loadHandlerKeys = async (): Promise<string[]> => {
+  const { pluginToMainAPI } = await import('../templating-worker-database');
+  return Object.keys(pluginToMainAPI);
+};
+
+describe('S1: bridge-handler scoping inventory', () => {
+  it('G1 — covers exactly the live pluginToMainAPI handler set (no drift)', async () => {
+    const liveKeys = (await loadHandlerKeys()).sort();
+    const inventoryKeys = HANDLER_INVENTORY.map(e => e.path).sort();
+    // A new handler with no inventory row, or a stale row for a removed handler, fails here.
+    expect(inventoryKeys).toEqual(liveKeys);
+  });
+
+  it('G1b — has no duplicate rows', () => {
+    const keys = HANDLER_INVENTORY.map(e => e.path);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('G2 — each row’s capability matches BRIDGE_PATH_CAPABILITIES exactly (null iff host-only)', () => {
+    for (const e of HANDLER_INVENTORY) {
+      const mapped = BRIDGE_PATH_CAPABILITIES[e.path] ?? null;
+      expect(e.capability, `capability mismatch for ${e.path}`).toBe(mapped);
+    }
+  });
+
+  it('G3 — no blanks: every row has ≥1 guard and a blast radius', () => {
+    for (const e of HANDLER_INVENTORY) {
+      expect(e.guards.length, `${e.path} has no guard`).toBeGreaterThan(0);
+      expect(e.blastRadius.trim().length, `${e.path} has no blast radius`).toBeGreaterThan(0);
+    }
+  });
+
+  it('G3b — plugin-facing rows are capability-gated; host-only rows never rely on the (bypassable) capability', () => {
+    for (const e of HANDLER_INVENTORY) {
+      if (e.capability !== null) {
+        // Reachable from inside the sandbox → must be bridge-gated.
+        expect(e.guards, `plugin-facing ${e.path} must list 'capability'`).toContain('capability');
+      } else {
+        // Directly dispatchable, not capability-gated: kwburns' #10286 lesson — the bridge capability
+        // is NOT a defense here, so a host-only handler must name a real inline guard instead.
+        expect(e.guards, `host-only ${e.path} must not claim 'capability' as a guard`).not.toContain('capability');
+        expect(
+          e.guards.some(g => g !== 'none'),
+          `host-only ${e.path} must name a real guard`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('G4 — every capability path maps to a live handler (or a known non-DB bridge path)', async () => {
+    const liveKeys = new Set(await loadHandlerKeys());
+    for (const path of Object.keys(BRIDGE_PATH_CAPABILITIES)) {
+      const known = liveKeys.has(path) || NON_DB_BRIDGE_PATHS.includes(path);
+      expect(known, `capability path '${path}' has no handler and is not an allowlisted non-DB bridge path`).toBe(true);
+    }
+  });
+
+  it('G5 — no file-write handler reaches its write with an unguarded caller bodyPath', async () => {
+    const { pluginToMainAPI } = await import('../templating-worker-database');
+    // Cross-check the static write detector against the rows we classified as fs-write.
+    expect(findUnguardedBodyPathWrites(pluginToMainAPI)).toEqual([]);
+    for (const e of HANDLER_INVENTORY.filter(e => e.sideEffect === 'fs-write')) {
+      expect(e.guards, `${e.path} writes files but has no ownership guard`).toContain('body-path-ownership');
+    }
+  });
+});

--- a/packages/insomnia/src/main/templating-worker-database-inventory.ts
+++ b/packages/insomnia/src/main/templating-worker-database-inventory.ts
@@ -17,8 +17,8 @@
 
 /** What a handler can touch. Drives which guards are mandatory. */
 export type SideEffectClass =
-  | 'pure' // compute only, no host state
-  | 'model-read' // reads a DB model (request/workspace/cookieJar/response/settings)
+  | 'pure' // no host mutation: pure compute, or a read-only host-info snapshot (e.g. nodeOS discloses OS/arch)
+  | 'model-read' // reads (or lazily get-or-creates, e.g. cookieJar.getOrCreateForParentId) a DB model
   | 'fs-read' // reads a file off disk
   | 'fs-write' // writes a file to disk
   | 'network' // makes an outbound network request
@@ -62,7 +62,7 @@ export interface HandlerInventoryEntry {
 export const NON_DB_BRIDGE_PATHS = ['util.render'];
 
 export const HANDLER_INVENTORY: HandlerInventoryEntry[] = [
-  // --- util (pure compute) ---
+  // --- util (pure compute; nodeOS is a read-only host-info snapshot) ---
   {
     path: 'nodeOS',
     // Reads host state (hostname, current OS user) rather than computing something from its
@@ -117,7 +117,7 @@ export const HANDLER_INVENTORY: HandlerInventoryEntry[] = [
     sideEffect: 'model-read',
     capability: 'models.read',
     guards: ['capability'],
-    blastRadius: 'reads a workspace\'s cookie jar, creating an empty one if none exists yet',
+    blastRadius: "reads a workspace's cookie jar, creating an empty one if none exists yet",
   },
   {
     path: 'cookieJar.getCookiesForUrl',
@@ -154,7 +154,7 @@ export const HANDLER_INVENTORY: HandlerInventoryEntry[] = [
     // parentId. It stops path traversal outside the responses directory, not a caller reading a
     // different, already-known response's body once it has that response's bodyPath.
     guards: ['capability', 'body-path-ownership'],
-    blastRadius: 'reads any known response\'s body by its bodyPath, or an arbitrary file if that check is not enforced',
+    blastRadius: "reads any known response's body by its bodyPath, or an arbitrary file if that check is not enforced",
   },
   {
     path: 'response.setBody',
@@ -243,7 +243,7 @@ export const HANDLER_INVENTORY: HandlerInventoryEntry[] = [
     sideEffect: 'credential',
     capability: 'models.read',
     guards: ['capability'],
-    blastRadius: 'discloses live OAuth2 access/refresh/identity tokens for a request\'s configured provider',
+    blastRadius: "discloses live OAuth2 access/refresh/identity tokens for a request's configured provider",
   },
 
   // --- credentials ---

--- a/packages/insomnia/src/main/templating-worker-database-inventory.ts
+++ b/packages/insomnia/src/main/templating-worker-database-inventory.ts
@@ -1,4 +1,4 @@
-// S1: the checked-in scoping inventory for every protocol-dispatch handler in `pluginToMainAPI`.
+// The checked-in scoping inventory for every protocol-dispatch handler in `pluginToMainAPI`.
 //
 // Two classes of handler share that map, and only the first is capability-gated:
 //   1. Plugin-facing bridge calls — reachable from inside the sandbox via `__bridge`, gated by
@@ -31,7 +31,11 @@ export type SideEffectClass =
 export type Guard =
   | 'capability' // gated by BRIDGE_PATH_CAPABILITIES at the in-sandbox bridge (filterByCapabilities)
   | 'path-allowlist' // caller path constrained to a secured-folder allowlist (secureReadFile)
-  | 'body-path-ownership' // caller bodyPath must belong to the claimed response (assert*BodyPath*Ownership)
+  // caller bodyPath must belong to *a* known response (assertResponseBodyPathReadOwnership, read side:
+  // existence-only, no identity comparison) or to *the specific claimed* response
+  // (assertResponseBodyPathOwnership, write side: also compares parentId) — see the two rows below,
+  // read and write are not equally strict despite sharing this guard name.
+  | 'body-path-ownership'
   | 'trusted-plugin' // plugin identity re-resolved from the registry, never caller-supplied (resolveTrustedPlugin)
   | 'bundle-allowlist' // only first-party bundle plugins (getAppBundlePlugins / appBundlePluginNames)
   | 'registry-lookup' // target resolved from the trusted getTemplateTags/getX registry, not caller input
@@ -49,7 +53,7 @@ export interface HandlerInventoryEntry {
   capability: string | null;
   /** Everything that protects this handler. A directly-dispatchable I/O handler needs more than 'capability'. */
   guards: Guard[];
-  /** One line: what an attacker gains if the guard(s) fail. */
+  /** One line: what becomes reachable if the guard(s) fail. */
   blastRadius: string;
 }
 
@@ -61,10 +65,13 @@ export const HANDLER_INVENTORY: HandlerInventoryEntry[] = [
   // --- util (pure compute) ---
   {
     path: 'nodeOS',
+    // Reads host state (hostname, current OS user) rather than computing something from its
+    // arguments; kept in 'util' alongside decode/encode since baseline callers already reach the
+    // same data via the built-in `os` template tag (host-bridge.ts's TEMPLATE_TAG_BASELINE_CAPABILITIES).
     sideEffect: 'pure',
     capability: 'util',
     guards: ['capability'],
-    blastRadius: 'discloses host OS/arch strings',
+    blastRadius: 'discloses hostname, OS user (os.userInfo(): username/homedir/shell), arch/platform/cpu info',
   },
   {
     path: 'decode',
@@ -105,17 +112,20 @@ export const HANDLER_INVENTORY: HandlerInventoryEntry[] = [
   },
   {
     path: 'cookieJar.getOrCreateForParentId',
+    // getOrCreateForParentId (cookie-jar.ts) creates a new jar document when none exists — a
+    // get-or-create, not a pure read.
     sideEffect: 'model-read',
     capability: 'models.read',
     guards: ['capability'],
-    blastRadius: 'reads/creates a cookie jar for a workspace',
+    blastRadius: 'reads a workspace\'s cookie jar, creating an empty one if none exists yet',
   },
   {
     path: 'cookieJar.getCookiesForUrl',
+    // Same getOrCreateForParentId call underneath — also a get-or-create, not a pure read.
     sideEffect: 'model-read',
     capability: 'models.read',
     guards: ['capability'],
-    blastRadius: 'reads cookies matching a url',
+    blastRadius: 'reads cookies matching a url, creating an empty cookie jar if none exists yet',
   },
   {
     path: 'response.getLatestForRequestId',
@@ -126,10 +136,11 @@ export const HANDLER_INVENTORY: HandlerInventoryEntry[] = [
   },
   {
     path: 'settings.get',
+    // services.settings.get() is a getOrCreate() — creates the Settings singleton on first access.
     sideEffect: 'model-read',
     capability: 'models.read',
     guards: ['capability'],
-    blastRadius: 'reads app settings',
+    blastRadius: 'reads app settings, creating the settings document if none exists yet',
   },
 
   // --- response body I/O (file-backed, caller-supplied bodyPath → ownership-checked) ---
@@ -137,8 +148,13 @@ export const HANDLER_INVENTORY: HandlerInventoryEntry[] = [
     path: 'response.getBodyBuffer',
     sideEffect: 'fs-read',
     capability: 'models.read',
+    // Read-side guard (assertResponseBodyPathReadOwnership) only confirms the bodyPath belongs to
+    // *some* persisted response, not that it belongs to the response the caller claims to be
+    // operating on — weaker than the write-side guard on response.setBody below, which also checks
+    // parentId. It stops path traversal outside the responses directory, not a caller reading a
+    // different, already-known response's body once it has that response's bodyPath.
     guards: ['capability', 'body-path-ownership'],
-    blastRadius: 'reads an arbitrary file if bodyPath ownership is not enforced',
+    blastRadius: 'reads any known response\'s body by its bodyPath, or an arbitrary file if that check is not enforced',
   },
   {
     path: 'response.setBody',
@@ -217,13 +233,17 @@ export const HANDLER_INVENTORY: HandlerInventoryEntry[] = [
     blastRadius: 'SSRF / arbitrary outbound request',
   },
 
-  // --- model reads (continued: OAuth tokens scoped to request) ---
+  // --- credentials (OAuth tokens, gated by the models.read baseline capability) ---
   {
     path: 'oAuth2Token.getByRequestId',
-    sideEffect: 'model-read',
+    // The returned OAuth2Token document (o-auth-2-token.ts) carries live accessToken/refreshToken/
+    // identityToken values — bearer credentials for the request's configured OAuth2 provider.
+    // Classified 'credential', like cloudCredential.*, since both disclose equivalent-sensitivity
+    // bearer material regardless of which capability group gates the handler.
+    sideEffect: 'credential',
     capability: 'models.read',
     guards: ['capability'],
-    blastRadius: 'reads OAuth2 tokens associated with a request',
+    blastRadius: 'discloses live OAuth2 access/refresh/identity tokens for a request\'s configured provider',
   },
 
   // --- credentials ---

--- a/packages/insomnia/src/main/templating-worker-database-inventory.ts
+++ b/packages/insomnia/src/main/templating-worker-database-inventory.ts
@@ -1,0 +1,387 @@
+// S1: the checked-in scoping inventory for every protocol-dispatch handler in `pluginToMainAPI`.
+//
+// Two classes of handler share that map, and only the first is capability-gated:
+//   1. Plugin-facing bridge calls — reachable from inside the sandbox via `__bridge`, gated by
+//      `BRIDGE_PATH_CAPABILITIES` (default-deny; `filterByCapabilities` rejects an unmapped path).
+//   2. Directly-dispatchable orchestration handlers — every `pluginToMainAPI` key is routed by
+//      `resolveDbByKey`, not only the ones reached through a wrapper, so a handler like
+//      `response.setBody` or `plugin.runUserResponseHook` can be invoked straight over the protocol.
+//      These are NOT in the capability map; their safety rests on an inline trust/ownership check.
+//
+// This inventory records, for every handler, its side-effect class, its capability (or null when it's
+// host-only orchestration), the guard(s) that actually protect it, and the blast radius if that guard
+// is wrong. `templating-worker-database-inventory.test.ts` enforces it against the live handler map so
+// it cannot drift: a new handler with no row, a capability that disagrees with `BRIDGE_PATH_CAPABILITIES`,
+// or a directly-dispatchable I/O handler whose only claimed defense is the (bypassable) bridge
+// capability all fail a test rather than shipping.
+
+/** What a handler can touch. Drives which guards are mandatory. */
+export type SideEffectClass =
+  | 'pure' // compute only, no host state
+  | 'model-read' // reads a DB model (request/workspace/cookieJar/response/settings)
+  | 'fs-read' // reads a file off disk
+  | 'fs-write' // writes a file to disk
+  | 'network' // makes an outbound network request
+  | 'credential' // reads or writes stored credentials
+  | 'storage' // reads or writes plugin key/value storage
+  | 'app' // drives a UI/app affordance (dialog, clipboard, open-in-browser)
+  | 'sandbox-orchestration'; // runs/inspects plugin code; host-only, not a plugin-facing capability
+
+/** The mechanism(s) that actually protect a handler. */
+export type Guard =
+  | 'capability' // gated by BRIDGE_PATH_CAPABILITIES at the in-sandbox bridge (filterByCapabilities)
+  | 'path-allowlist' // caller path constrained to a secured-folder allowlist (secureReadFile)
+  | 'body-path-ownership' // caller bodyPath must belong to the claimed response (assert*BodyPath*Ownership)
+  | 'trusted-plugin' // plugin identity re-resolved from the registry, never caller-supplied (resolveTrustedPlugin)
+  | 'bundle-allowlist' // only first-party bundle plugins (getAppBundlePlugins / appBundlePluginNames)
+  | 'registry-lookup' // target resolved from the trusted getTemplateTags/getX registry, not caller input
+  | 'plugin-scoped' // storage keyed/scoped by the owning plugin name
+  | 'none'; // pure — no sensitive sink to guard
+
+export interface HandlerInventoryEntry {
+  /** `pluginToMainAPI` key. */
+  path: string;
+  sideEffect: SideEffectClass;
+  /**
+   * The capability group from `BRIDGE_PATH_CAPABILITIES`, or null when the handler is host-only
+   * orchestration (not reachable from inside the sandbox and not a plugin-declarable capability).
+   */
+  capability: string | null;
+  /** Everything that protects this handler. A directly-dispatchable I/O handler needs more than 'capability'. */
+  guards: Guard[];
+  /** One line: what an attacker gains if the guard(s) fail. */
+  blastRadius: string;
+}
+
+// Capability paths served by a bridge OTHER than the pluginToMainAPI protocol (so they legitimately
+// have no pluginToMainAPI handler). `util.render` is handled by the render bridge / capUtilRenderDepth.
+export const NON_DB_BRIDGE_PATHS = ['util.render'];
+
+export const HANDLER_INVENTORY: HandlerInventoryEntry[] = [
+  // --- util (pure compute) ---
+  {
+    path: 'nodeOS',
+    sideEffect: 'pure',
+    capability: 'util',
+    guards: ['capability'],
+    blastRadius: 'discloses host OS/arch strings',
+  },
+  {
+    path: 'decode',
+    sideEffect: 'pure',
+    capability: 'util',
+    guards: ['capability'],
+    blastRadius: 'none beyond CPU (pure decode)',
+  },
+  {
+    path: 'encode',
+    sideEffect: 'pure',
+    capability: 'util',
+    guards: ['capability'],
+    blastRadius: 'none beyond CPU (pure encode)',
+  },
+
+  // --- model reads ---
+  {
+    path: 'request.getById',
+    sideEffect: 'model-read',
+    capability: 'models.read',
+    guards: ['capability'],
+    blastRadius: 'reads any request document by id',
+  },
+  {
+    path: 'request.getAncestors',
+    sideEffect: 'model-read',
+    capability: 'models.read',
+    guards: ['capability'],
+    blastRadius: 'reads a request ancestry chain',
+  },
+  {
+    path: 'workspace.getById',
+    sideEffect: 'model-read',
+    capability: 'models.read',
+    guards: ['capability'],
+    blastRadius: 'reads any workspace document by id',
+  },
+  {
+    path: 'cookieJar.getOrCreateForParentId',
+    sideEffect: 'model-read',
+    capability: 'models.read',
+    guards: ['capability'],
+    blastRadius: 'reads/creates a cookie jar for a workspace',
+  },
+  {
+    path: 'cookieJar.getCookiesForUrl',
+    sideEffect: 'model-read',
+    capability: 'models.read',
+    guards: ['capability'],
+    blastRadius: 'reads cookies matching a url',
+  },
+  {
+    path: 'response.getLatestForRequestId',
+    sideEffect: 'model-read',
+    capability: 'models.read',
+    guards: ['capability'],
+    blastRadius: 'reads the latest response metadata for a request',
+  },
+  {
+    path: 'settings.get',
+    sideEffect: 'model-read',
+    capability: 'models.read',
+    guards: ['capability'],
+    blastRadius: 'reads app settings',
+  },
+
+  // --- response body I/O (file-backed, caller-supplied bodyPath → ownership-checked) ---
+  {
+    path: 'response.getBodyBuffer',
+    sideEffect: 'fs-read',
+    capability: 'models.read',
+    guards: ['capability', 'body-path-ownership'],
+    blastRadius: 'reads an arbitrary file if bodyPath ownership is not enforced',
+  },
+  {
+    path: 'response.setBody',
+    sideEffect: 'fs-write',
+    capability: 'models.read',
+    guards: ['capability', 'body-path-ownership'],
+    blastRadius: 'overwrites another response body (or arbitrary file) if bodyPath ownership is not enforced',
+  },
+
+  // --- filesystem read (caller path → allowlist-contained) ---
+  {
+    path: 'readFile',
+    sideEffect: 'fs-read',
+    capability: 'fs-read',
+    guards: ['capability', 'path-allowlist'],
+    blastRadius: 'reads an arbitrary file if the secured-folder allowlist is not enforced',
+  },
+
+  // --- storage (plugin-scoped key/value) ---
+  {
+    path: 'pluginData.hasItem',
+    sideEffect: 'storage',
+    capability: 'storage',
+    guards: ['capability', 'plugin-scoped'],
+    blastRadius: 'probes another plugin’s storage keys if not scoped',
+  },
+  {
+    path: 'pluginData.setItem',
+    sideEffect: 'storage',
+    capability: 'storage',
+    guards: ['capability', 'plugin-scoped'],
+    blastRadius: 'writes another plugin’s storage if not scoped',
+  },
+  {
+    path: 'pluginData.getItem',
+    sideEffect: 'storage',
+    capability: 'storage',
+    guards: ['capability', 'plugin-scoped'],
+    blastRadius: 'reads another plugin’s storage if not scoped',
+  },
+  {
+    path: 'pluginData.removeItem',
+    sideEffect: 'storage',
+    capability: 'storage',
+    guards: ['capability', 'plugin-scoped'],
+    blastRadius: 'deletes another plugin’s storage if not scoped',
+  },
+  {
+    path: 'pluginData.clear',
+    sideEffect: 'storage',
+    capability: 'storage',
+    guards: ['capability', 'plugin-scoped'],
+    blastRadius: 'clears another plugin’s storage if not scoped',
+  },
+  {
+    path: 'pluginData.all',
+    sideEffect: 'storage',
+    capability: 'storage',
+    guards: ['capability', 'plugin-scoped'],
+    blastRadius: 'reads all of another plugin’s storage if not scoped',
+  },
+
+  // --- network ---
+  {
+    path: 'network.sendRequest',
+    sideEffect: 'network',
+    capability: 'network',
+    guards: ['capability'],
+    blastRadius: 'SSRF / arbitrary outbound request with side effects',
+  },
+  {
+    path: 'network.sendRequestWithoutSideEffects',
+    sideEffect: 'network',
+    capability: 'network',
+    guards: ['capability'],
+    blastRadius: 'SSRF / arbitrary outbound request',
+  },
+
+  // --- model reads (continued: OAuth tokens scoped to request) ---
+  {
+    path: 'oAuth2Token.getByRequestId',
+    sideEffect: 'model-read',
+    capability: 'models.read',
+    guards: ['capability'],
+    blastRadius: 'reads OAuth2 tokens associated with a request',
+  },
+
+  // --- credentials ---
+  {
+    path: 'cloudCredential.getById',
+    sideEffect: 'credential',
+    capability: 'credentials',
+    guards: ['capability'],
+    blastRadius: 'reads a stored cloud credential',
+  },
+  {
+    path: 'cloudCredential.update',
+    sideEffect: 'credential',
+    capability: 'credentials',
+    guards: ['capability'],
+    blastRadius: 'overwrites a stored cloud credential',
+  },
+
+  // --- app / UI affordances ---
+  {
+    path: 'openInBrowser',
+    sideEffect: 'app',
+    capability: 'app',
+    guards: ['capability'],
+    blastRadius: 'opens an arbitrary URL in the default browser',
+  },
+  {
+    path: 'app.alert',
+    sideEffect: 'app',
+    capability: 'app',
+    guards: ['capability'],
+    blastRadius: 'shows a modal alert',
+  },
+  {
+    path: 'app.dialog',
+    sideEffect: 'app',
+    capability: 'app',
+    guards: ['capability'],
+    blastRadius: 'shows a modal dialog',
+  },
+  {
+    path: 'app.prompt',
+    sideEffect: 'app',
+    capability: 'app',
+    guards: ['capability'],
+    blastRadius: 'shows a modal prompt',
+  },
+  {
+    path: 'app.getPath',
+    sideEffect: 'app',
+    capability: 'app',
+    guards: ['capability'],
+    blastRadius: 'discloses an app directory path',
+  },
+  {
+    path: 'app.showSaveDialog',
+    sideEffect: 'app',
+    capability: 'app',
+    guards: ['capability'],
+    blastRadius: 'shows a native save dialog',
+  },
+  {
+    path: 'app.clipboard.readText',
+    sideEffect: 'app',
+    capability: 'app',
+    guards: ['capability'],
+    blastRadius: 'reads the system clipboard',
+  },
+  {
+    path: 'app.clipboard.writeText',
+    sideEffect: 'app',
+    capability: 'app',
+    guards: ['capability'],
+    blastRadius: 'writes the system clipboard',
+  },
+  {
+    path: 'app.clipboard.clear',
+    sideEffect: 'app',
+    capability: 'app',
+    guards: ['capability'],
+    blastRadius: 'clears the system clipboard',
+  },
+
+  // --- sandbox orchestration (host-only; NOT a plugin capability; directly dispatchable) ---
+  {
+    path: 'plugin.getBundlePluginTemplateTags',
+    sideEffect: 'sandbox-orchestration',
+    capability: null,
+    guards: ['bundle-allowlist'],
+    blastRadius: 'lists first-party bundle tag metadata (trusted)',
+  },
+  {
+    path: 'plugin.executeBundlePluginTag',
+    sideEffect: 'sandbox-orchestration',
+    capability: null,
+    guards: ['bundle-allowlist'],
+    blastRadius: 'runs non-bundle code if the bundle allowlist is not enforced',
+  },
+  {
+    path: 'plugin.executeBundlePluginMainAction',
+    sideEffect: 'sandbox-orchestration',
+    capability: null,
+    guards: ['bundle-allowlist'],
+    blastRadius: 'runs non-bundle main-process code if the bundle allowlist is not enforced',
+  },
+  {
+    path: 'plugin.getUserPluginTemplateTags',
+    sideEffect: 'sandbox-orchestration',
+    capability: null,
+    guards: ['registry-lookup'],
+    blastRadius: 'lists user tag metadata from the trusted registry',
+  },
+  {
+    path: 'plugin.executeUserPluginTag',
+    sideEffect: 'sandbox-orchestration',
+    capability: null,
+    guards: ['registry-lookup'],
+    blastRadius: 'runs a plugin tag; target resolved from the trusted registry, not caller input',
+  },
+  {
+    path: 'plugin.discoverUserPluginExports',
+    sideEffect: 'sandbox-orchestration',
+    capability: null,
+    guards: ['trusted-plugin'],
+    blastRadius: 'evaluates plugin source from a caller-supplied directory if identity is not re-resolved',
+  },
+  {
+    path: 'plugin.runUserRequestHook',
+    sideEffect: 'sandbox-orchestration',
+    capability: null,
+    guards: ['trusted-plugin'],
+    blastRadius: 'runs a hook from a caller-supplied directory/permissions if identity is not re-resolved',
+  },
+  {
+    path: 'plugin.runUserResponseHook',
+    sideEffect: 'sandbox-orchestration',
+    capability: null,
+    guards: ['trusted-plugin', 'body-path-ownership'],
+    blastRadius: 'runs a hook that can redirect setBody onto another response if identity/ownership are not enforced',
+  },
+  {
+    path: 'plugin.runUserAction',
+    sideEffect: 'sandbox-orchestration',
+    capability: null,
+    guards: ['trusted-plugin'],
+    blastRadius: 'runs an action from a caller-supplied directory/permissions if identity is not re-resolved',
+  },
+];
+
+/** Handlers reachable from inside the sandbox (capability-gated). */
+export const pluginFacingInventory = (): HandlerInventoryEntry[] =>
+  HANDLER_INVENTORY.filter(e => e.capability !== null);
+
+/** Host-only orchestration handlers — directly dispatchable, never capability-gated. */
+export const hostOnlyInventory = (): HandlerInventoryEntry[] => HANDLER_INVENTORY.filter(e => e.capability === null);
+
+/** Renders one row for the human-readable print script. */
+export const formatInventoryEntry = (e: HandlerInventoryEntry): string =>
+  `${e.path.padEnd(38)} ${e.sideEffect.padEnd(22)} ${(e.capability ?? '(host-only)').padEnd(14)} ${e.guards.join('+')}`;
+
+export const formatInventory = (): string[] => HANDLER_INVENTORY.map(formatInventoryEntry);


### PR DESCRIPTION
## PR 13 — S1: capability & bridge-handler scoping audit (fail-closed by construction)

Final Phase 2 hardening step (see the sandbox plan gist). Generalizes the #10294 bodyPath detector into a full, drift-proof scoping audit of the entire `pluginToMainAPI` protocol surface.

### The problem
Two classes of handler share `pluginToMainAPI`, and only the first is capability-gated:
1. **Plugin-facing bridge calls** — reachable from inside the sandbox via `__bridge`, gated by `BRIDGE_PATH_CAPABILITIES` (default-deny).
2. **Directly-dispatchable orchestration handlers** — every key is routed by `resolveDbByKey`, not only the ones reached through a wrapper, so a handler like `response.setBody` or `plugin.runUserResponseHook` can be invoked straight over the protocol. These are **not** in the capability map; their safety rests on an inline trust/ownership check — the exact class of bug #10286/#10290/#10294 fixed one handler at a time.

Nothing forced a handler author to declare which class a new handler is, or prove it's guarded.

### What this ships
- **`templating-worker-database-inventory.ts`** — a checked-in row per handler: side-effect class (pure / model-read / fs-read / fs-write / network / credential / storage / app / sandbox-orchestration), capability (or `null` when host-only), the guard(s) that actually protect it (`capability` / `path-allowlist` / `body-path-ownership` / `trusted-plugin` / `bundle-allowlist` / `registry-lookup` / `plugin-scoped`), and the blast radius if the guard fails.
- **Enforcement gates** against the *live* handler map, so the inventory can't drift:
  - **G1** inventory paths === live `pluginToMainAPI` keys (a new handler with no row fails)
  - **G2** each row's capability === `BRIDGE_PATH_CAPABILITIES[path] ?? null`
  - **G3** no blanks (guard + blast radius required)
  - **G3b** plugin-facing rows must be capability-gated; **host-only rows must NOT claim the (bypassable) bridge capability** as a defense and must name a real inline guard — kwburns' #10286 point, mechanized
  - **G4** every capability path maps to a live handler (or the allowlisted non-DB bridge path `util.render`)
  - **G5** cross-checks the static write detector; every `fs-write` row names `body-path-ownership`
- **`npm run sandbox:bridge-inventory`** renders the table for humans.

Today: **42 handlers — 33 plugin-facing, 9 host-only.**

### Findings
The audit surfaced **no new gaps** — the body-path read/write cases were already closed by #10290 / #10294 / #10301. The value here is making the whole surface fail-closed *by construction*: the next unguarded I/O handler fails a unit test instead of shipping.

### Tests
`tsc` clean, eslint clean, 20 tests green (existing surface detectors + new inventory gates + print). Security assertions live at the unit/detector level (they forge payloads directly against the handler map), consistent with how #10294's detector shipped — no bespoke e2e.

Depends on the merged L1/H1/A1 work on develop.

_🤖 Authored by [Claude Code](https://claude.com/claude-code)_
