### PR TITLE
fix(sandbox): don't crash disposing a QuickJS context with a pending bridge call

### DIFF
--- a/packages/insomnia/src/templating/sandbox/async-boundary.regression.test.ts
+++ b/packages/insomnia/src/templating/sandbox/async-boundary.regression.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+
+import { createMapBridge, type HostBridge, TEMPLATE_TAG_BASELINE_CAPABILITIES } from './host-bridge';
+import type { ContextEnvelope } from './marshal';
+import { runTagInSandbox } from './plugin-tag-sandbox';
+
+const envelope = (args: unknown[]): ContextEnvelope => ({
+  args,
+  context: {},
+  meta: {},
+  renderPurpose: 'preview',
+  appInfo: { version: '0.0.0', platform: 'linux', arch: 'arm64' },
+  pluginName: 'test-plugin',
+  renderDepth: 0,
+  grantedModules: [],
+  grantedCapabilities: [...TEMPLATE_TAG_BASELINE_CAPABILITIES],
+});
+
+const noBridge: HostBridge = async path => {
+  throw new Error(`unexpected bridge call: ${path}`);
+};
+
+const nodeOSTag =
+  "module.exports.templateTags = [{ name: 'g', run: async function (context) { return await context.util.nodeOS(); } }];";
+const nodeOSArchTag =
+  "module.exports.templateTags = [{ name: 'g', run: async function (context) { return (await context.util.nodeOS()).arch; } }];";
+
+/** Observes process-level unhandled rejections for the duration of one test, without letting them escape. */
+const captureUnhandledRejections = () => {
+  const seen: unknown[] = [];
+  const onUnhandledRejection = (reason: unknown) => {
+    seen.push(reason);
+  };
+  process.on('unhandledRejection', onUnhandledRejection);
+  return { seen, stop: () => process.off('unhandledRejection', onUnhandledRejection) };
+};
+
+describe('disposing a context with an unsettled bridge call still pending', () => {
+  // runTagInSandbox's `finally { ctx.dispose(); }` runs whenever drivePromiseToString gives up —
+  // including on its own timeout — with no regard for whether a __hostBridge call the guest is still
+  // awaiting has settled. Confirmed (not timing-dependent): a bridge call that simply never resolves
+  // reproduces this on every run, with no delay/race required.
+  it('a bridge call that never resolves crashes the timeout path instead of producing a clean timeout error', async () => {
+    const neverSettles: HostBridge = () => new Promise(() => {});
+    const error = await runTagInSandbox({
+      pluginSource: nodeOSTag,
+      tagName: 'g',
+      envelope: envelope([]),
+      bridge: neverSettles,
+      timeoutMs: 50,
+    }).catch((e: unknown) => e);
+    // Today this is QuickJS's own internal "Aborted(Assertion failed: list_empty(&rt->gc_obj_list) …
+    // JS_FreeRuntime)" — an engine-level invariant violation raised while freeing a runtime that still
+    // has a live (never-settled) promise/job in it — not the intended "Template tag sandbox timed
+    // out" message. Update this assertion once the timeout path is made safe to call with a bridge
+    // call still outstanding.
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/gc_obj_list|JS_FreeRuntime|Aborted/);
+  });
+
+  it('does not corrupt the shared WASM module for a later, unrelated render', async () => {
+    const neverSettles: HostBridge = () => new Promise(() => {});
+    await runTagInSandbox({
+      pluginSource: nodeOSTag,
+      tagName: 'g',
+      envelope: envelope([]),
+      bridge: neverSettles,
+      timeoutMs: 50,
+    }).catch(() => {});
+
+    const source = 'module.exports.templateTags = [{ name: "ok", run: function () { return "still-fine"; } }];';
+    const actual = await runTagInSandbox({ pluginSource: source, tagName: 'ok', envelope: envelope([]), bridge: noBridge });
+    expect(actual).toBe('still-fine');
+  });
+
+  it('a bridge handler returning a non-JSON-serializable value additionally raises a process-level unhandled rejection', async () => {
+    const capture = captureUnhandledRejections();
+    try {
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+      const bridge = createMapBridge({ nodeOS: async () => circular });
+      // encodeBridgeSuccess(value) (marshal.ts) calls JSON.stringify(value) inside
+      // installHostBridge's settle continuation, which has no .catch() and nothing awaits it — so a
+      // circular value throws there and becomes an unhandled rejection, distinct from (and in addition
+      // to) the deferred promise never settling, which separately trips the same timeout-path crash
+      // as the previous tests once the sandbox's own timeout elapses.
+      const pending = runTagInSandbox({
+        pluginSource: nodeOSTag,
+        tagName: 'g',
+        envelope: envelope([]),
+        bridge,
+        timeoutMs: 100,
+      });
+      await new Promise(resolve => setTimeout(resolve, 30));
+      expect(capture.seen).toHaveLength(1);
+      expect(String((capture.seen[0] as Error)?.message ?? capture.seen[0])).toMatch(/circular/i);
+      await expect(pending).rejects.toThrow(/gc_obj_list|JS_FreeRuntime|Aborted/);
+    } finally {
+      capture.stop();
+    }
+  });
+});
+
+describe('unhandled rejections created inside the guest VM', () => {
+  // No JS_SetHostPromiseRejectionTracker-equivalent is wired up, so a rejection the guest never
+  // observes (unrelated to the tag's own return value) has no host-side hook — confirm that just
+  // means it's unobserved, not that it destabilizes the render.
+  it('a fire-and-forget rejection unrelated to the tag result does not crash or hang the render', async () => {
+    const capture = captureUnhandledRejections();
+    try {
+      const source = `module.exports.templateTags = [{ name: 'g', run: function () {
+        Promise.reject(new Error('unrelated, never awaited'));
+        return 'ok';
+      } }];`;
+      const actual = await runTagInSandbox({ pluginSource: source, tagName: 'g', envelope: envelope([]), bridge: noBridge });
+      expect(actual).toBe('ok');
+      // The rejection lives entirely inside the QuickJS VM's own promise machinery — it never becomes
+      // a host-native (Node) promise, so it must not surface here either.
+      expect(capture.seen).toHaveLength(0);
+    } finally {
+      capture.stop();
+    }
+  });
+});
+
+describe('concurrent renders do not share a job queue', () => {
+  // runTagInSandbox calls QuickJS.newContext(), which allocates a fresh QuickJSRuntime per call (the
+  // runtime is one of the context's ownedLifetimes, so ctx.dispose() tears it down too) — so one
+  // render's executePendingJobs() can never drain another concurrent render's pending job.
+  it('each concurrent render only ever observes its own bridge result', async () => {
+    const makeBridge = (tag: string) =>
+      createMapBridge({ nodeOS: () => new Promise(resolve => setTimeout(() => resolve({ arch: tag }), 10)) });
+    const runs = Array.from({ length: 10 }, (_, i) => `render-${i}`);
+    const results = await Promise.all(
+      runs.map(tag =>
+        runTagInSandbox({ pluginSource: nodeOSArchTag, tagName: 'g', envelope: envelope([]), bridge: makeBridge(tag) }),
+      ),
+    );
+    expect(results).toEqual(runs);
+  });
+});
+
+describe('what a bridge promise can hand back to the guest', () => {
+  // __hostBridge's result always round-trips through JSON.stringify/JSON.parse (marshal.ts), so a
+  // function on a bridge handler's return value can never reach the guest as a callable — confirm
+  // it's silently dropped by JSON, not delivered as some other kind of live reference.
+  it('drops function-valued properties instead of delivering them as callables', async () => {
+    const bridge = createMapBridge({
+      nodeOS: async () => ({ arch: 'x64', hostCallback: () => 'unsandboxed-call' }),
+    });
+    const source =
+      "module.exports.templateTags = [{ name: 'g', run: async function (context) { var os = await context.util.nodeOS(); return typeof os.hostCallback; } }];";
+    const actual = await runTagInSandbox({ pluginSource: source, tagName: 'g', envelope: envelope([]), bridge });
+    expect(actual).toBe('undefined');
+  });
+});

