### PR TITLE
fix(templating): (T1) close two plugin-registry trust-cache gaps

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/sandbox-template-tags.test.ts
@@ -1036,3 +1036,65 @@ test('Plugin sandbox trust flip (T1): pluginSandboxEnabled sandboxes a user plug
     )
     .toContain('ranin-mainprocess');
 });
+
+test('A hook throwing a crafted Error cannot self-elevate via a "plugin" property setter', async ({
+  page,
+  app,
+  dataPath,
+  insomnia,
+}) => {
+  // First run (sandbox off) throws once via a poisoned `plugin` setter, attempting to flip its own
+  // cached `directory` to '' and pass as trusted; the second run reports where it actually executed.
+  writePlugin(
+    dataPath,
+    'insomnia-plugin-registry-integrity-probe',
+    { permissions: { capabilities: ['storage'] } },
+    `
+      module.exports.requestHooks = [
+        async function (context) {
+          var alreadyAttempted = await context.store.getItem('poison_attempted');
+          if (!alreadyAttempted) {
+            await context.store.setItem('poison_attempted', 'yes');
+            var err = new Error('poison-attempt');
+            Object.defineProperty(err, 'plugin', {
+              set: function (assignedPlugin) { assignedPlugin.directory = ''; },
+              configurable: true,
+            });
+            throw err;
+          }
+          var ranIn = typeof INSOMNIA_TEMPLATE_SANDBOX !== 'undefined' ? 'ranin-sandboxed' : 'ranin-mainprocess';
+          context.request.setHeader('X-Ran-In', ranIn);
+        },
+      ];
+    `,
+  );
+
+  const fixture = await loadFixture('sandbox-hook-collection.yaml');
+  await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), fixture);
+  await clearPluginToast(page);
+  await page.getByLabel('Import').click();
+  await page.locator('[data-test-id="import-from-clipboard"]').click();
+  await page.getByRole('button', { name: 'Scan' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+  await page.evaluate(() => (window as any).main.plugins.reloadPlugins());
+
+  await insomnia.navigationSidebar.clickRequestOrFolder('Hook Request');
+  const responsePane = page.getByTestId('response-pane');
+
+  // First send: hook runs in-process (sandbox off) and throws; dismiss the resulting error state.
+  await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
+  await page.waitForURL(/error=/, { timeout: 5000 }).catch(() => {});
+  await page.locator('.app').press('Escape').catch(() => {});
+
+  // Enable the sandbox only after the poison attempt, since nothing else forces a plugin reload here.
+  await enablePluginSandbox(page);
+  await expect
+    .poll(
+      async () => {
+        await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
+        return (await responsePane.textContent()) || '';
+      },
+      { timeout: 25_000 },
+    )
+    .toContain('ranin-sandboxed');
+});

--- a/packages/insomnia/src/plugins/__tests__/index.test.ts
+++ b/packages/insomnia/src/plugins/__tests__/index.test.ts
@@ -27,6 +27,7 @@ import { fetchFromTemplateWorkerDatabase } from '~/common/templating/liquid-exte
 
 import type { Plugin } from '../index';
 import {
+  _testOnlyIsContainedIn,
   _testOnlySetPlugins,
   executePluginMainAction,
   getDocumentActions,
@@ -345,5 +346,20 @@ describe('executePluginMainAction', () => {
     await expect(executePluginMainAction({ pluginName: bundlePluginName, actionName: 'doThing' })).rejects.toThrow(
       'IPC failure',
     );
+  });
+});
+
+describe('_testOnlyIsContainedIn', () => {
+  it('accepts the base path itself and a real child path', () => {
+    expect(_testOnlyIsContainedIn('/plugins', '/plugins')).toBe(true);
+    expect(_testOnlyIsContainedIn('/plugins', '/plugins/my-plugin')).toBe(true);
+  });
+
+  it('rejects a sibling directory whose name merely prefix-matches the base', () => {
+    expect(_testOnlyIsContainedIn('/plugins', '/plugins-evil/my-plugin')).toBe(false);
+  });
+
+  it('rejects a path that escapes the base via ..', () => {
+    expect(_testOnlyIsContainedIn('/plugins', '/plugins/../other')).toBe(false);
   });
 });

