### PR TITLE
feat: add sidebar collection focus mode (INS-2912)

### DIFF
--- a/packages/insomnia-data/common-src/settings.ts
+++ b/packages/insomnia-data/common-src/settings.ts
@@ -151,6 +151,7 @@ export interface Settings {
   preferredHttpVersion: HttpVersion;
   proxyEnabled: boolean;
   showPasswords: boolean;
+  sidebarFocusForCollections: boolean;
   theme: string;
   timeout: number;
   updateAutomatically: boolean;

--- a/packages/insomnia-data/common-src/settings.ts
+++ b/packages/insomnia-data/common-src/settings.ts
@@ -152,6 +152,8 @@ export interface Settings {
   proxyEnabled: boolean;
   showPasswords: boolean;
   sidebarFocusForCollections: boolean;
+  /** True once the user has dismissed the one-time "Welcome to focus mode" onboarding popup. */
+  hasSeenSidebarFocusOnboarding: boolean;
   theme: string;
   timeout: number;
   updateAutomatically: boolean;

--- a/packages/insomnia-data/src/models/settings.ts
+++ b/packages/insomnia-data/src/models/settings.ts
@@ -68,6 +68,7 @@ export function init(): BaseSettings {
     proxyEnabled: false,
     showPasswords: false,
     sidebarFocusForCollections: true,
+    hasSeenSidebarFocusOnboarding: false,
     theme: getAppDefaultTheme(),
     // milliseconds
     timeout: 30_000,

--- a/packages/insomnia-data/src/models/settings.ts
+++ b/packages/insomnia-data/src/models/settings.ts
@@ -67,6 +67,7 @@ export function init(): BaseSettings {
     preferredHttpVersion: HttpVersions.default,
     proxyEnabled: false,
     showPasswords: false,
+    sidebarFocusForCollections: true,
     theme: getAppDefaultTheme(),
     // milliseconds
     timeout: 30_000,

--- a/packages/insomnia-smoke-test/playwright/pages/components/navigation-sidebar.ts
+++ b/packages/insomnia-smoke-test/playwright/pages/components/navigation-sidebar.ts
@@ -113,10 +113,25 @@ export class NavigationSidebar {
   async expectWorkspaceActive(workspaceName: string): Promise<void> {
     await expect.soft(this.workspaceRow(workspaceName)).toBeVisible();
     // In focus mode there's no grid row to check aria-selected on for this workspace — being
-    // shown as the focused header already proves it's the active one.
-    if (!(await this.isWorkspaceFocused(workspaceName))) {
-      await expect.soft(this.workspaceGridListItem(workspaceName)).toHaveAttribute('aria-selected', 'true');
-    }
+    // shown as the focused header already proves it's the active one. Poll for either outcome
+    // rather than deciding up front: right after navigating in, there's a brief window where
+    // neither is true yet (focus mode hasn't finished swapping the row for the header), and a
+    // one-shot check can catch that transient state and commit to the wrong branch.
+    await expect
+      .poll(
+        async () => {
+          if (await this.isWorkspaceFocused(workspaceName)) {
+            return true;
+          }
+          const gridItem = this.workspaceGridListItem(workspaceName);
+          if ((await gridItem.count()) === 0) {
+            return false;
+          }
+          return (await gridItem.getAttribute('aria-selected')) === 'true';
+        },
+        { timeout: 25_000 },
+      )
+      .toBe(true);
   }
 
   async selectWorkspace(workspaceName: string): Promise<void> {

--- a/packages/insomnia-smoke-test/playwright/pages/components/navigation-sidebar.ts
+++ b/packages/insomnia-smoke-test/playwright/pages/components/navigation-sidebar.ts
@@ -94,6 +94,31 @@ export class NavigationSidebar {
     return this.navigationTree.getByRole('row', { name: workspaceName });
   }
 
+  // When collection focus mode narrows the sidebar to one collection, that collection's tree
+  // row is replaced by the back-arrow header (same `workspace-node-*` testid, no ARIA "row").
+  async isWorkspaceFocused(workspaceName: string): Promise<boolean> {
+    return (await this.workspaceRow(workspaceName).getByLabel('Back to all projects').count()) > 0;
+  }
+
+  // Exits collection focus mode if currently focused; no-op otherwise. Needed before
+  // interacting with a different collection or project, since focus mode hides everything
+  // outside the focused collection.
+  async backToAllProjects(): Promise<void> {
+    const backButton = this.root.getByLabel('Back to all projects');
+    if (await backButton.isVisible().catch(() => false)) {
+      await backButton.click();
+    }
+  }
+
+  async expectWorkspaceActive(workspaceName: string): Promise<void> {
+    await expect.soft(this.workspaceRow(workspaceName)).toBeVisible();
+    // In focus mode there's no grid row to check aria-selected on for this workspace — being
+    // shown as the focused header already proves it's the active one.
+    if (!(await this.isWorkspaceFocused(workspaceName))) {
+      await expect.soft(this.workspaceGridListItem(workspaceName)).toHaveAttribute('aria-selected', 'true');
+    }
+  }
+
   async selectWorkspace(workspaceName: string): Promise<void> {
     await this.workspaceRow(workspaceName).click();
   }

--- a/packages/insomnia-smoke-test/playwright/paths.ts
+++ b/packages/insomnia-smoke-test/playwright/paths.ts
@@ -25,6 +25,26 @@ export const copyFixtureDatabase = async (fixturePath: string, dataPath: string)
   await fs.promises.cp(fixtureDir, dataPath, { recursive: true });
 };
 
+/**
+ * Pre-seeds a minimal Settings document into `dataPath` before Insomnia launches,
+ * so a test starts with specific settings instead of the app's defaults. Fields
+ * left out of `patch` aren't left blank — the app backfills any doc it loads with
+ * `models.settings.init()`'s defaults for fields the doc doesn't have — so this
+ * only needs to carry the overrides a test actually cares about.
+ */
+export const seedSettings = async (dataPath: string, patch: Record<string, unknown>) => {
+  await fs.promises.mkdir(dataPath, { recursive: true });
+  const doc = {
+    _id: `set_${uuidv4().replace(/-/g, '')}`,
+    type: 'Settings',
+    parentId: null,
+    modified: Date.now(),
+    created: Date.now(),
+    ...patch,
+  };
+  await fs.promises.writeFile(path.join(dataPath, 'insomnia.Settings.db'), `${JSON.stringify(doc)}\n`);
+};
+
 export const randomDataPath = () => path.join(os.tmpdir(), 'insomnia-smoke-test', `${uuidv4()}`);
 export const INSOMNIA_DATA_PATH = randomDataPath();
 

--- a/packages/insomnia-smoke-test/playwright/test.ts
+++ b/packages/insomnia-smoke-test/playwright/test.ts
@@ -8,7 +8,7 @@ import { test as baseTest } from '@playwright/test';
 import type { EnvOptions } from './launch';
 import { launchInsomnia, liveApps } from './launch';
 import { InsomniaApp } from './pages';
-import { randomDataPath } from './paths';
+import { randomDataPath, seedSettings } from './paths';
 
 // Throw an error if the condition fails
 // > Not providing an inline default argument for message as the result is smaller
@@ -176,6 +176,12 @@ export const test = baseTest.extend<{
   },
   dataPath: async ({}, use) => {
     const insomniaDataPath = randomDataPath();
+    // `sidebarFocusForCollections` defaults to on for real users, but it narrows the
+    // sidebar to a single collection on any click into it — hiding other collections,
+    // projects, and the project tabs — which breaks the many existing specs that assume
+    // the full tree stays visible. Default it off here; specs that want to exercise
+    // focus mode itself (see sidebar-focus-onboarding.test.ts) turn it on explicitly.
+    await seedSettings(insomniaDataPath, { sidebarFocusForCollections: false });
 
     await use(insomniaDataPath);
   },

--- a/packages/insomnia-smoke-test/tests/smoke/cloud-sync.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/cloud-sync.test.ts
@@ -72,7 +72,10 @@ test.describe('Cloud Sync', () => {
     await page.getByRole('button', { name: 'Send' }).click();
     await expect.soft(page.getByTestId('request-pane').getByText('foo=bar')).toBeHidden();
 
-    // select unsynced MCP project to check branch actions
+    // select unsynced MCP project to check branch actions. Sidebar is still focused on
+    // "My Collection R1"; unsynced workspace rows for any other workspace are hidden while
+    // focused, so back out first.
+    await insomnia.navigationSidebar.backToAllProjects();
     await insomnia.navigationSidebar.fetchUnsyncedWorkspace('My MCP Client');
     await page.getByLabel('Git Sync').click();
     await page.getByText('Branches').click();

--- a/packages/insomnia-smoke-test/tests/smoke/debug-sidebar-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/debug-sidebar-interactions.test.ts
@@ -16,27 +16,37 @@ test.describe('Debug-Sidebar', () => {
     //Open Properties in Global Sidebar
     await insomnia.navigationSidebar.openRequestActionsDropdown('example http');
     await page.getByRole('menuitemradio', { name: 'Settings' }).click();
-    // Close settings modal
-    await page.locator('.app').press('Escape');
+    // Close settings modal. Click the explicit close button rather than pressing Escape on
+    // `.app`: Escape's target depends on where focus lands, which is unreliable right after a
+    // modal opens (flaky in CI) — the close button always works regardless of focus.
+    await page.getByRole('button', { name: 'Modal Close Button' }).click();
 
     await insomnia.navigationSidebar.openRequestActionsDropdown('example grpc');
     await page.getByRole('menuitemradio', { name: 'Settings' }).click();
-    // Close settings modal
-    await page.locator('.app').press('Escape');
+    // Close settings modal. Click the explicit close button rather than pressing Escape on
+    // `.app`: Escape's target depends on where focus lands, which is unreliable right after a
+    // modal opens (flaky in CI) — the close button always works regardless of focus.
+    await page.getByRole('button', { name: 'Modal Close Button' }).click();
 
     await insomnia.navigationSidebar.openRequestActionsDropdown('example websocket');
     await page.getByRole('menuitemradio', { name: 'Settings' }).click();
-    // Close settings modal
-    await page.locator('.app').press('Escape');
+    // Close settings modal. Click the explicit close button rather than pressing Escape on
+    // `.app`: Escape's target depends on where focus lands, which is unreliable right after a
+    // modal opens (flaky in CI) — the close button always works regardless of focus.
+    await page.getByRole('button', { name: 'Modal Close Button' }).click();
 
     await insomnia.navigationSidebar.openRequestActionsDropdown('example graphql');
     await page.getByRole('menuitemradio', { name: 'Settings' }).click();
-    // Close settings modal
-    await page.locator('.app').press('Escape');
+    // Close settings modal. Click the explicit close button rather than pressing Escape on
+    // `.app`: Escape's target depends on where focus lands, which is unreliable right after a
+    // modal opens (flaky in CI) — the close button always works regardless of focus.
+    await page.getByRole('button', { name: 'Modal Close Button' }).click();
     await insomnia.navigationSidebar.openRequestGroupActionsDropdown('test folder');
     await page.getByRole('menuitemradio', { name: 'Settings' }).click();
-    // Close settings modal
-    await page.locator('.app').press('Escape');
+    // Close settings modal. Click the explicit close button rather than pressing Escape on
+    // `.app`: Escape's target depends on where focus lands, which is unreliable right after a
+    // modal opens (flaky in CI) — the close button always works regardless of focus.
+    await page.getByRole('button', { name: 'Modal Close Button' }).click();
 
     //Open properties of the collection
     await insomnia.navigationSidebar.openWorkspaceActionsDropdown('simple');
@@ -80,7 +90,7 @@ test.describe('Debug-Sidebar', () => {
     await insomnia.navigationSidebar.openRequestGroupActionsDropdown('test folder');
     await page.getByRole('menuitemradio', { name: 'Settings' }).click();
     await page.getByPlaceholder('test folder').fill('test folder1');
-    await page.locator('.app').press('Escape');
+    await page.getByRole('button', { name: 'Modal Close Button' }).click();
     await insomnia.navigationSidebar.clickRequestOrFolder('test folder1');
 
     // Rename a request

--- a/packages/insomnia-smoke-test/tests/smoke/git-sync.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/git-sync.test.ts
@@ -84,6 +84,8 @@ test.describe('Git Sync', () => {
     await page.getByRole('textbox', { name: 'File name' }).fill('collection_1');
     await page.getByRole('button', { name: 'Create', exact: true }).click();
     await page.getByText('Create a new Request Collection').waitFor({ state: 'hidden' });
+    // Creating the collection focused the sidebar on it; back out before selecting the project.
+    await insomnia.navigationSidebar.backToAllProjects();
     await insomnia.navigationSidebar.selectProject(GIT_PROJECT_NAME);
     await page.getByTestId('git-dropdown').click();
     await page.getByRole('menuitemradio', { name: 'Commit' }).click();

--- a/packages/insomnia-smoke-test/tests/smoke/insomnia-tab.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/insomnia-tab.test.ts
@@ -33,6 +33,8 @@ test.describe('multiple-tab feature test', () => {
     // rename
     await insomnia.navigationSidebar.renameRequestOrFolder('New Request', 'foo', 'Tab sync collection');
 
+    // Sidebar is still focused on "Tab sync collection"; back out before switching collections.
+    await insomnia.navigationSidebar.backToAllProjects();
     await insomnia.navigationSidebar.selectWorkspaceDropdownOption({
       workspaceName: 'My first collection',
       actionName: 'HTTP Request',
@@ -40,9 +42,13 @@ test.describe('multiple-tab feature test', () => {
     await insomnia.navigationSidebar.renameRequestOrFolder('New Request', 'bar', 'My first collection');
 
     await insomnia.navigationSidebar.clickRequestOrFolder('bar');
+    // "foo" lives in "Tab sync collection"; sidebar is currently focused on "My first collection".
+    await insomnia.navigationSidebar.backToAllProjects();
     await insomnia.navigationSidebar.clickRequestOrFolder('foo');
     const tabA = page.getByLabel('Insomnia Tabs').getByLabel('tab-foo', { exact: true });
     await expect.soft(tabA).toHaveAttribute('data-selected', 'true');
+    // "bar" lives in "My first collection"; clicking "foo" re-focused the sidebar on "Tab sync collection".
+    await insomnia.navigationSidebar.backToAllProjects();
     await insomnia.navigationSidebar.clickRequestOrFolder('bar');
     const tabB = page.getByLabel('Insomnia Tabs').getByLabel('tab-bar', { exact: true });
     await expect.soft(tabB).toHaveAttribute('data-selected', 'true');
@@ -50,6 +56,8 @@ test.describe('multiple-tab feature test', () => {
     //change icon after change request method
     await insomnia.projectPage.navigateFromWorkspaceBreadcrumb();
     await insomnia.projectPage.createCollection('Method icon collection');
+    // Sidebar is now focused on "Method icon collection"; back out to reach "My first collection".
+    await insomnia.navigationSidebar.backToAllProjects();
     await insomnia.navigationSidebar.selectWorkspaceDropdownOption({
       workspaceName: 'My first collection',
       actionName: 'HTTP Request',
@@ -82,6 +90,9 @@ test.describe('multiple-tab feature test', () => {
     await page.getByLabel('Select Workspace').selectOption({ label: 'My first collection' });
     await page.getByRole('dialog').getByRole('button', { name: 'Add' }).click();
     await page.getByRole('dialog').waitFor({ state: 'hidden' });
+    // The new request was added to "My first collection", but the sidebar is still focused on
+    // "Test add tab collection" (adding to another workspace via the modal doesn't navigate).
+    await insomnia.navigationSidebar.backToAllProjects();
     await expect.soft(insomnia.navigationSidebar.requestRow('New Request', 'My first collection')).toBeVisible();
 
     // close tab after delete a request

--- a/packages/insomnia-smoke-test/tests/smoke/sidebar-focus-onboarding.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/sidebar-focus-onboarding.test.ts
@@ -1,0 +1,48 @@
+import { expect } from '@playwright/test';
+
+import { test } from '../../playwright/test';
+
+// sidebarFocusForCollections defaults to on, so creating a collection immediately focuses the
+// sidebar on it. This covers the one-time "Welcome to focus mode" nudge that explains that
+// behavior and confirms dismissing it is actually persisted, not just in-memory for the session.
+test.describe('sidebar focus mode onboarding', () => {
+  test('shows once on first focus and stays dismissed after reload', async ({ page, insomnia }) => {
+    // A brand-new project starts empty, so the first collection comes from this welcome-state
+    // button rather than the "Create in project" menu (which only appears once a project has content).
+    await page.getByRole('button', { name: 'Create request collection', exact: true }).click();
+    await insomnia.navigationSidebar.expectWorkspaceActive('My first collection');
+
+    const onboarding = page.getByRole('dialog', { name: 'Sidebar focus mode onboarding' });
+    await expect.soft(onboarding).toBeVisible();
+    await expect.soft(onboarding.getByText('Welcome to focus mode')).toBeVisible();
+    await expect.soft(onboarding.getByText('Back to all projects')).toBeVisible();
+    await expect.soft(onboarding.getByText('Sidebar focus for collections')).toBeVisible();
+
+    await onboarding.getByRole('button', { name: 'Got It' }).click();
+    await expect.soft(onboarding).toBeHidden();
+
+    // Leaving and re-entering focus mode in the same session shouldn't bring it back.
+    await insomnia.navigationSidebar.backToAllProjects();
+    await insomnia.navigationSidebar.selectWorkspace('My first collection');
+    await insomnia.navigationSidebar.expectWorkspaceActive('My first collection');
+    await expect.soft(onboarding).toBeHidden();
+
+    // Reload to confirm the dismissal was actually written to settings, not just in-memory state.
+    await page.reload({ waitUntil: 'networkidle' });
+    await insomnia.navigationSidebar.expectWorkspaceActive('My first collection');
+    await expect.soft(onboarding).toBeHidden();
+  });
+
+  test('does not show when the setting is turned off', async ({ page, insomnia }) => {
+    await page.getByTestId('settings-button').click();
+    await page.locator('text=Insomnia Preferences').first().click();
+    await page.locator('text=Sidebar focus for collections').click();
+    await page.locator('.app').press('Escape');
+
+    await page.getByRole('button', { name: 'Create request collection', exact: true }).click();
+
+    const onboarding = page.getByRole('dialog', { name: 'Sidebar focus mode onboarding' });
+    await expect.soft(onboarding).toBeHidden();
+    await expect.soft(insomnia.navigationSidebar.workspaceGridListItem('My first collection')).toBeVisible();
+  });
+});

--- a/packages/insomnia-smoke-test/tests/smoke/sidebar-focus-onboarding.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/sidebar-focus-onboarding.test.ts
@@ -1,10 +1,21 @@
 import { expect } from '@playwright/test';
 
-import { test } from '../../playwright/test';
+import { seedSettings } from '../../playwright/paths';
+import { test as baseTest } from '../../playwright/test';
 
-// sidebarFocusForCollections defaults to on, so creating a collection immediately focuses the
-// sidebar on it. This covers the one-time "Welcome to focus mode" nudge that explains that
-// behavior and confirms dismissing it is actually persisted, not just in-memory for the session.
+// sidebarFocusForCollections defaults to on for real users (creating a collection
+// immediately focuses the sidebar on it), but the smoke-test harness defaults it off so the
+// rest of the suite isn't affected by focus mode (see playwright/test.ts). This spec is about
+// focus mode itself, so turn it back on for these tests specifically.
+const test = baseTest.extend({
+  dataPath: async ({ dataPath }, use) => {
+    await seedSettings(dataPath, { sidebarFocusForCollections: true });
+    await use(dataPath);
+  },
+});
+
+// This covers the one-time "Welcome to focus mode" nudge that explains that behavior and
+// confirms dismissing it is actually persisted, not just in-memory for the session.
 test.describe('sidebar focus mode onboarding', () => {
   test('shows once on first focus and stays dismissed after reload', async ({ page, insomnia }) => {
     // A brand-new project starts empty, so the first collection comes from this welcome-state
@@ -15,7 +26,7 @@ test.describe('sidebar focus mode onboarding', () => {
     const onboarding = page.getByRole('dialog', { name: 'Sidebar focus mode onboarding' });
     await expect.soft(onboarding).toBeVisible();
     await expect.soft(onboarding.getByText('Welcome to focus mode')).toBeVisible();
-    await expect.soft(onboarding.getByText('Back to all projects')).toBeVisible();
+    await expect.soft(onboarding.getByText('back arrow')).toBeVisible();
     await expect.soft(onboarding.getByText('Sidebar focus for collections')).toBeVisible();
 
     await onboarding.getByRole('button', { name: 'Got It' }).click();

--- a/packages/insomnia/src/ui/components/settings/general.tsx
+++ b/packages/insomnia/src/ui/components/settings/general.tsx
@@ -48,6 +48,11 @@ export const General: FC = () => {
           <BooleanSetting label="Reveal passwords" setting="showPasswords" />
           {!isMac && <BooleanSetting label="Hide menu bar" setting="autoHideMenuBar" />}
           <BooleanSetting label="Raw template syntax" setting="nunjucksPowerUserMode" />
+          <BooleanSetting
+            label="Sidebar focus for collections"
+            setting="sidebarFocusForCollections"
+            help="If checked, clicking a collection or anything inside it narrows the sidebar to that collection's contents. Otherwise the full project tree stays visible."
+          />
         </div>
       </div>
 

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/empty-node.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/empty-node.tsx
@@ -19,6 +19,9 @@ import type { EmptyNodeFlatItem } from './types';
 interface EmptyNodeProps {
   item: EmptyNodeFlatItem;
   storageRules: StorageRules;
+  // Number of ancestor indent levels to strip when the sidebar is focused on a
+  // single collection (the project and workspace rows are no longer shown).
+  depthOffset?: number;
 }
 
 interface ActionItem {
@@ -29,7 +32,7 @@ interface ActionItem {
   action: () => void;
 }
 
-export const EmptyNode = ({ item, storageRules }: EmptyNodeProps) => {
+export const EmptyNode = ({ item, storageRules, depthOffset = 0 }: EmptyNodeProps) => {
   const { organizationId, project, workspace, requestGroup, level = 0, kind } = item;
   const [newWorkspaceModalState, setNewWorkspaceModalState] = useState<{
     scope: WorkspaceScope;
@@ -218,21 +221,25 @@ export const EmptyNode = ({ item, storageRules }: EmptyNodeProps) => {
     }
   };
 
-  const paddingLeft = kind === 'emptyProject' ? '2em' : `${level + 3}rem`;
+  const paddingLeft = kind === 'emptyProject' ? '2em' : `${Math.max(level + 3 - depthOffset, 1)}rem`;
 
   return (
     <div className={ROW_CLASS} style={{ paddingLeft }} data-testid={`empty-node-${kind}`}>
       <Button slot="drag" className="hidden" />
-      <span className={`${GUIDE_LINE_CSS} left-6 group-hover/tree:bg-(--hl-sm)`} />
-      {kind !== 'emptyProject' && <span className={`${GUIDE_LINE_CSS} left-10 group-hover/tree:bg-(--hl-sm)`} />}
+      {depthOffset === 0 && <span className={`${GUIDE_LINE_CSS} left-6 group-hover/tree:bg-(--hl-sm)`} />}
+      {kind !== 'emptyProject' && depthOffset === 0 && (
+        <span className={`${GUIDE_LINE_CSS} left-10 group-hover/tree:bg-(--hl-sm)`} />
+      )}
       {kind === 'emptyFolder' &&
-        Array.from({ length: level + 2 }, (_, i) => (
-          <span
-            key={i}
-            className={`${GUIDE_LINE_CSS} group-hover/tree:bg-(--hl-sm)`}
-            style={{ left: `${i + 1.5}em` }}
-          />
-        ))}
+        Array.from({ length: level + 2 }, (_, i) => i)
+          .filter(i => i >= depthOffset)
+          .map(i => (
+            <span
+              key={i}
+              className={`${GUIDE_LINE_CSS} group-hover/tree:bg-(--hl-sm)`}
+              style={{ left: `${i + 1.5 - depthOffset}em` }}
+            />
+          ))}
       <span className={`${kind === 'emptyFolder' ? 'ml-7' : 'ml-3'} min-w-0 flex-1 truncate text-sm`}>
         {getLabel()}
       </span>

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
@@ -22,14 +22,17 @@ import * as reactUse from 'react-use';
 import { Button as BasicButton } from '~/basic-components/button';
 import { filterCollection, flattenCollectionChildren } from '~/common/collection';
 import type { SortOrder } from '~/common/constants';
+import { scopeToBgColorMap, scopeToIconMap, scopeToTextColorMap } from '~/common/get-workspace-label';
 import { getUnsyncedRemoteWorkspaces, type InsomniaFile } from '~/common/project';
 import { sortMethodMap } from '~/common/sorting';
 import type { SyncResult } from '~/konnect/sync';
 import { useRootLoaderData } from '~/root';
 import { useProjectDeleteActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.delete';
+import { useWorkspaceUpdateActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.update';
 import { AnalyticsEvent } from '~/ui/analytics';
 import type { WorkspaceSortOrder } from '~/ui/components/dropdowns/sidebar-project-dropdown';
 import { SidebarShortcutActionsDropdown } from '~/ui/components/dropdowns/sidebar-shortcut-actions-dropdown';
+import { SidebarWorkspaceDropdown } from '~/ui/components/dropdowns/sidebar-workspace-dropdown';
 import { useDocBodyKeyboardShortcuts } from '~/ui/components/keydown-binder';
 import { KongLogo } from '~/ui/components/kong-logo';
 import { showModal } from '~/ui/components/modals';
@@ -113,7 +116,11 @@ const ProjectNavigationSidebarInner = (
   ref: ForwardedRef<ProjectNavigationSidebarHandle>,
 ) => {
   const navigate = useNavigate();
-  const { organizationId, projectId: activeProjectId } = useParams() as {
+  const {
+    organizationId,
+    projectId: activeProjectId,
+    workspaceId: activeWorkspaceId,
+  } = useParams() as {
     organizationId: string;
     projectId?: string;
     workspaceId?: string;
@@ -126,6 +133,14 @@ const ProjectNavigationSidebarInner = (
   const tabNavigate = useTabNavigate();
 
   const [collectionSortOrders, setCollectionSortOrders] = useState<Record<string, SortOrder>>({});
+  // Focused-collection state: when set, the sidebar narrows to show only this
+  // collection's request tree. This is pure UI state — it never changes the route.
+  const [focusedWorkspaceId, setFocusedWorkspaceId] = useState<string | null>(null);
+  const [focusTransition, setFocusTransition] = useState<'none' | 'in' | 'out'>('none');
+  const [isFocusedWorkspaceMenuOpen, setIsFocusedWorkspaceMenuOpen] = useState(false);
+  const [isRenamingFocusedWorkspace, setIsRenamingFocusedWorkspace] = useState(false);
+  const [renamingWorkspaceValue, setRenamingWorkspaceValue] = useState('');
+  const updateWorkspaceFetcher = useWorkspaceUpdateActionFetcher();
   const [projectWorkspaceSortOrder, setProjectWorkspaceSortOrder] = useState<Record<string, WorkspaceSortOrder>>({});
   const [unsyncedFilesByProjectId, setUnsyncedFilesByProjectId] = useState<Map<string, InsomniaFile[]>>(new Map());
   // Optimistic override for request-group collapsed states
@@ -746,6 +761,77 @@ const ProjectNavigationSidebarInner = (
     [expandedProjectAndWorkspaceIds, activeFilter, setExpandedProjectAndWorkspaceIds],
   );
 
+  // User preference (Preferences > General > Application). When off, the sidebar
+  // never narrows into a single collection and always shows the full project tree.
+  const enableCollectionFocus = settings.sidebarFocusForCollections;
+
+  // Narrow the sidebar into the focused view of a single collection. Expands the
+  // collection (and its project) so its request tree is built, then focuses it.
+  const focusWorkspace = useCallback(
+    (workspaceId: string, projectId: string) => {
+      if (!enableCollectionFocus) {
+        return;
+      }
+      expandProjectOrWorkspaces([projectId, workspaceId]);
+      setFocusTransition('in');
+      setFocusedWorkspaceId(workspaceId);
+    },
+    [expandProjectOrWorkspaces, enableCollectionFocus],
+  );
+
+  // Back arrow: return to the full tree without touching the route, and reset
+  // the filter so it doesn't carry over silently scoped to the old collection.
+  const exitFocus = useCallback(() => {
+    setFocusTransition('out');
+    setFocusedWorkspaceId(null);
+    if (filterInputValue) {
+      setFilterInputValue('');
+    }
+  }, [filterInputValue]);
+
+  // Turning the preference off while a collection is focused returns to the full tree.
+  useEffect(() => {
+    if (!enableCollectionFocus) {
+      setFocusTransition('out');
+      setFocusedWorkspaceId(null);
+    }
+  }, [enableCollectionFocus]);
+
+  // Drive focus from the active route so navigating to a collection from
+  // anywhere (tabs, project dashboard, deep links) focuses it too, not just a
+  // direct sidebar click. Tracks the last-seen active workspace so the back
+  // arrow can un-focus while staying on the same route without re-focusing.
+  const prevActiveWorkspaceIdRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    if (activeWorkspaceId === prevActiveWorkspaceIdRef.current) {
+      return;
+    }
+    if (!activeWorkspaceId) {
+      // Navigated to the project dashboard (no active workspace) → full tree.
+      prevActiveWorkspaceIdRef.current = activeWorkspaceId;
+      setFocusTransition('out');
+      setFocusedWorkspaceId(null);
+      return;
+    }
+    // Wait until the workspace is present in the tree so we can read its scope.
+    // Don't advance the ref until then, so a fresh load/deep-link still focuses
+    // once the data arrives.
+    const workspaceItem = flatItems.find(
+      (i): i is Extract<FlatItem, { kind: 'workspace' }> => i.kind === 'workspace' && i.doc._id === activeWorkspaceId,
+    );
+    if (!workspaceItem) {
+      return;
+    }
+    prevActiveWorkspaceIdRef.current = activeWorkspaceId;
+    if (workspaceItem.doc.scope === 'collection') {
+      focusWorkspace(activeWorkspaceId, workspaceItem.project._id);
+    } else {
+      // Design docs, mock servers, environments etc. show the full tree.
+      setFocusTransition('out');
+      setFocusedWorkspaceId(null);
+    }
+  }, [activeWorkspaceId, flatItems, focusWorkspace]);
+
   useImperativeHandle(
     ref,
     () => ({
@@ -823,7 +909,33 @@ const ProjectNavigationSidebarInner = (
   const [isShortcutCreateOpen, setIsShortcutCreateOpen] = useState(false);
   // The item that the shortcut create dropdown is targeting by keyboard up and down arrow keys
   const [shortcutTargetItemId, setShortcutTargetItemId] = useState<string | null>(null);
-  const visibleFlatItems = useMemo(() => flatItems.filter(i => !i.hidden), [flatItems]);
+  const visibleFlatItems = useMemo(() => {
+    const notHidden = flatItems.filter(i => !i.hidden);
+    if (!focusedWorkspaceId) {
+      return notHidden;
+    }
+    // In focused mode show only the focused collection's tree (its request
+    // groups, requests, pinned items and empty-state nodes). The workspace
+    // header row is dropped — its name is shown in the back-arrow header.
+    return notHidden.filter(
+      item =>
+        ('workspace' in item && (item as { workspace?: { _id: string } }).workspace?._id === focusedWorkspaceId) ||
+        (item.kind === 'pinnedHeader' && item.doc._id === `${focusedWorkspaceId}-pinned-header`),
+    );
+  }, [flatItems, focusedWorkspaceId]);
+  const focusedWorkspaceItem = useMemo(
+    () =>
+      focusedWorkspaceId
+        ? flatItems.find(
+            (i): i is Extract<FlatItem, { kind: 'workspace' }> =>
+              i.kind === 'workspace' && i.doc._id === focusedWorkspaceId,
+          )
+        : undefined,
+    [flatItems, focusedWorkspaceId],
+  );
+  // In focus mode the project + workspace rows are hidden, so strip those two
+  // ancestor indent levels and let the tree indent from its first level.
+  const treeDepthOffset = focusedWorkspaceId ? 2 : 0;
   const virtualizer = useVirtualizer({
     getScrollElement: () => parentRef.current,
     count: visibleFlatItems.length,
@@ -946,31 +1058,116 @@ const ProjectNavigationSidebarInner = (
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden" data-testid="global-navigation-sidebar">
-      <Tabs selectedKey={activeTab} onSelectionChange={key => setActiveTab(key as ProjectNavigationSidebarTabId)}>
-        <SideBarTabList
-          konnectSyncEnabled={konnectSyncEnabled}
-          isScratchPad={isScratchPad}
-          nonKonnectProjectLength={nonKonnectProjects.length}
-          konnectProjectsLength={konnectProjects.length}
-        />
-      </Tabs>
+      {/* In focused mode the whole sidebar belongs to the collection, so the project/konnect tabs are hidden too. */}
+      {!focusedWorkspaceId && (
+        <Tabs selectedKey={activeTab} onSelectionChange={key => setActiveTab(key as ProjectNavigationSidebarTabId)}>
+          <SideBarTabList
+            konnectSyncEnabled={konnectSyncEnabled}
+            isScratchPad={isScratchPad}
+            nonKonnectProjectLength={nonKonnectProjects.length}
+            konnectProjectsLength={konnectProjects.length}
+          />
+        </Tabs>
+      )}
       {showKonnectSyncIntro ? (
         <KonnectSyncIntro onConfigure={() => setShowKonnectConfigModal(true)} />
       ) : (
         <>
-          <div className="flex justify-between gap-1 p-(--padding-sm)">
-            <SidebarSearchField
-              value={isProjectTabActive ? filterInputValue : konnectFilterInputValue}
-              isDisabled={organizationProjects.length === 0}
-              onChange={isProjectTabActive ? setFilterInputValue : setKonnectFilterInputValue}
-            />
-            {isProjectTabActive ? (
-              !isScratchPad && (
-                <NewProjectButton onPress={onCreateProject} isDisabled={organizationProjects.length === 0} />
-              )
-            ) : (
-              <div className="flex items-center gap-1">
-                {syncing ? (
+          {focusedWorkspaceId ? (
+            <div className={focusTransition === 'in' ? 'animate-[sidebar-focus-in_200ms_ease-out]' : ''}>
+              <div className="group flex items-center gap-1 px-(--padding-sm) pt-(--padding-sm)">
+                <TooltipTrigger delay={300}>
+                  <BasicButton
+                    aria-label="Back to all projects"
+                    onPress={exitFocus}
+                    className="flex aspect-square h-6 shrink-0 items-center justify-center rounded-xs px-1 text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
+                  >
+                    <Icon icon="chevron-left" className="h-3 w-3" />
+                  </BasicButton>
+                  <Tooltip
+                    placement="bottom"
+                    className="rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) px-3 py-1.5 text-xs text-(--color-font) shadow-lg select-none"
+                  >
+                    Back to all projects
+                  </Tooltip>
+                </TooltipTrigger>
+                <div
+                  className={`${scopeToBgColorMap.collection} ${scopeToTextColorMap.collection} flex h-5 w-5 shrink-0 items-center justify-center rounded-sm`}
+                >
+                  <Icon icon={scopeToIconMap.collection} className="h-3 w-3" />
+                </div>
+                {isRenamingFocusedWorkspace ? (
+                  <input
+                    autoFocus
+                    type="text"
+                    value={renamingWorkspaceValue}
+                    onChange={e => setRenamingWorkspaceValue(e.target.value)}
+                    onFocus={e => e.currentTarget.select()}
+                    onBlur={() => {
+                      const trimmed = renamingWorkspaceValue.trim();
+                      if (focusedWorkspaceItem && trimmed && trimmed !== focusedWorkspaceItem.doc.name) {
+                        updateWorkspaceFetcher.submit({
+                          organizationId,
+                          projectId: focusedWorkspaceItem.project._id,
+                          patch: { name: trimmed, workspaceId: focusedWorkspaceItem.doc._id },
+                        });
+                      }
+                      setIsRenamingFocusedWorkspace(false);
+                    }}
+                    onKeyDown={e => {
+                      if (e.key === 'Enter') {
+                        e.currentTarget.blur();
+                      } else if (e.key === 'Escape') {
+                        setIsRenamingFocusedWorkspace(false);
+                      }
+                    }}
+                    className="min-w-0 flex-1 truncate rounded-xs bg-(--hl-sm) p-1 font-semibold text-(--color-font) focus:ring-1 focus:ring-(--color-surprise) focus:outline-none"
+                  />
+                ) : (
+                  <span
+                    onClick={() => {
+                      setRenamingWorkspaceValue(focusedWorkspaceItem?.doc.name || '');
+                      setIsRenamingFocusedWorkspace(true);
+                    }}
+                    className="flex-1 truncate rounded-xs p-1 font-semibold text-(--color-font) transition-colors hover:cursor-text hover:bg-(--hl-xs)"
+                  >
+                    {focusedWorkspaceItem?.doc.name || 'Collection'}
+                  </span>
+                )}
+                <div className="ml-auto shrink-0">
+                  {focusedWorkspaceItem && (
+                    <SidebarWorkspaceDropdown
+                      workspace={focusedWorkspaceItem.doc}
+                      project={focusedWorkspaceItem.project}
+                      organizationId={organizationId}
+                      sortOrder={collectionSortOrders[focusedWorkspaceId] ?? 'type-manual'}
+                      onSortOrderChange={(newOrder: SortOrder) => {
+                        setCollectionSortOrders(prev => ({ ...prev, [focusedWorkspaceId]: newOrder }));
+                      }}
+                      isOpen={isFocusedWorkspaceMenuOpen}
+                      onOpenChange={setIsFocusedWorkspaceMenuOpen}
+                    />
+                  )}
+                </div>
+              </div>
+              <div className="flex justify-between gap-1 p-(--padding-sm)">
+                <SidebarSearchField value={filterInputValue} isDisabled={false} onChange={setFilterInputValue} />
+              </div>
+            </div>
+          ) : (
+            <div className="flex justify-between gap-1 p-(--padding-sm)">
+              <SidebarSearchField
+                value={isProjectTabActive ? filterInputValue : konnectFilterInputValue}
+                isDisabled={organizationProjects.length === 0}
+                onChange={isProjectTabActive ? setFilterInputValue : setKonnectFilterInputValue}
+              />
+              {isProjectTabActive ? (
+                !isScratchPad && (
+                  <NewProjectButton onPress={onCreateProject} isDisabled={organizationProjects.length === 0} />
+                )
+              ) : (
+                <div className="flex items-center gap-1">
+                  {syncing ? (
                   <Button
                     aria-label="Cancel sync"
                     onPress={cancelSync}
@@ -997,16 +1194,17 @@ const ProjectNavigationSidebarInner = (
                     </Tooltip>
                   </TooltipTrigger>
                 )}
-                <Button
-                  aria-label="Konnect settings"
-                  onPress={() => setShowKonnectConfigModal(true)}
-                  className="flex aspect-square h-full items-center justify-center rounded-xs border border-solid border-(--hl-sm) px-2 text-sm text-(--color-font) transition-all hover:bg-(--hl-xs) focus:outline-none"
-                >
-                  <Icon icon="gear" />
-                </Button>
-              </div>
-            )}
-          </div>
+                  <Button
+                    aria-label="Konnect settings"
+                    onPress={() => setShowKonnectConfigModal(true)}
+                    className="flex aspect-square h-full items-center justify-center rounded-xs border border-solid border-(--hl-sm) px-2 text-sm text-(--color-font) transition-all hover:bg-(--hl-xs) focus:outline-none"
+                  >
+                    <Icon icon="gear" />
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
 
           {!isProjectTabActive && syncing && (
             <p className="truncate px-4 pb-1 text-xs text-(--hl) italic">{progress}</p>
@@ -1052,6 +1250,16 @@ const ProjectNavigationSidebarInner = (
               }
             }}
           >
+            <div
+              key={focusedWorkspaceId ?? '__all__'}
+              className={
+                focusTransition === 'in'
+                  ? 'animate-[sidebar-focus-in_200ms_ease-out]'
+                  : focusTransition === 'out'
+                    ? 'animate-[sidebar-focus-out_200ms_ease-out]'
+                    : ''
+              }
+            >
             <GridList
               aria-label="Project Navigation Tree"
               items={virtualizer.getVirtualItems()}
@@ -1106,7 +1314,22 @@ const ProjectNavigationSidebarInner = (
                           !isScratchPad && navigate(`/organization/${organizationId}/project/${docId}`);
                         }
                       } else if (item.kind === 'workspace') {
-                        if (routeInfo?.resourceId === docId && routeInfo?.routeId !== 'runner') {
+                        if (item.doc.scope === 'collection' && enableCollectionFocus) {
+                          // Narrow the sidebar into this collection's tree, and open it
+                          // in the main pane if it isn't already active.
+                          focusWorkspace(docId, item.project._id);
+                          if (routeInfo?.resourceId !== docId || routeInfo?.routeId === 'runner') {
+                            tabNavigate(
+                              {
+                                organization: organizationId,
+                                project: item.project,
+                                workspace: item.doc,
+                                item: item.doc,
+                              },
+                              { withTab: isPrimaryClickModifier(e), shouldNavigate: true, searchParams },
+                            );
+                          }
+                        } else if (routeInfo?.resourceId === docId && routeInfo?.routeId !== 'runner') {
                           toggleProjectOrWorkspace(docId);
                         } else {
                           tabNavigate(
@@ -1124,6 +1347,11 @@ const ProjectNavigationSidebarInner = (
                           dismissEnvOnboarding();
                         }
                       } else if (item.kind === 'collectionChild' || item.kind === 'pinnedRequest') {
+                        // Clicking anything inside a collection (folder, request, etc.) focuses it.
+                        // Guard so re-clicking within an already-focused collection doesn't replay the transition.
+                        if (enableCollectionFocus && focusedWorkspaceId !== item.workspace._id) {
+                          focusWorkspace(item.workspace._id, item.project._id);
+                        }
                         if (
                           routeInfo?.resourceId === docId &&
                           models.requestGroup.isRequestGroupId(docId) &&
@@ -1192,23 +1420,26 @@ const ProjectNavigationSidebarInner = (
                       />
                     )}
 
-                    {item.kind === 'pinnedHeader' && <PinnedHeaderNode />}
+                    {item.kind === 'pinnedHeader' && <PinnedHeaderNode depthOffset={treeDepthOffset} />}
 
                     {item.kind === 'collectionChild' && (
-                      <RequestNode item={item} onToggleFolder={toggleRequestGroups} />
+                      <RequestNode item={item} onToggleFolder={toggleRequestGroups} depthOffset={treeDepthOffset} />
                     )}
 
-                    {item.kind === 'pinnedRequest' && <RequestNode item={item} onToggleFolder={toggleRequestGroups} />}
+                    {item.kind === 'pinnedRequest' && (
+                      <RequestNode item={item} onToggleFolder={toggleRequestGroups} depthOffset={treeDepthOffset} />
+                    )}
 
                     {item.kind === 'unsyncedWorkspace' && <UnsyncedWorkspaceNode item={item} />}
 
                     {item.kind === 'emptyProject' || item.kind === 'emptyCollection' || item.kind === 'emptyFolder' ? (
-                      <EmptyNode item={item} storageRules={storageRules} />
+                      <EmptyNode item={item} storageRules={storageRules} depthOffset={treeDepthOffset} />
                     ) : null}
                   </GridListItem>
                 );
               }}
             </GridList>
+            </div>
           </div>
           {shortcutTargetItem && (
             <SidebarShortcutActionsDropdown

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
@@ -44,12 +44,14 @@ import { SideBarTabList } from '~/ui/components/sidebar/project-navigation-sideb
 import { EmptyNode } from '~/ui/components/sidebar/project-navigation-sidebar/empty-node';
 import { KonnectEnvOnboarding } from '~/ui/components/sidebar/project-navigation-sidebar/konnect-env-onboarding';
 import { KonnectSyncIntro } from '~/ui/components/sidebar/project-navigation-sidebar/konnect-sync-intro/konnect-sync-intro';
+import { SidebarFocusOnboarding } from '~/ui/components/sidebar/project-navigation-sidebar/sidebar-focus-onboarding';
 import { UnsyncedWorkspaceNode } from '~/ui/components/sidebar/project-navigation-sidebar/unsynced-workspace-node';
 import uiEventBus, { CLOUD_SYNC_FILE_CHANGE } from '~/ui/event-bus';
 import { useTabNavigate } from '~/ui/hooks/use-insomnia-tab';
 import { useKonnectSync } from '~/ui/hooks/use-konnect-sync';
 import { useProjectNavigationSidebarData } from '~/ui/hooks/use-navigation-sidebar-data';
 import { useOrganizationPermissions } from '~/ui/hooks/use-organization-features';
+import { useSettingsPatcher } from '~/ui/hooks/use-request';
 import insomniaLogo from '~/ui/images/insomnia-logo.svg';
 import { isPrimaryClickModifier } from '~/ui/utils';
 import { getAllRemoteBackendProjectsOfOrg } from '~/ui/utils/remote-projects';
@@ -1054,6 +1056,16 @@ const ProjectNavigationSidebarInner = (
     setOnboardingEnvWorkspaceId(null);
   }, []);
 
+  // One-time nudge explaining collection focus mode, anchored to the "back to
+  // all projects" arrow (only rendered while a collection is actually focused).
+  const patchSettings = useSettingsPatcher();
+  const [focusedWorkspaceHeaderNode, setFocusedWorkspaceHeaderNode] = useState<HTMLDivElement | null>(null);
+  const showSidebarFocusOnboarding =
+    enableCollectionFocus && !settings.hasSeenSidebarFocusOnboarding && Boolean(focusedWorkspaceId);
+  const dismissSidebarFocusOnboarding = useCallback(() => {
+    patchSettings({ hasSeenSidebarFocusOnboarding: true });
+  }, [patchSettings]);
+
   const skippedRoutesByReason = useMemo(() => {
     const map = new Map<string, string[]>();
     for (const { routeName, reason, serviceName } of lastSyncResult?.skippedRoutes ?? []) {
@@ -1084,6 +1096,7 @@ const ProjectNavigationSidebarInner = (
           {focusedWorkspaceId ? (
             <div className={focusTransition === 'in' ? 'animate-[sidebar-focus-in_200ms_ease-out]' : ''}>
               <div
+                ref={setFocusedWorkspaceHeaderNode}
                 className="group flex items-center gap-1 px-(--padding-sm) pt-(--padding-sm)"
                 // Mirrors WorkspaceNode's row attributes so this header stands in for the
                 // (now-hidden) workspace row — e.g. for anything keyed off `workspace-node-*`.
@@ -1603,6 +1616,9 @@ const ProjectNavigationSidebarInner = (
 
       {onboardingEnvWorkspaceId && envOnboardingNode && (
         <KonnectEnvOnboarding triggerElement={envOnboardingNode} onDismiss={dismissEnvOnboarding} />
+      )}
+      {showSidebarFocusOnboarding && focusedWorkspaceHeaderNode && (
+        <SidebarFocusOnboarding triggerElement={focusedWorkspaceHeaderNode} onDismiss={dismissSidebarFocusOnboarding} />
       )}
     </div>
   );

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
@@ -779,23 +779,33 @@ const ProjectNavigationSidebarInner = (
     [expandProjectOrWorkspaces, enableCollectionFocus],
   );
 
+  // Clears focus along with any focus-only UI state (inline rename, options
+  // menu). Without this, leaving focus mode mid-rename or with the options
+  // menu open would leak that state into the next focus session (e.g. a
+  // different collection reopening pre-filled with the old rename text).
+  const clearFocusState = useCallback(() => {
+    setFocusTransition('out');
+    setFocusedWorkspaceId(null);
+    setIsRenamingFocusedWorkspace(false);
+    setRenamingWorkspaceValue('');
+    setIsFocusedWorkspaceMenuOpen(false);
+  }, []);
+
   // Back arrow: return to the full tree without touching the route, and reset
   // the filter so it doesn't carry over silently scoped to the old collection.
   const exitFocus = useCallback(() => {
-    setFocusTransition('out');
-    setFocusedWorkspaceId(null);
+    clearFocusState();
     if (filterInputValue) {
       setFilterInputValue('');
     }
-  }, [filterInputValue]);
+  }, [clearFocusState, filterInputValue]);
 
   // Turning the preference off while a collection is focused returns to the full tree.
   useEffect(() => {
     if (!enableCollectionFocus) {
-      setFocusTransition('out');
-      setFocusedWorkspaceId(null);
+      clearFocusState();
     }
-  }, [enableCollectionFocus]);
+  }, [enableCollectionFocus, clearFocusState]);
 
   // Drive focus from the active route so navigating to a collection from
   // anywhere (tabs, project dashboard, deep links) focuses it too, not just a
@@ -809,8 +819,7 @@ const ProjectNavigationSidebarInner = (
     if (!activeWorkspaceId) {
       // Navigated to the project dashboard (no active workspace) → full tree.
       prevActiveWorkspaceIdRef.current = activeWorkspaceId;
-      setFocusTransition('out');
-      setFocusedWorkspaceId(null);
+      clearFocusState();
       return;
     }
     // Wait until the workspace is present in the tree so we can read its scope.
@@ -827,10 +836,9 @@ const ProjectNavigationSidebarInner = (
       focusWorkspace(activeWorkspaceId, workspaceItem.project._id);
     } else {
       // Design docs, mock servers, environments etc. show the full tree.
-      setFocusTransition('out');
-      setFocusedWorkspaceId(null);
+      clearFocusState();
     }
-  }, [activeWorkspaceId, flatItems, focusWorkspace]);
+  }, [activeWorkspaceId, flatItems, focusWorkspace, clearFocusState]);
 
   useImperativeHandle(
     ref,
@@ -1075,7 +1083,13 @@ const ProjectNavigationSidebarInner = (
         <>
           {focusedWorkspaceId ? (
             <div className={focusTransition === 'in' ? 'animate-[sidebar-focus-in_200ms_ease-out]' : ''}>
-              <div className="group flex items-center gap-1 px-(--padding-sm) pt-(--padding-sm)">
+              <div
+                className="group flex items-center gap-1 px-(--padding-sm) pt-(--padding-sm)"
+                // Mirrors WorkspaceNode's row attributes so this header stands in for the
+                // (now-hidden) workspace row — e.g. for anything keyed off `workspace-node-*`.
+                data-testid={focusedWorkspaceItem ? `workspace-node-${focusedWorkspaceItem.doc.name}` : undefined}
+                data-project={focusedWorkspaceItem?.project.name}
+              >
                 <TooltipTrigger delay={300}>
                   <BasicButton
                     aria-label="Back to all projects"

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/request-node.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/request-node.tsx
@@ -126,9 +126,12 @@ interface RequestNodeProps {
   item: CollectionChildFlatItem | PinnedRequestFlatItem;
   onToggleFolder: (requestGroupIds: string[], workspace: Workspace) => void;
   className?: string;
+  // Number of ancestor indent levels to strip when the sidebar is focused on a
+  // single collection (the project and workspace rows are no longer shown).
+  depthOffset?: number;
 }
 
-export const RequestNode = ({ item, onToggleFolder, className }: RequestNodeProps) => {
+export const RequestNode = ({ item, onToggleFolder, className, depthOffset = 0 }: RequestNodeProps) => {
   const { doc, level: requestLevel, workspace, project, collapsed, pinned, kind } = item;
   const isPinnedRequest = kind === 'pinnedRequest';
   const isLastPinned = item.kind === 'pinnedRequest' && item.isLastPinned;
@@ -241,7 +244,7 @@ export const RequestNode = ({ item, onToggleFolder, className }: RequestNodeProp
   return (
     <div
       className={`${ROW_CLASS} ${className ?? ''} ${isPinnedRequest ? 'h-full! group-hover:bg-transparent! group-focus:bg-transparent!' : ''}`}
-      style={{ paddingLeft: `${level + 3}rem` }}
+      style={{ paddingLeft: `${Math.max(level + 3 - depthOffset, 1)}rem` }}
       data-testid={
         isPinnedRequest
           ? `pinned-request-node-${getRequestNameOrFallback(doc)}`
@@ -255,23 +258,25 @@ export const RequestNode = ({ item, onToggleFolder, className }: RequestNodeProp
       data-workspace={workspace.name}
       data-selected={isSelected}
     >
-      {isPinnedRequest ? (
-        <>
-          <span className={`${GUIDE_LINE_CSS} left-6 group-hover/tree:bg-(--hl-sm)`} />
-          <span className={`${GUIDE_LINE_CSS} left-10 group-hover/tree:bg-(--hl-sm)`} />
-        </>
-      ) : (
-        Array.from({ length: level + 2 }, (_, i) => {
-          const isActive = i === level + 1;
-          return (
-            <span
-              key={i}
-              className={`${GUIDE_LINE_CSS} group-hover/tree:bg-(--hl-sm) ${isActive ? 'group-hover:bg-(--hl-sm)' : ''}`}
-              style={{ left: `${i + 1.5}em` }}
-            />
-          );
-        })
-      )}
+      {isPinnedRequest
+        ? depthOffset === 0 && (
+            <>
+              <span className={`${GUIDE_LINE_CSS} left-6 group-hover/tree:bg-(--hl-sm)`} />
+              <span className={`${GUIDE_LINE_CSS} left-10 group-hover/tree:bg-(--hl-sm)`} />
+            </>
+          )
+        : Array.from({ length: level + 2 }, (_, i) => i)
+            .filter(i => i >= depthOffset)
+            .map(i => {
+              const isActive = i === level + 1;
+              return (
+                <span
+                  key={i}
+                  className={`${GUIDE_LINE_CSS} group-hover/tree:bg-(--hl-sm) ${isActive ? 'group-hover:bg-(--hl-sm)' : ''}`}
+                  style={{ left: `${i + 1.5 - depthOffset}em` }}
+                />
+              );
+            })}
       <span className={ACTIVE_BORDER_CLASS} />
       {isPinnedRequest ? (
         <div
@@ -286,15 +291,19 @@ export const RequestNode = ({ item, onToggleFolder, className }: RequestNodeProp
   );
 };
 
-export const PinnedHeaderNode = () => {
+export const PinnedHeaderNode = ({ depthOffset = 0 }: { depthOffset?: number }) => {
   return (
     <div
-      className={`${ROW_CLASS} group h-full! pl-12 group-hover:bg-transparent!`}
+      className={`${ROW_CLASS} group h-full! ${depthOffset > 0 ? 'pl-4' : 'pl-12'} group-hover:bg-transparent!`}
       data-testid="pinned-requests-header"
     >
       <Button slot="drag" className="hidden" />
-      <span className={`${GUIDE_LINE_CSS} left-6 group-hover/tree:bg-(--hl-sm)`} />
-      <span className={`${GUIDE_LINE_CSS} left-10 group-hover/tree:bg-(--hl-sm)`} />
+      {depthOffset === 0 && (
+        <>
+          <span className={`${GUIDE_LINE_CSS} left-6 group-hover/tree:bg-(--hl-sm)`} />
+          <span className={`${GUIDE_LINE_CSS} left-10 group-hover/tree:bg-(--hl-sm)`} />
+        </>
+      )}
       <div className="ml-1 flex w-full items-center self-stretch rounded-t-sm border border-b-0 border-solid border-(--hl-md) bg-(--hl-xs) px-2 pt-1 text-(--hl)">
         <Icon icon="thumb-tack" className="h-4 w-4 shrink-0" />
         <span className="ml-1 text-base">Pinned</span>

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/sidebar-focus-onboarding.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/sidebar-focus-onboarding.tsx
@@ -43,9 +43,8 @@ export const SidebarFocusOnboarding = ({ triggerElement, onDismiss }: SidebarFoc
         </button>
       </div>
       <p className="mt-2 text-sm text-(--hl)">
-        Insomnia now automatically narrows the sidebar to the collection you're working in. Click{' '}
-        <span className="font-bold text-(--color-font)">Back to all projects</span> at the top to see everything, or
-        turn this off anytime in Preferences with the{' '}
+        Insomnia now automatically narrows the sidebar to the collection you're working. Click the back arrow at the
+        top to return, or turn this off anytime in Preferences with the{' '}
         <span className="font-bold text-(--color-font)">Sidebar focus for collections</span> setting.
       </p>
       <button

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/sidebar-focus-onboarding.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/sidebar-focus-onboarding.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from 'react';
+
+import { Icon } from '../../icon';
+
+interface SidebarFocusOnboardingProps {
+  triggerElement: HTMLElement | null;
+  onDismiss: () => void;
+}
+
+export const SidebarFocusOnboarding = ({ triggerElement, onDismiss }: SidebarFocusOnboardingProps) => {
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!triggerElement) return;
+
+    const updatePosition = () => {
+      if (!popoverRef.current) return;
+      const triggerRect = triggerElement.getBoundingClientRect();
+      const popover = popoverRef.current;
+      popover.style.top = `${triggerRect.top + 78}px`;
+      popover.style.left = `${triggerRect.right + 4}px`;
+    };
+
+    updatePosition();
+
+    const observer = new ResizeObserver(updatePosition);
+    observer.observe(triggerElement);
+
+    return () => observer.disconnect();
+  }, [triggerElement]);
+
+  return (
+    <div
+      ref={popoverRef}
+      className="fixed z-50 w-72 rounded-md border border-solid border-(--hl-md) bg-(--color-bg) p-4 shadow-lg"
+      role="dialog"
+      aria-label="Sidebar focus mode onboarding"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <h3 className="text-sm font-semibold text-(--color-font)">Welcome to focus mode</h3>
+        <button className="shrink-0 text-(--hl) hover:text-(--color-font)" onClick={onDismiss} aria-label="Dismiss">
+          <Icon icon="close" />
+        </button>
+      </div>
+      <p className="mt-2 text-sm text-(--hl)">
+        Insomnia now automatically narrows the sidebar to the collection you're working in. Click{' '}
+        <span className="font-bold text-(--color-font)">Back to all projects</span> at the top to see everything, or
+        turn this off anytime in Preferences with the{' '}
+        <span className="font-bold text-(--color-font)">Sidebar focus for collections</span> setting.
+      </p>
+      <button
+        className="mt-3 rounded-md bg-(--color-surprise) px-4 py-1.5 text-sm font-medium text-(--color-font-surprise) transition-colors hover:opacity-90"
+        onClick={onDismiss}
+      >
+        Got It
+      </button>
+    </div>
+  );
+};

--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/sidebar-focus-onboarding.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/sidebar-focus-onboarding.tsx
@@ -43,7 +43,7 @@ export const SidebarFocusOnboarding = ({ triggerElement, onDismiss }: SidebarFoc
         </button>
       </div>
       <p className="mt-2 text-sm text-(--hl)">
-        Insomnia now automatically narrows the sidebar to the collection you're working. Click the back arrow at the
+        Insomnia now automatically narrows the sidebar to the collection you're working on. Click the back arrow at the
         top to return, or turn this off anytime in Preferences with the{' '}
         <span className="font-bold text-(--color-font)">Sidebar focus for collections</span> setting.
       </p>

--- a/packages/insomnia/src/ui/css/styles.css
+++ b/packages/insomnia/src/ui/css/styles.css
@@ -140,6 +140,29 @@ input[type='color']::-webkit-color-swatch {
 .new-sidebar {
   z-index: 0;
 }
+
+/* Sidebar collection-focus-mode swipe transitions */
+@keyframes sidebar-focus-in {
+  from {
+    transform: translateX(12px);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+@keyframes sidebar-focus-out {
+  from {
+    transform: translateX(-12px);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
 .new-sidebar .sidebar {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

Adds a "focus mode" to the project navigation sidebar: clicking a request collection (or anything inside it) narrows the sidebar down to just that collection's tree, with a back arrow to return to the full project list. Addresses the v13 GA feedback that the always-expanded tree is too noisy for people who work in one or two collections at a time.

Resolves the pain described in [discussion #10117](https://github.com/Kong/insomnia/discussions/10117). Design/interaction direction taken from the draft prototype in [#10297](https://github.com/Kong/insomnia/pull/10297) (reference only — didn't apply cleanly to current `develop`, so this reimplements the same behavior against current code).

## Problem

The v13 sidebar always renders the full project tree. Users with many collections/projects but who work in only a couple of them get a wall of unrelated items every time they open a collection, with no way to isolate their current context (the v12 behavior).

## Solution

- New preference, **Settings → General → "Sidebar focus for collections"** (default **on**). When enabled:
  - Clicking a `collection`-scope workspace row, or any folder/request inside it, narrows the sidebar to that collection's tree only. The project list, other collections, and the project/Konnect tabs are hidden.
  - The header switches to a back-arrow row: collection icon + name (click the name to rename inline, Enter to save), and the collection's options menu (same actions as in the full tree) revealed on hover.
  - The filter box now searches only within the focused collection. Clicking "back" clears the filter and restores the full tree.
  - Focus also follows the active route (tabs, project dashboard, deep links) so navigating to a collection any other way keeps the sidebar in sync, not just a direct sidebar click.
  - Turning the preference off (or a route to a non-collection workspace: design doc, mock server, environment) always shows the full tree, unchanged from today.
- Tree indentation and guide-lines (`RequestNode`, `PinnedHeaderNode`, `EmptyNode`) now accept a `depthOffset` so focused collections don't show a dead left margin / orphaned guide-lines for the two now-hidden ancestor rows (project, workspace).
- Small CSS swipe transition (`sidebar-focus-in`/`-out` keyframes) on entering/leaving focus mode.

Closes INS-2912