### PR TITLE
fix: Add `textValue` to method selector to avoid dev build warnings

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/method-selector.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/method-selector.tsx
@@ -115,7 +115,7 @@ export const MethodSelector = forwardRef<DropdownHandle, Props>(({ method, onCha
     >
       <DropdownSection>
         {HTTP_METHODS.map(m => (
-          <DropdownItem key={m}>
+          <DropdownItem key={m} textValue={m}>
             <ItemContent
               className={getMethodTextClasses(m)}
               label={m}
@@ -127,7 +127,7 @@ export const MethodSelector = forwardRef<DropdownHandle, Props>(({ method, onCha
       </DropdownSection>
 
       <DropdownSection>
-        <DropdownItem>
+        <DropdownItem textValue="Custom Method">
           <ItemContent
             className={getMethodTextClasses('')}
             label="Custom Method"


### PR DESCRIPTION
Changes:
Add `textValue` to method selector to avoid dev build keep showing 
```
[main] 15:51:28.217 › <Item> with non-plain text contents is unsupported by type to select for accessibility. Please add a `textValue` prop.
```

