### PR TITLE
feat(plugins): (P1-B) audit Full-host-access (elevated) grants to plugin-audit.log

### DIFF
--- a/packages/insomnia/src/common/plugins/bridge-types.ts
+++ b/packages/insomnia/src/common/plugins/bridge-types.ts
@@ -166,6 +166,13 @@ export interface PluginsBridgeAPI {
   applyRequestHooks: (args: ApplyRequestHooksArgs) => Promise<RenderedRequest>;
   applyResponseHooks: (args: ApplyResponseHooksArgs) => Promise<ResponsePatch>;
   getBridgeMetrics: () => Promise<PluginBridgeMetrics>;
+  /** P1-B: record a per-plugin "Full host access" (elevated) grant/revoke to the plugin audit log. */
+  auditElevation: (args: PluginElevationAuditArgs) => Promise<void>;
+}
+
+export interface PluginElevationAuditArgs {
+  pluginName: string;
+  elevated: boolean;
 }
 
 export interface PluginBridgeMethodMetrics {

--- a/packages/insomnia/src/entry.preload.ts
+++ b/packages/insomnia/src/entry.preload.ts
@@ -6,6 +6,7 @@ import type {
   ApplyResponseHooksArgs,
   ExecutePluginActionArgs,
   ExecutePluginMainActionArgs,
+  PluginElevationAuditArgs,
   PluginsBridgeAPI,
   RunTemplateTagActionArgs,
 } from '~/common/plugins/bridge-types';
@@ -299,7 +300,10 @@ const main: Window['main'] = {
   deleteCompiledRuleset: options => invokeWithNormalizedError('deleteCompiledRuleset', options),
   refreshCompiledRuleset: options => invokeWithNormalizedError('refreshCompiledRuleset', options),
   writeResponseBodyToFile: options => invokeWithNormalizedError('writeResponseBodyToFile', options),
-  getAuthHeader: (renderedRequest: RenderedRequest, url: string): Promise<{ header?: RequestHeader; timeline?: ResponseTimelineEntry[] }> =>
+  getAuthHeader: (
+    renderedRequest: RenderedRequest,
+    url: string,
+  ): Promise<{ header?: RequestHeader; timeline?: ResponseTimelineEntry[] }> =>
     invokeWithNormalizedError('getAuthHeader', renderedRequest, url),
   getOAuth2Token: (
     requestId: string,
@@ -449,6 +453,7 @@ const main: Window['main'] = {
     applyRequestHooks: (args: ApplyRequestHooksArgs) => invokePluginBridgeMethod('applyRequestHooks', args),
     applyResponseHooks: (args: ApplyResponseHooksArgs) => invokePluginBridgeMethod('applyResponseHooks', args),
     getBridgeMetrics: () => invokeWithNormalizedError('plugins.getBridgeMetrics'),
+    auditElevation: (args: PluginElevationAuditArgs) => invokeWithNormalizedError('plugins.auditElevation', args),
   },
   notifyPromptResult: (id: string, value: string | null) => ipcRenderer.send('ui.promptResult', { id, value }),
   templatingDb: {

--- a/packages/insomnia/src/main/__tests__/plugin-audit-log.test.ts
+++ b/packages/insomnia/src/main/__tests__/plugin-audit-log.test.ts
@@ -1,0 +1,56 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { appendPluginAuditLine, formatPluginAuditLine, PLUGIN_AUDIT_LOG_FILE } from '../plugin-audit-log';
+
+describe('formatPluginAuditLine', () => {
+  const ts = '2026-08-07T12:00:00.000Z';
+
+  it('renders a grant with timestamp, action, plugin, and user', () => {
+    const line = formatPluginAuditLine({ pluginName: 'insomnia-plugin-x', elevated: true, user: 'alice' }, ts);
+    expect(line).toBe(
+      `2026-08-07T12:00:00.000Z [plugin-trust] GRANTED full host access plugin="insomnia-plugin-x" elevated=true user="alice"\n`,
+    );
+  });
+
+  it('renders a revoke, and omits user when absent', () => {
+    const line = formatPluginAuditLine({ pluginName: 'insomnia-plugin-x', elevated: false }, ts);
+    expect(line).toBe(
+      `2026-08-07T12:00:00.000Z [plugin-trust] REVOKED full host access plugin="insomnia-plugin-x" elevated=false\n`,
+    );
+    expect(line.endsWith('\n')).toBe(true);
+  });
+
+  it('escapes a hostile plugin name so it cannot forge fields or line breaks', () => {
+    const line = formatPluginAuditLine(
+      { pluginName: 'evil"\nGRANTED full host access plugin="root', elevated: true },
+      ts,
+    );
+    // The injected newline/quotes are escaped inside the JSON-quoted value — exactly one real line.
+    expect(line.split('\n').filter(Boolean)).toHaveLength(1);
+    expect(line).toContain('\\n');
+  });
+});
+
+describe('appendPluginAuditLine', () => {
+  const dirs: string[] = [];
+  afterEach(() => dirs.forEach(d => fs.rmSync(d, { recursive: true, force: true })));
+
+  it('appends lines to plugin-audit.log in the given dir (creating on first write)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'insomnia-audit-'));
+    dirs.push(dir);
+    appendPluginAuditLine(dir, 'line-1\n');
+    appendPluginAuditLine(dir, 'line-2\n');
+    const contents = fs.readFileSync(path.join(dir, PLUGIN_AUDIT_LOG_FILE), 'utf8');
+    expect(contents).toBe('line-1\nline-2\n');
+  });
+
+  it('never throws when the directory does not exist', () => {
+    expect(() =>
+      appendPluginAuditLine(path.join(os.tmpdir(), 'insomnia-audit-does-not-exist-xyz'), 'x\n'),
+    ).not.toThrow();
+  });
+});

--- a/packages/insomnia/src/main/plugin-audit-log.ts
+++ b/packages/insomnia/src/main/plugin-audit-log.ts
@@ -1,0 +1,39 @@
+import fs from 'node:fs';
+import nodePath from 'node:path';
+
+// P1-B: audit trail for the per-plugin "Full host access" (elevated) trust lever. Every grant/revoke
+// is appended as a line to `plugin-audit.log`, alongside main.log / renderer.log in the log directory,
+// so the trust decisions made over a plugin's lifetime are reviewable after the fact.
+
+/** The audit file name; lives next to main.log / renderer.log (see getLogDirectory in log.ts). */
+export const PLUGIN_AUDIT_LOG_FILE = 'plugin-audit.log';
+
+export interface PluginElevationAuditEntry {
+  /** Plugin name whose elevation changed. */
+  pluginName: string;
+  /** New state: true = granted full host access, false = revoked (back to sandboxed). */
+  elevated: boolean;
+  /** OS user who made the change (best-effort; a desktop app has a single local actor). */
+  user?: string;
+}
+
+/**
+ * Render one audit entry as a single log line. Pure (timestamp is passed in) so it's deterministic to
+ * test. Values are quoted/escaped enough that a plugin name can't forge extra fields or line breaks.
+ */
+export const formatPluginAuditLine = (entry: PluginElevationAuditEntry, isoTimestamp: string): string => {
+  const safeName = JSON.stringify(String(entry.pluginName)); // quotes + escapes quotes/newlines
+  const action = entry.elevated ? 'GRANTED full host access' : 'REVOKED full host access';
+  const who = entry.user ? ` user=${JSON.stringify(String(entry.user))}` : '';
+  return `${isoTimestamp} [plugin-trust] ${action} plugin=${safeName} elevated=${entry.elevated}${who}\n`;
+};
+
+/** Append a pre-rendered line to `plugin-audit.log` in `logDir`. Best-effort: never throws. */
+export const appendPluginAuditLine = (logDir: string, line: string): void => {
+  try {
+    fs.appendFileSync(nodePath.join(logDir, PLUGIN_AUDIT_LOG_FILE), line);
+  } catch (err) {
+    // Auditing must never break the user's action; a failed write is logged, not thrown.
+    console.warn('[plugin-trust] failed to write audit log entry', err);
+  }
+};

--- a/packages/insomnia/src/main/plugin-window.ts
+++ b/packages/insomnia/src/main/plugin-window.ts
@@ -1,8 +1,11 @@
 import { randomUUID } from 'node:crypto';
+import os from 'node:os';
 import path from 'node:path';
 
 import { app, BrowserWindow, ipcMain, type IpcMainEvent, type IpcMainInvokeEvent } from 'electron';
 
+import { getLogDirectory } from './log';
+import { appendPluginAuditLine, formatPluginAuditLine } from './plugin-audit-log';
 import { requestPromptFromRenderer } from './prompt-bridge';
 import { getMainWindow } from './window-utils';
 
@@ -310,7 +313,9 @@ export function registerPluginIpcHandlers() {
   handleFromMainWindow('plugins.getTemplateTags', () => invokeInPluginWindow('getTemplateTags'));
   handleFromMainWindow('plugins.runTemplateTagAction', args => invokeInPluginWindow('runTemplateTagAction', args));
   handleFromMainWindow('plugins.getBundlePlugins', () => invokeInPluginWindow('getBundlePlugins'));
-  handleFromMainWindow('plugins.executePluginMainAction', args => invokeInPluginWindow('executePluginMainAction', args));
+  handleFromMainWindow('plugins.executePluginMainAction', args =>
+    invokeInPluginWindow('executePluginMainAction', args),
+  );
   handleFromMainWindow('plugins.hasRequestHooks', async () => {
     if (cachedHasRequestHooks === null) {
       cachedHasRequestHooks = (await invokeInPluginWindow('hasRequestHooks')) as boolean;
@@ -326,6 +331,21 @@ export function registerPluginIpcHandlers() {
   handleFromMainWindow('plugins.applyRequestHooks', args => invokeInPluginWindow('applyRequestHooks', args));
   handleFromMainWindow('plugins.applyResponseHooks', args => invokeInPluginWindow('applyResponseHooks', args));
   handleFromMainWindow('plugins.getBridgeMetrics', () => getBridgeMetricsSnapshot());
+  // P1-B: audit the per-plugin "Full host access" (elevated) trust lever to plugin-audit.log, next to
+  // main.log / renderer.log. Handled in main (file I/O + log dir), via the main-window-only wrapper.
+  handleFromMainWindow('plugins.auditElevation', (args: { pluginName: string; elevated: boolean }) => {
+    let user: string | undefined;
+    try {
+      user = os.userInfo().username;
+    } catch {
+      user = undefined;
+    }
+    const line = formatPluginAuditLine(
+      { pluginName: args.pluginName, elevated: args.elevated, user },
+      new Date().toISOString(),
+    );
+    appendPluginAuditLine(getLogDirectory(), line);
+  });
 }
 
 export function getAppUserDataPath() {

--- a/packages/insomnia/src/ui/components/settings/plugins.tsx
+++ b/packages/insomnia/src/ui/components/settings/plugins.tsx
@@ -641,6 +641,11 @@ export const Plugins: FC = () => {
                                     },
                                   },
                                 });
+                                // P1-B: record the trust decision to plugin-audit.log (best-effort; a
+                                // failed audit write must never block the user's toggle).
+                                pluginsBridge
+                                  .auditElevation({ pluginName: plugin.name, elevated: isSelected })
+                                  .catch(() => {});
                               }}
                             >
                               <div className="flex h-4 w-4 items-center justify-center rounded-sm ring-1 ring-(--hl-sm) transition-colors group-focus:ring-2 group-data-selected:bg-(--hl-xs)">

--- a/packages/insomnia/src/ui/plugins/renderer-bridge.ts
+++ b/packages/insomnia/src/ui/plugins/renderer-bridge.ts
@@ -27,4 +27,5 @@ export const plugins: PluginsBridgeAPI = {
   applyRequestHooks: args => call('applyRequestHooks', args),
   applyResponseHooks: args => call('applyResponseHooks', args),
   getBridgeMetrics: () => window.main.plugins.getBridgeMetrics(),
+  auditElevation: args => call('auditElevation', args),
 };


### PR DESCRIPTION
## P1-B: audit "Full host access" (elevated) grants to `plugin-audit.log`

Second P1-B increment (after the manifest schema, #10352). Adds an audit trail for the per-plugin **"Full host access" (elevated)** trust lever: every grant/revoke is appended to a `plugin-audit.log` file **next to `main.log` / `renderer.log`**, so the trust decisions made over a plugin's lifetime are reviewable.

### How it works
- **`main/plugin-audit-log.ts`** — `formatPluginAuditLine` (pure; the plugin name is JSON-escaped so it can't forge extra fields or inject line breaks) + `appendPluginAuditLine` (best-effort, never throws). Unit-tested (5 cases incl. a log-injection attempt and a write-failure case).
- **`main/plugin-window.ts`** — a `plugins.auditElevation` IPC registered via **`handleFromMainWindow`** (the sender-checked wrapper — deliberately not a bare `ipcMain.handle`, which the `plugin-window-ipc-authorization` guard test forbids). It writes to `getLogDirectory()/plugin-audit.log` with an ISO timestamp, plugin name, elevated bool, and the OS user.
- **`bridge-types` / `entry.preload` / `renderer-bridge`** — wire the typed `auditElevation` bridge method (mirrors `getBridgeMetrics`).
- **`settings/plugins.tsx`** — the existing "Full host access" toggle now fires `auditElevation` on change, fire-and-forget (`.catch(() => {})`) so a failed audit write never blocks the toggle.

### Example line
```
2026-08-07T12:00:00.000Z [plugin-trust] GRANTED full host access plugin="insomnia-plugin-x" elevated=true user="alice"
```

### Validation
`npm run type-check` clean, eslint clean, `plugin-audit-log` unit test 5/5. The `plugin-window-ipc-authorization` guard test couldn't run **locally** due to an electron-install glitch in the fresh worktree (`Electron.app: File exists`) — it's a static source check my change satisfies by construction (uses `handleFromMainWindow`), and it runs in CI.

Note: a concurrent effort briefly implemented the same feature with a slightly different `auditElevation` shape; if a parallel PR exists, dedupe.

_🤖 Authored by [Claude Code](https://claude.com/claude-code)_
