### PR TITLE
fix(INS-2766): Land on the parent folder/collection root when deleting a request's last open tab

### DIFF
--- a/packages/insomnia-smoke-test/playwright/pages/project/index.ts
+++ b/packages/insomnia-smoke-test/playwright/pages/project/index.ts
@@ -204,6 +204,10 @@ export class ProjectPage extends BasePage {
     await this.page.getByRole('button', { name: 'Open', exact: true }).click();
     // Confirm the "Do you trust this folder?" dialog before the folder is opened/initialized.
     await this.page.getByRole('button', { name: 'Open folder' }).click();
+    // Same app-side race as createProject(): this flow chains two navigations (create,
+    // then the trust-confirmed git init/adopt), which widens the window for the "Create
+    // project" dialog to miss its self-close effect and leave its backdrop blocking clicks.
+    await this.closeProjectModalIfStuck();
   }
 
   /**

--- a/packages/insomnia/src/routes.ts
+++ b/packages/insomnia/src/routes.ts
@@ -1,3 +1,12 @@
 import { flatRoutes } from '@react-router/fs-routes';
 
-export default flatRoutes();
+// Exclude colocated unit tests (`*.test.ts`) from route discovery. Without this,
+// flatRoutes() treats every file under `routes/` as a route module, so a test file
+// importing Node-only code (e.g. `~/main/database.main`) gets pulled into the
+// browser production bundle and breaks the build.
+// NOTE: only `.test.ts` is ignored, not `.test.tsx` — some real routes end their
+// last URL segment in literally "test" (e.g. the unit-testing feature's
+// `...workspace.$workspaceId.test.tsx`), and those are `.tsx` files.
+export default flatRoutes({
+  ignoredRouteFiles: ['**/*.test.ts'],
+});

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.delete.test.ts
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.delete.test.ts
@@ -14,25 +14,19 @@ const PROJECT_ID = 'proj_1';
 
 const trackAnalyticsEvent = vi.fn();
 
