### PR TITLE
feat(git): name app-managed git folders after their project instead of a bare hex id

### DIFF
--- a/packages/insomnia-data/common-src/misc.test.ts
+++ b/packages/insomnia-data/common-src/misc.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { slugify } from './misc';
+
+describe('slugify', () => {
+  it('lowercases and joins words with hyphens', () => {
+    expect(slugify('Cams Project!')).toBe('cams-project');
+  });
+
+  it('strips accents', () => {
+    expect(slugify('Café México')).toBe('cafe-mexico');
+  });
+
+  it('collapses runs of non-alphanumeric characters', () => {
+    expect(slugify('  --Weird__Name--  ')).toBe('weird-name');
+  });
+
+  it('returns an empty string when nothing usable remains', () => {
+    expect(slugify('🚀🚀🚀')).toBe('');
+  });
+
+  it('truncates to maxLength without leaving a trailing hyphen', () => {
+    const longName = 'a-very-long-project-name-that-goes-on-and-on-and-on';
+    const slug = slugify(longName, 20);
+
+    expect(slug.length).toBeLessThanOrEqual(20);
+    expect(slug.endsWith('-')).toBe(false);
+  });
+});

--- a/packages/insomnia-data/common-src/misc.ts
+++ b/packages/insomnia-data/common-src/misc.ts
@@ -13,3 +13,25 @@ export function generateId(prefix?: string) {
   }
   return id;
 }
+
+/**
+ * Turns arbitrary text into a filesystem-safe slug: lowercased, accents
+ * stripped, runs of non-alphanumeric characters collapsed to a single `-`,
+ * leading/trailing `-` trimmed, and truncated to `maxLength`.
+ *
+ * Returns `''` when nothing usable remains (e.g. all-emoji or all-punctuation
+ * input) — callers should treat that as "no slug available".
+ */
+export function slugify(input: string, maxLength = 40) {
+  const slug = input
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '') // strip accents (combining diacritical marks)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  if (slug.length <= maxLength) {
+    return slug;
+  }
+  return slug.slice(0, maxLength).replace(/-+$/g, '');
+}

--- a/packages/insomnia-data/common-src/misc.ts
+++ b/packages/insomnia-data/common-src/misc.ts
@@ -25,7 +25,7 @@ export function generateId(prefix?: string) {
 export function slugify(input: string, maxLength = 40) {
   const slug = input
     .normalize('NFKD')
-    .replace(/[̀-ͯ]/g, '') // strip accents (combining diacritical marks)
+    .replace(/[\u0300-\u036F]/g, '') // strip accents (combining diacritical marks)
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');

--- a/packages/insomnia-data/src/models/git-repository.test.ts
+++ b/packages/insomnia-data/src/models/git-repository.test.ts
@@ -1,0 +1,31 @@
+import { models } from 'insomnia-data';
+import { describe, expect, it } from 'vitest';
+
+describe('getGitRepoFolderName', () => {
+  it('returns the bare id when there is no folderSlug', () => {
+    const folderName = models.gitRepository.getGitRepoFolderName({
+      _id: 'git_57d071a646b34393929036c34dd0915e',
+      folderSlug: null,
+    });
+
+    expect(folderName).toBe('git_57d071a646b34393929036c34dd0915e');
+  });
+
+  it('embeds the slug between the "git" prefix and the hex id when set', () => {
+    const folderName = models.gitRepository.getGitRepoFolderName({
+      _id: 'git_57d071a646b34393929036c34dd0915e',
+      folderSlug: 'cams-project',
+    });
+
+    expect(folderName).toBe('git_cams-project_57d071a646b34393929036c34dd0915e');
+  });
+
+  it('falls back to the whole id if it somehow lacks the "git_" prefix', () => {
+    const folderName = models.gitRepository.getGitRepoFolderName({
+      _id: '57d071a646b34393929036c34dd0915e',
+      folderSlug: 'cams-project',
+    });
+
+    expect(folderName).toBe('git_cams-project_57d071a646b34393929036c34dd0915e');
+  });
+});

--- a/packages/insomnia-data/src/models/git-repository.test.ts
+++ b/packages/insomnia-data/src/models/git-repository.test.ts
@@ -28,4 +28,13 @@ describe('getGitRepoFolderName', () => {
 
     expect(folderName).toBe('git_cams-project_57d071a646b34393929036c34dd0915e');
   });
+
+  it('falls back to the bare id when folderSlug contains anything outside [a-z0-9-] (e.g. a corrupted or path-traversal value)', () => {
+    const folderName = models.gitRepository.getGitRepoFolderName({
+      _id: 'git_57d071a646b34393929036c34dd0915e',
+      folderSlug: '../../etc',
+    });
+
+    expect(folderName).toBe('git_57d071a646b34393929036c34dd0915e');
+  });
 });

