### PR TITLE
fix(plugins): (#10295 follow-ups) reload-shortcut cache invalidation + null-proto plugin maps

### DIFF
--- a/packages/insomnia/src/plugins/index.ts
+++ b/packages/insomnia/src/plugins/index.ts
@@ -122,7 +122,9 @@ export const _testOnlyIsContainedIn = isContainedIn;
 // Finds package.json `name`s claimed by more than one folder under `allPaths`, read-only and before
 // any folder is trusted, so the result doesn't depend on filesystem read order.
 async function findDuplicatePluginNames(allPaths: string[]): Promise<Set<string>> {
-  const nameCounts: Record<string, number> = {};
+  // Null-prototype so a plugin literally named `toString`/`valueOf`/`hasOwnProperty`/etc. can't collide
+  // with an inherited Object.prototype member (which would skew the count or dodge detection).
+  const nameCounts: Record<string, number> = Object.create(null);
 
   const walk = (paths: string[]) => {
     for (const p of paths) {
@@ -380,8 +382,11 @@ export async function getPlugins(force = false): Promise<Plugin[]> {
     const extendedPaths = basePaths.map(p => path.resolve(p, 'node_modules'));
     const allPaths = [...basePaths, ...extendedPaths];
 
-    // Store plugins in a map so that plugins with the same name only get added once
-    const pluginMap: Record<string, Plugin> = {};
+    // Store plugins in a map so that plugins with the same name only get added once. Null-prototype so
+    // a plugin named `toString`/`valueOf`/`hasOwnProperty`/etc. can't match an inherited Object.prototype
+    // member — otherwise the `name in pluginMap` check in the load-error handler would treat such a
+    // failed plugin as "already present" and silently drop it instead of surfacing a disabled row.
+    const pluginMap: Record<string, Plugin> = Object.create(null);
     const duplicatePluginNames = await findDuplicatePluginNames(allPaths);
     await traversePluginPath(pluginMap, allPaths, allConfigs, settings, duplicatePluginNames);
     const bundlePluginMap = getBundlePluginMap();

--- a/packages/insomnia/src/ui/hooks/use-global-keyboard-shortcuts.ts
+++ b/packages/insomnia/src/ui/hooks/use-global-keyboard-shortcuts.ts
@@ -1,5 +1,6 @@
 import { useRootLoaderData } from '~/root';
 import { plugins } from '~/ui/plugins/renderer-bridge';
+import { reload } from '~/ui/templating/renderer-safe';
 
 import { useDocBodyKeyboardShortcuts } from '../components/keydown-binder';
 import { showModal } from '../components/modals';
@@ -11,7 +12,12 @@ export const useGlobalKeyboardShortcuts = () => {
   const patchSettings = useSettingsPatcher();
 
   useDocBodyKeyboardShortcuts({
-    plugin_reload: () => plugins.reloadPlugins(),
+    // Route through the same path as Settings → Plugins reload: rescan plugins AND invalidate the
+    // render worker's cached Liquid engine, so a plugin that failed once actually recovers (#10295).
+    plugin_reload: async () => {
+      await plugins.reloadPlugins();
+      reload();
+    },
     // TODO: move this to workspace route
     environment_showVariableSourceAndValue: () =>
       patchSettings({ showVariableSourceAndValue: !settings.showVariableSourceAndValue }),


### PR DESCRIPTION
## What this PR does

Two small follow-ups to the #10295 plugin-vanish fix, both closing the *same bug class* the P0 review flagged. **Targets `fix/issue-10295`** so it can be folded into #10317 while that PR is still in progress.

### 1. `plugin_reload` keyboard shortcut bypassed the render-worker cache invalidation
`use-global-keyboard-shortcuts.ts` called only `plugins.reloadPlugins()`, skipping the worker `reload()` that Settings → Plugins does — so triggering a reload via the keyboard shortcut left the render worker's cached Liquid engine (and the main registry) stale. That's a live instance of the exact P0-A staleness bug #10317 fixes for the Settings path. It now rescans **and** invalidates the engine cache.

### 2. `pluginMap` / `nameCounts` are plain objects → prototype-method plugin names misbehave
Both maps in `plugins/index.ts` were `{}`. A plugin literally named `toString` / `valueOf` / `hasOwnProperty` / etc. matches an inherited `Object.prototype` member, which (a) skews duplicate detection in `findDuplicatePluginNames`, and (b) via `name in pluginMap` in the load-error handler, makes a **failed** plugin with such a name read as "already present" and get silently dropped — a P0-B hole (silent disappearance) for those names. Switched both to `Object.create(null)`.

## Notes
- No behavior change for normal plugin names; these only affect the reload-shortcut path and prototype-method-named plugins.
- Validated: `tsc` clean, eslint clean, `plugins/index.test.ts` (35) green.

_🤖 Authored by [Claude Code](https://claude.com/claude-code)_
