### PR TITLE
fix(codemirror): guard unsound TextMarker assertion in nunjucks-tags drag handler

### DIFF
--- a/packages/insomnia/src/ui/components/.client/codemirror/extensions/nunjucks-tags.ts
+++ b/packages/insomnia/src/ui/components/.client/codemirror/extensions/nunjucks-tags.ts
@@ -213,10 +213,14 @@ async function _highlightNunjucksTags(
         // TODO: Actually only use dropEffect for this logic. For some reason
         // changing it doesn't seem to take affect in Chromium 56 (maybe bug?)
         if (droppedInSameEditor) {
-          // TODO: unsound non-null assertion
+          const pos = mark.find();
 
-          const { from, to } = mark.find()!;
-          this.replaceRange('', from, to, '+dnd');
+          if (pos) {
+            const { from, to } = pos;
+            this.replaceRange('', from, to, '+dnd');
+          } else {
+            console.warn('Tried to remove mark that did not exist', mark);
+          }
         }
 
         // Remove listeners we added

--- a/packages/insomnia/src/ui/components/error-boundary.tsx
+++ b/packages/insomnia/src/ui/components/error-boundary.tsx
@@ -30,6 +30,9 @@ class SingleErrorBoundary extends PureComponent<Props, State> {
     const { children } = this.props;
     const firstChild = Array.isArray(children) && children.length === 1 ? children[0] : children;
     this.setState({ error, info });
+    // The fallback below only shows error.message; log the full stack and component
+    // stack so a crash can actually be diagnosed from the console.
+    console.error('ErrorBoundary caught an error:', error, info.componentStack);
     let componentName = 'component';
 
     try {


### PR DESCRIPTION
## What

Two small fixes found while investigating INS-2767 ("flipping a param to
Multiline text throws Render Failure: Cannot read properties of undefined
(reading 'from')"):

1. **`nunjucks-tags.ts`** — the `dragend` listener destructured
   `mark.find()!` with a non-null assertion, even though `mark.find()`
   legitimately returns `undefined` once a TextMarker has been cleared.
   Guarded it the same way the identical call 8 lines above already is
   (`if (pos) { ... } else { console.warn(...) }`).

2. **`error-boundary.tsx`** — `componentDidCatch` captured `info.componentStack`
   into state but never logged or rendered it, and the fallback UI only ever
   shows `error.message`. Any crash caught by this boundary was effectively
   undiagnosable. Added a `console.error` with the full error + component
   stack so the next crash is traceable from devtools.

## Does this fix INS-2767?

**Not confirmed.** I could not reproduce the reported crash live (tried twice
via Playwright/Electron: a plain param value, and a param value containing a
live `{{ _.variable }}` tag with a simulated drag) — both toggled to
"Multiline text" cleanly with no error. The `nunjucks-tags.ts` line fixed here
matches the exact error text and is a real, independently-existing bug, but
it's wired to a native `dragend` event, not the dropdown click itself, so it
may not be the actual trigger for this ticket.

These fixes are correct and worth merging regardless, but INS-2767 should
stay open pending a repro against the actual collection/environment where it
was seen (the working screenshot shows a *resolved* `_.base_url` variable
pill, which the local repro didn't reproduce).