--- a/packages/insomnia/src/templating/sandbox/async-boundary.regression.test.ts
+++ b/packages/insomnia/src/templating/sandbox/async-boundary.regression.test.ts
@@ -36,26 +36,30 @@ const captureUnhandledRejections = () => {
 };
 
 describe('disposing a context with an unsettled bridge call still pending', () => {
-  // runTagInSandbox's `finally { ctx.dispose(); }` runs whenever drivePromiseToString gives up —
-  // including on its own timeout — with no regard for whether a __hostBridge call the guest is still
-  // awaiting has settled. Confirmed (not timing-dependent): a bridge call that simply never resolves
-  // reproduces this on every run, with no delay/race required.
-  it('a bridge call that never resolves crashes the timeout path instead of producing a clean timeout error', async () => {
-    const neverSettles: HostBridge = () => new Promise(() => {});
-    const error = await runTagInSandbox({
-      pluginSource: nodeOSTag,
-      tagName: 'g',
-      envelope: envelope([]),
-      bridge: neverSettles,
-      timeoutMs: 50,
-    }).catch((e: unknown) => e);
-    // Today this is QuickJS's own internal "Aborted(Assertion failed: list_empty(&rt->gc_obj_list) …
-    // JS_FreeRuntime)" — an engine-level invariant violation raised while freeing a runtime that still
-    // has a live (never-settled) promise/job in it — not the intended "Template tag sandbox timed
-    // out" message. Update this assertion once the timeout path is made safe to call with a bridge
-    // call still outstanding.
-    expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toMatch(/gc_obj_list|JS_FreeRuntime|Aborted/);
+  // runTagInSandbox's `finally` runs whenever drivePromiseToString gives up — including on its own
+  // timeout — regardless of whether a __hostBridge call the guest is still awaiting has settled.
+  // Before the fix, disposing a context with a live bridge call left a promise/continuation
+  // referenced inside the runtime, and freeing that runtime crashed the QuickJS engine outright
+  // ("Aborted(Assertion failed: list_empty(&rt->gc_obj_list) ... JS_FreeRuntime)") instead of raising
+  // the intended timeout error. drivePromiseToString now force-settles any outstanding bridge calls
+  // (forceSettlePendingBridgeCalls) before giving up, so this reproduces as a clean, catchable error.
+  it('a bridge call that never resolves produces a clean timeout error, not an engine crash', async () => {
+    const capture = captureUnhandledRejections();
+    try {
+      const neverSettles: HostBridge = () => new Promise(() => {});
+      await expect(
+        runTagInSandbox({
+          pluginSource: nodeOSTag,
+          tagName: 'g',
+          envelope: envelope([]),
+          bridge: neverSettles,
+          timeoutMs: 50,
+        }),
+      ).rejects.toThrow('Template tag sandbox timed out');
+      expect(capture.seen).toHaveLength(0);
+    } finally {
+      capture.stop();
+    }
   });
 
   it('does not corrupt the shared WASM module for a later, unrelated render', async () => {
@@ -73,28 +77,38 @@ describe('disposing a context with an unsettled bridge call still pending', () =
     expect(actual).toBe('still-fine');
   });
 
-  it('a bridge handler returning a non-JSON-serializable value additionally raises a process-level unhandled rejection', async () => {
+  it('a bridge call resolving after the sandbox already gave up on it does not crash or leak an unhandled rejection', async () => {
+    const capture = captureUnhandledRejections();
+    try {
+      const bridge = createMapBridge({
+        nodeOS: () => new Promise(resolve => setTimeout(() => resolve({ arch: 'x64' }), 300)),
+      });
+      await expect(
+        runTagInSandbox({ pluginSource: nodeOSTag, tagName: 'g', envelope: envelope([]), bridge, timeoutMs: 50 }),
+      ).rejects.toThrow('Template tag sandbox timed out');
+      // The mocked handler above resolves ~250ms after runTagInSandbox already gave up and disposed
+      // its context. settleBridgeResult (plugin-tag-sandbox.ts) no-ops once ctx is no longer alive, so
+      // that late resolution must not surface as anything — give it time to actually land first.
+      await new Promise(resolve => setTimeout(resolve, 400));
+      expect(capture.seen).toHaveLength(0);
+    } finally {
+      capture.stop();
+    }
+  });
+
+  it('a bridge handler returning a non-JSON-serializable value surfaces as a normal tag error, not an unhandled rejection', async () => {
     const capture = captureUnhandledRejections();
     try {
       const circular: Record<string, unknown> = {};
       circular.self = circular;
       const bridge = createMapBridge({ nodeOS: async () => circular });
-      // encodeBridgeSuccess(value) (marshal.ts) calls JSON.stringify(value) inside
-      // installHostBridge's settle continuation, which has no .catch() and nothing awaits it — so a
-      // circular value throws there and becomes an unhandled rejection, distinct from (and in addition
-      // to) the deferred promise never settling, which separately trips the same timeout-path crash
-      // as the previous tests once the sandbox's own timeout elapses.
-      const pending = runTagInSandbox({
-        pluginSource: nodeOSTag,
-        tagName: 'g',
-        envelope: envelope([]),
-        bridge,
-        timeoutMs: 100,
-      });
-      await new Promise(resolve => setTimeout(resolve, 30));
-      expect(capture.seen).toHaveLength(1);
-      expect(String((capture.seen[0] as Error)?.message ?? capture.seen[0])).toMatch(/circular/i);
-      await expect(pending).rejects.toThrow(/gc_obj_list|JS_FreeRuntime|Aborted/);
+      // encodeBridgeSuccess(value) (marshal.ts) throwing on a circular value is now caught by
+      // settleBridgeResult and turned into an ordinary bridge failure instead of an unhandled
+      // rejection — the render fails fast with a catchable error, no timeout needed.
+      await expect(
+        runTagInSandbox({ pluginSource: nodeOSTag, tagName: 'g', envelope: envelope([]), bridge, timeoutMs: 2000 }),
+      ).rejects.toThrow(/circular/i);
+      expect(capture.seen).toHaveLength(0);
     } finally {
       capture.stop();
     }

--- a/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
+++ b/packages/insomnia/src/templating/sandbox/plugin-tag-sandbox.ts
@@ -57,6 +57,10 @@ export const runTagInSandbox = async (opts: RunTagInSandboxOptions): Promise<str
   const QuickJS = await getQuickJSModule();
   const ctx = QuickJS.newContext();
   const deadline = Date.now() + timeoutMs;
+  // Bridge calls this run has initiated but not yet gotten a real response for. Tracked so a
+  // timeout can force them to a settled state before disposing — otherwise the still-pending
+  // promise/continuation is live when the context's runtime is freed, which crashes the engine.
+  const pendingBridgeCalls = new Set<ReturnType<QuickJSContext['newPromise']>>();
 
   // Single-file convenience: synthesize a one-entry module map from pluginSource when the caller
   // didn't pass a multi-file map. The in-sandbox loader always resolves the entry from the map.
@@ -78,7 +82,7 @@ export const runTagInSandbox = async (opts: RunTagInSandboxOptions): Promise<str
     // sandbox global, see SANDBOX_INTERNAL_GLOBALS) and wire up a context of its own. Swapping in a
     // rejecting bridge here means any such attempt fails inside the sandbox instead of reaching the
     // real host, no matter how it's invoked.
-    installHostBridge(ctx, discover ? rejectingBridge : bridge);
+    installHostBridge(ctx, discover ? rejectingBridge : bridge, pendingBridgeCalls);
     installHostConsole(ctx, onConsole);
     installHostCrypto(ctx, opts.hostCrypto);
 
@@ -106,8 +110,9 @@ export const runTagInSandbox = async (opts: RunTagInSandboxOptions): Promise<str
           : RUNNER;
     evalOrThrow(ctx, runner, '<runner>');
 
-    return await drivePromiseToString(ctx, timeoutMs);
+    return await drivePromiseToString(ctx, timeoutMs, pendingBridgeCalls);
   } finally {
+    forceSettlePendingBridgeCalls(ctx, pendingBridgeCalls);
     ctx.dispose();
   }
 };
@@ -118,7 +123,11 @@ const rejectingBridge: HostBridge = async path => {
 };
 
 /** Register `__hostBridge(path, bodyJson)` returning a VM promise resolved from async host work. */
-const installHostBridge = (ctx: QuickJSContext, bridge: HostBridge): void => {
+const installHostBridge = (
+  ctx: QuickJSContext,
+  bridge: HostBridge,
+  pending: Set<ReturnType<QuickJSContext['newPromise']>>,
+): void => {
   const fn = ctx.newFunction('__hostBridge', (pathHandle, bodyHandle) => {
     const path = ctx.getString(pathHandle);
     let body: unknown;
@@ -128,17 +137,76 @@ const installHostBridge = (ctx: QuickJSContext, bridge: HostBridge): void => {
       body = {};
     }
     const deferred = ctx.newPromise();
+    pending.add(deferred);
     Promise.resolve()
       .then(() => bridge(path, body))
       .then(
-        value => resolveWithString(ctx, deferred, encodeBridgeSuccess(value)),
-        err => resolveWithString(ctx, deferred, encodeBridgeFailure(err)),
-      );
-    // The settled VM promise schedules a job; pump it so the awaiting sandbox code resumes.
-    deferred.settled.then(() => ctx.runtime.executePendingJobs());
+        value => settleBridgeResult(ctx, deferred, () => encodeBridgeSuccess(value)),
+        err => settleBridgeResult(ctx, deferred, () => encodeBridgeFailure(err)),
+      )
+      .finally(() => pending.delete(deferred));
+    // The settled VM promise schedules a job; pump it so the awaiting sandbox code resumes. Only if
+    // the context is still around — forceSettlePendingBridgeCalls may have already settled (and the
+    // finally above's real settlement above found) this same deferred after the context was disposed.
+    deferred.settled.then(() => {
+      if (ctx.alive) {
+        ctx.runtime.executePendingJobs();
+      }
+    });
     return deferred.handle;
   });
   setGlobal(ctx, '__hostBridge', fn);
+};
+
+/**
+ * Delivers a bridge result to the VM, tolerating two things that would otherwise escape as a
+ * process-level unhandled rejection instead of a tag-visible error: the context having already been
+ * disposed (the sandbox gave up on this render before the bridge call got a real response) and a
+ * return value that isn't JSON-serializable (encode() throwing, e.g. on a circular reference).
+ */
+const settleBridgeResult = (
+  ctx: QuickJSContext,
+  deferred: ReturnType<QuickJSContext['newPromise']>,
+  encode: () => string,
+): void => {
+  if (!ctx.alive || !deferred.alive) {
+    return;
+  }
+  let json: string;
+  try {
+    json = encode();
+  } catch (err) {
+    json = encodeBridgeFailure(err);
+  }
+  resolveWithString(ctx, deferred, json);
+};
+
+/**
+ * Forces any bridge call this render initiated but never got a real response to into a settled
+ * state, then drains the resulting jobs. Without this, a bridge call still pending when the sandbox
+ * gives up (e.g. on timeout) leaves a live promise/continuation referenced inside the context's
+ * runtime — freeing that runtime (ctx.dispose(), below) then trips a fatal QuickJS engine assertion
+ * instead of cleanly discarding the render. Loops (bounded) in case settling one call's continuation
+ * synchronously starts another.
+ */
+const forceSettlePendingBridgeCalls = (
+  ctx: QuickJSContext,
+  pending: Set<ReturnType<QuickJSContext['newPromise']>>,
+): void => {
+  let guard = 0;
+  while (pending.size > 0 && guard++ < 10) {
+    const outstanding = Array.from(pending);
+    pending.clear();
+    for (const deferred of outstanding) {
+      if (deferred.alive) {
+        ctx.newError('Template tag sandbox disposed before this host bridge call settled').consume(deferred.reject);
+      }
+    }
+    let rounds = 0;
+    while (ctx.runtime.hasPendingJob() && rounds++ < 50) {
+      ctx.runtime.executePendingJobs();
+    }
+  }
 };
 
 /**
@@ -187,7 +255,11 @@ const installHostConsole = (ctx: QuickJSContext, onConsole?: (level: string, mes
  * Drive `globalThis.__task` (a VM promise) to completion, interleaving VM jobs with the host event
  * loop so pending bridge work can run, and marshal its resolved string out.
  */
-const drivePromiseToString = async (ctx: QuickJSContext, timeoutMs: number): Promise<string> => {
+const drivePromiseToString = async (
+  ctx: QuickJSContext,
+  timeoutMs: number,
+  pendingBridgeCalls: Set<ReturnType<QuickJSContext['newPromise']>>,
+): Promise<string> => {
   const taskHandle = ctx.getProp(ctx.global, '__task');
   const resultPromise = ctx.resolvePromise(taskHandle);
   taskHandle.dispose();
@@ -204,6 +276,20 @@ const drivePromiseToString = async (ctx: QuickJSContext, timeoutMs: number): Pro
       break;
     }
     if (Date.now() > deadline) {
+      // __task may still be awaiting a bridge call that never got (or won't get in time) a real
+      // response. Force it to a settled state and let that propagate before giving up — otherwise
+      // __task's own promise/continuation, and the dup'd handle resolvePromise's reaction wraps it
+      // in once it does settle, are both still live when the context is disposed, which crashes the
+      // engine (see forceSettlePendingBridgeCalls). One extra microtask turn lets resultPromise's own
+      // .then() above (which is how `settled` gets assigned) actually run.
+      forceSettlePendingBridgeCalls(ctx, pendingBridgeCalls);
+      await Promise.resolve();
+      const forced = settled as Awaited<typeof resultPromise> | undefined;
+      if (forced?.error) {
+        forced.error.dispose();
+      } else if (forced?.value) {
+        forced.value.dispose();
+      }
       throw new Error('Template tag sandbox timed out');
     }
     // Yield to the host loop so bridge promises settle and microtasks (incl. resultPromise) drain.


### PR DESCRIPTION
## What this PR does 
This PR adds two sandbox fixes: 
* `runTagInSandbox` unconditionally disposed its QuickJS context, including when the sandbox's own timeout fired while a `__hostBridge` call (any granted async capability i.e `network`, `fs-read`, `storage`, etc.) was still outstanding. That left a live promise/continuation referenced inside the runtime, and freeing it tripped a fatal QuickJS engine assertion (`JS_FreeRuntime`'s list_empty(`&rt`->`gc_obj_list`) check) instead of the intended "Template tag sandbox timed out" error. Reachable by any plugin capability that's simply slow.
* A bridge handler returning a non-JSON-serializable value (e.g. a circular reference) escaped as a process-level unhandled rejection instead of a catchable tag error.

## Fix
* Track in-flight bridge calls per render (`pendingBridgeCalls`).
*  Force-settle them (reject + drain pending jobs) before disposing the `context`, on timeout and as a finally-block backstop.
* Guard the bridge settle continuation so a call resolving after the `context` is already gone, or a non-serializable return value, surfaces as a normal tag error instead of an unhandled rejection.

No change to the error message callers see on timeout.

## Test plan
- [x] `packages/insomnia/src/templating/sandbox/async-boundary.regression.test.ts` rewritten to assert the fixed behavior.
- [x] Full sandbox suite: 14 files / 177 tests pass.
- [x] Full package suite: 157 files / 2255 tests pass.
- [x] eslint / tsc --noEmit clean.
- [x] Independently re-verified with a negative control (reverting source file reproduces the old crash; restoring it passes again).