### PR TITLE
fix(git): recover gracefully when a push fails after a successful commit [INS-3013]

### DIFF
--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -2441,7 +2441,11 @@ export const createNewGitBranchAction = async ({
       invariant(credentials, 'Git Credentials not found');
       providerName = credentials.provider;
     }
-    await GitVCS.checkout(branch);
+    // Create directly rather than GitVCS.checkout(branch) — the collision
+    // check above already ruled out an existing branch of this name, so
+    // checkout()'s own re-check (which repeats the same local/synced/remote
+    // lookups, including a network round-trip) would just be redundant work.
+    await GitVCS.branch(branch, true);
     trackAnalyticsEvent(AnalyticsEvent.vcsAction, {
       ...vcsEventProperties('git', 'create_branch'),
       providerName,

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -2418,6 +2418,23 @@ export const createNewGitBranchAction = async ({
   invariant(typeof branch === 'string', 'Branch name is required');
 
   try {
+    // `GitVCS.checkout()` silently falls back to checking out an existing branch
+    // of the same name instead of branching from HEAD (see its implementation) —
+    // which would strand any local commits on the branch the user is leaving,
+    // with no indication anything happened differently than a real "create".
+    // Since this action's whole contract is "create a NEW branch", refuse up
+    // front rather than let that ambiguity through.
+    const [localBranches, syncedBranches, remoteBranches] = await Promise.all([
+      GitVCS.listBranches(),
+      GitVCS.listRemoteBranches(),
+      GitVCS.fetchRemoteBranches(),
+    ]);
+    if ([...localBranches, ...syncedBranches, ...remoteBranches].includes(branch)) {
+      return {
+        errors: [`A branch named "${branch}" already exists. Choose a different name, or use "Switch branch" instead.`],
+      };
+    }
+
     let providerName = 'custom';
     if (gitRepository?.credentialsId) {
       const credentials = await services.gitCredentials.getById(gitRepository.credentialsId);
@@ -2479,6 +2496,17 @@ export const checkoutGitBranchAction = async ({
   try {
     const gitRepository = await getGitRepository({ workspaceId, projectId });
 
+    // Capture the branch being left, and whether it has commits that haven't
+    // been pushed, before switching away from it — those commits aren't lost,
+    // but they won't be reachable again until the user switches back.
+    const previousBranch = await GitVCS.getCurrentBranch();
+    let hadUnpushedChangesOnPreviousBranch = false;
+    try {
+      hadUnpushedChangesOnPreviousBranch = await GitVCS.canPush(gitRepository.credentialsId);
+    } catch (err) {
+      console.error('Error checking for unpushed changes before branch switch', err);
+    }
+
     const bufferId = await database.bufferChanges();
     await GitVCS.checkout(branch);
 
@@ -2510,19 +2538,25 @@ export const checkoutGitBranchAction = async ({
 
     await database.flushChanges(bufferId);
 
+    const warnings: string[] = [];
+
+    if (hadUnpushedChangesOnPreviousBranch && previousBranch !== branch) {
+      warnings.push(
+        `"${previousBranch}" has commits that haven't been pushed. They're safe — switch back to "${previousBranch}" to push them.`,
+      );
+    }
+
     const branchRemoteInfo = await GitVCS.getBranchRemoteInfo(branch);
     if (!branchRemoteInfo.isOrigin) {
-      return {
-        success: true,
-        warnings: [
-          `Branch "${branch}" tracks remote "${branchRemoteInfo.trackingRemote}". ` +
-            `Push, pull, and fetch will not work from Insomnia. Use the git CLI to sync this branch.`,
-        ],
-      };
+      warnings.push(
+        `Branch "${branch}" tracks remote "${branchRemoteInfo.trackingRemote}". ` +
+          `Push, pull, and fetch will not work from Insomnia. Use the git CLI to sync this branch.`,
+      );
     }
 
     return {
       success: true,
+      ...(warnings.length > 0 ? { warnings } : {}),
     };
   } catch (err) {
     if (err instanceof Errors.HttpError) {

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -2130,6 +2130,12 @@ export const resetGitRepoAction = async ({ projectId, workspaceId }: { projectId
 
 export interface CommitToGitRepoResult {
   errors?: string[];
+  /**
+   * True when the local commit succeeded but the subsequent push failed (e.g. a
+   * protected branch rejected it). The user's work is safe in a local commit —
+   * callers should offer a way to retry the push rather than implying data loss.
+   */
+  pushFailedAfterCommit?: boolean;
 }
 
 export const commitToGitRepoAction = async ({
@@ -2298,14 +2304,21 @@ export const commitAndPushToGitRepoAction = async ({
   try {
     canPush = await GitVCS.canPush(repo.credentialsId);
   } catch (err) {
+    // The commit above already succeeded — a failure here is just the
+    // pushability check, so persist that the commit is still unpushed.
+    await services.gitRepository.update(repo, {
+      hasUnpushedChanges: true,
+    });
+
     if (err instanceof Errors.HttpError) {
       return {
         errors: [`${err.message}, ${err.data.response}`],
+        pushFailedAfterCommit: true,
       };
     }
     const errorMessage = getErrorMessage(err);
 
-    return { errors: [errorMessage] };
+    return { errors: [errorMessage], pushFailedAfterCommit: true };
   }
   // If nothing to push, display that to the user
   if (!canPush) {
@@ -2337,9 +2350,18 @@ export const commitAndPushToGitRepoAction = async ({
       cachedGitLastCommitTime: Date.now(),
     });
   } catch (err: unknown) {
+    // The commit above already succeeded and is safe on disk — only the push
+    // failed. Reflect that in the persisted repo state so indicators elsewhere
+    // in the app (e.g. the unpushed-changes badge) stay accurate, and flag it
+    // for the UI so it can offer a retry instead of implying data loss.
+    await services.gitRepository.update(repo, {
+      hasUnpushedChanges: true,
+    });
+
     if (err instanceof Errors.PushRejectedError && err.data.reason === 'not-fast-forward') {
       return {
         errors: [GitVCSOperationErrors.RequiredPullRemoteChangesError],
+        pushFailedAfterCommit: true,
       };
     }
 
@@ -2348,12 +2370,14 @@ export const commitAndPushToGitRepoAction = async ({
         errors: [
           'Push Rejected. It seems that the tag you are trying to push already exists in the remote repository.',
         ],
+        pushFailedAfterCommit: true,
       };
     }
 
     if (err instanceof Errors.HttpError) {
       return {
         errors: [`${err.message}, ${err.data.response}`],
+        pushFailedAfterCommit: true,
       };
     }
     const errorMessage = getErrorMessage(err);
@@ -2366,6 +2390,7 @@ export const commitAndPushToGitRepoAction = async ({
 
     return {
       errors: [`Error Pushing Repository, ${errorMessage}`],
+      pushFailedAfterCommit: true,
     };
   }
 
@@ -2656,6 +2681,12 @@ export interface PushToGitRemoteResult {
   errors?: string[];
   success?: boolean;
   gitRepository?: GitRepository;
+  /**
+   * True when the push failed but local commits exist and are safe on disk
+   * (i.e. this wasn't "nothing to push" or an upfront auth/connectivity check
+   * failure). Callers should offer a way to retry the push.
+   */
+  pushFailedAfterCommit?: boolean;
 }
 
 export const pushToGitRemoteAction = async ({
@@ -2728,11 +2759,18 @@ export const pushToGitRemoteAction = async ({
     });
     await database.flushChanges(bufferId);
   } catch (err: unknown) {
+    // The local commit(s) that made canPush true above are untouched by a
+    // failed push — persist that so indicators elsewhere in the app stay
+    // accurate, and flag it for the UI so it can offer a retry.
+    await services.gitRepository.update(gitRepository, {
+      hasUnpushedChanges: true,
+    });
+
     if (err instanceof Errors.PushRejectedError && err.data.reason === 'not-fast-forward') {
       return {
         errors: [GitVCSOperationErrors.RequiredPullRemoteChangesError],
-
         gitRepository,
+        pushFailedAfterCommit: true,
       };
     }
 
@@ -2741,6 +2779,7 @@ export const pushToGitRemoteAction = async ({
         errors: [
           'Push Rejected. It seems that the tag you are trying to push already exists in the remote repository.',
         ],
+        pushFailedAfterCommit: true,
       };
     }
 
@@ -2751,6 +2790,7 @@ export const pushToGitRemoteAction = async ({
       return {
         errors: [GitVCSOperationErrors.AuthenticationRequiredError],
         gitRepository,
+        pushFailedAfterCommit: true,
       };
     }
 
@@ -2758,6 +2798,7 @@ export const pushToGitRemoteAction = async ({
       return {
         errors: [`${err.message}, ${err.data.response}`],
         gitRepository,
+        pushFailedAfterCommit: true,
       };
     }
     const errorMessage = getErrorMessage(err);
@@ -2771,6 +2812,7 @@ export const pushToGitRemoteAction = async ({
     return {
       errors: [`Error Pushing Repository, ${errorMessage}`],
       gitRepository,
+      pushFailedAfterCommit: true,
     };
   }
 

--- a/packages/insomnia/src/ui/components/modals/git-branches-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-branches-modal.tsx
@@ -60,6 +60,21 @@ const LocalBranchItem = ({
 
   useEffect(() => {
     if (
+      checkoutBranchFetcher.data &&
+      'warnings' in checkoutBranchFetcher.data &&
+      checkoutBranchFetcher.data.warnings &&
+      checkoutBranchFetcher.data.warnings.length > 0 &&
+      checkoutBranchFetcher.state === 'idle'
+    ) {
+      showModal(AlertModal, {
+        title: 'Heads up',
+        message: checkoutBranchFetcher.data.warnings.join('\n\n'),
+      });
+    }
+  }, [checkoutBranchFetcher.data, checkoutBranchFetcher.state]);
+
+  useEffect(() => {
+    if (
       deleteBranchFetcher.data &&
       'errors' in deleteBranchFetcher.data &&
       deleteBranchFetcher.data.errors &&
@@ -224,6 +239,21 @@ const RemoteBranchItem = ({
       showModal(AlertModal, {
         title: 'Error while pulling branch.',
         message: error,
+      });
+    }
+  }, [checkoutBranchFetcher.data, checkoutBranchFetcher.state]);
+
+  useEffect(() => {
+    if (
+      checkoutBranchFetcher.data &&
+      'warnings' in checkoutBranchFetcher.data &&
+      checkoutBranchFetcher.data.warnings &&
+      checkoutBranchFetcher.data.warnings.length > 0 &&
+      checkoutBranchFetcher.state === 'idle'
+    ) {
+      showModal(AlertModal, {
+        title: 'Heads up',
+        message: checkoutBranchFetcher.data.warnings.join('\n\n'),
       });
     }
   }, [checkoutBranchFetcher.data, checkoutBranchFetcher.state]);

--- a/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
@@ -120,6 +120,23 @@ function getModificationClassName(type: GitFileType) {
   return '';
 }
 
+// `pushToGitRemoteAction` (used by the AI multi-commit flow and by "Retry
+// push") normalizes a push-time 401/403 into this constant instead of the
+// raw isomorphic-git "HTTP Error: 40x" text that `isGitRepoLoadAuthHttp40Error`
+// looks for. Recognize both forms so those flows can still offer
+// re-authentication instead of a dead-end "Retry push" button.
+function isPushAuthError(errors: string[]): boolean {
+  return isGitRepoLoadAuthHttp40Error(errors) || errors.includes(GitVCSOperationErrors.AuthenticationRequiredError);
+}
+
+// GitOauthAuthBanner only renders for errors matching isGitRepoLoadAuthHttp40Error
+// (it does its own internal gating) — translate the normalized constant into an
+// equivalent it recognizes, so the banner actually shows instead of silently
+// rendering nothing.
+function toOAuthBannerErrors(errors: string[]): string[] {
+  return isGitRepoLoadAuthHttp40Error(errors) ? errors : ['HTTP Error: 401 Unauthorized, Authentication required'];
+}
+
 // Shown when a commit succeeded locally but the push that followed it failed
 // (e.g. a protected branch rejected it). The work is safe in a local commit —
 // this offers a retry instead of implying the changes were lost.
@@ -465,7 +482,7 @@ const GeneratedCommitsForm: FC<GeneratedCommitsFormProps> = ({
       // An auth failure needs the re-auth banner (GitOauthAuthBanner), even if
       // it happened after a successful commit — a plain "retry push" button
       // would just fail again without letting the user re-authenticate.
-      if (pushFailedAfterCommit && !isGitRepoLoadAuthHttp40Error(errors)) {
+      if (pushFailedAfterCommit && !isPushAuthError(errors)) {
         setOperationError(null);
         setPushFailedError(errors.join('\n'));
       } else {
@@ -491,7 +508,7 @@ const GeneratedCommitsForm: FC<GeneratedCommitsFormProps> = ({
     }
     const errors = pushRetryFetcher.data.errors;
     if (errors && errors.length > 0) {
-      if (isGitRepoLoadAuthHttp40Error(errors)) {
+      if (isPushAuthError(errors)) {
         setPushFailedError(null);
         setOperationError(errors.join('\n'));
         return;
@@ -714,11 +731,11 @@ const GeneratedCommitsForm: FC<GeneratedCommitsFormProps> = ({
           onRetry={retryPush}
           projectId={projectId}
         />
-      ) : operationError && selectedProvider && isGitRepoLoadAuthHttp40Error([operationError]) ? (
+      ) : operationError && selectedProvider && isPushAuthError([operationError]) ? (
         <GitOauthAuthBanner
           selectedCredential={selectedCredential}
           gitRepository={gitRepository}
-          repoLoadErrors={[operationError]}
+          repoLoadErrors={toOAuthBannerErrors([operationError])}
           provider={selectedProvider}
         />
       ) : operationError && selectedCredential?.provider === 'custom' ? (
@@ -842,7 +859,7 @@ const ManualCommitForm: FC<ManualCommitFormProps> = ({
     if (errors && errors.length > 0) {
       if (errors.includes(GitVCSOperationErrors.RequiredPullRemoteChangesError)) {
         onPullRequired();
-      } else if (commitFetcher.data.pushFailedAfterCommit && !isGitRepoLoadAuthHttp40Error(errors)) {
+      } else if (commitFetcher.data.pushFailedAfterCommit && !isPushAuthError(errors)) {
         // The commit itself succeeded — only clear the message/error state
         // for that, and surface the push failure as a retryable banner.
         setMessage('');
@@ -878,7 +895,7 @@ const ManualCommitForm: FC<ManualCommitFormProps> = ({
         onPullRequired();
         return;
       }
-      if (isGitRepoLoadAuthHttp40Error(errors)) {
+      if (isPushAuthError(errors)) {
         setPushFailedError(null);
         setOperationError(errors.join('\n'));
         return;
@@ -1029,11 +1046,11 @@ const ManualCommitForm: FC<ManualCommitFormProps> = ({
           onRetry={retryPush}
           projectId={projectId}
         />
-        ) : operationError && selectedProvider && isGitRepoLoadAuthHttp40Error([operationError]) ? (
+        ) : operationError && selectedProvider && isPushAuthError([operationError]) ? (
           <GitOauthAuthBanner
             selectedCredential={selectedCredential}
             gitRepository={gitRepository}
-            repoLoadErrors={[operationError]}
+            repoLoadErrors={toOAuthBannerErrors([operationError])}
             provider={selectedProvider}
           />
         ) : operationError && selectedCredential?.provider === 'custom' ? (

--- a/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
@@ -459,13 +459,18 @@ const GeneratedCommitsForm: FC<GeneratedCommitsFormProps> = ({
       ('success' in commitsFetcher.data && commitsFetcher.data.success) ||
       ('errors' in commitsFetcher.data && commitsFetcher.data.errors?.length === 0);
     if (hasErrors && 'errors' in commitsFetcher.data) {
+      const errors = commitsFetcher.data.errors as string[];
       const pushFailedAfterCommit =
         'pushFailedAfterCommit' in commitsFetcher.data && commitsFetcher.data.pushFailedAfterCommit;
-      if (pushFailedAfterCommit) {
+      // An auth failure needs the re-auth banner (GitOauthAuthBanner), even if
+      // it happened after a successful commit — a plain "retry push" button
+      // would just fail again without letting the user re-authenticate.
+      if (pushFailedAfterCommit && !isGitRepoLoadAuthHttp40Error(errors)) {
         setOperationError(null);
-        setPushFailedError((commitsFetcher.data.errors as string[]).join('\n'));
+        setPushFailedError(errors.join('\n'));
       } else {
-        setOperationError((commitsFetcher.data.errors as string[]).join('\n'));
+        setPushFailedError(null);
+        setOperationError(errors.join('\n'));
       }
       return;
     }
@@ -486,6 +491,11 @@ const GeneratedCommitsForm: FC<GeneratedCommitsFormProps> = ({
     }
     const errors = pushRetryFetcher.data.errors;
     if (errors && errors.length > 0) {
+      if (isGitRepoLoadAuthHttp40Error(errors)) {
+        setPushFailedError(null);
+        setOperationError(errors.join('\n'));
+        return;
+      }
       setPushFailedError(errors.join('\n'));
       showToast({ icon: 'exclamation-triangle', title: 'Push failed again', status: 'error' });
       return;
@@ -832,13 +842,17 @@ const ManualCommitForm: FC<ManualCommitFormProps> = ({
     if (errors && errors.length > 0) {
       if (errors.includes(GitVCSOperationErrors.RequiredPullRemoteChangesError)) {
         onPullRequired();
-      } else if (commitFetcher.data.pushFailedAfterCommit) {
+      } else if (commitFetcher.data.pushFailedAfterCommit && !isGitRepoLoadAuthHttp40Error(errors)) {
         // The commit itself succeeded — only clear the message/error state
         // for that, and surface the push failure as a retryable banner.
         setMessage('');
         setOperationError(null);
         setPushFailedError(errors.join('\n'));
       } else {
+        // An auth failure needs the re-auth banner (GitOauthAuthBanner), even
+        // if it happened after a successful commit — a plain "retry push"
+        // button would just fail again without letting the user re-authenticate.
+        setPushFailedError(null);
         setOperationError(errors.join('\n'));
       }
       return;
@@ -862,6 +876,11 @@ const ManualCommitForm: FC<ManualCommitFormProps> = ({
       if (errors.includes(GitVCSOperationErrors.RequiredPullRemoteChangesError)) {
         setPushFailedError(null);
         onPullRequired();
+        return;
+      }
+      if (isGitRepoLoadAuthHttp40Error(errors)) {
+        setPushFailedError(null);
+        setOperationError(errors.join('\n'));
         return;
       }
       setPushFailedError(errors.join('\n'));

--- a/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
@@ -17,6 +17,7 @@ import {
   GridList,
   GridListItem,
   Heading,
+  Input,
   isTextDropItem,
   Label,
   Modal,
@@ -36,6 +37,7 @@ import { Button as BasicButton } from '~/basic-components/button';
 import { LearnMoreLink } from '~/basic-components/link';
 import { scopeToBgColorMap, scopeToIconMap, scopeToTextColorMap } from '~/common/get-workspace-label';
 import { useAIGenerateActionFetcher } from '~/routes/ai.generate-commit-messages';
+import { useGitProjectNewBranchActionFetcher } from '~/routes/git.branch.new';
 import { useGitProjectChangesFetcher } from '~/routes/git.changes';
 import { useGitProjectCommitActionFetcher } from '~/routes/git.commit';
 import { useGitProjectCommitsActionFetcher } from '~/routes/git.commits';
@@ -139,10 +141,41 @@ function getGitHubProtectedBranchTip(error: string): string | null {
   return null;
 }
 
-const PushFailedAfterCommitBanner = (props: { error: string; isRetrying: boolean; onRetry: () => void }) => {
+const PushFailedAfterCommitBanner = (props: {
+  error: string;
+  isRetrying: boolean;
+  onRetry: () => void;
+  projectId: string;
+}) => {
   const [showDetails, setShowDetails] = useState(false);
+  const [isCreateBranchModalOpen, setIsCreateBranchModalOpen] = useState(false);
   const detail = stripRedundantPushErrorPrefix(props.error);
   const tip = getGitHubProtectedBranchTip(detail);
+
+  const createBranchFetcher = useGitProjectNewBranchActionFetcher();
+  const isCreatingBranch = createBranchFetcher.state !== 'idle';
+  const createBranchError =
+    createBranchFetcher.data?.errors && createBranchFetcher.data.errors.length > 0
+      ? createBranchFetcher.data.errors.join('\n')
+      : null;
+
+  const { onRetry } = props;
+  const prevCreateBranchStateRef = useRef(createBranchFetcher.state);
+  useEffect(() => {
+    const prevState = prevCreateBranchStateRef.current;
+    prevCreateBranchStateRef.current = createBranchFetcher.state;
+    if (!(prevState !== 'idle' && createBranchFetcher.state === 'idle' && createBranchFetcher.data)) {
+      return;
+    }
+    if (createBranchFetcher.data.errors && createBranchFetcher.data.errors.length > 0) {
+      // Most likely a name collision — let the user try a different name.
+      return;
+    }
+    // The branch was created from (and includes) the commit that failed to
+    // push, and is now checked out — push it right away.
+    setIsCreateBranchModalOpen(false);
+    onRetry();
+  }, [createBranchFetcher.state, createBranchFetcher.data, onRetry]);
 
   return (
     <Banner
@@ -168,18 +201,38 @@ const PushFailedAfterCommitBanner = (props: { error: string; isRetrying: boolean
         </div>
       }
       footer={
-        <Button
-          type="button"
-          isDisabled={props.isRetrying}
-          onPress={props.onRetry}
-          className="flex h-7 items-center gap-2 rounded-xs bg-(--hl-xxs) px-3 text-sm ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset"
-        >
-          <Icon
-            icon={props.isRetrying ? 'spinner' : 'cloud-arrow-up'}
-            className={props.isRetrying ? 'animate-spin' : ''}
-          />
-          Retry push
-        </Button>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            isDisabled={props.isRetrying}
+            onPress={props.onRetry}
+            className="flex h-7 items-center gap-2 rounded-xs bg-(--hl-xxs) px-3 text-sm ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset"
+          >
+            <Icon
+              icon={props.isRetrying ? 'spinner' : 'cloud-arrow-up'}
+              className={props.isRetrying ? 'animate-spin' : ''}
+            />
+            Retry push
+          </Button>
+          {tip && (
+            <Button
+              type="button"
+              onPress={() => setIsCreateBranchModalOpen(true)}
+              className="flex h-7 items-center gap-2 rounded-xs bg-(--hl-xxs) px-3 text-sm ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset"
+            >
+              <Icon icon="code-branch" />
+              Create branch &amp; push
+            </Button>
+          )}
+          {isCreateBranchModalOpen && (
+            <CreateBranchAndPushModal
+              isCreating={isCreatingBranch}
+              error={createBranchError}
+              onClose={() => setIsCreateBranchModalOpen(false)}
+              onSubmit={branch => createBranchFetcher.submit({ projectId: props.projectId, branch })}
+            />
+          )}
+        </div>
       }
     />
   );
@@ -645,7 +698,12 @@ const GeneratedCommitsForm: FC<GeneratedCommitsFormProps> = ({
         </div>
       )}
       {pushFailedError ? (
-        <PushFailedAfterCommitBanner error={pushFailedError} isRetrying={isRetryingPush} onRetry={retryPush} />
+        <PushFailedAfterCommitBanner
+          error={pushFailedError}
+          isRetrying={isRetryingPush}
+          onRetry={retryPush}
+          projectId={projectId}
+        />
       ) : operationError && selectedProvider && isGitRepoLoadAuthHttp40Error([operationError]) ? (
         <GitOauthAuthBanner
           selectedCredential={selectedCredential}
@@ -946,7 +1004,12 @@ const ManualCommitForm: FC<ManualCommitFormProps> = ({
           </div>
         )}
         {pushFailedError ? (
-          <PushFailedAfterCommitBanner error={pushFailedError} isRetrying={isRetryingPush} onRetry={retryPush} />
+          <PushFailedAfterCommitBanner
+          error={pushFailedError}
+          isRetrying={isRetryingPush}
+          onRetry={retryPush}
+          projectId={projectId}
+        />
         ) : operationError && selectedProvider && isGitRepoLoadAuthHttp40Error([operationError]) ? (
           <GitOauthAuthBanner
             selectedCredential={selectedCredential}
@@ -1829,6 +1892,102 @@ const ConfirmDiscardModal = ({ message, onConfirm, onClose }: ConfirmModalProps)
                 </Button>
               </div>
             </div>
+          )}
+        </Dialog>
+      </Modal>
+    </ModalOverlay>
+  );
+};
+
+// Focused, single-purpose modal for the "push failed" banner's branch-creation
+// shortcut. Deliberately not the full Branches modal — that has checkout/delete/
+// merge actions for every branch, which would distract from this one specific
+// recovery step.
+const CreateBranchAndPushModal = ({
+  isCreating,
+  error,
+  onSubmit,
+  onClose,
+}: {
+  isCreating: boolean;
+  error: string | null;
+  onSubmit: (branchName: string) => void;
+  onClose: () => void;
+}) => {
+  const [branchName, setBranchName] = useState('');
+
+  return (
+    <ModalOverlay
+      isOpen
+      onOpenChange={isOpen => {
+        !isOpen && onClose();
+      }}
+      isDismissable
+      className="fixed top-[50%] left-0 z-10 flex h-(--visual-viewport-height) w-full translate-y-[-50%] items-center justify-center bg-black/30"
+    >
+      <Modal
+        onOpenChange={isOpen => {
+          !isOpen && onClose();
+        }}
+        className="flex w-full max-w-md flex-col rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) p-(--padding-lg) text-(--color-font)"
+      >
+        <Dialog className="outline-hidden">
+          {({ close }) => (
+            <form
+              onSubmit={e => {
+                e.preventDefault();
+                const name = branchName.trim();
+                if (!name) {
+                  return;
+                }
+                onSubmit(name);
+              }}
+              className="flex flex-col gap-4"
+            >
+              <div className="flex shrink-0 items-center justify-between gap-2">
+                <Heading slot="title" className="flex items-center gap-2 text-2xl">
+                  Create branch &amp; push
+                </Heading>
+                <Button
+                  type="button"
+                  className="flex aspect-square h-6 shrink-0 items-center justify-center rounded-xs text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
+                  onPress={close}
+                >
+                  <Icon icon="x" />
+                </Button>
+              </div>
+              <TextField autoFocus className="flex flex-col gap-2">
+                <Label className="font-bold">Branch name</Label>
+                <Input
+                  value={branchName}
+                  onChange={e => setBranchName(e.target.value)}
+                  placeholder="e.g. fix/protected-branch"
+                  className="h-8 rounded-xs border border-solid border-(--hl-sm) bg-(--color-bg) px-2 text-(--color-font) transition-colors placeholder:italic placeholder:opacity-60 focus:ring-1 focus:ring-(--hl-md) focus:outline-hidden"
+                />
+              </TextField>
+              {error && (
+                <p className="rounded-xs bg-(--color-danger)/20 p-2 text-sm text-(--color-font-danger)">
+                  <Icon icon="exclamation-triangle" /> {error}
+                </p>
+              )}
+              <div className="flex h-10 shrink-0 items-center justify-end gap-2">
+                <Button
+                  type="button"
+                  className="h-full gap-2 rounded-md bg-(--color-bg) px-4 py-2 text-sm font-semibold ring-1 ring-transparent transition-all hover:bg-(--hl-xs)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm) aria-pressed:opacity-80"
+                  onPress={close}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  isDisabled={isCreating || !branchName.trim()}
+                  className="flex h-full items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80 disabled:opacity-50"
+                >
+                  <Icon icon={isCreating ? 'spinner' : 'code-branch'} className={isCreating ? 'animate-spin' : ''} />
+                  Create branch &amp; push
+                </Button>
+              </div>
+            </form>
           )}
         </Dialog>
       </Modal>

--- a/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
@@ -41,6 +41,7 @@ import { useGitProjectCommitActionFetcher } from '~/routes/git.commit';
 import { useGitProjectCommitsActionFetcher } from '~/routes/git.commits';
 import { useGitProjectDiffLoaderFetcher } from '~/routes/git.diff';
 import { useGitProjectDiscardActionFetcher } from '~/routes/git.discard';
+import { useGitProjectPushActionFetcher } from '~/routes/git.push';
 import { useGitProjectStageActionFetcher } from '~/routes/git.stage';
 import { useGitProjectUnstageActionFetcher } from '~/routes/git.unstage';
 import { useGitCredentialsLoaderFetcher } from '~/routes/git-credentials';
@@ -116,6 +117,73 @@ function getModificationClassName(type: GitFileType) {
 
   return '';
 }
+
+// Shown when a commit succeeded locally but the push that followed it failed
+// (e.g. a protected branch rejected it). The work is safe in a local commit —
+// this offers a retry instead of implying the changes were lost.
+// Some errors (e.g. GitHub's protected-branch rejection) are pre-formatted
+// by the backend as "Error Pushing Repository, <raw remote message>" for use
+// in the plain-text error banner elsewhere. Here the banner title already
+// says "push failed", so that prefix is just noise — strip it if present.
+function stripRedundantPushErrorPrefix(error: string) {
+  return error.replace(/^Error Pushing Repository,\s*/, '');
+}
+
+// Recognize GitHub's protected-branch push rejection (GH006) so we can show a
+// concrete next step instead of just the raw remote log. Other providers/errors
+// fall back to the generic message — this only covers the one pattern we know.
+function getGitHubProtectedBranchTip(error: string): string | null {
+  if (/protected branch/i.test(error) || /\bGH006\b/.test(error)) {
+    return 'This branch is protected, your commit is safe locally. Push to a new branch and open a pull request, or ask an admin to allow it.';
+  }
+  return null;
+}
+
+const PushFailedAfterCommitBanner = (props: { error: string; isRetrying: boolean; onRetry: () => void }) => {
+  const [showDetails, setShowDetails] = useState(false);
+  const detail = stripRedundantPushErrorPrefix(props.error);
+  const tip = getGitHubProtectedBranchTip(detail);
+
+  return (
+    <Banner
+      type="warning"
+      title="Push failed"
+      message={
+        <div className="flex flex-col gap-2">
+          <p>
+            {tip ?? "Your commit is safe locally — it just hasn't been pushed yet."}{' '}
+            <Button
+              type="button"
+              onPress={() => setShowDetails(!showDetails)}
+              className="inline cursor-pointer border-0 bg-transparent p-0 underline"
+            >
+              {showDetails ? 'Show less' : 'Show more'}
+            </Button>
+          </p>
+          {showDetails && (
+            <p className="rounded-xs bg-(--hl-xs) p-2 font-mono text-xs whitespace-pre-wrap text-(--color-font-danger)">
+              {detail}
+            </p>
+          )}
+        </div>
+      }
+      footer={
+        <Button
+          type="button"
+          isDisabled={props.isRetrying}
+          onPress={props.onRetry}
+          className="flex h-7 items-center gap-2 rounded-xs bg-(--hl-xxs) px-3 text-sm ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset"
+        >
+          <Icon
+            icon={props.isRetrying ? 'spinner' : 'cloud-arrow-up'}
+            className={props.isRetrying ? 'animate-spin' : ''}
+          />
+          Retry push
+        </Button>
+      }
+    />
+  );
+};
 
 interface GeneratedCommitsFormProps {
   commits: { id: string; message: string; files: string[] }[];
@@ -296,9 +364,13 @@ const GeneratedCommitsForm: FC<GeneratedCommitsFormProps> = ({
   isNonOriginBranch,
 }) => {
   const commitsFetcher = useGitProjectCommitsActionFetcher();
+  const pushRetryFetcher = useGitProjectPushActionFetcher();
   const committingActionRef = useRef<'commit' | 'commit-push' | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
   const [operationError, setOperationError] = useState<string | null>(null);
+  // Set when the commits succeeded but the push that followed them failed —
+  // the commits are safe locally, so we offer a retry rather than a plain error.
+  const [pushFailedError, setPushFailedError] = useState<string | null>(null);
   const completeSignInFetcher = useGitProviderCompleteSignInFetcher({ key: GIT_PROVIDER_COMPLETE_SIGN_IN_FETCHER_KEY });
   const prevCompleteSignInStateRef = useRef(completeSignInFetcher.state);
   useEffect(() => {
@@ -334,14 +406,44 @@ const GeneratedCommitsForm: FC<GeneratedCommitsFormProps> = ({
       ('success' in commitsFetcher.data && commitsFetcher.data.success) ||
       ('errors' in commitsFetcher.data && commitsFetcher.data.errors?.length === 0);
     if (hasErrors && 'errors' in commitsFetcher.data) {
-      setOperationError((commitsFetcher.data.errors as string[]).join('\n'));
+      const pushFailedAfterCommit =
+        'pushFailedAfterCommit' in commitsFetcher.data && commitsFetcher.data.pushFailedAfterCommit;
+      if (pushFailedAfterCommit) {
+        setOperationError(null);
+        setPushFailedError((commitsFetcher.data.errors as string[]).join('\n'));
+      } else {
+        setOperationError((commitsFetcher.data.errors as string[]).join('\n'));
+      }
       return;
     }
     if (isSuccess && !hasErrors) {
       setOperationError(null);
+      setPushFailedError(null);
       onCommitSuccess({ push: action === 'commit-push' });
     }
   }, [commitsFetcher.data, onCommitSuccess, isCommitting]);
+
+  const isRetryingPush = pushRetryFetcher.state !== 'idle';
+  const prevPushRetryStateRef = useRef(pushRetryFetcher.state);
+  useEffect(() => {
+    const prevState = prevPushRetryStateRef.current;
+    prevPushRetryStateRef.current = pushRetryFetcher.state;
+    if (!(prevState !== 'idle' && pushRetryFetcher.state === 'idle' && pushRetryFetcher.data)) {
+      return;
+    }
+    const errors = pushRetryFetcher.data.errors;
+    if (errors && errors.length > 0) {
+      setPushFailedError(errors.join('\n'));
+      showToast({ icon: 'exclamation-triangle', title: 'Push failed again', status: 'error' });
+      return;
+    }
+    setPushFailedError(null);
+    onCommitSuccess({ push: true });
+  }, [pushRetryFetcher.state, pushRetryFetcher.data, onCommitSuccess]);
+
+  const retryPush = () => {
+    pushRetryFetcher.submit({ projectId });
+  };
 
   const moveFileToDoNotCommit = (fileItem: FileItem) => {
     try {
@@ -542,7 +644,9 @@ const GeneratedCommitsForm: FC<GeneratedCommitsFormProps> = ({
           </Button>
         </div>
       )}
-      {operationError && selectedProvider && isGitRepoLoadAuthHttp40Error([operationError]) ? (
+      {pushFailedError ? (
+        <PushFailedAfterCommitBanner error={pushFailedError} isRetrying={isRetryingPush} onRetry={retryPush} />
+      ) : operationError && selectedProvider && isGitRepoLoadAuthHttp40Error([operationError]) ? (
         <GitOauthAuthBanner
           selectedCredential={selectedCredential}
           gitRepository={gitRepository}
@@ -610,6 +714,7 @@ const ManualCommitForm: FC<ManualCommitFormProps> = ({
   isNonOriginBranch,
 }) => {
   const commitFetcher = useGitProjectCommitActionFetcher();
+  const pushRetryFetcher = useGitProjectPushActionFetcher();
 
   const stagedCount = changes.staged.length;
   const unstagedCount = changes.unstaged.length;
@@ -620,6 +725,9 @@ const ManualCommitForm: FC<ManualCommitFormProps> = ({
   const [pendingCommit, setPendingCommit] = useState<{ message: string; push: boolean } | null>(null);
   const committingActionRef = useRef<'commit' | 'commit-push' | null>(null);
   const [operationError, setOperationError] = useState<string | null>(null);
+  // Set when a commit succeeded but the push that followed it failed — the
+  // commit is safe locally, so we offer a retry rather than a plain error.
+  const [pushFailedError, setPushFailedError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
 
   const repoPath = gitRepository?._id ? resolveGitRepoBaseDir(gitRepository) : '';
@@ -666,6 +774,12 @@ const ManualCommitForm: FC<ManualCommitFormProps> = ({
     if (errors && errors.length > 0) {
       if (errors.includes(GitVCSOperationErrors.RequiredPullRemoteChangesError)) {
         onPullRequired();
+      } else if (commitFetcher.data.pushFailedAfterCommit) {
+        // The commit itself succeeded — only clear the message/error state
+        // for that, and surface the push failure as a retryable banner.
+        setMessage('');
+        setOperationError(null);
+        setPushFailedError(errors.join('\n'));
       } else {
         setOperationError(errors.join('\n'));
       }
@@ -673,8 +787,36 @@ const ManualCommitForm: FC<ManualCommitFormProps> = ({
     }
     setMessage('');
     setOperationError(null);
+    setPushFailedError(null);
     onCommitSuccess({ push: action === 'commit-push' });
   }, [commitFetcher.data, onCommitSuccess, onPullRequired, isCommitting]);
+
+  const isRetryingPush = pushRetryFetcher.state !== 'idle';
+  const prevPushRetryStateRef = useRef(pushRetryFetcher.state);
+  useEffect(() => {
+    const prevState = prevPushRetryStateRef.current;
+    prevPushRetryStateRef.current = pushRetryFetcher.state;
+    if (!(prevState !== 'idle' && pushRetryFetcher.state === 'idle' && pushRetryFetcher.data)) {
+      return;
+    }
+    const errors = pushRetryFetcher.data.errors;
+    if (errors && errors.length > 0) {
+      if (errors.includes(GitVCSOperationErrors.RequiredPullRemoteChangesError)) {
+        setPushFailedError(null);
+        onPullRequired();
+        return;
+      }
+      setPushFailedError(errors.join('\n'));
+      showToast({ icon: 'exclamation-triangle', title: 'Push failed again', status: 'error' });
+      return;
+    }
+    setPushFailedError(null);
+    onCommitSuccess({ push: true });
+  }, [pushRetryFetcher.state, pushRetryFetcher.data, onCommitSuccess, onPullRequired]);
+
+  const retryPush = () => {
+    pushRetryFetcher.submit({ projectId });
+  };
 
   return (
     <>
@@ -803,7 +945,9 @@ const ManualCommitForm: FC<ManualCommitFormProps> = ({
             )}
           </div>
         )}
-        {operationError && selectedProvider && isGitRepoLoadAuthHttp40Error([operationError]) ? (
+        {pushFailedError ? (
+          <PushFailedAfterCommitBanner error={pushFailedError} isRetrying={isRetryingPush} onRetry={retryPush} />
+        ) : operationError && selectedProvider && isGitRepoLoadAuthHttp40Error([operationError]) ? (
           <GitOauthAuthBanner
             selectedCredential={selectedCredential}
             gitRepository={gitRepository}
@@ -1726,7 +1870,8 @@ const ConfirmCommitAllModal = ({ onConfirm, onClose }: Omit<ConfirmModalProps, '
                 </Button>
               </div>
               <div className="">
-                There are no staged changes to commit. Would you like to stage all your changes and commit them directly?
+                There are no staged changes to commit. Would you like to stage all your changes and commit them
+                directly?
               </div>
               <div className="flex h-10 shrink-0 items-center justify-end gap-2">
                 <Button


### PR DESCRIPTION
## What

Previously, if a commit succeeded but the subsequent push failed (e.g. pushing
to a protected branch), the UI showed a plain error banner that read like the
work had failed outright — with no indication the commit was actually safe
on disk, and no way to recover without dropping to the CLI.

This PR:

- Adds a `pushFailedAfterCommit` flag to the git actions (`commitAndPushToGitRepoAction`,
  `pushToGitRemoteAction`, `commitToGitRepoAction`) so the backend can distinguish
  "push failed but your commit is safe" from other failure modes, and persists
  `hasUnpushedChanges` on the repo so app-wide indicators stay accurate.
- Adds a "Push failed" banner in the commit modal (manual and AI-generated commit
  flows) that surfaces this case explicitly, with a **Retry push** action and,
  for GitHub's protected-branch rejection (GH006) specifically, a **Create branch
  & push** shortcut that branches off the local commit and pushes it immediately.
- `createNewGitBranchAction` now checks local/synced/remote branches up front and
  rejects with a clear error if the name already exists, instead of silently
  falling back to checking out the existing branch (which could strand unpushed
  commits without any signal that "create" didn't actually happen).
- `checkoutGitBranchAction` now warns when the branch being left has unpushed
  commits, so switching away doesn't look like those commits disappeared.

## Why

Users hitting a protected-branch push rejection had no in-app path to recover —
just a raw error message — even though nothing was actually lost. This makes the
recovery path explicit and one click away.

https://www.loom.com/share/e281ddf55ff548b796563507d7e1fcd4
<img width="960" height="722" alt="image" src="https://github.com/user-attachments/assets/6386f2de-7fdd-4cee-a73b-b31947ac7f04" />

Closes: INS-3013

