### PR TITLE
fix(sandbox): handle bracketed IPv6 hosts in the URL global shim

### DIFF
--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.test.ts
@@ -615,6 +615,44 @@ describe('ambient globals — sandbox stdlib (M2)', () => {
       const actual = await runGlobal("return new URL('https://h/p?a=1&a=2&b=3').searchParams.getAll('a').join(',');");
       expect(actual).toBe('1,2');
     });
+
+    it('parses a bracketed IPv6 host, keeping brackets in hostname/host per WHATWG', async () => {
+      const u = 'http://[::1]:8080/path';
+      const actual = await runGlobal(
+        "var u = new URL(arguments[1]); return [u.hostname, u.port, u.host, u.href].join('|');",
+        [u],
+      );
+      const expected = new URL(u);
+      expect(actual).toBe([expected.hostname, expected.port, expected.host, expected.href].join('|'));
+      expect(actual).toBe('[::1]|8080|[::1]:8080|http://[::1]:8080/path');
+    });
+
+    it('drops the default port for a bracketed IPv6 host like WHATWG', async () => {
+      const actual = await runGlobal("var u = new URL('https://[::1]:443/x'); return u.host + '|' + u.port;");
+      expect(actual).toBe('[::1]|');
+    });
+
+    it('lowercases hex in an IPv6 host like WHATWG', async () => {
+      const actual = await runGlobal("return new URL('http://[2001:DB8::1]/x').hostname;");
+      expect(actual).toBe(new URL('http://[2001:DB8::1]/x').hostname);
+      expect(actual).toBe('[2001:db8::1]');
+    });
+
+    it('parses auth alongside a bracketed IPv6 host', async () => {
+      const u = 'http://user:pass@[::1]:8080/path';
+      const actual = await runGlobal(
+        "var u = new URL(arguments[1]); return [u.username, u.password, u.hostname, u.host, u.href].join('|');",
+        [u],
+      );
+      const expected = new URL(u);
+      expect(actual).toBe(
+        [expected.username, expected.password, expected.hostname, expected.host, expected.href].join('|'),
+      );
+    });
+
+    it('throws on an unclosed IPv6 bracket', async () => {
+      await expect(runGlobal("return new URL('http://[::1/x').href;")).rejects.toThrow();
+    });
   });
 
   describe('sandbox identity marker', () => {

--- a/packages/insomnia/src/templating/sandbox/sandbox-globals.ts
+++ b/packages/insomnia/src/templating/sandbox/sandbox-globals.ts
@@ -259,9 +259,20 @@ export const SANDBOX_GLOBALS_SOURCE = [
   '        this.username = ci === -1 ? creds : creds.slice(0, ci);',
   '        this.password = ci === -1 ? "" : creds.slice(ci + 1);',
   '      } else { this.username = ""; this.password = ""; }',
-  '      var colon = authority.indexOf(":");',
-  '      if (colon === -1) { this.hostname = authority.toLowerCase(); this.port = ""; }',
-  '      else { this.hostname = authority.slice(0, colon).toLowerCase(); this.port = authority.slice(colon + 1); }',
+  // IPv6 literal (bracketed): the bracketed form is kept verbatim (lowercased) as hostname, matching
+  // WHATWG (new URL("http://[::1]:8080/").hostname === "[::1]") — a bare authority.indexOf(":") here
+  // would otherwise split on the first colon INSIDE the brackets, corrupting both fields.
+  '      if (authority.charAt(0) === "[") {',
+  '        var closeBracket = authority.indexOf("]");',
+  '        if (closeBracket === -1) { throw new TypeError("Invalid URL: " + url); }',
+  '        this.hostname = authority.slice(0, closeBracket + 1).toLowerCase();',
+  '        var afterBracket = authority.slice(closeBracket + 1);',
+  '        this.port = afterBracket.charAt(0) === ":" ? afterBracket.slice(1) : "";',
+  '      } else {',
+  '        var colon = authority.indexOf(":");',
+  '        if (colon === -1) { this.hostname = authority.toLowerCase(); this.port = ""; }',
+  '        else { this.hostname = authority.slice(0, colon).toLowerCase(); this.port = authority.slice(colon + 1); }',
+  '      }',
   '      if (this.port !== "" && __defaultPorts[this.protocol] === this.port) { this.port = ""; }',
   '      this.host = this.port === "" ? this.hostname : this.hostname + ":" + this.port;',
   '      this.pathname = m[4] || (authority ? "/" : "");',


### PR DESCRIPTION
`new URL("http://[::1]:8080/")` inside the QuickJS sandbox mis-parsed the bracketed IPv6 host — the authority split on the first colon *inside* the brackets, producing `hostname: "["`, `port: ":1]:8080"`.

Fixes the shim to detect a bracketed literal and match WHATWG behavior: brackets stay in `hostname`/`host`, hex is lowercased, and an unclosed bracket throws (matching `new URL()`'s real error). Verified byte-for-byte against real Node's `URL` for IPv6 (with/without port/auth, default-port stripping, mixed-case hex) and the unclosed-bracket throw case.