### PR TITLE
Apply runner filters to requests/iterations as well as tests [INS-3348]

### DIFF
--- a/packages/insomnia/src/ui/components/panes/__tests__/request-test-result-pane.test.ts
+++ b/packages/insomnia/src/ui/components/panes/__tests__/request-test-result-pane.test.ts
@@ -1,0 +1,107 @@
+import type { RequestTestResult } from 'insomnia-data';
+import { describe, expect, it } from 'vitest';
+
+import { filterTestResults, hasMatchingTestResults, isFilterEngaged } from '../request-test-result-pane';
+
+const testResult = (overrides: Partial<RequestTestResult> = {}): RequestTestResult => ({
+  testCase: 'renders a response',
+  status: 'passed',
+  executionTime: 1,
+  category: 'after-response',
+  ...overrides,
+});
+
+describe('filterTestResults', () => {
+  const results: RequestTestResult[] = [
+    testResult({ testCase: 'status code is 200', status: 'passed' }),
+    testResult({ testCase: 'has expected body', status: 'failed' }),
+    testResult({ testCase: 'pre-request runs', status: 'skipped' }),
+  ];
+
+  it('returns everything, with original indexes, when targetTests is "all" and there is no text filter', () => {
+    expect(filterTestResults(results, 'all', '')).toEqual([
+      { result: results[0], index: 0 },
+      { result: results[1], index: 1 },
+      { result: results[2], index: 2 },
+    ]);
+  });
+
+  it('filters to only passed results', () => {
+    expect(filterTestResults(results, 'passed', '')).toEqual([{ result: results[0], index: 0 }]);
+  });
+
+  it('filters to only failed results', () => {
+    expect(filterTestResults(results, 'failed', '')).toEqual([{ result: results[1], index: 1 }]);
+  });
+
+  it('filters to only skipped results', () => {
+    expect(filterTestResults(results, 'skipped', '')).toEqual([{ result: results[2], index: 2 }]);
+  });
+
+  it('applies the text filter on top of the status filter', () => {
+    expect(filterTestResults(results, 'all', 'expected')).toEqual([{ result: results[1], index: 1 }]);
+  });
+
+  it('returns nothing when the text filter matches no test case in the selected status', () => {
+    expect(filterTestResults(results, 'passed', 'expected')).toEqual([]);
+  });
+
+  it('ignores a whitespace-only text filter', () => {
+    expect(filterTestResults(results, 'all', '   ')).toHaveLength(3);
+  });
+
+  it('returns an empty array when there are no test results to filter', () => {
+    expect(filterTestResults([], 'all', '')).toEqual([]);
+    expect(filterTestResults([], 'passed', '')).toEqual([]);
+  });
+});
+
+describe('isFilterEngaged', () => {
+  it('is not engaged for the default "all" status with no text filter', () => {
+    expect(isFilterEngaged('all', '')).toBe(false);
+  });
+
+  it('is not engaged when the text filter is only whitespace', () => {
+    expect(isFilterEngaged('all', '   ')).toBe(false);
+  });
+
+  it('is engaged when a non-"all" status is selected', () => {
+    expect(isFilterEngaged('passed', '')).toBe(true);
+    expect(isFilterEngaged('failed', '')).toBe(true);
+    expect(isFilterEngaged('skipped', '')).toBe(true);
+  });
+
+  it('is engaged when a text filter is present', () => {
+    expect(isFilterEngaged('all', 'expected')).toBe(true);
+  });
+});
+
+describe('hasMatchingTestResults', () => {
+  const results: RequestTestResult[] = [testResult({ testCase: 'status code is 200', status: 'passed' })];
+
+  it('is true when no filter is engaged, even with no test results at all', () => {
+    expect(hasMatchingTestResults([], 'all', '')).toBe(true);
+    expect(hasMatchingTestResults(results, 'all', '')).toBe(true);
+  });
+
+  it('is true when a filter is engaged and at least one result matches', () => {
+    expect(hasMatchingTestResults(results, 'passed', '')).toBe(true);
+  });
+
+  it('is false when a status filter is engaged and no result matches', () => {
+    expect(hasMatchingTestResults(results, 'failed', '')).toBe(false);
+    expect(hasMatchingTestResults(results, 'skipped', '')).toBe(false);
+  });
+
+  it('is false when a status filter is engaged and there are no results at all', () => {
+    expect(hasMatchingTestResults([], 'failed', '')).toBe(false);
+  });
+
+  it('is false when a text filter is engaged and no result matches', () => {
+    expect(hasMatchingTestResults(results, 'all', 'nonexistent test name')).toBe(false);
+  });
+
+  it('is true when a text filter is engaged and a result matches', () => {
+    expect(hasMatchingTestResults(results, 'all', 'status code')).toBe(true);
+  });
+});

