### PR TITLE
docs(plugins): sandbox/trust + permissions + troubleshooting guides (P1-A draft)

### DIFF
--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -1,0 +1,36 @@
+<!--
+DRAFT (P1-A docs). Iterating in-repo before porting to developer.konghq.com.
+These pages document the plugin sandbox / trust model introduced across the L1/H1/A1/T1/S1 work
+and the #10295 load-failure fix. Verify anything marked TODO against source before publishing.
+-->
+
+# Insomnia plugin sandbox & trust — authoring guide (draft)
+
+This folder is a working draft of the plugin-authoring docs for the sandboxed plugin model. It's
+here so we can iterate on the content in review; the published home is developer.konghq.com.
+
+## Pages
+
+- **[Sandbox & trust model](./sandbox-and-trust.md)** — how plugin code runs (in-process vs the
+  QuickJS sandbox), the `pluginSandboxEnabled` setting, the per-plugin "Full host access" (elevated)
+  opt-in, and the migration from the older `templateTagSandboxEnabled` experiment.
+- **[Permissions (`insomnia.permissions`)](./permissions.md)** — declaring the modules and host
+  capabilities a plugin needs, the default-deny baseline, and the capability reference.
+- **[Troubleshooting](./troubleshooting.md)** — "my plugin disappeared", disabled rows with a
+  reason, and current known limitations.
+
+## What changed (hardening vs. regression)
+
+The sandbox work is a deliberate security hardening, not a set of regressions. Distinguishing the two:
+
+| Change | Kind | Author-visible effect |
+|---|---|---|
+| User plugins run in the QuickJS sandbox when the sandbox is on | hardening | plugin code no longer has raw Node/`fs`/`child_process`; reaches the host only through declared capabilities |
+| `require()` resolves only from a curated registry | hardening | arbitrary npm/`node_modules` requires fail unless the module is in the registry **and** declared |
+| Default-deny permissions (baseline only unless declared) | hardening | a plugin that used network/fs/credentials without declaring them must add an `insomnia.permissions` block |
+| Plugin load failures show as a disabled row with a reason (#10295) | **regression fix** | a plugin that fails to load (or whose name collides) no longer silently vanishes |
+| Bundle (first-party) plugins stay in-process | unchanged | n/a |
+
+> Release-notes wording (TODO): lead with the #10295 regression fix (visible, user-facing win), then
+> summarize the hardening as "plugins are now sandboxed by default when the setting is on; declare
+> what you need in `insomnia.permissions`" with a link to [permissions](./permissions.md).

--- a/docs/plugins/permissions.md
+++ b/docs/plugins/permissions.md
@@ -1,0 +1,79 @@
+<!--
+DRAFT (P1-A). Sources of truth:
+- capabilities: packages/insomnia/src/templating/sandbox/host-bridge.ts (BRIDGE_PATH_CAPABILITIES, Capability)
+- modules: packages/insomnia/src/templating/sandbox/module-registry.ts (ALL_SANDBOX_MODULES / SANDBOX_MODULES)
+- baseline: TEMPLATE_TAG_BASELINE_MODULES / TEMPLATE_TAG_BASELINE_CAPABILITIES
+The module list below is illustrative — generate the canonical list from ALL_SANDBOX_MODULES before publishing.
+-->
+
+# Plugin permissions (`insomnia.permissions`) — draft
+
+When a plugin runs sandboxed, it is **default-deny** on two axes: which modules it can `require()`,
+and which host capabilities it can call. You declare what your plugin needs in its `package.json`
+under the `insomnia.permissions` key.
+
+```jsonc
+{
+  "name": "insomnia-plugin-example",
+  "insomnia": {
+    "permissions": {
+      "modules": ["crypto", "ajv"],        // require() allow-list (registry names)
+      "capabilities": ["network", "storage"] // host APIs the plugin may reach
+    }
+  }
+}
+```
+
+A plugin with **no** `permissions` block gets the baseline only (see below). Requesting anything
+beyond the baseline requires declaring it, or the call fails with an actionable error such as:
+
+> `capability 'network' not granted — add it to insomnia.permissions.capabilities`
+
+## Baseline (no manifest)
+
+| Axis | Baseline grant |
+|---|---|
+| Modules | `path`, `crypto` |
+| Capabilities | `render`, `models.read`, `util`, `crypto` |
+
+Anything network-, filesystem-, credential-, storage-, or app/UI-related must be declared explicitly.
+
+## Capabilities reference
+
+Declarable values for `insomnia.permissions.capabilities`:
+
+| Capability | Grants |
+|---|---|
+| `render` | nested template rendering (`context.util.render`) |
+| `models.read` | read requests, workspaces, cookie jars, responses, settings, OAuth2 tokens |
+| `util` | encode/decode + host OS info helpers |
+| `crypto` | the host-backed `crypto` module (hash/hmac/random) |
+| `network` | outbound HTTP via `context.network.sendRequest*` |
+| `storage` | plugin-scoped key/value store (`context.store`) |
+| `fs-read` | allow-listed file reads |
+| `credentials` | read/update stored cloud credentials |
+| `app` | dialogs, prompts, clipboard, open-in-browser |
+
+> Note: `models.read` includes reading **OAuth2 tokens**, which are live bearer credentials. It's part
+> of the baseline; treat it as a credential-disclosure surface when reasoning about what a manifest-less
+> plugin can see. (TODO: decide whether token reads should move behind `credentials` in a future rev.)
+
+## Modules reference (`require()` allow-list)
+
+Inside the sandbox, `require(name)` resolves **only** from Insomnia's curated registry — never your
+plugin's `node_modules` and never raw Node built-ins. Declaring a module in `permissions.modules` is
+what unlocks it; the registry is what makes a safe implementation available.
+
+Categories (representative — **canonical list is `ALL_SANDBOX_MODULES`**):
+
+- **Baseline:** `path`, `crypto`
+- **Polyfilled built-ins:** e.g. `events` (and others — verify against the registry)
+- **Vetted libraries:** e.g. `ajv`, `uuid` (and others — verify against the registry)
+
+Two distinct failure messages tell you which problem you have:
+
+- `Module 'X' not permitted by manifest` — the module exists in the registry but you didn't declare it.
+- `Module 'X' not available in sandbox` — you declared it, but it isn't in the registry.
+
+> TODO(before publish): replace the "representative" module list with the generated `ALL_SANDBOX_MODULES`
+> set, ideally via a docs-gen step so it can't drift.

--- a/docs/plugins/sandbox-and-trust.md
+++ b/docs/plugins/sandbox-and-trust.md
@@ -1,0 +1,69 @@
+<!-- DRAFT (P1-A). Source of truth: packages/insomnia/src/common/plugins/sandbox-mode.ts -->
+
+# Sandbox & trust model (draft)
+
+## How plugin code runs
+
+Insomnia can run an installed (user) plugin's code in one of two places:
+
+- **In-process** — directly in the app's main/renderer process, with full Node.js access
+  (`fs`, `child_process`, arbitrary `require`, etc.). This is the legacy behaviour.
+- **In the QuickJS sandbox** — an isolated JS runtime with no direct Node access. The plugin reaches
+  the host only through a **capability-gated bridge**, and `require()` resolves only from a curated
+  module registry. See [Permissions](./permissions.md).
+
+Which one is used depends on a global setting and a per-plugin opt-in.
+
+## The setting: `pluginSandboxEnabled`
+
+Preferences → Scripting → **"Sandbox all plugin code"**. When on, every *untrusted* (user) plugin
+surface — template tags, request/response hooks, actions, and load-time code — runs in the sandbox.
+
+It supersedes the older experiment **`templateTagSandboxEnabled`** ("Run template tags in sandbox").
+For migration, **either** flag being on activates the sandbox, so if you already opted into the
+template-tag experiment nothing changes for you. New guidance should refer only to
+`pluginSandboxEnabled`.
+
+## Execution modes
+
+For a given plugin, the resolved mode is one of (see `resolvePluginExecutionMode`):
+
+| Mode | When | Runs | Host access |
+|---|---|---|---|
+| **Trusted** | first-party bundle plugin (ships with Insomnia) | in-process | full (by design) |
+| **Sandboxed** | user plugin, sandbox on, not elevated | QuickJS sandbox | only declared capabilities |
+| **Elevated** | user plugin, sandbox on, you turned on "Full host access" | in-process | full |
+| **In-process** | user plugin, sandbox off | in-process | full (legacy) |
+
+Preferences → Plugins shows each plugin's mode as a badge.
+
+## The escape hatch: "Full host access" (elevated)
+
+Some community plugins genuinely need native modules or host access the sandbox doesn't grant. For
+those, Preferences → Plugins has a per-plugin **"Full host access"** toggle. It's:
+
+- **off by default** — a plugin is sandboxed unless you deliberately elevate it;
+- **per-plugin** — never global;
+- a **trust decision** — an elevated plugin runs in-process with full Node access, exactly like the
+  pre-sandbox world. Only elevate plugins you trust.
+
+## Migration guide (for plugin authors)
+
+If your plugin worked before the sandbox and breaks with it on:
+
+1. **Do you `require()` `fs` / `child_process` / an arbitrary npm package?** Those aren't reachable in
+   the sandbox. Move to a registry module (see [Permissions](./permissions.md)) and declare it, or ask
+   the user to enable "Full host access" for your plugin.
+2. **Do you call `context.network` / read files / use storage / credentials?** Declare the matching
+   capability in `insomnia.permissions.capabilities`. Undeclared calls fail with an actionable error
+   naming the missing capability.
+3. **Multi-file plugin?** Your own `node_modules` is **not** consulted at runtime — third-party deps
+   must be registry modules, declared in `permissions.modules`.
+
+## Caveats
+
+- **The `inso` CLI has no sandbox host.** Under the pure-Node CLI, user-plugin hooks run in-process
+  regardless of the setting — CLI users are trusting their own plugins.
+- **Bundle template tags** run in the sandbox only under the legacy `templateTagSandboxEnabled`
+  experiment (a hardening opt-in); the `pluginSandboxEnabled` flip leaves trusted bundle plugins
+  in-process.

--- a/docs/plugins/troubleshooting.md
+++ b/docs/plugins/troubleshooting.md
@@ -1,0 +1,47 @@
+<!-- DRAFT (P1-A). Covers the #10295 fix behaviour + current known limitations. -->
+
+# Plugin troubleshooting (draft)
+
+## "My plugin disappeared from the list"
+
+As of the #10295 fix, a plugin that fails to load **no longer silently vanishes**. Instead it appears
+in Preferences → Plugins as a **disabled row with a reason**:
+
+- Open Preferences → **Plugins** and look for a row marked **"Failed to load plugin"** (warning icon,
+  no enable checkbox). Expand it to see the exact error.
+
+Common reasons and fixes:
+
+| Reason shown | Cause | Fix |
+|---|---|---|
+| `Cannot find module '…'` | a `require()` failed (missing dep, or a module not in the sandbox registry) | add the dep as a registry module in `permissions.modules`, or fix the missing dependency; see [Permissions](./permissions.md) |
+| `Multiple plugin folders declare the name "…"` | two folders under your plugin paths declare the same plugin `name` | remove/rename the duplicate folder — while a name is claimed by more than one folder, **none** of them load (this is deliberate, to avoid an ambiguous trust grant) |
+| other load-time error | the plugin's top-level code threw | see the message; if it needs host access the sandbox doesn't grant, consider "Full host access" (see [Sandbox & trust](./sandbox-and-trust.md)) |
+
+### A plugin stayed broken even after I fixed the error
+
+Older versions cached the plugin/render engine for the whole session, so a plugin that failed once
+stayed broken until restart. This is fixed: use Preferences → Plugins → **Reload plugins** (or the
+`plugin_reload` shortcut) — reload now rebuilds the render engine and re-scans the registry, so a
+plugin recovers once its underlying error is fixed. No reinstall-into-a-fresh-folder needed.
+
+## Known limitations
+
+### Passing DOM / non-serializable values across the plugin boundary
+
+APIs that pass rich objects (e.g. `context.app.dialog()` with DOM nodes) don't round-trip through the
+sandbox bridge, which marshals plain JSON. Prefer serializable data.
+
+### Folder actions (`requestGroupActions`) — see #10292
+
+`requestGroupActions` (folder-level actions) are reported broken in
+[#10292](https://github.com/Kong/insomnia/issues/10292).
+
+> TODO(triage): confirm whether this is a sandbox/marshalling limitation to document here, or an A1
+> action-routing regression to fix. If it's a regression, this belongs in a fix PR, not the
+> known-limitations list. **Do not finalize this section until #10292 is triaged.**
+
+## Still stuck?
+
+File an issue at https://github.com/Kong/insomnia/issues with the exact text from the plugin's
+disabled-row reason and your `package.json` `insomnia` block.


### PR DESCRIPTION
## Draft: plugin sandbox / trust authoring docs (P1-A)

Starting point for the **P1-A documentation** deliverables from the sandboxing plan, so we can iterate on the *content* in review. These are drafted as markdown under `docs/plugins/` in this repo for convenience — **the published home is developer.konghq.com**; they'll be ported/adapted there (point me at that repo and I'll move them).

### Pages
- **README** — index + a "what changed (hardening vs. regression)" table for release notes.
- **sandbox-and-trust** — in-process vs QuickJS sandbox, `pluginSandboxEnabled` (supersedes `templateTagSandboxEnabled`), the four execution modes, the per-plugin "Full host access" (elevated) opt-in, a migration guide, and the CLI/bundle caveats.
- **permissions** — `insomnia.permissions` (`modules` + `capabilities`), the default-deny baseline, and a capability reference table.
- **troubleshooting** — the #10295 "my plugin disappeared → disabled row with a reason" flow, reload-recovers-after-fix, and known limitations.

### Deliverable coverage (§6 of the plan)
- [x] Troubleshooting page (plugin disappearance)
- [x] `pluginSandboxEnabled` migration guide
- [x] Capability reference
- [x] Known-limitations note (dialog/DOM APIs; folder actions **#10292**)
- [x] Release-notes framing (hardening vs. regression)

### Open TODOs (called out inline in the drafts)
- Replace the illustrative module list in `permissions.md` with the generated `ALL_SANDBOX_MODULES` set (ideally a docs-gen step so it can't drift).
- **Triage #10292** (folder actions) before finalizing that known-limitations section — it may be an A1 regression to fix rather than a limitation to document.
- Decide the canonical home (developer.konghq.com repo) and port.

Grounded in source: `sandbox-mode.ts`, `host-bridge.ts` (`BRIDGE_PATH_CAPABILITIES`), `module-registry.ts`, and the merged #10295 fix (#10317).

_🤖 Drafted by [Claude Code](https://claude.com/claude-code)_
