### PR TITLE
fix: remove horizontal scrollbar in Plugins settings tab [INS-3490]

### DIFF
--- a/packages/insomnia/src/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/settings-modal.tsx
@@ -208,7 +208,7 @@ export const SettingsModal = forwardRef<SettingsModalHandle, ModalProps>((props,
           <TabPanel className="h-full w-full overflow-y-auto p-4" id="keyboard">
             <Shortcuts />
           </TabPanel>
-          <TabPanel className="h-full w-full overflow-y-auto p-4" id="plugins">
+          <TabPanel className="h-full w-full overflow-x-hidden overflow-y-auto p-4" id="plugins">
             <Plugins />
           </TabPanel>
           <TabPanel className="h-full w-full overflow-y-auto p-4" id="credentials">

--- a/packages/insomnia/src/ui/components/settings/plugins.tsx
+++ b/packages/insomnia/src/ui/components/settings/plugins.tsx
@@ -658,7 +658,7 @@ export const Plugins: FC = () => {
                             </Checkbox>
                           )}
                           <div className="flex w-[8ch] cursor-auto items-center justify-center">{plugin.version}</div>
-                          <div className="flex w-[8ch] cursor-auto items-center gap-1">
+                          <div className="flex w-auto min-w-[8ch] cursor-auto items-center gap-1">
                             <CopyButton
                               size="small"
                               variant="text"


### PR DESCRIPTION
## What
Fixes an unwanted horizontal scrollbar on the Plugins tab in Preferences,
which cut off content on the left and forced users to scroll right to see
the full panel.

## Root cause
The installed-plugins list row has a "Folder" action cell hard-coded to
`w-[8ch]`, but its contents (a copy button + an open-folder button) need
more space than that to render — the row was wider than its box. Because
the Plugins `TabPanel` only set `overflow-y-auto` (no `overflow-x`), that
overflow escaped the row and dragged the *entire* tab panel into
horizontal scroll instead of staying contained.

## Fix
- `settings-modal.tsx`: add `overflow-x-hidden` to the Plugins `TabPanel`
  as a guard, scoped to this tab only.
- `plugins.tsx`: change the Folder cell from a fixed `w-[8ch]` to
  `w-auto min-w-[8ch]` so it sizes to fit its buttons instead of
  overflowing.