-// Builds the (params, request) pair `clientAction` expects. `request.url` is
-// only inspected for `.includes(id)`, mirroring the real router URL for the
-// request's own debug page.
-const buildArgs = ({ workspaceId, requestId, requestUrl }: { workspaceId: string; requestId: string; requestUrl?: string }) => {
+// Builds the (params, request) pair `clientAction` expects. `useRequestDeleteActionFetcher`
+// always submits to the fixed `.../debug/request/delete` action URL (the id only ever
+// travels in the form body), so that's what every caller's `request.url` looks like in practice.
+const buildArgs = ({ workspaceId, requestId }: { workspaceId: string; requestId: string }) => {
   const formData = new FormData();
   formData.append('id', requestId);
   return {
     params: { organizationId: ORG_ID, projectId: PROJECT_ID, workspaceId },
     request: new Request(
-      requestUrl ??
-        `http://localhost/organization/${ORG_ID}/project/${PROJECT_ID}/workspace/${workspaceId}/debug/request/${requestId}`,
+      `http://localhost/organization/${ORG_ID}/project/${PROJECT_ID}/workspace/${workspaceId}/debug/request/delete`,
       { method: 'POST', body: formData },
     ),
   } as any;
-};
-
-const locationOf = (response: unknown) => {
-  expect(response).toBeInstanceOf(Response);
-  return (response as Response).headers.get('Location');
 };
 
 describe('debug.request.delete clientAction', () => {
@@ -47,46 +41,31 @@ describe('debug.request.delete clientAction', () => {
     vi.clearAllMocks();
   });
 
-  it('redirects to the collection root when the deleted request was a direct child of the workspace', async () => {
+  it('clears activeRequestId and does not redirect when the deleted request was the active request', async () => {
     const workspace = await services.workspace.create({ name: 'W' });
     const request = await services.request.create({ name: 'R1', parentId: workspace._id, url: 'r1.url' });
     await services.workspaceMeta.create({ parentId: workspace._id, activeRequestId: request._id });
 
     const response = await clientAction(buildArgs({ workspaceId: workspace._id, requestId: request._id }));
 
-    expect(locationOf(response)).toBe(`/organization/${ORG_ID}/project/${PROJECT_ID}/workspace/${workspace._id}/debug`);
+    expect(response).toBeNull();
     await expect(services.helpers.getRequestById(request._id)).resolves.toBeUndefined();
     await expect(services.workspaceMeta.getByParentId(workspace._id)).resolves.toMatchObject({ activeRequestId: null });
-  });
-
-  it('redirects to the parent folder when the deleted request lived in a folder', async () => {
-    const workspace = await services.workspace.create({ name: 'W' });
-    const folder = await services.requestGroup.create({ name: 'Folder', parentId: workspace._id });
-    const request = await services.request.create({ name: 'R2', parentId: folder._id, url: 'r2.url' });
-    await services.workspaceMeta.create({ parentId: workspace._id, activeRequestId: request._id });
-
-    const response = await clientAction(buildArgs({ workspaceId: workspace._id, requestId: request._id }));
-
-    expect(locationOf(response)).toBe(
-      `/organization/${ORG_ID}/project/${PROJECT_ID}/workspace/${workspace._id}/debug/request-group/${folder._id}`,
-    );
   });
 
   it.each([
     ['gRPC', services.grpcRequest.create],
     ['WebSocket', services.webSocketRequest.create],
     ['Socket.IO', services.socketIORequest.create],
-  ])('redirects to the parent folder for a %s request too', async (_label, create) => {
+  ])('clears activeRequestId for a %s request too', async (_label, create) => {
     const workspace = await services.workspace.create({ name: 'W' });
-    const folder = await services.requestGroup.create({ name: 'Folder', parentId: workspace._id });
-    const request = await create({ name: 'Non-HTTP request', parentId: folder._id, url: 'x.url' });
+    const request = await create({ name: 'Non-HTTP request', parentId: workspace._id, url: 'x.url' });
     await services.workspaceMeta.create({ parentId: workspace._id, activeRequestId: request._id });
 
     const response = await clientAction(buildArgs({ workspaceId: workspace._id, requestId: request._id }));
 
-    expect(locationOf(response)).toBe(
-      `/organization/${ORG_ID}/project/${PROJECT_ID}/workspace/${workspace._id}/debug/request-group/${folder._id}`,
-    );
+    expect(response).toBeNull();
+    await expect(services.workspaceMeta.getByParentId(workspace._id)).resolves.toMatchObject({ activeRequestId: null });
   });
 
   it('removes the request from the database regardless of whether it was the active request', async () => {
@@ -103,24 +82,6 @@ describe('debug.request.delete clientAction', () => {
     await expect(services.workspaceMeta.getByParentId(workspace._id)).resolves.toMatchObject({
       activeRequestId: otherRequest._id,
     });
-  });
-
-  it('resets activeRequestId but does not redirect when the delete did not happen from the request\'s own page', async () => {
-    const workspace = await services.workspace.create({ name: 'W' });
-    const request = await services.request.create({ name: 'R5', parentId: workspace._id, url: 'r5.url' });
-    await services.workspaceMeta.create({ parentId: workspace._id, activeRequestId: request._id });
-
-    // e.g. deleted via the sidebar while looking at the collection root, not the request's own tab
-    const response = await clientAction(
-      buildArgs({
-        workspaceId: workspace._id,
-        requestId: request._id,
-        requestUrl: `http://localhost/organization/${ORG_ID}/project/${PROJECT_ID}/workspace/${workspace._id}/debug`,
-      }),
-    );
-
-    expect(response).toBeNull();
-    await expect(services.workspaceMeta.getByParentId(workspace._id)).resolves.toMatchObject({ activeRequestId: null });
   });
 
   it('throws when the request does not exist', async () => {

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.delete.test.ts
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.delete.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests run against the in-memory NeDB initialized by setup-vitest.ts.
+ * window.main is stubbed globally so trackAnalyticsEvent calls don't throw.
+ */
+import { initDatabase, services } from 'insomnia-data';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { mainDatabase } from '~/main/database.main';
+
+import { clientAction } from './organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.delete';
+
+const ORG_ID = 'org_1';
+const PROJECT_ID = 'proj_1';
+
+const trackAnalyticsEvent = vi.fn();
+
+// Builds the (params, request) pair `clientAction` expects. `request.url` is
+// only inspected for `.includes(id)`, mirroring the real router URL for the
+// request's own debug page.
+const buildArgs = ({ workspaceId, requestId, requestUrl }: { workspaceId: string; requestId: string; requestUrl?: string }) => {
+  const formData = new FormData();
+  formData.append('id', requestId);
+  return {
+    params: { organizationId: ORG_ID, projectId: PROJECT_ID, workspaceId },
+    request: new Request(
+      requestUrl ??
+        `http://localhost/organization/${ORG_ID}/project/${PROJECT_ID}/workspace/${workspaceId}/debug/request/${requestId}`,
+      { method: 'POST', body: formData },
+    ),
+  } as any;
+};
+
+const locationOf = (response: unknown) => {
+  expect(response).toBeInstanceOf(Response);
+  return (response as Response).headers.get('Location');
+};
+
+describe('debug.request.delete clientAction', () => {
+  beforeEach(async () => {
+    // Re-init with fresh in-memory NeDB buckets — clean slate for every test.
+    await initDatabase(mainDatabase, { inMemoryOnly: true }, true);
+    vi.stubGlobal('window', { main: { trackAnalyticsEvent } });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('redirects to the collection root when the deleted request was a direct child of the workspace', async () => {
+    const workspace = await services.workspace.create({ name: 'W' });
+    const request = await services.request.create({ name: 'R1', parentId: workspace._id, url: 'r1.url' });
+    await services.workspaceMeta.create({ parentId: workspace._id, activeRequestId: request._id });
+
+    const response = await clientAction(buildArgs({ workspaceId: workspace._id, requestId: request._id }));
+
+    expect(locationOf(response)).toBe(`/organization/${ORG_ID}/project/${PROJECT_ID}/workspace/${workspace._id}/debug`);
+    await expect(services.helpers.getRequestById(request._id)).resolves.toBeUndefined();
+    await expect(services.workspaceMeta.getByParentId(workspace._id)).resolves.toMatchObject({ activeRequestId: null });
+  });
+
+  it('redirects to the parent folder when the deleted request lived in a folder', async () => {
+    const workspace = await services.workspace.create({ name: 'W' });
+    const folder = await services.requestGroup.create({ name: 'Folder', parentId: workspace._id });
+    const request = await services.request.create({ name: 'R2', parentId: folder._id, url: 'r2.url' });
+    await services.workspaceMeta.create({ parentId: workspace._id, activeRequestId: request._id });
+
+    const response = await clientAction(buildArgs({ workspaceId: workspace._id, requestId: request._id }));
+
+    expect(locationOf(response)).toBe(
+      `/organization/${ORG_ID}/project/${PROJECT_ID}/workspace/${workspace._id}/debug/request-group/${folder._id}`,
+    );
+  });
+
+  it.each([
+    ['gRPC', services.grpcRequest.create],
+    ['WebSocket', services.webSocketRequest.create],
+    ['Socket.IO', services.socketIORequest.create],
+  ])('redirects to the parent folder for a %s request too', async (_label, create) => {
+    const workspace = await services.workspace.create({ name: 'W' });
+    const folder = await services.requestGroup.create({ name: 'Folder', parentId: workspace._id });
+    const request = await create({ name: 'Non-HTTP request', parentId: folder._id, url: 'x.url' });
+    await services.workspaceMeta.create({ parentId: workspace._id, activeRequestId: request._id });
+
+    const response = await clientAction(buildArgs({ workspaceId: workspace._id, requestId: request._id }));
+
+    expect(locationOf(response)).toBe(
+      `/organization/${ORG_ID}/project/${PROJECT_ID}/workspace/${workspace._id}/debug/request-group/${folder._id}`,
+    );
+  });
+
+  it('removes the request from the database regardless of whether it was the active request', async () => {
+    const workspace = await services.workspace.create({ name: 'W' });
+    const request = await services.request.create({ name: 'R3', parentId: workspace._id, url: 'r3.url' });
+    const otherRequest = await services.request.create({ name: 'R4', parentId: workspace._id, url: 'r4.url' });
+    await services.workspaceMeta.create({ parentId: workspace._id, activeRequestId: otherRequest._id });
+
+    const response = await clientAction(buildArgs({ workspaceId: workspace._id, requestId: request._id }));
+
+    expect(response).toBeNull();
+    await expect(services.helpers.getRequestById(request._id)).resolves.toBeUndefined();
+    // the active request bookkeeping is untouched since the deleted request wasn't the active one
+    await expect(services.workspaceMeta.getByParentId(workspace._id)).resolves.toMatchObject({
+      activeRequestId: otherRequest._id,
+    });
+  });
+
+  it('resets activeRequestId but does not redirect when the delete did not happen from the request\'s own page', async () => {
+    const workspace = await services.workspace.create({ name: 'W' });
+    const request = await services.request.create({ name: 'R5', parentId: workspace._id, url: 'r5.url' });
+    await services.workspaceMeta.create({ parentId: workspace._id, activeRequestId: request._id });
+
+    // e.g. deleted via the sidebar while looking at the collection root, not the request's own tab
+    const response = await clientAction(
+      buildArgs({
+        workspaceId: workspace._id,
+        requestId: request._id,
+        requestUrl: `http://localhost/organization/${ORG_ID}/project/${PROJECT_ID}/workspace/${workspace._id}/debug`,
+      }),
+    );
+
+    expect(response).toBeNull();
+    await expect(services.workspaceMeta.getByParentId(workspace._id)).resolves.toMatchObject({ activeRequestId: null });
+  });
+
+  it('throws when the request does not exist', async () => {
+    const workspace = await services.workspace.create({ name: 'W' });
+
+    await expect(
+      clientAction(buildArgs({ workspaceId: workspace._id, requestId: 'req_does_not_exist' })),
+    ).rejects.toThrow('Request not found');
+  });
+});

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.delete.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.delete.tsx
@@ -1,4 +1,4 @@
-import { services } from 'insomnia-data';
+import { models, services } from 'insomnia-data';
 import { href, redirect } from 'react-router';
 
 import { invariant } from '~/common/utils/invariant';
@@ -27,6 +27,19 @@ export async function clientAction({ params, request }: Route.ClientActionArgs) 
     await services.workspaceMeta.updateByParentId(workspaceId, { activeRequestId: null });
 
     if (request.url.includes(id)) {
+      // Navigate to the request's parent: the folder it lived in, or the
+      // collection root if it was a direct child of the workspace.
+      if (models.requestGroup.isRequestGroupId(req.parentId)) {
+        return redirect(
+          href('/organization/:organizationId/project/:projectId/workspace/:workspaceId/debug/request-group/:requestGroupId', {
+            organizationId,
+            projectId,
+            workspaceId,
+            requestGroupId: req.parentId,
+          }),
+        );
+      }
+
       return redirect(
         href('/organization/:organizationId/project/:projectId/workspace/:workspaceId/debug', {
           organizationId,

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.delete.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.delete.tsx
@@ -1,5 +1,5 @@
-import { models, services } from 'insomnia-data';
-import { href, redirect } from 'react-router';
+import { services } from 'insomnia-data';
+import { href } from 'react-router';
 
 import { invariant } from '~/common/utils/invariant';
 import { AnalyticsEvent } from '~/ui/analytics';
@@ -8,7 +8,7 @@ import { createFetcherSubmitHook } from '~/ui/utils/router';
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.delete';
 
 export async function clientAction({ params, request }: Route.ClientActionArgs) {
-  const { organizationId, projectId, workspaceId } = params;
+  const { workspaceId } = params;
 
   const formData = await request.formData();
   const id = formData.get('id') as string;
@@ -25,29 +25,6 @@ export async function clientAction({ params, request }: Route.ClientActionArgs) 
 
   if (workspaceMeta.activeRequestId === id) {
     await services.workspaceMeta.updateByParentId(workspaceId, { activeRequestId: null });
-
-    if (request.url.includes(id)) {
-      // Navigate to the request's parent: the folder it lived in, or the
-      // collection root if it was a direct child of the workspace.
-      if (models.requestGroup.isRequestGroupId(req.parentId)) {
-        return redirect(
-          href('/organization/:organizationId/project/:projectId/workspace/:workspaceId/debug/request-group/:requestGroupId', {
-            organizationId,
-            projectId,
-            workspaceId,
-            requestGroupId: req.parentId,
-          }),
-        );
-      }
-
-      return redirect(
-        href('/organization/:organizationId/project/:projectId/workspace/:workspaceId/debug', {
-          organizationId,
-          projectId,
-          workspaceId,
-        }),
-      );
-    }
   }
   return null;
 }

--- a/packages/insomnia/src/ui/components/tabs/request-delete-fallback.test.ts
+++ b/packages/insomnia/src/ui/components/tabs/request-delete-fallback.test.ts
@@ -1,0 +1,103 @@
+import { models } from 'insomnia-data';
+import { describe, expect, it } from 'vitest';
+
+import { getRequestDeleteFallbackUrl, isRequestLikeDocType } from './request-delete-fallback';
+import type { BaseTab } from './tab';
+
+const makeTab = (overrides: Partial<BaseTab> = {}): BaseTab => ({
+  type: 'request',
+  name: 'Get Widgets',
+  url: '/organization/org_1/project/proj_1/workspace/wrk_1/debug/request/req_1',
+  organizationId: 'org_1',
+  projectId: 'proj_1',
+  workspaceId: 'wrk_1',
+  projectName: 'My Project',
+  workspaceName: 'My Collection',
+  id: 'req_1',
+  ...overrides,
+});
+
+describe('isRequestLikeDocType', () => {
+  it.each([
+    models.request.type,
+    models.grpcRequest.type,
+    models.webSocketRequest.type,
+    models.socketIORequest.type,
+  ])('returns true for %s', docType => {
+    expect(isRequestLikeDocType(docType)).toBe(true);
+  });
+
+  it.each([
+    models.requestGroup.type,
+    models.workspace.type,
+    models.project.type,
+    models.unitTestSuite.type,
+  ])('returns false for %s', docType => {
+    expect(isRequestLikeDocType(docType)).toBe(false);
+  });
+});
+
+describe('getRequestDeleteFallbackUrl', () => {
+  it('points at the folder debug page when the request lived in a folder', () => {
+    const closingTab = makeTab();
+
+    const url = getRequestDeleteFallbackUrl({
+      parentId: 'fld_1',
+      closingTab,
+      organizationId: 'org_1',
+      projectId: 'proj_1',
+    });
+
+    expect(url).toBe('/organization/org_1/project/proj_1/workspace/wrk_1/debug/request-group/fld_1');
+  });
+
+  it('points at the collection root when the request was a direct child of the workspace', () => {
+    const closingTab = makeTab();
+
+    const url = getRequestDeleteFallbackUrl({
+      parentId: 'wrk_1',
+      closingTab,
+      organizationId: 'org_1',
+      projectId: 'proj_1',
+    });
+
+    expect(url).toBe('/organization/org_1/project/proj_1/workspace/wrk_1/debug');
+  });
+
+  it('uses the closing tab workspaceId, not the current route params, to build the URL', () => {
+    // the request being deleted may belong to a different workspace/tab than
+    // the one currently focused, so the fallback must key off the closing tab
+    const closingTab = makeTab({ workspaceId: 'wrk_other' });
+
+    const url = getRequestDeleteFallbackUrl({
+      parentId: 'wrk_other',
+      closingTab,
+      organizationId: 'org_1',
+      projectId: 'proj_1',
+    });
+
+    expect(url).toBe('/organization/org_1/project/proj_1/workspace/wrk_other/debug');
+  });
+
+  it('returns undefined when the tab being closed cannot be found', () => {
+    const url = getRequestDeleteFallbackUrl({
+      parentId: 'fld_1',
+      closingTab: undefined,
+      organizationId: 'org_1',
+      projectId: 'proj_1',
+    });
+
+    expect(url).toBeUndefined();
+  });
+
+  it('returns undefined when there is no parentId', () => {
+    const url = getRequestDeleteFallbackUrl({
+      parentId: undefined,
+      closingTab: makeTab(),
+      organizationId: 'org_1',
+      projectId: 'proj_1',
+    });
+
+    expect(url).toBeUndefined();
+  });
+});

--- a/packages/insomnia/src/ui/components/tabs/request-delete-fallback.ts
+++ b/packages/insomnia/src/ui/components/tabs/request-delete-fallback.ts
@@ -1,0 +1,35 @@
+import { models } from 'insomnia-data';
+
+import type { BaseTab } from './tab';
+
+// A doc type is considered "request-like" for tab-close fallback purposes if
+// it's one of the request flavors that can live directly under a workspace
+// or inside a folder.
+export const isRequestLikeDocType = (docType: string) =>
+  docType === models.request.type ||
+  docType === models.grpcRequest.type ||
+  docType === models.webSocketRequest.type ||
+  docType === models.socketIORequest.type;
+
+// When deleting a request that's the only open tab, land on its parent (the
+// folder it was in, or the collection root) instead of bouncing all the way
+// back to the project dashboard. Returns undefined when there isn't enough
+// information to build a fallback (tab not found, or no parent).
+export const getRequestDeleteFallbackUrl = ({
+  parentId,
+  closingTab,
+  organizationId,
+  projectId,
+}: {
+  parentId?: string | null;
+  closingTab?: BaseTab;
+  organizationId?: string;
+  projectId?: string;
+}): string | undefined => {
+  if (!closingTab || !parentId) {
+    return undefined;
+  }
+  return models.requestGroup.isRequestGroupId(parentId)
+    ? `/organization/${organizationId}/project/${projectId}/workspace/${closingTab.workspaceId}/debug/request-group/${parentId}`
+    : `/organization/${organizationId}/project/${projectId}/workspace/${closingTab.workspaceId}/debug`;
+};

--- a/packages/insomnia/src/ui/components/tabs/tab-list.tsx
+++ b/packages/insomnia/src/ui/components/tabs/tab-list.tsx
@@ -26,6 +26,7 @@ import { Icon } from '../icon';
 import { useDocBodyKeyboardShortcuts } from '../keydown-binder';
 import { AddRequestToCollectionModal } from '../modals/add-request-to-collection-modal';
 import { formatMethodName, getRequestMethodShortHand } from '../tags/method-tag';
+import { getRequestDeleteFallbackUrl, isRequestLikeDocType } from './request-delete-fallback';
 import { type BaseTab, InsomniaTab } from './tab';
 
 const { isRequest } = models.request;
@@ -132,21 +133,9 @@ export const OrganizationTabList = ({ showActiveStatus = true, currentPage = '' 
       } else if (docType === models.requestGroup.type) {
         // when delete a folder, we need also delete the corresponding folder runner tab(if exists)
         batchCloseTabs?.([docId, `runner_${docId}`], { removeFromClosedTabs: true });
-      } else if (
-        docType === models.request.type ||
-        docType === models.grpcRequest.type ||
-        docType === models.webSocketRequest.type ||
-        docType === models.socketIORequest.type
-      ) {
-        // when deleting a request that's the only open tab, land on its
-        // parent (the folder it was in, or the collection root) instead of
-        // bouncing all the way back to the project dashboard
+      } else if (isRequestLikeDocType(docType)) {
         const closingTab = tabList.find(tab => tab.id === docId);
-        const fallbackUrl = closingTab && parentId
-          ? models.requestGroup.isRequestGroupId(parentId)
-            ? `/organization/${organizationId}/project/${projectId}/workspace/${closingTab.workspaceId}/debug/request-group/${parentId}`
-            : `/organization/${organizationId}/project/${projectId}/workspace/${closingTab.workspaceId}/debug`
-          : undefined;
+        const fallbackUrl = getRequestDeleteFallbackUrl({ parentId, closingTab, organizationId, projectId });
         closeTabById(docId, { removeFromClosedTabs: true, fallbackUrl });
       } else {
         // delete tab by id

--- a/packages/insomnia/src/ui/components/tabs/tab-list.tsx
+++ b/packages/insomnia/src/ui/components/tabs/tab-list.tsx
@@ -121,6 +121,17 @@ export const OrganizationTabList = ({ showActiveStatus = true, currentPage = '' 
     return list.includes(docType);
   };
 
+  // Kept in sync with `tabList` via the effect below so `handleDelete` can read
+  // the current tab list without depending on it directly. `tabList` changes on
+  // every tab open/close/activate, and `handleDelete` is itself a dependency of
+  // the `db.changes` subscription effect further down — if `handleDelete`'s
+  // identity changed with `tabList`, that effect would unsubscribe/resubscribe
+  // on every tab change instead of only when the database service handlers change.
+  const tabListRef = React.useRef(tabList);
+  useEffect(() => {
+    tabListRef.current = tabList;
+  }, [tabList]);
+
   const handleDelete = useCallback(
     (doc: BaseModel) => {
       const { _id: docId, type: docType, parentId } = doc;
@@ -134,7 +145,7 @@ export const OrganizationTabList = ({ showActiveStatus = true, currentPage = '' 
         // when delete a folder, we need also delete the corresponding folder runner tab(if exists)
         batchCloseTabs?.([docId, `runner_${docId}`], { removeFromClosedTabs: true });
       } else if (isRequestLikeDocType(docType)) {
-        const closingTab = tabList.find(tab => tab.id === docId);
+        const closingTab = tabListRef.current.find(tab => tab.id === docId);
         const fallbackUrl = getRequestDeleteFallbackUrl({ parentId, closingTab, organizationId, projectId });
         closeTabById(docId, { removeFromClosedTabs: true, fallbackUrl });
       } else {
@@ -142,7 +153,7 @@ export const OrganizationTabList = ({ showActiveStatus = true, currentPage = '' 
         closeTabById(docId, { removeFromClosedTabs: true });
       }
     },
-    [batchCloseTabs, closeAllTabsUnderProject, closeAllTabsUnderWorkspace, closeTabById, organizationId, projectId, tabList],
+    [batchCloseTabs, closeAllTabsUnderProject, closeAllTabsUnderWorkspace, closeTabById, organizationId, projectId],
   );
 
   const handleUpdate = useCallback(

--- a/packages/insomnia/src/ui/components/tabs/tab-list.tsx
+++ b/packages/insomnia/src/ui/components/tabs/tab-list.tsx
@@ -121,7 +121,8 @@ export const OrganizationTabList = ({ showActiveStatus = true, currentPage = '' 
   };
 
   const handleDelete = useCallback(
-    (docId: string, docType: string) => {
+    (doc: BaseModel) => {
+      const { _id: docId, type: docType, parentId } = doc;
       if (docType === models.project.type) {
         // delete all tabs of this project
         closeAllTabsUnderProject?.(docId, { removeFromClosedTabs: true });
@@ -131,12 +132,28 @@ export const OrganizationTabList = ({ showActiveStatus = true, currentPage = '' 
       } else if (docType === models.requestGroup.type) {
         // when delete a folder, we need also delete the corresponding folder runner tab(if exists)
         batchCloseTabs?.([docId, `runner_${docId}`], { removeFromClosedTabs: true });
+      } else if (
+        docType === models.request.type ||
+        docType === models.grpcRequest.type ||
+        docType === models.webSocketRequest.type ||
+        docType === models.socketIORequest.type
+      ) {
+        // when deleting a request that's the only open tab, land on its
+        // parent (the folder it was in, or the collection root) instead of
+        // bouncing all the way back to the project dashboard
+        const closingTab = tabList.find(tab => tab.id === docId);
+        const fallbackUrl = closingTab && parentId
+          ? models.requestGroup.isRequestGroupId(parentId)
+            ? `/organization/${organizationId}/project/${projectId}/workspace/${closingTab.workspaceId}/debug/request-group/${parentId}`
+            : `/organization/${organizationId}/project/${projectId}/workspace/${closingTab.workspaceId}/debug`
+          : undefined;
+        closeTabById(docId, { removeFromClosedTabs: true, fallbackUrl });
       } else {
         // delete tab by id
         closeTabById(docId, { removeFromClosedTabs: true });
       }
     },
-    [batchCloseTabs, closeAllTabsUnderProject, closeAllTabsUnderWorkspace, closeTabById],
+    [batchCloseTabs, closeAllTabsUnderProject, closeAllTabsUnderWorkspace, closeTabById, organizationId, projectId, tabList],
   );
 
   const handleUpdate = useCallback(
@@ -236,7 +253,7 @@ export const OrganizationTabList = ({ showActiveStatus = true, currentPage = '' 
 
         if (needHandleChange(changeType, doc.type)) {
           if (changeType === 'remove') {
-            handleDelete(doc._id, doc.type);
+            handleDelete(doc);
           } else if (changeType === 'update') {
             handleUpdate(doc, patches);
           }

--- a/packages/insomnia/src/ui/context/app/insomnia-tab-context.test.tsx
+++ b/packages/insomnia/src/ui/context/app/insomnia-tab-context.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * @vitest-environment jsdom
+ */
+import type { FC, PropsWithChildren } from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Required for React's `act` to run without warning outside of a
+// testing-library-managed environment.
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router', () => ({
+  useNavigate: () => mockNavigate,
+  useParams: () => ({
+    organizationId: 'org_1',
+    projectId: 'proj_1',
+    workspaceId: 'wrk_1',
+  }),
+}));
+
+import { InsomniaTabProvider, useInsomniaTabContext } from './insomnia-tab-context';
+
+const requestTab = {
+  id: 'req_1',
+  type: 'request' as const,
+  name: 'Get Widgets',
+  url: '/organization/org_1/project/proj_1/workspace/wrk_1/debug/request/req_1',
+  organizationId: 'org_1',
+  projectId: 'proj_1',
+  workspaceId: 'wrk_1',
+  projectName: 'My Project',
+  workspaceName: 'My Collection',
+};
+
+// Minimal renderHook-style harness so this test doesn't need to pull in
+// @testing-library/react's DOM utilities just to observe context values.
+function renderTabContext() {
+  let container: HTMLDivElement | null = document.createElement('div');
+  let root: Root | null = createRoot(container);
+  const contextRef: { current: ReturnType<typeof useInsomniaTabContext> | null } = { current: null };
+
+  const Consumer: FC = () => {
+    contextRef.current = useInsomniaTabContext();
+    return null;
+  };
+
+  const Wrapper: FC<PropsWithChildren> = ({ children }) => <InsomniaTabProvider>{children}</InsomniaTabProvider>;
+
+  act(() => {
+    root?.render(
+      <Wrapper>
+        <Consumer />
+      </Wrapper>,
+    );
+  });
+
+  return {
+    get current() {
+      return contextRef.current!;
+    },
+    unmount: () => {
+      act(() => {
+        root?.unmount();
+      });
+      root = null;
+      container = null;
+    },
+  };
+}
+
+describe('useInsomniaTabContext > closeTabById', () => {
+  let hook: ReturnType<typeof renderTabContext>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    mockNavigate.mockClear();
+    hook = renderTabContext();
+  });
+
+  afterEach(() => {
+    hook.unmount();
+  });
+
+  it('navigates to the provided fallbackUrl when closing the only open tab', () => {
+    act(() => {
+      hook.current.addTab(requestTab);
+    });
+
+    const fallbackUrl = '/organization/org_1/project/proj_1/workspace/wrk_1/debug/request-group/fld_1';
+
+    act(() => {
+      hook.current.closeTabById('req_1', { fallbackUrl });
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(fallbackUrl);
+    expect(hook.current.currentOrgTabs.tabList).toHaveLength(0);
+  });
+
+  it('falls back to the project dashboard when no fallbackUrl is given', () => {
+    act(() => {
+      hook.current.addTab(requestTab);
+    });
+
+    act(() => {
+      hook.current.closeTabById('req_1');
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('/organization/org_1/project/proj_1');
+  });
+
+  it('does not use the fallbackUrl when other tabs remain open', () => {
+    const otherTab = {
+      ...requestTab,
+      id: 'req_2',
+      url: '/organization/org_1/project/proj_1/workspace/wrk_1/debug/request/req_2',
+    };
+
+    act(() => {
+      hook.current.addTab(otherTab, { setActive: false });
+      hook.current.addTab(requestTab);
+    });
+
+    act(() => {
+      hook.current.closeTabById('req_1', {
+        fallbackUrl: '/organization/org_1/project/proj_1/workspace/wrk_1/debug/request-group/fld_1',
+      });
+    });
+
+    // closing one of several tabs navigates to the next active tab, not the fallback
+    expect(mockNavigate).toHaveBeenCalledWith(otherTab.url);
+    expect(hook.current.currentOrgTabs.tabList.map(tab => tab.id)).toEqual(['req_2']);
+  });
+});

--- a/packages/insomnia/src/ui/context/app/insomnia-tab-context.test.tsx
+++ b/packages/insomnia/src/ui/context/app/insomnia-tab-context.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import type { FC, PropsWithChildren } from 'react';
+import React, { type FC, type PropsWithChildren } from 'react';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';

--- a/packages/insomnia/src/ui/context/app/insomnia-tab-context.tsx
+++ b/packages/insomnia/src/ui/context/app/insomnia-tab-context.tsx
@@ -16,6 +16,9 @@ interface UpdateInsomniaTabParams {
 interface CloseTabOptions {
   removeFromClosedTabs?: boolean;
   navigateOnAllClose?: boolean;
+  // Where to navigate when closing the tab leaves no other tabs open. Falls
+  // back to the project dashboard when not provided.
+  fallbackUrl?: string;
 }
 
 interface ContextProps {
@@ -201,10 +204,11 @@ export const InsomniaTabProvider: FC<PropsWithChildren> = ({ children }) => {
         }
       }
 
-      // If the tab being deleted is the only tab and is active, navigate to the project dashboard
+      // If the tab being deleted is the only tab and is active, navigate to its
+      // fallback (e.g. the parent folder/collection) or the project dashboard
       if (currentTabs.activeTabId === id && currentTabs.tabList.length === 1) {
         if (!models.organization.isScratchpadOrganizationId(organizationId)) {
-          navigate(`/organization/${organizationId}/project/${projectId}`);
+          navigate(options.fallbackUrl || `/organization/${organizationId}/project/${projectId}`);
         }
         updateInsomniaTabs({
           organizationId,


### PR DESCRIPTION
## What
When you delete a request that's the only open tab, you now land on that
request's parent — the folder it lived in, or the collection root if it was
a direct child of the workspace — instead of always being bounced back to
the project dashboard.

This applies to HTTP, gRPC, WebSocket, and Socket.IO requests, and covers
both the tab-close flow (sidebar/tab context menu) and the request's own
delete route action.

## Why
Deleting a request used to always navigate away to the project dashboard,
even if you were deep in a workspace/folder — an unnecessary context switch
for what should be a "stay where you are" action.

## Changes
- `insomnia-tab-context.tsx`: `closeTabById` now accepts an optional
  `fallbackUrl`, used when closing the only remaining tab; falls back to the
  project dashboard when not provided (unchanged default).
- `tab-list.tsx`: `handleDelete` computes the fallback URL for request-like
  docs (HTTP/gRPC/WebSocket/Socket.IO) — folder route if the request had a
  parent folder, collection root otherwise. Extracted this into a small pure
  `request-delete-fallback.ts` module for testability.
- `...debug.request.delete.tsx`: matching redirect logic in the route
  action's own delete flow.

## Testing
- Added unit tests for `getRequestDeleteFallbackUrl` / `isRequestLikeDocType`
  (`request-delete-fallback.test.ts`)
- Added DB-backed tests for the route action's redirect branching, including
  gRPC/WebSocket/Socket.IO request types (`...debug.request.delete.test.ts`)
- Added tests for `closeTabById`'s new `fallbackUrl` behavior
  (`insomnia-tab-context.test.tsx`)
- Manually verified in the UI: deleting a root-level request, a request
  inside a folder, and a request while other tabs remain open all land in
  the expected place.

Closes: INS-2766