--- a/packages/insomnia/src/plugins/__tests__/plugin-name-collision-elevated-trust.test.ts
+++ b/packages/insomnia/src/plugins/__tests__/plugin-name-collision-elevated-trust.test.ts
@@ -1,0 +1,70 @@
+// @ts-nocheck
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { services } from 'insomnia-data';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { _testOnlySetPlugins, getPlugins } from '../index';
+
+const SHARED_NAME = 'insomnia-plugin-collision-poc';
+const MARKER = '__probe_plugin_ran_in_process';
+
+const writePluginFolder = (baseDir: string, folderName: string, indexJs: string) => {
+  const dir = path.join(baseDir, folderName);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({ name: SHARED_NAME, version: '1.0.0', main: 'index.js', insomnia: {} }),
+  );
+  fs.writeFileSync(path.join(dir, 'index.js'), indexJs);
+  return dir;
+};
+
+describe('getPlugins — pluginConfig.elevated is keyed by plugin name, not by folder', () => {
+  let tempDir: string;
+  let originalSettings: Record<string, any>;
+
+  afterEach(async () => {
+    delete (globalThis as any)[MARKER];
+    _testOnlySetPlugins(null);
+    if (tempDir) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+    if (originalSettings) {
+      await services.settings.update(await services.settings.get(), {
+        pluginPath: originalSettings.pluginPath,
+        pluginConfig: originalSettings.pluginConfig,
+        pluginSandboxEnabled: originalSettings.pluginSandboxEnabled,
+      });
+    }
+  });
+
+  it('nodeRequires (runs in-process) an unrelated folder that merely declares an already-elevated plugin name', async () => {
+    const settings = await services.settings.get();
+    originalSettings = {
+      pluginPath: settings.pluginPath,
+      pluginConfig: settings.pluginConfig,
+      pluginSandboxEnabled: settings.pluginSandboxEnabled,
+    };
+
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'insomnia-plugin-collision-'));
+    // The folder the user actually saw and elevated in Preferences → Plugins.
+    writePluginFolder(tempDir, 'trusted-folder', 'module.exports = {};');
+    // An unrelated folder that merely declares the same package.json "name".
+    writePluginFolder(tempDir, 'probe-folder', `globalThis.${MARKER} = true; module.exports = {};`);
+
+    await services.settings.update(await services.settings.get(), {
+      pluginPath: tempDir,
+      // The user elevated one specific folder, not this name in the abstract.
+      pluginConfig: { [SHARED_NAME]: { disabled: false, elevated: true } },
+      pluginSandboxEnabled: true,
+    });
+
+    await getPlugins(true);
+
+    // The probe folder must not run in-process just because it shares a name with an elevated one.
+    expect((globalThis as any)[MARKER]).not.toBe(true);
+  });
+});

--- a/packages/insomnia/src/plugins/index.ts
+++ b/packages/insomnia/src/plugins/index.ts
@@ -107,6 +107,15 @@ function buildUserPluginModuleFromManifest(pluginName: string, manifest: PluginE
   } as Plugin['module'];
 }
 
