### PR TITLE
feat(settings): add proxyIntegrations option for first-party integrations

### DIFF
--- a/packages/insomnia-data/common-src/settings.ts
+++ b/packages/insomnia-data/common-src/settings.ts
@@ -87,7 +87,7 @@ export enum UpdateChannel {
 }
 
 // How far the configured HTTP/HTTPS proxy reaches.
-export const ProxyScope = {
+export const ProxyScopes = {
   // Only requests sent from collections use the proxy (default, matches pre-13.1 behavior).
   // Insomnia's own traffic (login, git, Konnect, auto-updates, analytics, etc.) always goes direct.
   requests: 'requests',
@@ -95,7 +95,7 @@ export const ProxyScope = {
   all: 'all',
 } as const;
 
-export type ProxyScope = ValueOf<typeof ProxyScope>;
+export type ProxyScope = ValueOf<typeof ProxyScopes>;
 
 /** Gets a subset of Settings where the values match a condition */
 export type SettingsOfType<MatchType> = NonNullable<

--- a/packages/insomnia-data/common-src/settings.ts
+++ b/packages/insomnia-data/common-src/settings.ts
@@ -137,6 +137,12 @@ export interface Settings {
   hotKeyRegistry: HotKeyRegistry;
   httpProxy: string;
   httpsProxy: string;
+  /**
+   * When false (default), the configured proxy is not used for Insomnia's own first-party
+   * integrations (the Insomnia API/website, mock service, AI helper, Konnect, GitHub) — only for
+   * the user's own requests. When true, that traffic is routed through the proxy too.
+   */
+  proxyIntegrations: boolean;
   showVariableSourceAndValue: boolean;
   lightTheme: string;
   lineWrapping?: boolean;

--- a/packages/insomnia-data/common-src/settings.ts
+++ b/packages/insomnia-data/common-src/settings.ts
@@ -86,6 +86,17 @@ export enum UpdateChannel {
   beta = 'beta',
 }
 
+// How far the configured HTTP/HTTPS proxy reaches.
+export const ProxyScope = {
+  // Only requests sent from collections use the proxy (default, matches pre-13.1 behavior).
+  // Insomnia's own traffic (login, git, Konnect, auto-updates, analytics, etc.) always goes direct.
+  requests: 'requests',
+  // Every outbound call Insomnia makes, including its own traffic above, uses the proxy.
+  all: 'all',
+} as const;
+
+export type ProxyScope = ValueOf<typeof ProxyScope>;
+
 /** Gets a subset of Settings where the values match a condition */
 export type SettingsOfType<MatchType> = NonNullable<
   {
@@ -137,12 +148,8 @@ export interface Settings {
   hotKeyRegistry: HotKeyRegistry;
   httpProxy: string;
   httpsProxy: string;
-  /**
-   * When false (default), the configured proxy is not used for Insomnia's own first-party
-   * integrations (the Insomnia API/website, mock service, AI helper, Konnect, GitHub) — only for
-   * the user's own requests. When true, that traffic is routed through the proxy too.
-   */
-  proxyIntegrations: boolean;
+  /** How far the configured proxy reaches — see `ProxyScope`. */
+  proxyScope: ProxyScope;
   showVariableSourceAndValue: boolean;
   lightTheme: string;
   lineWrapping?: boolean;

--- a/packages/insomnia-data/src/models/settings.ts
+++ b/packages/insomnia-data/src/models/settings.ts
@@ -4,7 +4,7 @@ import {
   getAppDefaultTheme,
   HttpVersions,
   newDefaultRegistry,
-  ProxyScope,
+  ProxyScopes,
   type Settings as BaseSettings,
   UpdateChannel,
 } from 'insomnia-data/common';
@@ -62,7 +62,7 @@ export function init(): BaseSettings {
     maxTimelineDataSizeKB: 10,
     pluginNodeExtraCerts: '',
     noProxy: '',
-    proxyScope: ProxyScope.requests,
+    proxyScope: ProxyScopes.requests,
     nunjucksPowerUserMode: false,
     pluginConfig: {},
     pluginPath: '',

--- a/packages/insomnia-data/src/models/settings.ts
+++ b/packages/insomnia-data/src/models/settings.ts
@@ -61,6 +61,7 @@ export function init(): BaseSettings {
     maxTimelineDataSizeKB: 10,
     pluginNodeExtraCerts: '',
     noProxy: '',
+    proxyIntegrations: false,
     nunjucksPowerUserMode: false,
     pluginConfig: {},
     pluginPath: '',

--- a/packages/insomnia-data/src/models/settings.ts
+++ b/packages/insomnia-data/src/models/settings.ts
@@ -4,6 +4,7 @@ import {
   getAppDefaultTheme,
   HttpVersions,
   newDefaultRegistry,
+  ProxyScope,
   type Settings as BaseSettings,
   UpdateChannel,
 } from 'insomnia-data/common';
@@ -61,7 +62,7 @@ export function init(): BaseSettings {
     maxTimelineDataSizeKB: 10,
     pluginNodeExtraCerts: '',
     noProxy: '',
-    proxyIntegrations: false,
+    proxyScope: ProxyScope.requests,
     nunjucksPowerUserMode: false,
     pluginConfig: {},
     pluginPath: '',

--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -118,6 +118,8 @@ export const getMockServiceBinURL = (mockServer: MockServer, path: string) => {
 };
 
 export const getAIServiceURL = () => env.INSOMNIA_AI_URL || 'https://ai-helper.insomnia.rest';
+// Customer.io CDP (analytics/in-app messaging) — see ui/hooks/use-cio.tsx
+export const getCioCdnUrl = () => 'https://cdp-eu.customer.io';
 export const getKonnectApiUrl = () => env.KONNECT_API_URL || 'api.konghq.com';
 export const getKonnectApiRegions = (): string[] => {
   const regions = (env.KONNECT_API_REGIONS ?? '')

--- a/packages/insomnia/src/main/install-plugin.ts
+++ b/packages/insomnia/src/main/install-plugin.ts
@@ -6,6 +6,7 @@ import { promisify } from 'node:util';
 
 import { app } from 'electron';
 import { services } from 'insomnia-data';
+import { ProxyScope } from 'insomnia-data/common';
 
 import { validatePluginName } from '~/common/utils/plugin-name';
 import { AnalyticsEvent, trackAnalyticsEvent } from '~/main/analytics';
@@ -433,11 +434,11 @@ export async function getYarnEnvValues(): Promise<Record<string, string>> {
   // Add proxy settings if enabled. Yarn runs as a separate child process — it never touches
   // Electron's session, so it needs its own HTTP_PROXY/HTTPS_PROXY env vars (main/proxy.ts's
   // session-level bypass rules don't apply here). The default public npm registry is treated
-  // like Insomnia's other first-party integrations: bypassed unless proxyIntegrations is on. A
+  // like Insomnia's other first-party integrations: bypassed unless `proxyScope` is 'all'. A
   // custom registry is a user-configured target, so it always respects the proxy setting.
   if (settings.proxyEnabled === true) {
     const usingDefaultRegistry = (await getRegistryUrl()) === DEFAULT_NPM_REGISTRY;
-    if (settings.proxyIntegrations === true || !usingDefaultRegistry) {
+    if (settings.proxyScope === ProxyScope.all || !usingDefaultRegistry) {
       Object.assign(yarnEnv, buildProxyEnv(settings));
     }
   }

--- a/packages/insomnia/src/main/install-plugin.ts
+++ b/packages/insomnia/src/main/install-plugin.ts
@@ -6,7 +6,7 @@ import { promisify } from 'node:util';
 
 import { app } from 'electron';
 import { services } from 'insomnia-data';
-import { ProxyScope } from 'insomnia-data/common';
+import { ProxyScopes } from 'insomnia-data/common';
 
 import { validatePluginName } from '~/common/utils/plugin-name';
 import { AnalyticsEvent, trackAnalyticsEvent } from '~/main/analytics';
@@ -438,7 +438,7 @@ export async function getYarnEnvValues(): Promise<Record<string, string>> {
   // custom registry is a user-configured target, so it always respects the proxy setting.
   if (settings.proxyEnabled === true) {
     const usingDefaultRegistry = (await getRegistryUrl()) === DEFAULT_NPM_REGISTRY;
-    if (settings.proxyScope === ProxyScope.all || !usingDefaultRegistry) {
+    if (settings.proxyScope === ProxyScopes.all || !usingDefaultRegistry) {
       Object.assign(yarnEnv, buildProxyEnv(settings));
     }
   }

--- a/packages/insomnia/src/main/install-plugin.ts
+++ b/packages/insomnia/src/main/install-plugin.ts
@@ -430,9 +430,16 @@ export async function getYarnEnvValues(): Promise<Record<string, string>> {
     yarnEnv.NODE_EXTRA_CA_CERTS = extraCerts;
   }
 
-  // Add proxy settings if enabled
+  // Add proxy settings if enabled. Yarn runs as a separate child process — it never touches
+  // Electron's session, so it needs its own HTTP_PROXY/HTTPS_PROXY env vars (main/proxy.ts's
+  // session-level bypass rules don't apply here). The default public npm registry is treated
+  // like Insomnia's other first-party integrations: bypassed unless proxyIntegrations is on. A
+  // custom registry is a user-configured target, so it always respects the proxy setting.
   if (settings.proxyEnabled === true) {
-    Object.assign(yarnEnv, buildProxyEnv(settings));
+    const usingDefaultRegistry = (await getRegistryUrl()) === DEFAULT_NPM_REGISTRY;
+    if (settings.proxyIntegrations === true || !usingDefaultRegistry) {
+      Object.assign(yarnEnv, buildProxyEnv(settings));
+    }
   }
 
   if (isDevelopment()) {

--- a/packages/insomnia/src/main/proxy.ts
+++ b/packages/insomnia/src/main/proxy.ts
@@ -1,5 +1,6 @@
 import { session } from 'electron/main';
 import { models, services } from 'insomnia-data';
+import { ProxyScope } from 'insomnia-data/common';
 
 import {
   getAIServiceURL,
@@ -17,7 +18,7 @@ import { type ChangeBufferEvent, database as db } from '../common/database';
 import { getUpdatesBaseURL } from './updates';
 
 // Insomnia's own first-party integrations — fixed hosts, not user-configured targets like a
-// self-hosted GitLab or MCP server. Bypassed by default (see `proxyIntegrations` below) so a
+// self-hosted GitLab or MCP server. Bypassed unless `proxyScope` is 'all' (see below), so a
 // user's proxy — typically set up for their own requests — doesn't also have to know how to
 // route to these, matching how this traffic behaved before the app's proxy setting covered it.
 function insomniaIntegrationHosts() {
@@ -38,7 +39,7 @@ function insomniaIntegrationHosts() {
     //
     // Actual git remote traffic (github.com, self-hosted GitLab, GitHub Enterprise, etc.) is
     // NOT listed here — it's handled directly in sync/git/http-client.ts, which treats all
-    // git-sync traffic uniformly under `proxyIntegrations` via its own dedicated direct session,
+    // git-sync traffic uniformly under `proxyScope` via its own dedicated direct session,
     // scoped to just those requests rather than this session-wide bypass list.
     getGitHubRestApiUrl(),
 
@@ -70,7 +71,7 @@ function insomniaIntegrationHosts() {
 
 // Update the proxy settings before making the request.
 async function updateProxy() {
-  const { proxyEnabled, httpProxy, httpsProxy, noProxy, proxyIntegrations } = await services.settings.get();
+  const { proxyEnabled, httpProxy, httpsProxy, noProxy, proxyScope } = await services.settings.get();
 
   if (proxyEnabled) {
     try {
@@ -89,9 +90,10 @@ async function updateProxy() {
         proxyRules.push(`https=${parseProxyFromUrl(httpsProxy)}`);
       }
 
-      const bypassRules = proxyIntegrations
-        ? (noProxy ?? '')
-        : [noProxy, ...insomniaIntegrationHosts()].filter(Boolean).join(',');
+      const bypassRules =
+        proxyScope === ProxyScope.all
+          ? (noProxy ?? '')
+          : [noProxy, ...insomniaIntegrationHosts()].filter(Boolean).join(',');
 
       // Set proxy rules in the main session https://www.electronjs.org/docs/latest/api/structures/proxy-config
       await session.defaultSession.setProxy({
@@ -125,7 +127,7 @@ export async function watchProxySettings() {
           old.httpProxy !== doc.httpProxy ||
           old.httpsProxy !== doc.httpsProxy ||
           old.noProxy !== doc.noProxy ||
-          old.proxyIntegrations !== doc.proxyIntegrations;
+          old.proxyScope !== doc.proxyScope;
         if (hasProxyChanged) {
           await updateProxy();
           old = doc;

--- a/packages/insomnia/src/main/proxy.ts
+++ b/packages/insomnia/src/main/proxy.ts
@@ -26,15 +26,17 @@ function insomniaIntegrationHosts() {
     getKonnectApiUrl(),
     getGitHubRestApiUrl(),
   ];
-  return urls
-    .map(url => {
-      try {
-        return new URL(setDefaultProtocol(url)).host;
-      } catch {
-        return null;
-      }
-    })
-    .filter(Boolean);
+  return urls.flatMap(url => {
+    try {
+      const host = new URL(setDefaultProtocol(url)).host;
+      // Leading-dot form also bypasses subdomains — needed for e.g. Insomnia Cloud's
+      // per-mock-server `mock-<id>.mock.insomnia.run` hosts (see getMockServiceBinURL).
+      // Same convention already documented on the `noProxy` setting in the UI.
+      return [host, `.${host}`];
+    } catch {
+      return [];
+    }
+  });
 }
 
 // Update the proxy settings before making the request.

--- a/packages/insomnia/src/main/proxy.ts
+++ b/packages/insomnia/src/main/proxy.ts
@@ -1,6 +1,6 @@
 import { session } from 'electron/main';
 import { models, services } from 'insomnia-data';
-import { ProxyScope } from 'insomnia-data/common';
+import { ProxyScopes } from 'insomnia-data/common';
 
 import {
   getAIServiceURL,
@@ -91,7 +91,7 @@ async function updateProxy() {
       }
 
       const bypassRules =
-        proxyScope === ProxyScope.all
+        proxyScope === ProxyScopes.all
           ? (noProxy ?? '')
           : [noProxy, ...insomniaIntegrationHosts()].filter(Boolean).join(',');
 

--- a/packages/insomnia/src/main/proxy.ts
+++ b/packages/insomnia/src/main/proxy.ts
@@ -1,13 +1,45 @@
 import { session } from 'electron/main';
 import { models, services } from 'insomnia-data';
 
+import {
+  getAIServiceURL,
+  getApiBaseURL,
+  getAppWebsiteBaseURL,
+  getGitHubRestApiUrl,
+  getKonnectApiUrl,
+  getMockServiceURL,
+} from '~/common/constants';
 import { setDefaultProtocol } from '~/common/utils/url/protocol';
 
 import { type ChangeBufferEvent, database as db } from '../common/database';
 
+// Insomnia's own first-party integrations — fixed hosts, not user-configured targets like a
+// self-hosted GitLab or MCP server. Bypassed by default (see `proxyIntegrations` below) so a
+// user's proxy — typically set up for their own requests — doesn't also have to know how to
+// route to these, matching how this traffic behaved before the app's proxy setting covered it.
+function insomniaIntegrationHosts() {
+  const urls = [
+    getApiBaseURL(),
+    getAppWebsiteBaseURL(),
+    getMockServiceURL(),
+    getAIServiceURL(),
+    getKonnectApiUrl(),
+    getGitHubRestApiUrl(),
+  ];
+  return urls
+    .map(url => {
+      try {
+        return new URL(setDefaultProtocol(url)).host;
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
 // Update the proxy settings before making the request.
 async function updateProxy() {
-  const { proxyEnabled, httpProxy, httpsProxy, noProxy } = await services.settings.get();
+  const { proxyEnabled, httpProxy, httpsProxy, noProxy, proxyIntegrations } = await services.settings.get();
 
   if (proxyEnabled) {
     try {
@@ -26,10 +58,14 @@ async function updateProxy() {
         proxyRules.push(`https=${parseProxyFromUrl(httpsProxy)}`);
       }
 
+      const bypassRules = proxyIntegrations
+        ? (noProxy ?? '')
+        : [noProxy, ...insomniaIntegrationHosts()].filter(Boolean).join(',');
+
       // Set proxy rules in the main session https://www.electronjs.org/docs/latest/api/structures/proxy-config
       await session.defaultSession.setProxy({
         proxyRules: proxyRules.join(';'),
-        proxyBypassRules: noProxy ?? '',
+        proxyBypassRules: bypassRules,
         mode: 'fixed_servers',
       });
       return;
@@ -57,7 +93,8 @@ export async function watchProxySettings() {
           old.proxyEnabled !== doc.proxyEnabled ||
           old.httpProxy !== doc.httpProxy ||
           old.httpsProxy !== doc.httpsProxy ||
-          old.noProxy !== doc.noProxy;
+          old.noProxy !== doc.noProxy ||
+          old.proxyIntegrations !== doc.proxyIntegrations;
         if (hasProxyChanged) {
           await updateProxy();
           old = doc;

--- a/packages/insomnia/src/main/proxy.ts
+++ b/packages/insomnia/src/main/proxy.ts
@@ -5,13 +5,16 @@ import {
   getAIServiceURL,
   getApiBaseURL,
   getAppWebsiteBaseURL,
+  getCioCdnUrl,
   getGitHubRestApiUrl,
   getKonnectApiUrl,
   getMockServiceURL,
+  getSentryDsn,
 } from '~/common/constants';
 import { setDefaultProtocol } from '~/common/utils/url/protocol';
 
 import { type ChangeBufferEvent, database as db } from '../common/database';
+import { getUpdatesBaseURL } from './updates';
 
 // Insomnia's own first-party integrations — fixed hosts, not user-configured targets like a
 // self-hosted GitLab or MCP server. Bypassed by default (see `proxyIntegrations` below) so a
@@ -19,12 +22,38 @@ import { type ChangeBufferEvent, database as db } from '../common/database';
 // route to these, matching how this traffic behaved before the app's proxy setting covered it.
 function insomniaIntegrationHosts() {
   const urls = [
+    // Insomnia's own backend/CDN
     getApiBaseURL(),
     getAppWebsiteBaseURL(),
     getMockServiceURL(),
     getAIServiceURL(),
+    getUpdatesBaseURL,
+    'https://static.insomnia.rest',
+
+    // Kong Konnect
     getKonnectApiUrl(),
+
+    // GitHub REST API — OAuth/repo listing (main/sync/git/providers/github.ts). This is the app
+    // talking to GitHub on the user's behalf, so it's safe to bypass unconditionally.
+    //
+    // Actual git remote traffic (github.com, self-hosted GitLab, GitHub Enterprise, etc.) is
+    // NOT listed here — it's handled directly in sync/git/http-client.ts, which treats all
+    // git-sync traffic uniformly under `proxyIntegrations` via its own dedicated direct session,
+    // scoped to just those requests rather than this session-wide bypass list.
     getGitHubRestApiUrl(),
+
+    // Analytics & error monitoring — main/analytics.ts (Segment, via net.fetch),
+    // main/sentry.ts (Sentry, via @sentry/electron's own net.request-based transport)
+    'https://api.segment.io',
+    getSentryDsn(),
+
+    // Customer.io — ui/hooks/use-cio.tsx's CDP client, plus the in-app messaging ("Gist")
+    // widget iframe and the Google Fonts it loads (see main/api.protocol.ts)
+    getCioCdnUrl(),
+    'https://renderer.gist.build',
+    'https://code.gist.build',
+    'https://fonts.googleapis.com',
+    'https://fonts.gstatic.com',
   ];
   return urls.flatMap(url => {
     try {

--- a/packages/insomnia/src/main/updates.ts
+++ b/packages/insomnia/src/main/updates.ts
@@ -41,7 +41,7 @@ const isUpdateSupported = () => {
   return true;
 };
 
-const getUpdatesBaseURL = process.env.INSOMNIA_UPDATES_URL || 'https://updates.insomnia.rest';
+export const getUpdatesBaseURL = process.env.INSOMNIA_UPDATES_URL || 'https://updates.insomnia.rest';
 export const getUpdateUrl = (updateChannel: string): string | null => {
   const fullUrl = new URL(
     process.platform === 'win32' ? getUpdatesBaseURL + '/updates/win' : getUpdatesBaseURL + '/builds/check/mac',

--- a/packages/insomnia/src/sync/git/http-client.ts
+++ b/packages/insomnia/src/sync/git/http-client.ts
@@ -1,5 +1,6 @@
 import type * as Electron from 'electron';
 import { services } from 'insomnia-data';
+import { ProxyScope } from 'insomnia-data/common';
 import type { GitHttpRequest, GitHttpResponse, HttpClient } from 'isomorphic-git';
 
 /**
@@ -55,11 +56,11 @@ function fromStream(stream: ReadableStream<Uint8Array>) {
 }
 
 // All git-sync traffic (any remote — github.com, a self-hosted GitLab, GitHub Enterprise, etc.)
-// is treated as one Insomnia integration surface, same as main/proxy.ts's bypass list: enabling a
-// proxy for your own request testing shouldn't also break git-sync out of the box. When
-// proxyIntegrations is off (default), this session-scoped direct session is used instead of
-// electron.net.fetch (session.defaultSession), so only git-sync's own requests bypass — nothing
-// else that might share that session.
+// is treated as one Insomnia integration surface, same as main/proxy.ts's bypass list: with
+// `proxyScope` set to 'requests' (default), enabling a proxy for your own request testing
+// shouldn't also break git-sync out of the box. This session-scoped direct session is used
+// instead of electron.net.fetch (session.defaultSession), so only git-sync's own requests bypass
+// — nothing else that might share that session.
 let directSession: Electron.Session | undefined;
 async function getDirectSession(electron: typeof Electron) {
   if (!directSession) {
@@ -71,7 +72,7 @@ async function getDirectSession(electron: typeof Electron) {
 
 async function shouldBypassProxy(): Promise<boolean> {
   const settings = await services.settings.get();
-  return settings.proxyEnabled === true && settings.proxyIntegrations !== true;
+  return settings.proxyEnabled === true && settings.proxyScope !== ProxyScope.all;
 }
 
 async function request({ url, method = 'GET', headers = {}, body }: GitHttpRequest): Promise<GitHttpResponse> {

--- a/packages/insomnia/src/sync/git/http-client.ts
+++ b/packages/insomnia/src/sync/git/http-client.ts
@@ -1,6 +1,6 @@
 import type * as Electron from 'electron';
 import { services } from 'insomnia-data';
-import { ProxyScope } from 'insomnia-data/common';
+import { ProxyScopes } from 'insomnia-data/common';
 import type { GitHttpRequest, GitHttpResponse, HttpClient } from 'isomorphic-git';
 
 /**
@@ -72,7 +72,7 @@ async function getDirectSession(electron: typeof Electron) {
 
 async function shouldBypassProxy(): Promise<boolean> {
   const settings = await services.settings.get();
-  return settings.proxyEnabled === true && settings.proxyScope !== ProxyScope.all;
+  return settings.proxyEnabled === true && settings.proxyScope !== ProxyScopes.all;
 }
 
 async function request({ url, method = 'GET', headers = {}, body }: GitHttpRequest): Promise<GitHttpResponse> {

--- a/packages/insomnia/src/sync/git/http-client.ts
+++ b/packages/insomnia/src/sync/git/http-client.ts
@@ -1,3 +1,5 @@
+import type * as Electron from 'electron';
+import { services } from 'insomnia-data';
 import type { GitHttpRequest, GitHttpResponse, HttpClient } from 'isomorphic-git';
 
 /**
@@ -52,6 +54,26 @@ function fromStream(stream: ReadableStream<Uint8Array>) {
   };
 }
 
+// All git-sync traffic (any remote — github.com, a self-hosted GitLab, GitHub Enterprise, etc.)
+// is treated as one Insomnia integration surface, same as main/proxy.ts's bypass list: enabling a
+// proxy for your own request testing shouldn't also break git-sync out of the box. When
+// proxyIntegrations is off (default), this session-scoped direct session is used instead of
+// electron.net.fetch (session.defaultSession), so only git-sync's own requests bypass — nothing
+// else that might share that session.
+let directSession: Electron.Session | undefined;
+async function getDirectSession(electron: typeof Electron) {
+  if (!directSession) {
+    directSession = electron.session.fromPartition('git-sync-direct', { cache: false });
+    await directSession.setProxy({ mode: 'direct' });
+  }
+  return directSession;
+}
+
+async function shouldBypassProxy(): Promise<boolean> {
+  const settings = await services.settings.get();
+  return settings.proxyEnabled === true && settings.proxyIntegrations !== true;
+}
+
 async function request({ url, method = 'GET', headers = {}, body }: GitHttpRequest): Promise<GitHttpResponse> {
   if (body) {
     body = await collect(body);
@@ -59,7 +81,9 @@ async function request({ url, method = 'GET', headers = {}, body }: GitHttpReque
 
   const electron = await import('electron');
 
-  const res = await electron.net.fetch(url, { method, headers, body });
+  const res = (await shouldBypassProxy())
+    ? await (await getDirectSession(electron)).fetch(url, { method, headers, body })
+    : await electron.net.fetch(url, { method, headers, body });
   const iter = res.body ? fromStream(res.body) : [new Uint8Array(await res.arrayBuffer())];
   // convert Header object to ordinary JSON
   headers = {};

--- a/packages/insomnia/src/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/settings-modal.tsx
@@ -1,4 +1,4 @@
-import { ProxyScope } from 'insomnia-data/common';
+import { type ProxyScope, ProxyScopes } from 'insomnia-data/common';
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { Tab, TabList, TabPanel, Tabs } from 'react-aria-components';
 import { useParams } from 'react-router';
@@ -183,8 +183,8 @@ export const SettingsModal = forwardRef<SettingsModalHandle, ModalProps>((props,
                 setting="proxyScope"
                 disabled={!settings.proxyEnabled}
                 values={[
-                  { value: ProxyScope.requests, name: 'Only when sending requests in Insomnia' },
-                  { value: ProxyScope.all, name: 'All traffic sent by Insomnia' },
+                  { value: ProxyScopes.requests, name: 'Only when sending requests in Insomnia' },
+                  { value: ProxyScopes.all, name: 'All traffic sent by Insomnia' },
                 ]}
                 help="When All traffic is selected, Insomnia uses the configured proxy for all calls, including login, git, auto-updates, etc."
               />

--- a/packages/insomnia/src/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/settings-modal.tsx
@@ -200,7 +200,7 @@ export const SettingsModal = forwardRef<SettingsModalHandle, ModalProps>((props,
               label="Use proxy for Insomnia's integrations"
               setting="proxyIntegrations"
               disabled={!settings.proxyEnabled}
-              help="If checked, the proxy above is also used for Insomnia's own integrations (the Insomnia API and website, mock service, AI helper, Konnect, and GitHub). Unchecked (default), those go direct and only your own requests use the proxy."
+              help="If checked, the proxy above is also used for Insomnia's own services and integrations (the Insomnia API, website, mock service, AI helper, and CDN; Konnect; GitHub; auto-updates; and analytics/error monitoring). Unchecked (default), those go direct and only your own requests use the proxy."
             />
           </TabPanel>
           <TabPanel className="h-full w-full overflow-y-auto p-4" id="data">

--- a/packages/insomnia/src/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/settings-modal.tsx
@@ -1,3 +1,4 @@
+import { ProxyScope } from 'insomnia-data/common';
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { Tab, TabList, TabPanel, Tabs } from 'react-aria-components';
 import { useParams } from 'react-router';
@@ -15,6 +16,7 @@ import { Modal, type ModalHandle, type ModalProps } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
 import { BooleanSetting } from '../settings/boolean-setting';
+import { EnumSetting } from '../settings/enum-setting';
 import { General } from '../settings/general';
 import { ImportExport } from '../settings/import-export';
 import { MaskedSetting } from '../settings/masked-setting';
@@ -175,6 +177,19 @@ export const SettingsModal = forwardRef<SettingsModalHandle, ModalProps>((props,
               help="If checked, enables a global network proxy on all requests sent through Insomnia. This proxy supports Basic Auth, digest, and NTLM authentication."
             />
 
+            <div className="pt-4">
+              <EnumSetting<ProxyScope>
+                label="Use proxy for"
+                setting="proxyScope"
+                disabled={!settings.proxyEnabled}
+                values={[
+                  { value: ProxyScope.requests, name: 'Only when sending requests in Insomnia' },
+                  { value: ProxyScope.all, name: 'All traffic sent by Insomnia' },
+                ]}
+                help="When All traffic is selected, Insomnia uses the configured proxy for all calls, including login, git, auto-updates, etc."
+              />
+            </div>
+
             <div className="form-row pad-top-sm">
               <MaskedSetting
                 label="Proxy for HTTP"
@@ -195,13 +210,6 @@ export const SettingsModal = forwardRef<SettingsModalHandle, ModalProps>((props,
                 placeholder="localhost,127.0.0.1"
               />
             </div>
-
-            <BooleanSetting
-              label="Use proxy for Insomnia's integrations"
-              setting="proxyIntegrations"
-              disabled={!settings.proxyEnabled}
-              help="If checked, the proxy above is also used for Insomnia's own services and integrations (the Insomnia API, website, mock service, AI helper, and CDN; Konnect; GitHub; auto-updates; and analytics/error monitoring). Unchecked (default), those go direct and only your own requests use the proxy."
-            />
           </TabPanel>
           <TabPanel className="h-full w-full overflow-y-auto p-4" id="data">
             <ImportExport

--- a/packages/insomnia/src/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/settings-modal.tsx
@@ -42,7 +42,7 @@ type SettingsModalTabKey =
 
 export const SettingsModal = forwardRef<SettingsModalHandle, ModalProps>((props, ref) => {
   const [defaultTabKey, setDefaultTabKey] = useState('general');
-  const { userSession } = useRootLoaderData()!;
+  const { userSession, settings } = useRootLoaderData()!;
   const modalRef = useRef<ModalHandle>(null);
   const [keyboardClosable, setKeyboardClosable] = useState(true);
   const { organizationId } = useParams() as { organizationId?: string };
@@ -195,6 +195,13 @@ export const SettingsModal = forwardRef<SettingsModalHandle, ModalProps>((props,
                 placeholder="localhost,127.0.0.1"
               />
             </div>
+
+            <BooleanSetting
+              label="Use proxy for Insomnia's integrations"
+              setting="proxyIntegrations"
+              disabled={!settings.proxyEnabled}
+              help="If checked, the proxy above is also used for Insomnia's own integrations (the Insomnia API and website, mock service, AI helper, Konnect, and GitHub). Unchecked (default), those go direct and only your own requests use the proxy."
+            />
           </TabPanel>
           <TabPanel className="h-full w-full overflow-y-auto p-4" id="data">
             <ImportExport

--- a/packages/insomnia/src/ui/components/settings/enum-setting.tsx
+++ b/packages/insomnia/src/ui/components/settings/enum-setting.tsx
@@ -13,6 +13,7 @@ interface Props<T> {
     name: string;
     value: T;
   }[];
+  disabled?: boolean;
 }
 
 export const EnumSetting = <T extends string | number>({
@@ -20,6 +21,7 @@ export const EnumSetting = <T extends string | number>({
   label,
   setting,
   values,
+  disabled = false,
 }: PropsWithChildren<Props<T>>) => {
   const { settings } = useRootLoaderData()!;
 
@@ -34,6 +36,7 @@ export const EnumSetting = <T extends string | number>({
           value={String(settings[setting]) || '__NULL__'}
           name={setting}
           onChange={event => patchSettings({ [setting]: event.currentTarget.value })}
+          disabled={disabled}
         >
           {values.map(({ name, value }) => (
             <option key={value} value={value}>

--- a/packages/insomnia/src/ui/hooks/use-cio.tsx
+++ b/packages/insomnia/src/ui/hooks/use-cio.tsx
@@ -1,7 +1,7 @@
 import type { AnalyticsBrowser } from '@customerio/cdp-analytics-browser';
 import { useEffect, useRef } from 'react';
 
-import { getCioSiteId, getCioWriteKey } from '~/common/constants';
+import { getCioCdnUrl, getCioSiteId, getCioWriteKey } from '~/common/constants';
 import { useRootLoaderData } from '~/root';
 
 // Global singleton
@@ -45,7 +45,7 @@ export const useCio = () => {
       .then(({ AnalyticsBrowser }) => {
         globalAnalyticsInstance = AnalyticsBrowser.load(
           {
-            cdnURL: 'https://cdp-eu.customer.io',
+            cdnURL: getCioCdnUrl(),
             writeKey: getCioWriteKey(),
           },
           {


### PR DESCRIPTION
## Summary

Fixes account sign-in (and other Insomnia-integration traffic) breaking when an HTTP/HTTPS proxy is enabled in Settings. Users reported that a workflow which worked fine on 13.0.0 with a proxy enabled stopped working on 13.0.2 — disabling the proxy was the only workaround.

## Root cause

A trio of recent, deliberate fixes (#10075, #10228, #10265) corrected a long-standing bug where Insomnia's configured proxy settings were silently ignored — `session.defaultSession` was always forced into `mode: 'system'`, so **none** of the app's own network traffic (account login, git OAuth, telemetry, etc.) ever actually respected the user's typed-in proxy config; it always went either via the OS system proxy or direct.

Once that bug was fixed, the app's own first-party integration traffic — the Insomnia API, website, mock service, AI helper, and GitHub OAuth calls — started being routed through the user's configured proxy for the first time. For anyone using their proxy setting for its most common purpose (a personal debugging proxy like Charles/mitmproxy/Fiddler aimed at their own collection requests), that proxy generally has no idea how to route traffic to `api.insomnia.rest`, `api.github.com`, etc., so account sign-in (and other integration calls) started failing outright.

## Fix

Added a new setting, **"Use proxy for Insomnia's integrations"**, in the Proxy tab of Settings:

- **Default: off.** Insomnia's own first-party integrations (API, website, mock service, AI helper, Konnect, GitHub) bypass the configured proxy by default — restoring the pre-regression behavior — while the user's own requests continue to respect the proxy exactly as they do today.
- **Opt-in: on.** Routes that integration traffic through the configured proxy too, for anyone who genuinely needs all traffic — including the app's own — to go through a mandatory corporate egress proxy.

This is fully backwards compatible: existing settings docs that predate this field simply treat it as falsy, which is the new default, so no migration is needed.

## What changed

- `insomnia-data`: new `proxyIntegrations` field on the `Settings` model/type (default `false`).
- `main/proxy.ts`: when the new setting is off, Insomnia's fixed first-party integration hosts are added to the proxy's bypass list; user-configured targets (e.g. a self-hosted GitLab instance, MCP servers) are left untouched and always follow the normal proxy rules.
- Settings modal: new checkbox under the Proxy tab, disabled unless "Enable proxy" is checked.
