### PR TITLE
fix: Plugin actions is missing in the workspace dropdown on sidebar- #10356

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/sidebar-workspace-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/sidebar-workspace-dropdown.tsx
@@ -7,7 +7,7 @@ import {
 import type { MockServer, Project, Workspace } from 'insomnia-data';
 import { models, services } from 'insomnia-data';
 import type { PlatformKeyCombinations } from 'insomnia-data/common';
-import React, { Fragment, useState } from 'react';
+import React, { Fragment, useCallback, useState } from 'react';
 import {
   Button,
   Collection,
@@ -28,19 +28,22 @@ import {
 } from 'react-aria-components';
 import { href } from 'react-router';
 
+import { database as db } from '~/common/database';
+import type { SerializableActionMeta } from '~/common/plugins/bridge-types';
 import { useRequestNewActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new';
 import { useRequestGroupNewActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.new';
 import { useWorkspaceDeleteActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.delete';
 import { useWorkspaceUpdateActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.update';
 import { useTabNavigate } from '~/ui/hooks/use-insomnia-tab';
 import type { CreateRequestType } from '~/ui/hooks/use-request';
+import { plugins } from '~/ui/plugins/renderer-bridge';
 
 import { getProductName, SORT_ORDERS, type SortOrder, sortOrderName } from '../../../common/constants';
 import { getWorkspaceLabel } from '../../../common/get-workspace-label';
 import { AnalyticsEvent } from '../../analytics';
 import { DropdownHint } from '../base/dropdown/dropdown-hint';
 import { Icon } from '../icon';
-import { showModal } from '../modals';
+import { showError, showModal } from '../modals';
 import { ExportRequestsModal } from '../modals/export-requests-modal';
 import { ImportModal } from '../modals/import-modal/import-modal';
 import { PasteCurlModal } from '../modals/paste-curl-modal';
@@ -95,6 +98,7 @@ export const SidebarWorkspaceDropdown = ({
   const [settingsData, setSettingsData] = useState<{ mockServer: MockServer | null; gitFilePath: string | null }>();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isPasteCurlModalOpen, setPasteCurlModalOpen] = useState(false);
+  const [actionPlugins, setActionPlugins] = useState<SerializableActionMeta[]>([]);
 
   const updateWorkspaceFetcher = useWorkspaceUpdateActionFetcher();
   const deleteWorkspaceFetcher = useWorkspaceDeleteActionFetcher();
@@ -124,6 +128,36 @@ export const SidebarWorkspaceDropdown = ({
       { organization: organizationId, project, workspace, item: workspace },
       isRunner ? { shouldNavigate: true, asRunner: true } : { withTab: true, shouldNavigate: true },
     );
+  };
+
+  const handleDropdownOpen = useCallback(async () => {
+    try {
+      const actionPlugins = await plugins.getWorkspaceActions();
+      setActionPlugins(actionPlugins);
+    } catch (error) {
+      setActionPlugins([]);
+      console.error('Failed to get workspace action plugins', error);
+    }
+  }, []);
+
+  const handlePluginClick = async ({ pluginName, label }: SerializableActionMeta) => {
+    try {
+      const docs = await db.getWithDescendants(workspace, [models.request.type, models.requestGroup.type]);
+      const requests = docs.filter(models.request.isRequest).filter(doc => !doc.isPrivate);
+      const requestGroups = docs.filter(models.requestGroup.isRequestGroup);
+      await plugins.executeAction({
+        type: 'workspace',
+        pluginName,
+        label,
+        projectId: project._id,
+        domainData: { workspace, requests, requestGroups },
+      });
+    } catch (error) {
+      showError({
+        title: 'Plugin Action Failed',
+        error,
+      });
+    }
   };
 
   const createSection: ActionSection = {
@@ -317,9 +351,21 @@ export const SidebarWorkspaceDropdown = ({
     ],
   };
 
+  const pluginActionSection: ActionSection = {
+    name: 'Plugins',
+    id: 'plugins',
+    icon: 'plug' as IconName,
+    items: actionPlugins.map(plugin => ({
+      id: `${plugin.pluginName}:${plugin.label}`,
+      name: plugin.label,
+      icon: (plugin.icon as IconName) || 'plug',
+      action: () => handlePluginClick(plugin),
+    })),
+  };
+
   const allSections: ActionSection[] = isScratchpadWorkspace
     ? [...createSections, scratchpadActionList]
-    : [...createSections, actionSection];
+    : [...createSections, actionSection, ...(actionPlugins.length > 0 ? [pluginActionSection] : [])];
 
   return (
     <Fragment>
@@ -327,6 +373,9 @@ export const SidebarWorkspaceDropdown = ({
         isOpen={isOpen}
         onOpenChange={isOpen => {
           onOpenChange(isOpen);
+          if (isOpen) {
+            handleDropdownOpen();
+          }
         }}
       >
         <Button


### PR DESCRIPTION
Fix the issue that Plugin actions is missing in the workspace dropdown on sidebar.

[INS-3511](https://konghq.atlassian.net/browse/INS-3511)

[INS-3511]: https://konghq.atlassian.net/browse/INS-3511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