--- a/packages/insomnia/src/ui/components/panes/request-result-card.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-result-card.tsx
@@ -11,7 +11,7 @@ import {
   type RunnerLiveItem,
 } from '../../../common/runner-feedback';
 import { RenderedText } from '../rendered-text';
-import { RequestTestResultRows } from './request-test-result-pane';
+import { filterTestResults, RequestTestResultRows } from './request-test-result-pane';
 
 interface Props {
   item: RunnerResultPerRequest | RunnerLiveItem;
@@ -48,6 +48,11 @@ export const RequestResultCard: FC<Props> = ({
   const showInlineStats = isExpanded && !isSkipped && stats;
 
   const requestId = 'requestId' in item ? item.requestId : undefined;
+
+  const isFilterEngaged = targetTests !== 'all' || resultFilter.trim() !== '';
+  if (isFilterEngaged && filterTestResults(results, targetTests, resultFilter).length === 0) {
+    return null;
+  }
 
   return (
     <div data-testid={testId} className="m-3 rounded-sm border border-solid border-(--hl-md) p-3">

--- a/packages/insomnia/src/ui/components/panes/request-result-card.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-result-card.tsx
@@ -11,7 +11,7 @@ import {
   type RunnerLiveItem,
 } from '../../../common/runner-feedback';
 import { RenderedText } from '../rendered-text';
-import { filterTestResults, RequestTestResultRows } from './request-test-result-pane';
+import { hasMatchingTestResults, RequestTestResultRows } from './request-test-result-pane';
 
 interface Props {
   item: RunnerResultPerRequest | RunnerLiveItem;
@@ -49,8 +49,7 @@ export const RequestResultCard: FC<Props> = ({
 
   const requestId = 'requestId' in item ? item.requestId : undefined;
 
-  const isFilterEngaged = targetTests !== 'all' || resultFilter.trim() !== '';
-  if (isFilterEngaged && filterTestResults(results, targetTests, resultFilter).length === 0) {
+  if (!hasMatchingTestResults(results, targetTests, resultFilter)) {
     return null;
   }
 

--- a/packages/insomnia/src/ui/components/panes/request-result-card.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-result-card.tsx
@@ -11,12 +11,12 @@ import {
   type RunnerLiveItem,
 } from '../../../common/runner-feedback';
 import { RenderedText } from '../rendered-text';
-import { hasMatchingTestResults, RequestTestResultRows } from './request-test-result-pane';
+import { hasMatchingTestResults, RequestTestResultRows, type TargetTestType } from './request-test-result-pane';
 
 interface Props {
   item: RunnerResultPerRequest | RunnerLiveItem;
   resultFilter?: string;
-  targetTests?: string;
+  targetTests?: TargetTestType;
   onSkip?: () => void;
   testId?: string;
   defaultExpanded?: boolean;

--- a/packages/insomnia/src/ui/components/panes/request-test-result-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-test-result-pane.tsx
@@ -3,7 +3,7 @@ import { fuzzyMatch } from 'insomnia-data/common';
 import React, { type FC, useState } from 'react';
 import { Toolbar } from 'react-aria-components';
 
-type TargetTestType = 'all' | 'passed' | 'failed' | 'skipped';
+export type TargetTestType = 'all' | 'passed' | 'failed' | 'skipped';
 
 const filterClassnames =
   'mx-1 w-24 text-center rounded-md h-(--line-height-xxs) text-sm cursor-pointer outline-hidden select-none px-2 py-1 hover:bg-[rgba(var(--color-surprise-rgb),50%)] text-(--hl) aria-selected:text-(--color-font-surprise) hover:text-(--color-font-surprise) aria-selected:bg-[rgba(var(--color-surprise-rgb),40%)] transition-colors duration-300';
@@ -13,12 +13,12 @@ const activeFilterClassnames =
 export interface RequestTestResultRowsProps {
   requestTestResults: RequestTestResult[];
   resultFilter: string;
-  targetTests: string;
+  targetTests: TargetTestType;
 }
 
 export function filterTestResults(
   requestTestResults: RequestTestResult[],
-  targetTests: string,
+  targetTests: TargetTestType,
   resultFilter: string,
 ): { result: RequestTestResult; index: number }[] {
   return requestTestResults
@@ -51,13 +51,13 @@ export function filterTestResults(
     });
 }
 
-export function isFilterEngaged(targetTests: string, resultFilter: string): boolean {
+export function isFilterEngaged(targetTests: TargetTestType, resultFilter: string): boolean {
   return targetTests !== 'all' || resultFilter.trim() !== '';
 }
 
 export function hasMatchingTestResults(
   requestTestResults: RequestTestResult[],
-  targetTests: string,
+  targetTests: TargetTestType,
   resultFilter: string,
 ): boolean {
   return (

--- a/packages/insomnia/src/ui/components/panes/request-test-result-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-test-result-pane.tsx
@@ -16,20 +16,12 @@ export interface RequestTestResultRowsProps {
   targetTests: string;
 }
 
-export const RequestTestResultRows: FC<RequestTestResultRowsProps> = ({
-  requestTestResults,
-  resultFilter,
-  targetTests,
-}: RequestTestResultRowsProps) => {
-  if (requestTestResults.length === 0) {
-    return (
-      <div className="my-2 w-full pl-3 text-sm text-neutral-400">
-        No test was detected, add test cases in scripts to see results.
-      </div>
-    );
-  }
-
-  const testResultRows = requestTestResults
+export function filterTestResults(
+  requestTestResults: RequestTestResult[],
+  targetTests: string,
+  resultFilter: string,
+): { result: RequestTestResult; index: number }[] {
+  return requestTestResults
     .map((result, index) => ({ result, index }))
     .filter(({ result }) => {
       switch (targetTests) {
@@ -56,7 +48,23 @@ export const RequestTestResultRows: FC<RequestTestResultRowsProps> = ({
       }
 
       return Boolean(fuzzyMatch(resultFilter, result.testCase, { splitSpace: false, loose: true })?.indexes);
-    })
+    });
+}
+
+export const RequestTestResultRows: FC<RequestTestResultRowsProps> = ({
+  requestTestResults,
+  resultFilter,
+  targetTests,
+}: RequestTestResultRowsProps) => {
+  if (requestTestResults.length === 0) {
+    return (
+      <div className="my-2 w-full pl-3 text-sm text-neutral-400">
+        No test was detected, add test cases in scripts to see results.
+      </div>
+    );
+  }
+
+  const testResultRows = filterTestResults(requestTestResults, targetTests, resultFilter)
     .map(({ result, index }) => {
       const statusText = {
         passed: 'PASS',

--- a/packages/insomnia/src/ui/components/panes/request-test-result-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-test-result-pane.tsx
@@ -51,6 +51,21 @@ export function filterTestResults(
     });
 }
 
+export function isFilterEngaged(targetTests: string, resultFilter: string): boolean {
+  return targetTests !== 'all' || resultFilter.trim() !== '';
+}
+
+export function hasMatchingTestResults(
+  requestTestResults: RequestTestResult[],
+  targetTests: string,
+  resultFilter: string,
+): boolean {
+  return (
+    !isFilterEngaged(targetTests, resultFilter) ||
+    filterTestResults(requestTestResults, targetTests, resultFilter).length > 0
+  );
+}
+
 export const RequestTestResultRows: FC<RequestTestResultRowsProps> = ({
   requestTestResults,
   resultFilter,

--- a/packages/insomnia/src/ui/components/panes/runner-test-result-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/runner-test-result-pane.tsx
@@ -124,7 +124,7 @@ export const RunnerTestResultPane: FC<Props> = ({ result }) => {
               resultsByIteration
             ) : (
               <div className="mt-5 text-center">
-                <div>No "{resultFilter || targetTests}" requests/tests to display</div>
+                <div>No matching requests/tests to display</div>
               </div>
             )}
           </div>

--- a/packages/insomnia/src/ui/components/panes/runner-test-result-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/runner-test-result-pane.tsx
@@ -6,6 +6,7 @@ import { useRootLoaderData } from '~/root';
 import { Hotkey } from '~/ui/components/hotkey';
 
 import { RequestResultCard } from './request-result-card';
+import { filterTestResults } from './request-test-result-pane';
 
 type TargetTestType = 'all' | 'passed' | 'failed' | 'skipped';
 
@@ -52,10 +53,20 @@ export const RunnerTestResultPane: FC<Props> = ({ result }) => {
   const selectFailedTests = () => setTargetTests('failed');
   const selectSkippedTests = () => setTargetTests('skipped');
 
+  const isFilterEngaged = targetTests !== 'all' || resultFilter.trim() !== '';
+
   const resultsByIteration = result.iterationResults.map((iterationResults: RunnerResultPerRequest[], i: number) => {
     const key = `runner-test-result-iteration-${i + 1}`;
 
     if (Array.isArray(iterationResults)) {
+      const hasVisibleRequest = !isFilterEngaged || iterationResults.some(
+        requestTestResult => filterTestResults(requestTestResult.results ?? [], targetTests, resultFilter).length > 0,
+      );
+
+      if (!hasVisibleRequest) {
+        return null;
+      }
+
       const resultByRequest = iterationResults.map((requestTestResult: RunnerResultPerRequest, reqIndex: number) => {
         const key = `request-test-result-${reqIndex}`;
         return (

--- a/packages/insomnia/src/ui/components/panes/runner-test-result-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/runner-test-result-pane.tsx
@@ -6,9 +6,7 @@ import { useRootLoaderData } from '~/root';
 import { Hotkey } from '~/ui/components/hotkey';
 
 import { RequestResultCard } from './request-result-card';
-import { hasMatchingTestResults } from './request-test-result-pane';
-
-type TargetTestType = 'all' | 'passed' | 'failed' | 'skipped';
+import { hasMatchingTestResults, type TargetTestType } from './request-test-result-pane';
 
 const filterClassnames =
   'mx-1 w-24 text-center rounded-md h-(--line-height-xxs) text-sm cursor-pointer outline-hidden select-none px-2 py-1 hover:bg-[rgba(var(--color-surprise-rgb),50%)] text-(--hl) aria-selected:text-(--color-font-surprise) hover:text-(--color-font-surprise) aria-selected:bg-[rgba(var(--color-surprise-rgb),40%)] transition-colors duration-300';
@@ -93,7 +91,7 @@ export const RunnerTestResultPane: FC<Props> = ({ result }) => {
 
   return (
     <>
-      <div className="flex h-full flex-col divide-y divide-solid divide-(--hl-md)">
+      <div className="flex h-[calc(100%-var(--line-height-sm))] flex-col divide-y divide-solid divide-(--hl-md)">
         <div className="h-[calc(100%-var(--line-height-sm))]">
           <Toolbar className="box-border flex h-(--line-height-sm) flex-row items-center overflow-x-auto border-b border-solid border-b-(--hl-md) pl-2 text-(--font-size-sm)">
             <button
@@ -126,7 +124,7 @@ export const RunnerTestResultPane: FC<Props> = ({ result }) => {
               resultsByIteration
             ) : (
               <div className="mt-5 text-center">
-                <div>No {targetTests} requests/tests to display</div>
+                <div>No "{resultFilter || targetTests}" requests/tests to display</div>
               </div>
             )}
           </div>

--- a/packages/insomnia/src/ui/components/panes/runner-test-result-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/runner-test-result-pane.tsx
@@ -91,6 +91,8 @@ export const RunnerTestResultPane: FC<Props> = ({ result }) => {
     return <div key={key}>Invalid test result format</div>;
   });
 
+  const hasVisibleResults = resultsByIteration.some(Boolean);
+
   return (
     <>
       <div className="flex h-full flex-col divide-y divide-solid divide-(--hl-md)">
@@ -122,7 +124,13 @@ export const RunnerTestResultPane: FC<Props> = ({ result }) => {
             </button>
           </Toolbar>
           <div className="h-[calc(100%-var(--line-height-sm))] w-auto overflow-x-auto overflow-y-auto">
-            {resultsByIteration}
+            {hasVisibleResults ? (
+              resultsByIteration
+            ) : (
+              <div className="mt-5 text-center">
+                <div>No {targetTests} requests/tests to display</div>
+              </div>
+            )}
           </div>
         </div>
         <Toolbar className="box-border flex h-(--line-height-sm) shrink-0 flex-row items-center overflow-x-auto text-(--font-size-sm)">

--- a/packages/insomnia/src/ui/components/panes/runner-test-result-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/runner-test-result-pane.tsx
@@ -6,7 +6,7 @@ import { useRootLoaderData } from '~/root';
 import { Hotkey } from '~/ui/components/hotkey';
 
 import { RequestResultCard } from './request-result-card';
-import { filterTestResults } from './request-test-result-pane';
+import { hasMatchingTestResults } from './request-test-result-pane';
 
 type TargetTestType = 'all' | 'passed' | 'failed' | 'skipped';
 
@@ -53,14 +53,12 @@ export const RunnerTestResultPane: FC<Props> = ({ result }) => {
   const selectFailedTests = () => setTargetTests('failed');
   const selectSkippedTests = () => setTargetTests('skipped');
 
-  const isFilterEngaged = targetTests !== 'all' || resultFilter.trim() !== '';
-
   const resultsByIteration = result.iterationResults.map((iterationResults: RunnerResultPerRequest[], i: number) => {
     const key = `runner-test-result-iteration-${i + 1}`;
 
     if (Array.isArray(iterationResults)) {
-      const hasVisibleRequest = !isFilterEngaged || iterationResults.some(
-        requestTestResult => filterTestResults(requestTestResult.results ?? [], targetTests, resultFilter).length > 0,
+      const hasVisibleRequest = iterationResults.some(
+        requestTestResult => hasMatchingTestResults(requestTestResult.results ?? [], targetTests, resultFilter),
       );
 
       if (!hasVisibleRequest) {


### PR DESCRIPTION
Using the Passed/Failed/Skipped filters in the collection runner results currently only filter through tests, leaving requests/iterations in place even if there are no matching children.

<img width="894" height="331" alt="image" src="https://github.com/user-attachments/assets/33b18ede-5cc4-43fc-8d9b-0a5a2e8c69ed" />

This can lead to a degraded experience in scenarios where there may be a large number of requests/tests/iterations with very few failures/successes. Engaging a filter in such a case will still lead to a significant amount of screen real estate being dedicated to "empty" requests/iterations, thereby still necessitating that the user manually scroll to find the test that's failing/passing/skipped. This PR updates the filter logic to:

- Hide a request altogether if there are no tests matching the filter criteria.
- Hide an iteration if there are no tests matching the filter criteria.

| Before | After |
|---|---|
| <img width="1792" height="1042" alt="image" src="https://github.com/user-attachments/assets/4d6cf318-3910-4920-9759-bfe663c36b7b" /> | <img width="1792" height="1042" alt="image" src="https://github.com/user-attachments/assets/2c45f100-7cd0-481a-9391-764cbcff88b4" /> |

Since it's now possible for the entire pane to be empty if _nothing_ matches a filter, this PR also adds a very basic empty state:

<img width="897" height="177" alt="image" src="https://github.com/user-attachments/assets/0671b9eb-5aeb-4bb9-bfe8-f8f89f971807" />

Changes were tested manually by running collections of various sizes for 1-10 iterations, and automated tests have also been added to verify the internal business logic. Tests to actually run through the GUI have not been added since they've proven to be a source of flakiness, and the business logic-only tests should be good enough IMO.