--- a/packages/insomnia-data/src/models/git-repository.ts
+++ b/packages/insomnia-data/src/models/git-repository.ts
@@ -85,11 +85,12 @@ export interface BaseGitRepository {
   /**
    * A filesystem-safe slug derived from the owning project's name at the time
    * the app-managed folder was created (or, for repos that predate this field,
-   * backfilled the first time the repo is loaded). It is baked into the
-   * managed folder name for readability (see {@link getGitRepoFolderName}) and
-   * is intentionally NOT kept in sync with later project renames — renaming
-   * the folder on every project rename would risk moving a directory out from
-   * under an open editor, terminal, or native git process.
+   * backfilled by a one-time best-effort startup pass before the window is
+   * created). It is baked into the managed folder name for readability (see
+   * {@link getGitRepoFolderName}) and is intentionally NOT kept in sync with
+   * later project renames — renaming the folder on every project rename would
+   * risk moving a directory out from under an open editor, terminal, or
+   * native git process.
    *
    * `null` means either the repo uses a user-chosen `directory` (irrelevant),
    * or the folder still uses its legacy bare-id name.
@@ -99,13 +100,20 @@ export interface BaseGitRepository {
 
 export const isGitRepository = (model: Pick<BaseModel, 'type'>): model is GitRepository => model.type === type;
 
+// `folderSlug` is only ever written via `slugify()`, which already restricts
+// its output to this charset — this is a second, independent check at the
+// point the value gets baked into a filesystem path, so a corrupted or
+// otherwise unsanitized `folderSlug` can never introduce a path separator or
+// a `..` traversal segment into the computed folder name.
+const SAFE_FOLDER_SLUG_PATTERN = /^[a-z0-9-]+$/;
+
 /**
  * Computes the on-disk folder name for a Git repository's app-managed
  * location: `git_<slug>_<hex>` when a `folderSlug` snapshot is available,
  * otherwise the bare `_id` (e.g. pre-existing repos not yet backfilled).
  */
 export function getGitRepoFolderName(repo: Pick<GitRepository, '_id' | 'folderSlug'>): string {
-  if (!repo.folderSlug) {
+  if (!repo.folderSlug || !SAFE_FOLDER_SLUG_PATTERN.test(repo.folderSlug)) {
     return repo._id;
   }
   const hex = repo._id.startsWith(`${prefix}_`) ? repo._id.slice(prefix.length + 1) : repo._id;

--- a/packages/insomnia-data/src/models/git-repository.ts
+++ b/packages/insomnia-data/src/models/git-repository.ts
@@ -33,6 +33,7 @@ export function init(): BaseGitRepository {
     uriNeedsMigration: true,
     repoMigrationVersion: 0,
     directory: null,
+    folderSlug: null,
   };
 }
 
@@ -75,14 +76,41 @@ export interface BaseGitRepository {
    * repository's working tree and .git directory live.
    *
    * `null` (the default) means the repository is stored in the app-managed
-   * location: `{INSOMNIA_DATA_PATH || userData}/version-control/git/{_id}`.
-   * Insomnia owns that managed folder. When `directory` is set, the user owns
-   * the folder and Insomnia must not delete it on project removal.
+   * location: `{INSOMNIA_DATA_PATH || userData}/version-control/git/{folder}`,
+   * where `folder` is computed by {@link getGitRepoFolderName}. Insomnia owns
+   * that managed folder. When `directory` is set, the user owns the folder and
+   * Insomnia must not delete it on project removal.
    */
   directory: string | null;
+  /**
+   * A filesystem-safe slug derived from the owning project's name at the time
+   * the app-managed folder was created (or, for repos that predate this field,
+   * backfilled the first time the repo is loaded). It is baked into the
+   * managed folder name for readability (see {@link getGitRepoFolderName}) and
+   * is intentionally NOT kept in sync with later project renames — renaming
+   * the folder on every project rename would risk moving a directory out from
+   * under an open editor, terminal, or native git process.
+   *
+   * `null` means either the repo uses a user-chosen `directory` (irrelevant),
+   * or the folder still uses its legacy bare-id name.
+   */
+  folderSlug: string | null;
 }
 
 export const isGitRepository = (model: Pick<BaseModel, 'type'>): model is GitRepository => model.type === type;
+
+/**
+ * Computes the on-disk folder name for a Git repository's app-managed
+ * location: `git_<slug>_<hex>` when a `folderSlug` snapshot is available,
+ * otherwise the bare `_id` (e.g. pre-existing repos not yet backfilled).
+ */
+export function getGitRepoFolderName(repo: Pick<GitRepository, '_id' | 'folderSlug'>): string {
+  if (!repo.folderSlug) {
+    return repo._id;
+  }
+  const hex = repo._id.startsWith(`${prefix}_`) ? repo._id.slice(prefix.length + 1) : repo._id;
+  return `${prefix}_${repo.folderSlug}_${hex}`;
+}
 
 export interface GitAuthor {
   name: string;

--- a/packages/insomnia-smoke-test/playwright/pages/project/index.ts
+++ b/packages/insomnia-smoke-test/playwright/pages/project/index.ts
@@ -170,9 +170,12 @@ export class ProjectPage extends BasePage {
     await this.page.locator('[data-test-id="project-modal-close-button"]').click();
 
     // The name/type fields were filled in, so closing can trigger a "discard unsaved changes" confirmation.
+    // App-side race: an in-flight navigation (e.g. from the project just being created) can force-close
+    // the whole modal - confirm dialog included - independent of this click, detaching the "Yes" button
+    // mid-click. Tolerate that here; the waitFor below is the real assertion that the modal is gone.
     const discardConfirmDialog = this.page.getByRole('dialog', { name: 'Unsaved changes' });
     if (await discardConfirmDialog.isVisible().catch(() => false)) {
-      await discardConfirmDialog.getByRole('button', { name: 'Yes' }).click();
+      await discardConfirmDialog.getByRole('button', { name: 'Yes' }).click({ timeout: 5000 }).catch(() => {});
     }
 
     await dialog.waitFor({ state: 'hidden' });
@@ -251,9 +254,12 @@ export class ProjectPage extends BasePage {
     if (await projectModalCloseButton.isVisible()) {
       await projectModalCloseButton.click();
       // The name/type fields were filled in, so closing can trigger a "discard unsaved changes" confirmation.
+      // App-side race: an in-flight navigation (e.g. from the project just being created) can force-close
+      // the whole modal - confirm dialog included - independent of this click, detaching the "Yes" button
+      // mid-click. Tolerate that here; the waitFor below is the real assertion that the modal is gone.
       const discardConfirmDialog = this.page.getByRole('dialog', { name: 'Unsaved changes' });
       if (await discardConfirmDialog.isVisible().catch(() => false)) {
-        await discardConfirmDialog.getByRole('button', { name: 'Yes' }).click();
+        await discardConfirmDialog.getByRole('button', { name: 'Yes' }).click({ timeout: 5000 }).catch(() => {});
       }
     }
     // The modal's backdrop still intercepts clicks for a moment after closing

--- a/packages/insomnia-smoke-test/playwright/pages/project/index.ts
+++ b/packages/insomnia-smoke-test/playwright/pages/project/index.ts
@@ -250,10 +250,17 @@ export class ProjectPage extends BasePage {
     await projectModalCloseButton.waitFor({ state: 'visible', timeout: 5000 }).catch(() => {});
     if (await projectModalCloseButton.isVisible()) {
       await projectModalCloseButton.click();
+      // The name/type fields were filled in, so closing can trigger a "discard unsaved changes" confirmation.
+      const discardConfirmDialog = this.page.getByRole('dialog', { name: 'Unsaved changes' });
+      if (await discardConfirmDialog.isVisible().catch(() => false)) {
+        await discardConfirmDialog.getByRole('button', { name: 'Yes' }).click();
+      }
     }
     // The modal's backdrop still intercepts clicks for a moment after closing
-    // (exit animation / unmount), which flakily blocks the click below.
-    await this.page.getByRole('dialog').waitFor({ state: 'hidden' });
+    // (exit animation / unmount), which flakily blocks the click below. Named rather than a bare
+    // `getByRole('dialog')`: the discard confirmation above can briefly coexist with this one, and
+    // a bare role locator matching both is a Playwright strict-mode violation.
+    await this.page.getByRole('dialog', { name: 'Create or update dialog' }).waitFor({ state: 'hidden' });
     await this.page.getByRole('button', { name: 'Personal workspace Organizations' }).click();
     await this.page.getByRole('option', { name: /Magic/ }).click();
     await this.page.getByRole('button', { name: /Magic/ }).click();

--- a/packages/insomnia-smoke-test/playwright/pages/project/index.ts
+++ b/packages/insomnia-smoke-test/playwright/pages/project/index.ts
@@ -251,6 +251,9 @@ export class ProjectPage extends BasePage {
     if (await projectModalCloseButton.isVisible()) {
       await projectModalCloseButton.click();
     }
+    // The modal's backdrop still intercepts clicks for a moment after closing
+    // (exit animation / unmount), which flakily blocks the click below.
+    await this.page.getByRole('dialog').waitFor({ state: 'hidden' });
     await this.page.getByRole('button', { name: 'Personal workspace Organizations' }).click();
     await this.page.getByRole('option', { name: /Magic/ }).click();
     await this.page.getByRole('button', { name: /Magic/ }).click();

--- a/packages/insomnia/src/entry.main.ts
+++ b/packages/insomnia/src/entry.main.ts
@@ -29,7 +29,7 @@ import { AnalyticsEvent, trackAnalyticsEvent } from './main/analytics';
 import { registerInsomniaProtocols } from './main/api.protocol';
 import { backupIfNewerVersionAvailable } from './main/backup';
 import { registerSyncHandlers } from './main/cloud-sync/ipc';
-import { registerGitServiceAPI } from './main/git-service';
+import { backfillAllManagedGitFolderSlugs, registerGitServiceAPI } from './main/git-service';
 import { registerCookieHandlers } from './main/ipc/cookies';
 import { ipcMainOn, ipcMainOnce, registerElectronHandlers } from './main/ipc/electron';
 import { registerElectronStorageHandlers } from './main/ipc/electron-storage';
@@ -150,6 +150,12 @@ app.on('ready', async () => {
   sentryWatchAnalyticsEnabled();
 
   await runGitCredentialsMigration();
+  // Must run — and finish — before the window/renderer exists: it's the only
+  // point in the app's lifecycle where nothing else (a file watcher, a git
+  // operation kicked off by a route loader) can be concurrently reading or
+  // writing these same folders, so the rename can never race another reader
+  // into resurrecting the old path (see backfillManagedFolderSlug).
+  await backfillAllManagedGitFolderSlugs();
 
   await _launchApp();
 

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -28,6 +28,7 @@ import type {
   WorkspaceScope,
 } from 'insomnia-data';
 import { models, services } from 'insomnia-data';
+import { slugify } from 'insomnia-data/common';
 import { Errors, type PromiseFsClient } from 'isomorphic-git';
 import YAML, { parse } from 'yaml';
 
@@ -393,26 +394,31 @@ async function assertBranchOnOrigin(context: string): Promise<void> {
  * - When the repository has a user-chosen `directory`, that path is used as-is
  *   (the user owns it; Insomnia must not delete it on project removal).
  * - Otherwise the repository lives in the app-managed location
- *   `{INSOMNIA_DATA_PATH || userData}/version-control/git/{id}`.
+ *   `{INSOMNIA_DATA_PATH || userData}/version-control/git/{folder}`, where
+ *   `folder` is computed by `models.gitRepository.getGitRepoFolderName` (the
+ *   bare id, or `git_<slug>_<hex>` once a `folderSlug` has been set).
  *
  * This is the single source of truth for repo paths. Callers that already have
- * the GitRepository document should pass `directory` to avoid a DB lookup;
- * otherwise the directory is resolved from the database by id.
+ * the GitRepository document should pass `directory`/`folderSlug` to avoid a DB
+ * lookup; otherwise both are resolved from the database by id.
  */
-async function getRepoBaseDir(gitRepositoryId: string, directory?: string | null): Promise<string> {
+async function getRepoBaseDir(gitRepositoryId: string, directory?: string | null, folderSlug?: string | null): Promise<string> {
   let dir = directory;
+  let slug = folderSlug;
   if (dir === undefined) {
     const repo = await services.gitRepository.getById(gitRepositoryId);
     dir = repo?.directory ?? null;
+    slug = repo?.folderSlug ?? null;
   }
 
   if (dir) {
     return dir;
   }
 
+  const folderName = models.gitRepository.getGitRepoFolderName({ _id: gitRepositoryId, folderSlug: slug ?? null });
   return path.join(
     process.env['INSOMNIA_DATA_PATH'] || app.getPath('userData'),
-    `version-control/git/${gitRepositoryId}`,
+    `version-control/git/${folderName}`,
   );
 }
 
@@ -423,17 +429,93 @@ async function getRepoBaseDir(gitRepositoryId: string, directory?: string | null
  * `directory` belongs to the user and must never be deleted when the project is
  * removed. Failures are logged, not thrown — losing a project record should not be blocked by a stale folder.
  */
-async function deleteManagedRepoFolderIfOwned(repo: Pick<GitRepository, '_id' | 'directory'>) {
+async function deleteManagedRepoFolderIfOwned(repo: Pick<GitRepository, '_id' | 'directory' | 'folderSlug'>) {
   if (repo.directory) {
     // User-owned folder — leave it on disk.
     return;
   }
 
-  const baseDir = await getRepoBaseDir(repo._id, null);
+  const baseDir = await getRepoBaseDir(repo._id, null, repo.folderSlug);
   try {
     await fs.promises.rm(baseDir, { recursive: true, force: true });
   } catch (e) {
     console.warn('[git] Failed to remove managed repo folder', baseDir, e);
+  }
+}
+
+// Defensive in-process guard against calling this twice for the same repo
+// concurrently (only matters if `backfillAllManagedGitFolderSlugs` is ever
+// invoked more than once in a process) — the second call reuses the first
+// call's in-flight result instead of racing it on the same rename.
+const foldersBeingBackfilled = new Map<string, Promise<GitRepository>>();
+
+/**
+ * One-time, best-effort backfill: gives an app-managed repo folder a
+ * human-readable name derived from its owning project's name.
+ *
+ * MUST only be called from `backfillAllManagedGitFolderSlugs` at main-process
+ * startup, before the app window/renderer exists. Renaming a folder that any
+ * other code might concurrently read (a file watcher, a route loader's git
+ * call) is unsafe: a reader holding the old path can recreate it via the FS
+ * client's auto-mkdir-on-write behavior microseconds after the rename,
+ * silently forking the repo's files across both directories. Before startup
+ * completes, nothing else can be touching these folders yet, so no such
+ * reader exists.
+ *
+ * No-ops (returns `repo` unchanged) when there's nothing on disk yet to rename,
+ * the target name is already taken, the project has no usable name, or any I/O
+ * error occurs — callers keep working against the legacy (unslugged) folder
+ * name via `getRepoBaseDir`'s fallback. Never throws.
+ */
+async function backfillManagedFolderSlug(repo: GitRepository, projectId: string): Promise<GitRepository> {
+  const inFlight = foldersBeingBackfilled.get(repo._id);
+  if (inFlight) {
+    return inFlight;
+  }
+
+  const promise = (async () => {
+    try {
+      const project = await services.project.getById(projectId);
+      const slug = project ? slugify(project.name) : '';
+      if (!slug) {
+        return repo;
+      }
+
+      const gitRoot = path.join(process.env['INSOMNIA_DATA_PATH'] || app.getPath('userData'), 'version-control', 'git');
+      const oldDir = path.join(gitRoot, models.gitRepository.getGitRepoFolderName(repo));
+      const newDir = path.join(gitRoot, models.gitRepository.getGitRepoFolderName({ _id: repo._id, folderSlug: slug }));
+
+      const oldDirExists = await fs.promises
+        .stat(oldDir)
+        .then(stat => stat.isDirectory())
+        .catch(() => false);
+      if (!oldDirExists) {
+        // Nothing on disk yet — just record the slug so it's used from now on.
+        return await services.gitRepository.update(repo, { folderSlug: slug });
+      }
+
+      const newDirExists = await fs.promises
+        .access(newDir)
+        .then(() => true)
+        .catch(() => false);
+      if (newDirExists) {
+        console.warn('[git] Skipping managed repo folder rename — target already exists:', newDir);
+        return repo;
+      }
+
+      await fs.promises.rename(oldDir, newDir);
+      return await services.gitRepository.update(repo, { folderSlug: slug });
+    } catch (e) {
+      console.warn('[git] Failed to give managed repo folder a readable name', e);
+      return repo;
+    }
+  })();
+
+  foldersBeingBackfilled.set(repo._id, promise);
+  try {
+    return await promise;
+  } finally {
+    foldersBeingBackfilled.delete(repo._id);
   }
 }
 
@@ -445,6 +527,7 @@ async function deleteManagedRepoFolderIfOwned(repo: Pick<GitRepository, '_id' | 
  * @param workspaceId - Optional workspace ID (if provided, uses workspace-specific client)
  * @param gitRepositoryId - The Git repository ID
  * @param directory - Optional user-chosen repo directory (resolved from DB when omitted)
+ * @param folderSlug - Optional pre-fetched `GitRepository.folderSlug` (resolved from DB when omitted)
  * @returns File system client configured for the appropriate context
  */
 
@@ -453,14 +536,16 @@ async function getGitFSClient({
   workspaceId,
   gitRepositoryId,
   directory,
+  folderSlug,
 }: {
   projectId: string;
   workspaceId?: string;
   gitRepositoryId: string;
   directory?: string | null;
+  folderSlug?: string | null;
 }) {
   // Base directory where Git data is stored
-  const baseDir = await getRepoBaseDir(gitRepositoryId, directory);
+  const baseDir = await getRepoBaseDir(gitRepositoryId, directory, folderSlug);
 
   // Workspace FS Client - used when working with a specific workspace
   if (workspaceId) {
@@ -594,7 +679,7 @@ export async function loadGitRepository({ projectId, workspaceId }: { projectId:
   try {
     const gitRepository = await getGitRepository({ workspaceId, projectId });
 
-    const baseDir = await getRepoBaseDir(gitRepository._id, gitRepository.directory);
+    const baseDir = await getRepoBaseDir(gitRepository._id, gitRepository.directory, gitRepository.folderSlug);
 
     // For a user-owned folder, detect that it has been moved/renamed/deleted (or
     // its drive unmounted) BEFORE creating the FS client — `fsClient` auto-creates
@@ -626,6 +711,7 @@ export async function loadGitRepository({ projectId, workspaceId }: { projectId:
       projectId,
       workspaceId,
       directory: gitRepository.directory,
+      folderSlug: gitRepository.folderSlug,
     });
 
     if (GitVCS.isInitializedForRepo(gitRepository._id) && !gitRepository.needsFullClone) {
@@ -1332,9 +1418,10 @@ export const cloneGitRepoAction = async ({
         projectId: project._id,
         gitRepositoryId: gitRepository._id,
         directory: gitRepository.directory,
+        folderSlug: gitRepository.folderSlug,
       });
 
-      const repoBaseDir = await getRepoBaseDir(gitRepository._id, gitRepository.directory);
+      const repoBaseDir = await getRepoBaseDir(gitRepository._id, gitRepository.directory, gitRepository.folderSlug);
 
       if (gitRepository.needsFullClone) {
         await GitVCS.initFromClone({
@@ -1788,7 +1875,7 @@ export const relocateGitRepoAction = async ({
   const repo = await services.gitRepository.getById(gitRepositoryId);
   invariant(repo, 'Git Repository not found');
 
-  const currentBaseDir = await getRepoBaseDir(repo._id, repo.directory);
+  const currentBaseDir = await getRepoBaseDir(repo._id, repo.directory, repo.folderSlug);
   if (path.resolve(currentBaseDir) === targetDir) {
     return { errors: ['The repository is already in that folder.'] };
   }
@@ -1937,7 +2024,7 @@ export const updateGitRepoAction = async ({
       credentialsId: credentialsId,
       legacyDiff: Boolean(workspaceId),
       ref,
-      repoPath: await getRepoBaseDir(gitRepository._id, gitRepository.directory),
+      repoPath: await getRepoBaseDir(gitRepository._id, gitRepository.directory, gitRepository.folderSlug),
     });
 
     await GitVCS.setAuthor();
@@ -3317,6 +3404,52 @@ async function getCurrentBranchByRepositoryId({
   return GitVCSClass.getRepoCurrentBranch({
     fs,
   });
+}
+
+/**
+ * Best-effort startup pass: gives every app-managed git folder that predates
+ * `folderSlug` a human-readable name.
+ *
+ * MUST be awaited before the app window/renderer is created (see
+ * `entry.main.ts`) and MUST NOT be called again afterwards. Renaming these
+ * folders is only safe while nothing else — a file watcher, a route loader's
+ * git call — can be concurrently reading or writing them; once the renderer
+ * exists, it can trigger exactly that, and a rename racing a reader can
+ * silently fork a repo's files across the old and new folder (a reader that
+ * already resolved the old path can recreate it via the FS client's
+ * auto-mkdir-on-write behavior microseconds after the rename moves it away).
+ *
+ * Skips user-owned `directory` repos and already-slugged repos. Failures are
+ * logged, never thrown — this is a purely cosmetic upgrade, not worth failing
+ * startup over.
+ */
+export async function backfillAllManagedGitFolderSlugs(): Promise<void> {
+  try {
+    const allProjects = await services.project.list();
+    const gitProjects = allProjects.filter((p): p is GitProject => models.project.isConnectedGitProject(p));
+    if (gitProjects.length === 0) {
+      return;
+    }
+
+    const repoIds = gitProjects.map(p => models.project.getEffectiveRepoId(p)).filter(Boolean) as string[];
+    const gitRepositories = await database.find<GitRepository>(models.gitRepository.type, {
+      _id: { $in: repoIds },
+    });
+    const repoById = new Map(gitRepositories.map(r => [r._id, r]));
+
+    await Promise.all(
+      gitProjects.map(async project => {
+        const repoId = models.project.getEffectiveRepoId(project);
+        const repo = repoId ? repoById.get(repoId) : undefined;
+        if (!repo || repo.directory || repo.folderSlug || GitVCS.isInitializedForRepo(repo._id)) {
+          return;
+        }
+        await backfillManagedFolderSlug(repo, project._id);
+      }),
+    );
+  } catch (e) {
+    console.warn('[git] Failed to backfill managed repo folder names on startup', e);
+  }
 }
 
 export interface MigrationSummary {

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -444,8 +444,14 @@ async function getRepoBaseDir(gitRepositoryId: string, directory?: string | null
   if (!resolved) {
     // Should be unreachable — getGitRepoFolderName already validates folderSlug — but
     // fall back to the safe bare-id path rather than ever returning one outside gitRoot.
+    // Re-validate the fallback too: never return a path derived from untrusted input
+    // without confirming it still resolves inside gitRoot.
     console.warn('[git] Computed managed repo folder path escaped the git root, falling back to bare id:', folderName);
-    return path.join(gitRoot, gitRepositoryId);
+    const fallback = resolveWithinGitRoot(gitRoot, gitRepositoryId);
+    if (!fallback) {
+      throw new Error(`Unable to resolve a safe on-disk path for git repository "${gitRepositoryId}"`);
+    }
+    return fallback;
   }
   return resolved;
 }

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -387,6 +387,29 @@ async function assertBranchOnOrigin(context: string): Promise<void> {
   }
 }
 
+function getManagedGitRoot(): string {
+  return path.join(process.env['INSOMNIA_DATA_PATH'] || app.getPath('userData'), 'version-control', 'git');
+}
+
+/**
+ * Joins `folderName` onto `gitRoot` and refuses to return a path that would
+ * escape it, returning `null` instead. `folderName` comes from
+ * `models.gitRepository.getGitRepoFolderName`, which already restricts
+ * `folderSlug` to `[a-z0-9-]` — this is a second, independent guard at the
+ * point the path is actually used on disk, in case that invariant is ever
+ * broken upstream. (`path.join`/`path.normalize` alone would silently collapse
+ * a `..` segment instead of rejecting it.)
+ */
+function resolveWithinGitRoot(gitRoot: string, folderName: string): string | null {
+  const resolvedGitRoot = path.resolve(gitRoot);
+  const resolvedPath = path.resolve(gitRoot, folderName);
+  const relative = path.relative(resolvedGitRoot, resolvedPath);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    return null;
+  }
+  return resolvedPath;
+}
+
 /**
  * Resolves the absolute base directory where a Git repository's working tree and
  * .git directory live on disk.
@@ -415,11 +438,16 @@ async function getRepoBaseDir(gitRepositoryId: string, directory?: string | null
     return dir;
   }
 
+  const gitRoot = getManagedGitRoot();
   const folderName = models.gitRepository.getGitRepoFolderName({ _id: gitRepositoryId, folderSlug: slug ?? null });
-  return path.join(
-    process.env['INSOMNIA_DATA_PATH'] || app.getPath('userData'),
-    `version-control/git/${folderName}`,
-  );
+  const resolved = resolveWithinGitRoot(gitRoot, folderName);
+  if (!resolved) {
+    // Should be unreachable — getGitRepoFolderName already validates folderSlug — but
+    // fall back to the safe bare-id path rather than ever returning one outside gitRoot.
+    console.warn('[git] Computed managed repo folder path escaped the git root, falling back to bare id:', folderName);
+    return path.join(gitRoot, gitRepositoryId);
+  }
+  return resolved;
 }
 
 /**
@@ -481,9 +509,15 @@ async function backfillManagedFolderSlug(repo: GitRepository, projectId: string)
         return repo;
       }
 
-      const gitRoot = path.join(process.env['INSOMNIA_DATA_PATH'] || app.getPath('userData'), 'version-control', 'git');
-      const oldDir = path.join(gitRoot, models.gitRepository.getGitRepoFolderName(repo));
-      const newDir = path.join(gitRoot, models.gitRepository.getGitRepoFolderName({ _id: repo._id, folderSlug: slug }));
+      const gitRoot = getManagedGitRoot();
+      const oldDir = resolveWithinGitRoot(gitRoot, models.gitRepository.getGitRepoFolderName(repo));
+      const newDir = resolveWithinGitRoot(gitRoot, models.gitRepository.getGitRepoFolderName({ _id: repo._id, folderSlug: slug }));
+      if (!oldDir || !newDir) {
+        // Should be unreachable — getGitRepoFolderName already validates folderSlug — but
+        // never rename into/out of a path outside gitRoot.
+        console.warn('[git] Computed managed repo folder path escaped the git root, skipping backfill for', repo._id);
+        return repo;
+      }
 
       const oldDirExists = await fs.promises
         .stat(oldDir)

--- a/packages/insomnia/src/ui/utils/git-repo-path.ts
+++ b/packages/insomnia/src/ui/utils/git-repo-path.ts
@@ -1,14 +1,16 @@
-import type { GitRepository } from 'insomnia-data';
+import { type GitRepository, models } from 'insomnia-data';
 
 /**
  * Resolve a Git repository's on-disk base directory in the renderer.
  *
  * Mirrors the main-process `getRepoBaseDir` (git-service.ts): a user-chosen
- * `directory` when set, else the app-managed location.
+ * `directory` when set, else the app-managed location (named via
+ * `models.gitRepository.getGitRepoFolderName`).
  */
-export const resolveGitRepoBaseDir = (gitRepository: Pick<GitRepository, '_id' | 'directory'>): string => {
+export const resolveGitRepoBaseDir = (gitRepository: Pick<GitRepository, '_id' | 'directory' | 'folderSlug'>): string => {
   if (gitRepository.directory) {
     return gitRepository.directory;
   }
-  return window.path.join(window.app.getPath('userData'), `version-control/git/${gitRepository._id}`);
+  const folderName = models.gitRepository.getGitRepoFolderName(gitRepository);
+  return window.path.join(window.app.getPath('userData'), `version-control/git/${folderName}`);
 };


### PR DESCRIPTION
## What

App-managed git repo folders (`~/…/version-control/git/<id>`) are named after
nothing but a random 32-char hex id, making it impossible to tell projects
apart on disk (see screenshot in INS-2612). This adds a human-readable slug:

    git_57d071a646b34393929036c34dd0915e
    → git_camsproject_57d071a646b34393929036c34dd0915e

## How

- `GitRepository` gains a `folderSlug` field: a filesystem-safe slug of the
  owning project's name, snapshotted once and **not** kept in sync with later
  project renames (renaming the folder live is unsafe — see below).
- `models.gitRepository.getGitRepoFolderName()` computes the on-disk folder
  name from `folderSlug` (falls back to the bare id when unset), used by both
  the main-process `getRepoBaseDir`/`getGitFSClient` and the renderer's
  `resolveGitRepoBaseDir`.
- New repos, and any existing repo missing a slug, get backfilled by
  `backfillAllManagedGitFolderSlugs()` — a best-effort pass that runs once,
  **awaited before the app window is created** (`entry.main.ts`).

  That timing is load-bearing, not incidental: renaming a folder while
  anything else (a file watcher, a route loader's git call) can concurrently
  resolve the *old* path is unsafe — a reader holding the stale path can
  recreate it via the FS client's auto-mkdir-on-write behavior microseconds
  after the rename moves the real data away, silently forking a repo's files
  across two directories. An earlier version of this change did the backfill
  lazily on each repo's first load instead, and this exact race was reproduced
  against a real profile (verified below). Doing it once, pre-window, removes
  the race entirely: nothing can be reading these folders yet.
- User-chosen `directory` repos are never touched — Insomnia doesn't own that
  folder.