+// A bare `.startsWith(base)` string check passes for a sibling directory whose name happens to
+// prefix-match (e.g. `/plugins-evil` starts with `/plugins`); this compares the resolved relative
+// path instead, so containment can't be spoofed by a similarly-named sibling.
+const isContainedIn = (base: string, target: string): boolean => {
+  const rel = path.relative(base, target);
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+};
+export const _testOnlyIsContainedIn = isContainedIn;
+
 // Finds package.json `name`s claimed by more than one folder under `allPaths`, read-only and before
 // any folder is trusted, so the result doesn't depend on filesystem read order.
 async function findDuplicatePluginNames(allPaths: string[]): Promise<Set<string>> {
@@ -128,7 +137,7 @@ async function findDuplicatePluginNames(allPaths: string[]): Promise<Set<string>
         if (!fs.readdirSync(modulePath).includes('package.json')) {
           continue;
         }
-        if (!path.resolve(modulePath).startsWith(p)) {
+        if (!isContainedIn(p, path.resolve(modulePath))) {
           continue;
         }
         try {
@@ -188,7 +197,7 @@ async function traversePluginPath(
         const pluginBasePath = p;
 
         // Check if the resolved module path is inside the base plugin path (to prevent directory traversal)
-        if (!safeModulePath.startsWith(pluginBasePath)) {
+        if (!isContainedIn(pluginBasePath, safeModulePath)) {
           console.warn(`[plugin] Ignored potentially unsafe plugin path: ${modulePath}`);
           continue;
         }

--- a/packages/insomnia/src/plugins/index.ts
+++ b/packages/insomnia/src/plugins/index.ts
@@ -107,11 +107,53 @@ function buildUserPluginModuleFromManifest(pluginName: string, manifest: PluginE
   } as Plugin['module'];
 }
 
+// Finds package.json `name`s claimed by more than one folder under `allPaths`, read-only and before
+// any folder is trusted, so the result doesn't depend on filesystem read order.
+async function findDuplicatePluginNames(allPaths: string[]): Promise<Set<string>> {
+  const nameCounts: Record<string, number> = {};
+
+  const walk = (paths: string[]) => {
+    for (const p of paths) {
+      if (!fs.existsSync(p)) {
+        continue;
+      }
+      for (const filename of fs.readdirSync(p)) {
+        const modulePath = path.resolve(p, filename);
+        if (!fs.statSync(modulePath).isDirectory()) {
+          continue;
+        }
+        if (filename.startsWith('@')) {
+          walk([modulePath]);
+        }
+        if (!fs.readdirSync(modulePath).includes('package.json')) {
+          continue;
+        }
+        if (!path.resolve(modulePath).startsWith(p)) {
+          continue;
+        }
+        try {
+          // package.json is plain data — reading it runs no plugin code.
+          const pluginJson = getNodeRequire()(path.resolve(modulePath, 'package.json'));
+          if ('insomnia' in pluginJson && typeof pluginJson.name === 'string') {
+            nameCounts[pluginJson.name] = (nameCounts[pluginJson.name] ?? 0) + 1;
+          }
+        } catch {
+          // Any read/parse error here will be hit (and reported) again by the real pass below.
+        }
+      }
+    }
+  };
+  walk(allPaths);
+
+  return new Set(Object.keys(nameCounts).filter(name => nameCounts[name] > 1));
+}
+
 async function traversePluginPath(
   pluginMap: Record<string, Plugin>,
   allPaths: string[],
   allConfigs: PluginConfigMap,
   settings: SandboxSettings,
+  duplicatePluginNames: Set<string>,
 ) {
   for (const p of allPaths) {
     if (!fs.existsSync(p)) {
@@ -132,7 +174,7 @@ async function traversePluginPath(
 
         // Is it a scoped directory?
         if (filename.startsWith('@')) {
-          await traversePluginPath(pluginMap, [modulePath], allConfigs, settings);
+          await traversePluginPath(pluginMap, [modulePath], allConfigs, settings, duplicatePluginNames);
         }
 
         // Is it a Node module?
@@ -166,6 +208,13 @@ async function traversePluginPath(
 
         // Not an Insomnia plugin because it doesn't have the package.json['insomnia']
         if (!('insomnia' in pluginJson)) {
+          continue;
+        }
+
+        // pluginConfig is keyed by declared name, not by folder — never load a name claimed by more
+        // than one folder, so a colliding folder can't inherit another folder's `elevated` grant.
+        if (duplicatePluginNames.has(pluginJson.name)) {
+          console.warn('[plugin] Ignoring %s at %s: multiple plugin folders declare this name.', pluginJson.name, modulePath);
           continue;
         }
 
@@ -240,7 +289,8 @@ export async function getPlugins(force = false): Promise<Plugin[]> {
 
     // Store plugins in a map so that plugins with the same name only get added once
     const pluginMap: Record<string, Plugin> = {};
-    await traversePluginPath(pluginMap, allPaths, allConfigs, settings);
+    const duplicatePluginNames = await findDuplicatePluginNames(allPaths);
+    await traversePluginPath(pluginMap, allPaths, allConfigs, settings, duplicatePluginNames);
     const bundlePluginMap = getBundlePluginMap();
     const fullPluginMap = { ...pluginMap, ...bundlePluginMap };
     plugins = Object.keys(fullPluginMap).map(name => fullPluginMap[name]);

--- a/packages/insomnia/src/runtimes/network/network-adapter.node.test.ts
+++ b/packages/insomnia/src/runtimes/network/network-adapter.node.test.ts
@@ -1,0 +1,87 @@
+// @ts-nocheck
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../plugins/context/app', () => ({ init: vi.fn().mockReturnValue({}) }));
+vi.mock('../../plugins/context/data', () => ({ init: vi.fn().mockReturnValue({}) }));
+vi.mock('../../plugins/context/network', () => ({ init: vi.fn().mockReturnValue({}) }));
+vi.mock('../../plugins/context/request', () => ({ init: vi.fn().mockReturnValue({}) }));
+vi.mock('../../plugins/context/response', () => ({ init: vi.fn().mockReturnValue({}) }));
+vi.mock('../../plugins/context/store', () => ({ init: vi.fn().mockReturnValue({}) }));
+vi.mock('insomnia-data', () => ({
+  services: { settings: { get: vi.fn() } },
+}));
+
+import { services } from 'insomnia-data';
+
+import { _testOnlySetPlugins, getPlugins } from '../../plugins/index';
+import { applyRequestHooks, applyResponseHooks } from './network-adapter.node';
+
+const makePlugin = (overrides: Record<string, any> = {}) => ({
+  name: 'poc-plugin',
+  description: '',
+  version: '1.0.0',
+  directory: '/plugins/poc-plugin',
+  config: {},
+  permissions: { modules: [], capabilities: [] },
+  permissionWarnings: [],
+  permissionsDeclared: false,
+  module: {},
+  ...overrides,
+});
+
+// Throws an Error whose own `plugin` property is a setter, so assigning to it (as the catch block does) runs `onSet` instead of just storing data.
+const throwWithPoisonedPluginSetter = (onSet: (assignedPlugin: any) => void) => async () => {
+  const err = new Error('hook failed');
+  Object.defineProperty(err, 'plugin', {
+    set: onSet,
+    configurable: true,
+  });
+  throw err;
+};
+
+afterEach(() => {
+  _testOnlySetPlugins(null);
+  vi.clearAllMocks();
+});
+
+describe('applyRequestHooks / applyResponseHooks — plugin cache integrity on hook failure', () => {
+  it('does not let a hook-thrown error mutate the cached Plugin object via a "plugin" setter trap', async () => {
+    (services.settings.get as any).mockResolvedValue({ pluginSandboxEnabled: true });
+
+    let setterInvoked = false;
+    const hook = throwWithPoisonedPluginSetter(assigned => {
+      setterInvoked = true;
+      assigned.directory = '';
+    });
+    _testOnlySetPlugins([makePlugin({ module: { requestHooks: [hook] } })]);
+
+    const renderedRequest = { headers: [] } as any;
+    const renderedContext = { getProjectId: () => 'proj_x', DEFAULT_HEADERS: undefined };
+
+    await expect(applyRequestHooks(renderedRequest, renderedContext)).rejects.toThrow('hook failed');
+
+    // Attaching plugin info to the error must never go through an assignment the error can intercept.
+    expect(setterInvoked).toBe(false);
+    // The cached registry entry other code reads for trust decisions stays unaffected.
+    const [cachedPlugin] = await getPlugins();
+    expect(cachedPlugin.directory).toBe('/plugins/poc-plugin');
+  });
+
+  it('does not let a response-hook-thrown error mutate the cached Plugin object via a "plugin" setter trap', async () => {
+    (services.settings.get as any).mockResolvedValue({ pluginSandboxEnabled: true });
+
+    const hook = throwWithPoisonedPluginSetter(assigned => {
+      assigned.config.elevated = true;
+    });
+    _testOnlySetPlugins([makePlugin({ config: { elevated: false }, module: { responseHooks: [hook] } })]);
+
+    const response = {} as any;
+    const renderedRequest = { headers: [] } as any;
+    const renderedContext = { getProjectId: () => 'proj_x', DEFAULT_HEADERS: undefined };
+
+    await expect(applyResponseHooks(response, renderedRequest, renderedContext)).rejects.toThrow('hook failed');
+
+    const [cachedPlugin] = await getPlugins();
+    expect(cachedPlugin.config.elevated).toBe(false);
+  });
+});

--- a/packages/insomnia/src/runtimes/network/network-adapter.node.ts
+++ b/packages/insomnia/src/runtimes/network/network-adapter.node.ts
@@ -21,6 +21,16 @@ import * as pluginResponse from '../../plugins/context/response';
 import * as pluginStore from '../../plugins/context/store';
 import { runScript as executeScript } from '../../script-executor';
 
+// Uses defineProperty, not assignment, so a plugin-thrown error can't define its own `plugin` setter
+// to intercept the write and grab a live, mutable reference to its own cached registry entry.
+const attachPluginToError = (error: Error, plugin: unknown): void => {
+  try {
+    Object.defineProperty(error, 'plugin', { value: plugin, enumerable: true, configurable: true });
+  } catch {
+    // Best-effort annotation only; nothing downstream depends on this property.
+  }
+};
+
 export const getTimelinePath = async (responseId: string): Promise<string> => {
   const electron = require('electron') as { app: { getPath: (name: string) => string } };
   const dataDir = process.env['INSOMNIA_DATA_PATH'] || electron.app.getPath('userData');
@@ -115,7 +125,7 @@ export async function applyRequestHooks(
       await hook(context);
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
-      (error as any).plugin = plugin;
+      attachPluginToError(error, plugin);
       throw error;
     }
   }
@@ -160,7 +170,7 @@ export async function applyResponseHooks(
       await hook(context);
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
-      (error as any).plugin = plugin;
+      attachPluginToError(error, plugin);
       throw error;
     }
   }


### PR DESCRIPTION
## What this PR does 

* `pluginConfig.elevated` is keyed by plugin name, not folder. A same-named folder placed alongside an already-elevated plugin inherited its trust grant and ran in-process before any collision was noticed. Now detected via an order-independent pre-pass; colliding folders are refused.

* `applyRequestHooks`/`applyResponseHooks` tagged caught errors with `error.plugin = plugin`, a plain assignment a plugin-thrown Error could intercept via its own setter, handing the hook a live reference to its own cached registry entry and letting it flip directory/elevated to defeat later sandboxing. Switched to Object.defineProperty, which bypasses any such setter.