### PR TITLE
fix: pressing Enter within a modal triggers primary CTA properly

### DIFF
--- a/packages/insomnia/src/ui/components/git-credentials/git-repository-select.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/git-repository-select.tsx
@@ -69,12 +69,7 @@ export const GitRepositorySelect = ({
           id: repo.cloneUrl,
           name: repo.fullName,
         }))}
-        // Not "focus": that opens the menu whenever the field is focused for ANY
-        // reason, including native form-validation grabbing focus on an invalid
-        // submit — which would pop the menu open instead of just showing the
-        // inline error. Typing still opens/filters it, and the caret button (an
-        // explicit trigger, independent of menuTrigger) still opens it on click.
-        menuTrigger="input"
+        menuTrigger="input" // focus causes the dropdown to open when no option is selected and scan for files is clicked, which is not the desired behaviour.
         defaultFilter={(repoName: string, inputValue: string) =>
           Boolean(fuzzyMatch(inputValue, repoName, { splitSpace: true, loose: false })?.indexes)
         }

--- a/packages/insomnia/src/ui/components/git-credentials/git-repository-select.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/git-repository-select.tsx
@@ -69,7 +69,12 @@ export const GitRepositorySelect = ({
           id: repo.cloneUrl,
           name: repo.fullName,
         }))}
-        menuTrigger="focus"
+        // Not "focus": that opens the menu whenever the field is focused for ANY
+        // reason, including native form-validation grabbing focus on an invalid
+        // submit — which would pop the menu open instead of just showing the
+        // inline error. Typing still opens/filters it, and the caret button (an
+        // explicit trigger, independent of menuTrigger) still opens it on click.
+        menuTrigger="input"
         defaultFilter={(repoName: string, inputValue: string) =>
           Boolean(fuzzyMatch(inputValue, repoName, { splitSpace: true, loose: false })?.indexes)
         }

--- a/packages/insomnia/src/ui/components/modals/add-request-to-collection-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/add-request-to-collection-modal.tsx
@@ -13,6 +13,8 @@ import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
 import { Icon } from '../icon';
 
+const FORM_ID = 'add-request-to-collection-form';
+
 interface AddRequestModalProps extends ModalProps {
   onHide: () => void;
 }
@@ -87,58 +89,68 @@ export const AddRequestToCollectionModal: FC<AddRequestModalProps> = ({ onHide }
       <Modal onHide={onHide} ref={modalRef}>
         <ModalHeader>Add Request</ModalHeader>
         <ModalBody className="wide">
-          <div className="form-control form-control--outlined">
-            <label>
-              {strings.project.plural}:
-              <select name="projectId" value={selectedProjectId} onChange={e => setSelectedProjectId(e.target.value)}>
-                {projectOptions.map(project => (
-                  <option key={project._id} value={project._id}>
-                    {project.name}
-                    {project._id === currentProjectId && ' (current)'}
-                  </option>
-                ))}
-              </select>
-            </label>
-          </div>
-          {!selectedProjectId && (
-            <p
-              className="margin-top-sm"
-              style={{
-                color: 'var(--color-danger)',
-              }}
-            >
-              Project is required
-            </p>
-          )}
-
-          <div className="form-control form-control--outlined">
-            <label>
-              {strings.collection.plural}:
-              <select
-                aria-label="Select Workspace"
-                name="workspaceId"
-                value={selectedWorkspaceId}
-                onChange={e => setSelectedWorkspaceId(e.target.value)}
+          <form
+            id={FORM_ID}
+            onSubmit={e => {
+              e.preventDefault();
+              if (!isBtnDisabled) {
+                createNewRequest();
+              }
+            }}
+          >
+            <div className="form-control form-control--outlined">
+              <label>
+                {strings.project.plural}:
+                <select autoFocus name="projectId" value={selectedProjectId} onChange={e => setSelectedProjectId(e.target.value)}>
+                  {projectOptions.map(project => (
+                    <option key={project._id} value={project._id}>
+                      {project.name}
+                      {project._id === currentProjectId && ' (current)'}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+            {!selectedProjectId && (
+              <p
+                className="margin-top-sm"
+                style={{
+                  color: 'var(--color-danger)',
+                }}
               >
-                {workspaceOptions.map(workspace => (
-                  <option aria-label={workspace.name} key={workspace._id} value={workspace._id}>
-                    {workspace.name}
-                    {workspace._id === currentWorkspaceId && ' (current)'}
-                  </option>
-                ))}
-              </select>
-            </label>
-          </div>
-          {!selectedWorkspaceId && (
-            <p
-              className="margin-top-sm"
-              style={{
-                color: 'var(--color-danger)',
-              }}
-            >
-              Collection is required
-            </p>
-          )}
+                Project is required
+              </p>
+            )}
+
+            <div className="form-control form-control--outlined">
+              <label>
+                {strings.collection.plural}:
+                <select
+                  aria-label="Select Workspace"
+                  name="workspaceId"
+                  value={selectedWorkspaceId}
+                  onChange={e => setSelectedWorkspaceId(e.target.value)}
+                >
+                  {workspaceOptions.map(workspace => (
+                    <option aria-label={workspace.name} key={workspace._id} value={workspace._id}>
+                      {workspace.name}
+                      {workspace._id === currentWorkspaceId && ' (current)'}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+            {!selectedWorkspaceId && (
+              <p
+                className="margin-top-sm"
+                style={{
+                  color: 'var(--color-danger)',
+                }}
+              >
+                Collection is required
+              </p>
+            )}
+          </form>
         </ModalBody>
         <ModalFooter>
           <div>
@@ -149,7 +161,7 @@ export const AddRequestToCollectionModal: FC<AddRequestModalProps> = ({ onHide }
             >
               Cancel
             </button>
-            <button disabled={isBtnDisabled} form="workspace-duplicate-form" className="btn" onClick={createNewRequest}>
+            <button disabled={isBtnDisabled} type="submit" form={FORM_ID} className="btn">
               {requestFetcher.state !== 'idle' && <Icon icon="spinner" className="animate-spin" />} Add
             </button>
           </div>

--- a/packages/insomnia/src/ui/components/modals/add-request-to-collection-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/add-request-to-collection-modal.tsx
@@ -1,7 +1,7 @@
 import type { BaseModel } from 'insomnia-data';
 import { models, services } from 'insomnia-data';
 import { strings } from 'insomnia-data/common';
-import React, { type FC, type MouseEventHandler, useEffect, useRef, useState } from 'react';
+import React, { type FC, type MouseEventHandler, useEffect, useId, useRef, useState } from 'react';
 import { OverlayContainer } from 'react-aria';
 import { useParams } from 'react-router';
 
@@ -12,8 +12,6 @@ import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
 import { Icon } from '../icon';
-
-const FORM_ID = 'add-request-to-collection-form';
 
 interface AddRequestModalProps extends ModalProps {
   onHide: () => void;
@@ -35,6 +33,7 @@ export const AddRequestToCollectionModal: FC<AddRequestModalProps> = ({ onHide }
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState('');
 
   const requestFetcher = useRequestNewActionFetcher();
+  const formId = useId();
 
   useEffect(() => {
     (async () => {
@@ -90,7 +89,7 @@ export const AddRequestToCollectionModal: FC<AddRequestModalProps> = ({ onHide }
         <ModalHeader>Add Request</ModalHeader>
         <ModalBody className="wide">
           <form
-            id={FORM_ID}
+            id={formId}
             onSubmit={e => {
               e.preventDefault();
               if (!isBtnDisabled) {
@@ -161,7 +160,7 @@ export const AddRequestToCollectionModal: FC<AddRequestModalProps> = ({ onHide }
             >
               Cancel
             </button>
-            <button disabled={isBtnDisabled} type="submit" form={FORM_ID} className="btn">
+            <button disabled={isBtnDisabled} type="submit" form={formId} className="btn">
               {requestFetcher.state !== 'idle' && <Icon icon="spinner" className="animate-spin" />} Add
             </button>
           </div>

--- a/packages/insomnia/src/ui/components/modals/cloud-credential-modal/cloud-credential-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/cloud-credential-modal/cloud-credential-modal.tsx
@@ -183,8 +183,7 @@ export const CloudCredentialModal = (props: CloudCredentialModalProps) => {
                       URL in Azure to here.
                     </p>
                     <Form
-                      className="form-control form-control--outlined no-pad-top"
-                      style={{ display: 'flex' }}
+                      className="form-control form-control--outlined no-pad-top flex"
                       onSubmit={e => {
                         e.preventDefault();
                         exchangeAzureCode();

--- a/packages/insomnia/src/ui/components/modals/cloud-credential-modal/cloud-credential-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/cloud-credential-modal/cloud-credential-modal.tsx
@@ -1,7 +1,7 @@
 import type { CloudProviderCredential } from 'insomnia-data';
 import { models } from 'insomnia-data';
 import React, { useEffect, useState } from 'react';
-import { Button, Dialog, Heading, Modal, ModalOverlay } from 'react-aria-components';
+import { Button, Dialog, Form, Heading, Modal, ModalOverlay } from 'react-aria-components';
 
 import { useUpdateCloudCredentialActionFetcher } from '~/routes/cloud-credentials.$cloudCredentialId.update';
 import { useCreateCloudCredentialActionFetcher } from '~/routes/cloud-credentials.create';
@@ -182,8 +182,16 @@ export const CloudCredentialModal = (props: CloudCredentialModalProps) => {
                       If your browser does not open the Insomnia app automatically you can manually paste the redirect
                       URL in Azure to here.
                     </p>
-                    <div className="form-control form-control--outlined no-pad-top" style={{ display: 'flex' }}>
+                    <Form
+                      className="form-control form-control--outlined no-pad-top"
+                      style={{ display: 'flex' }}
+                      onSubmit={e => {
+                        e.preventDefault();
+                        exchangeAzureCode();
+                      }}
+                    >
                       <input
+                        autoFocus
                         type="text"
                         className="mr-(--padding-sm)"
                         placeholder="Manually paste the authentication url if you are not redirected"
@@ -193,7 +201,6 @@ export const CloudCredentialModal = (props: CloudCredentialModalProps) => {
                         className="btn btn--super-compact btn--outlined flex items-center gap-(--padding-xs)"
                         type="submit"
                         disabled={isAuthenticating}
-                        onClick={exchangeAzureCode}
                       >
                         <Icon
                           icon={isAuthenticating ? 'spinner' : 'sign-in'}
@@ -201,7 +208,7 @@ export const CloudCredentialModal = (props: CloudCredentialModalProps) => {
                         />
                         Auth
                       </button>
-                    </div>
+                    </Form>
                   </div>
                   {error && <p className="notice error margin-bottom-sm w-full">{error}</p>}
                 </div>

--- a/packages/insomnia/src/ui/components/modals/git-pull-required-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-pull-required-modal.tsx
@@ -51,6 +51,7 @@ export const GitPullRequiredModal = ({ title, message, okLabel, onConfirm, onClo
                   Cancel
                 </Button>
                 <Button
+                  autoFocus
                   className="flex h-full items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
                   onPress={() => {
                     if (typeof onConfirm === 'function') {

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -627,7 +627,6 @@ const ScanResourcesForm = ({
 };
 
 const DEFAULT_NEW_PROJECT_NAME = 'New Project';
-const IMPORT_FORM_ID = 'import-resources-form';
 
 const ImportResourcesForm = ({
   onImport,
@@ -653,6 +652,7 @@ const ImportResourcesForm = ({
     organizationId: string;
     projectId: string;
   };
+  const formId = useId();
   const [overrideBaseEnvironmentData, setOverrideBaseEnvironmentData] = useState(true);
   const workspacesFetcher = useProjectListWorkspacesLoaderFetcher();
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState('');
@@ -700,7 +700,7 @@ const ImportResourcesForm = ({
   return (
     <Fragment>
       <Form
-        id={IMPORT_FORM_ID}
+        id={formId}
         className="flex max-h-[50vh] flex-col gap-(--padding-md) overflow-auto"
         onSubmit={e => {
           e.preventDefault();
@@ -806,7 +806,7 @@ const ImportResourcesForm = ({
       <div className="flex w-full items-end justify-end gap-(--padding-sm)">
         <Button
           type="submit"
-          form={IMPORT_FORM_ID}
+          form={formId}
           variant="contained"
           bg="surprise"
           disabled={disabled || loading}

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -3,7 +3,7 @@ import { formatDistanceToNowStrict } from 'date-fns';
 import { models } from 'insomnia-data';
 import React, { type FC, Fragment, type ReactNode, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { type DirectoryDropItem, type FileDropItem, OverlayContainer, useDrop } from 'react-aria';
-import { Heading, Link } from 'react-aria-components';
+import { Form, Heading, Link } from 'react-aria-components';
 import { useNavigate, useParams } from 'react-router';
 
 import { isNotNullOrUndefined } from '~/common/misc';
@@ -627,6 +627,7 @@ const ScanResourcesForm = ({
 };
 
 const DEFAULT_NEW_PROJECT_NAME = 'New Project';
+const IMPORT_FORM_ID = 'import-resources-form';
 
 const ImportResourcesForm = ({
   onImport,
@@ -687,9 +688,27 @@ const ImportResourcesForm = ({
         .filter(isNotNullOrUndefined)
         .filter(w => w.scope === 'collection' || w.scope === 'design') || [];
   const shouldShowWorkspaceSelect = !scanResults.some(requiresNewWorkspace) && workspacesForActiveProject.length > 0;
+
+  const handleImport = () =>
+    onImport(
+      overrideBaseEnvironmentData,
+      selectedProjectId,
+      selectedWorkspaceId,
+      selectedNewProject ? newProjectName || 'New Project' : undefined,
+    );
+
   return (
     <Fragment>
-      <div className="flex max-h-[50vh] flex-col gap-(--padding-md) overflow-auto">
+      <Form
+        id={IMPORT_FORM_ID}
+        className="flex max-h-[50vh] flex-col gap-(--padding-md) overflow-auto"
+        onSubmit={e => {
+          e.preventDefault();
+          if (!disabled && !loading) {
+            handleImport();
+          }
+        }}
+      >
         <div className="overflow-y-auto">
           <ScanResultsTable scanResults={scanResults} />
           <div className="form-row mt-2">
@@ -697,6 +716,7 @@ const ImportResourcesForm = ({
               <label>
                 Select Project:
                 <select
+                  autoFocus
                   aria-label="Select Project"
                   name="projectId"
                   value={selectedProjectId}
@@ -781,21 +801,15 @@ const ImportResourcesForm = ({
             </div>
           )}
         </div>
-      </div>
+      </Form>
 
       <div className="flex w-full items-end justify-end gap-(--padding-sm)">
         <Button
+          type="submit"
+          form={IMPORT_FORM_ID}
           variant="contained"
           bg="surprise"
           disabled={disabled || loading}
-          onClick={() =>
-            onImport(
-              overrideBaseEnvironmentData,
-              selectedProjectId,
-              selectedWorkspaceId,
-              selectedNewProject ? newProjectName || 'New Project' : undefined,
-            )
-          }
           className="btn h-10 gap-(--padding-sm)"
         >
           {loading ? (

--- a/packages/insomnia/src/ui/components/modals/konnect-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/konnect-settings-modal.tsx
@@ -174,6 +174,7 @@ export const KonnectSettingsModal = ({
                         Enter a Personal Access Token (PAT) to sync your Konnect control planes into Insomnia projects.
                       </p>
                       <button
+                        type="button"
                         className="w-fit text-sm text-(--hl) underline hover:opacity-80"
                         onClick={() => window.main.openInBrowser('https://cloud.konghq.com/global/account/tokens')}
                       >

--- a/packages/insomnia/src/ui/components/modals/konnect-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/konnect-settings-modal.tsx
@@ -1,6 +1,6 @@
 import { services } from 'insomnia-data';
 import { useEffect, useState } from 'react';
-import { Button, Dialog, Heading, Modal, ModalOverlay } from 'react-aria-components';
+import { Button, Dialog, Form, Heading, Modal, ModalOverlay } from 'react-aria-components';
 
 import { database } from '~/common/database';
 import { fetchKonnectOrganizationId, validatePat } from '~/konnect/api';
@@ -23,6 +23,7 @@ export const KonnectSettingsModal = ({
   const patchSettings = useSettingsPatcher();
 
   const [pat, setPat] = useState('');
+  const [connectedPat, setConnectedPat] = useState(''); // The last PAT known to be connected, so we can tell if pat state above was actually edited.
   const [isPatVisible, setIsPatVisible] = useState(false);
   // 'idle' | 'validating' | 'valid' | 'invalid'
   const [status, setStatus] = useState<'idle' | 'validating' | 'valid' | 'invalid'>('idle');
@@ -54,6 +55,7 @@ export const KonnectSettingsModal = ({
       window.main.secretStorage.getSecret('konnectPat').then(secret => {
         if (secret) {
           setPat(secret);
+          setConnectedPat(secret);
         }
       });
     }
@@ -73,6 +75,7 @@ export const KonnectSettingsModal = ({
       return;
     }
     await window.main.secretStorage.setSecret('konnectPat', trimmed);
+    setConnectedPat(trimmed);
     patchSettings({ hasKonnectPat: true, konnectOrganizationId: orgId ?? null });
     syncKonnectProjectsAndNotifyRef.current(orgId ?? null);
     onClose();
@@ -102,6 +105,7 @@ export const KonnectSettingsModal = ({
   };
 
   const hasStoredPat = settings.hasKonnectPat && status !== 'invalid';
+  const isPatUnchanged = hasStoredPat && pat.trim() === connectedPat.trim();
 
   return (
     <ModalOverlay
@@ -154,7 +158,13 @@ export const KonnectSettingsModal = ({
                   </div>
                 </>
               ) : (
-                <>
+                <Form
+                  className="contents"
+                  onSubmit={e => {
+                    e.preventDefault();
+                    handleConnect();
+                  }}
+                >
                   <div className="flex flex-col gap-3">
                     <div className="flex flex-col gap-1">
                       <label className="text-sm font-semibold" htmlFor="konnect-modal-pat">
@@ -172,6 +182,7 @@ export const KonnectSettingsModal = ({
                     </div>
                     <div className="relative">
                       <input
+                        autoFocus
                         id="konnect-modal-pat"
                         type={isPatVisible ? 'text' : 'password'}
                         className="w-full rounded-xs border border-solid border-(--hl-sm) bg-(--color-bg) px-2 py-1.5 pr-8 text-(--color-font) focus:border-(--hl-lg) focus:outline-hidden"
@@ -208,9 +219,9 @@ export const KonnectSettingsModal = ({
 
                   <div className="flex items-center gap-2">
                     <Button
+                      type="submit"
                       className="rounded-xs border border-solid border-(--hl-sm) px-3 py-1.5 text-sm text-(--color-font) hover:bg-(--hl-xs) disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
-                      isDisabled={!pat.trim() || status === 'validating'}
-                      onPress={handleConnect}
+                      isDisabled={!pat.trim() || status === 'validating' || isPatUnchanged}
                     >
                       {status === 'validating' ? <Icon icon="spinner" className="animate-spin" /> : 'Connect & Sync'}
                     </Button>
@@ -224,7 +235,7 @@ export const KonnectSettingsModal = ({
                       </Button>
                     )}
                   </div>
-                </>
+                </Form>
               )}
             </div>
           )}

--- a/packages/insomnia/src/ui/components/modals/select-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/select-modal.tsx
@@ -1,12 +1,10 @@
-import React, { forwardRef, useImperativeHandle, useRef, useState } from 'react';
+import React, { forwardRef, useId, useImperativeHandle, useRef, useState } from 'react';
 
 import { Modal, type ModalHandle, type ModalProps } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
 import { showModal } from '.';
-
-const FORM_ID = 'select-modal-form';
 
 export interface SelectModalOptions {
   message: string | null;
@@ -25,6 +23,7 @@ export interface SelectModalHandle {
 
 export const SelectModal = forwardRef<SelectModalHandle, ModalProps>((_, ref) => {
   const modalRef = useRef<ModalHandle>(null);
+  const formId = useId();
   const [state, setState] = useState<SelectModalOptions>({
     message: null,
     options: [],
@@ -58,7 +57,7 @@ export const SelectModal = forwardRef<SelectModalHandle, ModalProps>((_, ref) =>
       <ModalBody className="wide pad" data-testid="global-select-modal">
         <p>{message}</p>
         <form
-          id={FORM_ID}
+          id={formId}
           className="form-control form-control--outlined"
           onSubmit={e => {
             e.preventDefault();
@@ -79,7 +78,7 @@ export const SelectModal = forwardRef<SelectModalHandle, ModalProps>((_, ref) =>
         </form>
       </ModalBody>
       <ModalFooter>
-        <button type="submit" form={FORM_ID} className="btn">
+        <button type="submit" form={formId} className="btn">
           Done
         </button>
       </ModalFooter>

--- a/packages/insomnia/src/ui/components/modals/select-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/select-modal.tsx
@@ -6,6 +6,8 @@ import { ModalFooter } from '../base/modal-footer';
 import { ModalHeader } from '../base/modal-header';
 import { showModal } from '.';
 
+const FORM_ID = 'select-modal-form';
+
 export interface SelectModalOptions {
   message: string | null;
   onDone?: (selectedValue: string | null) => void | Promise<void>;
@@ -45,13 +47,26 @@ export const SelectModal = forwardRef<SelectModalHandle, ModalProps>((_, ref) =>
   );
   const { message, title, options, value, onDone } = state;
 
+  const handleDone = () => {
+    modalRef.current?.hide();
+    onDone?.(value);
+  };
+
   return (
     <Modal ref={modalRef}>
       <ModalHeader>{title || 'Confirm?'}</ModalHeader>
       <ModalBody className="wide pad" data-testid="global-select-modal">
         <p>{message}</p>
-        <div className="form-control form-control--outlined">
+        <form
+          id={FORM_ID}
+          className="form-control form-control--outlined"
+          onSubmit={e => {
+            e.preventDefault();
+            handleDone();
+          }}
+        >
           <select
+            autoFocus
             onChange={event => setState(state => ({ ...state, value: event.target.value }))}
             value={value ?? undefined}
           >
@@ -61,16 +76,10 @@ export const SelectModal = forwardRef<SelectModalHandle, ModalProps>((_, ref) =>
               </option>
             ))}
           </select>
-        </div>
+        </form>
       </ModalBody>
       <ModalFooter>
-        <button
-          className="btn"
-          onClick={() => {
-            modalRef.current?.hide();
-            onDone?.(value);
-          }}
-        >
+        <button type="submit" form={FORM_ID} className="btn">
           Done
         </button>
       </ModalFooter>

--- a/packages/insomnia/src/ui/components/modals/variable-missing-error-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/variable-missing-error-modal.tsx
@@ -50,6 +50,7 @@ export const VariableMissingErrorModal = ({
                 {cancelText || 'Cancel'}
               </Button>
               <Button
+                autoFocus
                 className="flex items-center gap-2 rounded-xs border border-solid border-(--hl-md) bg-(--color-surprise) px-3 py-2 text-(--color-font-surprise) transition-colors hover:bg-(--color-surprise)/90 hover:no-underline"
                 onPress={onOk}
               >

--- a/packages/insomnia/src/ui/components/project/git-repo-form.tsx
+++ b/packages/insomnia/src/ui/components/project/git-repo-form.tsx
@@ -109,6 +109,8 @@ export const GitRepoForm: FC<Props> = ({
     onCredentialValidationChange?.(isCredentialInvalid);
   }, [isCredentialInvalid, onCredentialValidationChange]);
 
+  const showForm = !needToSetupCredentials && !projectData.connectRepositoryLater;
+
   return (
     <ErrorBoundary>
       <Checkbox
@@ -121,7 +123,7 @@ export const GitRepoForm: FC<Props> = ({
 
       {needToSetupCredentials && !projectData.connectRepositoryLater && <GitCredentialSetup providers={providers} />}
 
-      {!needToSetupCredentials && !projectData.connectRepositoryLater && (
+      {showForm && (
         <Form
           aria-label="Git Setup Form"
           id={formId}

--- a/packages/insomnia/src/ui/components/project/git-repo-form.tsx
+++ b/packages/insomnia/src/ui/components/project/git-repo-form.tsx
@@ -109,8 +109,6 @@ export const GitRepoForm: FC<Props> = ({
     onCredentialValidationChange?.(isCredentialInvalid);
   }, [isCredentialInvalid, onCredentialValidationChange]);
 
-  const showForm = !needToSetupCredentials && !projectData.connectRepositoryLater;
-
   return (
     <ErrorBoundary>
       <Checkbox
@@ -123,7 +121,7 @@ export const GitRepoForm: FC<Props> = ({
 
       {needToSetupCredentials && !projectData.connectRepositoryLater && <GitCredentialSetup providers={providers} />}
 
-      {showForm && (
+      {!needToSetupCredentials && !projectData.connectRepositoryLater && (
         <Form
           aria-label="Git Setup Form"
           id={formId}

--- a/packages/insomnia/src/ui/components/project/project-create-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-create-form.tsx
@@ -1,7 +1,7 @@
 import type { StorageRules } from 'insomnia-api';
 import type { GitCredentials } from 'insomnia-data';
 import type { FC } from 'react';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useId, useRef, useState } from 'react';
 import { Button, Form, Input, Label, TextField } from 'react-aria-components';
 import { useNavigate, useParams } from 'react-router';
 
@@ -14,15 +14,18 @@ import { GitRepoForm } from '~/ui/components/project/git-repo-form';
 import { GitRepoScanResult } from '~/ui/components/project/git-repo-scan-result';
 import { ProjectTypeSelect } from '~/ui/components/project/project-type-select';
 import { ProjectTypeWarning } from '~/ui/components/project/project-type-warning';
-import { deriveRepoName, getLastCloneParentDir, type ProjectData, type ProjectType, useActiveView } from '~/ui/components/project/utils';
+import {
+  deriveRepoName,
+  getLastCloneParentDir,
+  type ProjectData,
+  type ProjectType,
+  useActiveView,
+} from '~/ui/components/project/utils';
 import { useIsGitSyncEnabled } from '~/ui/hooks/use-organization-features';
 import { confirmOpenFolderTrust } from '~/ui/utils/git-folder-trust';
 import { selectFileOrFolder } from '~/ui/utils/select-file-or-folder';
 
 import { Icon } from '../icon';
-
-const FORMID = 'git-repo-form';
-const UPSERT_FORM_ID = 'project-upsert-form';
 
 interface Props {
   storageRules: StorageRules;
@@ -45,6 +48,8 @@ export const ProjectCreateForm: FC<Props> = ({
 }) => {
   const { organizationId } = useParams() as { organizationId: string };
   const navigate = useNavigate();
+  const gitFormId = useId();
+  const upsertFormId = useId();
 
   const isGitSyncEnabled = useIsGitSyncEnabled(organizationId);
 
@@ -176,51 +181,44 @@ export const ProjectCreateForm: FC<Props> = ({
   // Local/cloud projects (and the git "connect later"/"open folder" variants) create
   // directly; a fresh git clone scans the remote for files first.
   const isUpsertPrimaryAction = storageType !== 'git' || projectData.connectRepositoryLater || isGitOpen;
-  const canUpsertProject =
-    !!storageType && newProjectFetcher.state === 'idle' && !(isGitOpen && (!openExistingDir || !!existingFolderProject));
+  const isAdoptingInvalidFolder = isGitOpen && (!openExistingDir || !!existingFolderProject);
+  const canUpsertProject = !!storageType && newProjectFetcher.state === 'idle' && !isAdoptingInvalidFolder;
   const canScanForFiles = isGitSyncEnabled && !isGitCredentialInvalid;
   const canCloneAfterScan = newProjectFetcher.state === 'idle' && initCloneGitRepositoryFetcher.state === 'idle';
-
-  // React Aria's FocusScope can hand initial focus to the modal header's close
-  // button ahead of this field's `autoFocus`; claim it back once mounted.
-  const nameInputRef = useRef<HTMLInputElement>(null);
-  useEffect(() => {
-    nameInputRef.current?.focus();
-  }, []);
 
   // Choosing a type collapses the type list, unmounting the focused radio. The
   // child restores focus to its collapsed summary, but Enter there would just
   // reopen the list — put focus back on the name field so Enter runs the CTA.
   // Child effects run before parent effects, so this wins.
+  const nameInputRef = useRef<HTMLInputElement>(null);
   useEffect(() => {
     if (storageType) {
       nameInputRef.current?.focus();
     }
   }, [storageType]);
 
-  // The name field's correct submit-target is dynamic (Create vs. Scan for
-  // files), but that's fine inside a real <Form> — onSubmit is just a callback,
-  // it can dispatch on current state same as any other handler. This form wraps
-  // only the name field + type picker, stopping before the git-clone subtree:
-  // GitRepoForm owns its own separate, natively-submitting <Form id={FORMID}>,
-  // and nesting two <form> elements is invalid, so they must stay DOM siblings.
   const handleUpsertFormSubmit = (event: React.FormEvent) => {
     event.preventDefault();
+    // for cloud / local projects CTA trigger (create)
     if (isUpsertPrimaryAction) {
       if (canUpsertProject) {
         onUpsertProject();
       }
       return;
     }
+    // for fresh git projects CTA trigger (scan for files)
     if (canScanForFiles) {
-      (document.getElementById(FORMID) as HTMLFormElement | null)?.requestSubmit();
+      // GitRepoForm's scan logic lives inside its own <Form onSubmit>, reading
+      // field values via `new FormData(e.currentTarget)` — there's no exposed
+      // callback to call directly. requestSubmit() dispatches a real `submit`
+      // event on that form (unlike `.submit()`, which skips it entirely), so
+      // this reruns GitRepoForm's own onSubmit as if its button were clicked.
+      (document.getElementById(gitFormId) as HTMLFormElement | null)?.requestSubmit();
     }
   };
 
-  // No inputs on this results screen, so there's nothing for native form
-  // submission to key off — focus the primary action button once it's ready,
-  // same as a native "default button" convention (its own Enter-activation
-  // then just works, like any other focused button).
+  // No input fields on this results screen, so there's nothing for native form
+  // submission to key off — focus the primary action button once it's ready.
   const cloneButtonRef = useRef<HTMLButtonElement>(null);
   useEffect(() => {
     if (activeView === 'git-results' && initCloneGitRepositoryFetcher.state === 'idle') {
@@ -243,7 +241,7 @@ export const ProjectCreateForm: FC<Props> = ({
         <div
           className={`flex w-full flex-col justify-start gap-4 pb-2 text-left ${activeView === 'project' ? '' : 'hidden'}`}
         >
-          <Form id={UPSERT_FORM_ID} className="contents" onSubmit={handleUpsertFormSubmit}>
+          <Form id={upsertFormId} className="contents" onSubmit={handleUpsertFormSubmit}>
             <TextField
               autoFocus
               name="name"
@@ -290,7 +288,7 @@ export const ProjectCreateForm: FC<Props> = ({
 
               {gitMode === 'clone' ? (
                 <GitRepoForm
-                  formId={FORMID}
+                  formId={gitFormId}
                   projectData={projectData}
                   setProjectData={setProjectData}
                   initCloneGitRepositoryFetcher={initCloneGitRepositoryFetcher}
@@ -382,7 +380,7 @@ export const ProjectCreateForm: FC<Props> = ({
             {isUpsertPrimaryAction ? (
               <Button
                 type="submit"
-                form={UPSERT_FORM_ID}
+                form={upsertFormId}
                 isDisabled={!canUpsertProject}
                 className="flex h-full w-[10ch] items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
               >
@@ -392,7 +390,7 @@ export const ProjectCreateForm: FC<Props> = ({
             ) : (
               <Button
                 type="submit"
-                form={FORMID}
+                form={gitFormId}
                 isDisabled={!canScanForFiles}
                 className="flex h-full items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
               >

--- a/packages/insomnia/src/ui/components/project/project-create-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-create-form.tsx
@@ -1,8 +1,8 @@
 import type { StorageRules } from 'insomnia-api';
 import type { GitCredentials } from 'insomnia-data';
 import type { FC } from 'react';
-import React, { useEffect, useState } from 'react';
-import { Button, Input, Label, TextField } from 'react-aria-components';
+import React, { useEffect, useRef, useState } from 'react';
+import { Button, Form, Input, Label, TextField } from 'react-aria-components';
 import { useNavigate, useParams } from 'react-router';
 
 import { useGitProjectInitCloneActionFetcher } from '~/routes/git.init-clone';
@@ -22,6 +22,7 @@ import { selectFileOrFolder } from '~/ui/utils/select-file-or-folder';
 import { Icon } from '../icon';
 
 const FORMID = 'git-repo-form';
+const UPSERT_FORM_ID = 'project-upsert-form';
 
 interface Props {
   storageRules: StorageRules;
@@ -172,6 +173,61 @@ export const ProjectCreateForm: FC<Props> = ({
   const hideActionButtons =
     storageType === 'git' && gitMode === 'clone' && !projectData.connectRepositoryLater && credentials.length === 0;
 
+  // Local/cloud projects (and the git "connect later"/"open folder" variants) create
+  // directly; a fresh git clone scans the remote for files first.
+  const isUpsertPrimaryAction = storageType !== 'git' || projectData.connectRepositoryLater || isGitOpen;
+  const canUpsertProject =
+    !!storageType && newProjectFetcher.state === 'idle' && !(isGitOpen && (!openExistingDir || !!existingFolderProject));
+  const canScanForFiles = isGitSyncEnabled && !isGitCredentialInvalid;
+  const canCloneAfterScan = newProjectFetcher.state === 'idle' && initCloneGitRepositoryFetcher.state === 'idle';
+
+  // React Aria's FocusScope can hand initial focus to the modal header's close
+  // button ahead of this field's `autoFocus`; claim it back once mounted.
+  const nameInputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    nameInputRef.current?.focus();
+  }, []);
+
+  // Choosing a type collapses the type list, unmounting the focused radio. The
+  // child restores focus to its collapsed summary, but Enter there would just
+  // reopen the list — put focus back on the name field so Enter runs the CTA.
+  // Child effects run before parent effects, so this wins.
+  useEffect(() => {
+    if (storageType) {
+      nameInputRef.current?.focus();
+    }
+  }, [storageType]);
+
+  // The name field's correct submit-target is dynamic (Create vs. Scan for
+  // files), but that's fine inside a real <Form> — onSubmit is just a callback,
+  // it can dispatch on current state same as any other handler. This form wraps
+  // only the name field + type picker, stopping before the git-clone subtree:
+  // GitRepoForm owns its own separate, natively-submitting <Form id={FORMID}>,
+  // and nesting two <form> elements is invalid, so they must stay DOM siblings.
+  const handleUpsertFormSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (isUpsertPrimaryAction) {
+      if (canUpsertProject) {
+        onUpsertProject();
+      }
+      return;
+    }
+    if (canScanForFiles) {
+      (document.getElementById(FORMID) as HTMLFormElement | null)?.requestSubmit();
+    }
+  };
+
+  // No inputs on this results screen, so there's nothing for native form
+  // submission to key off — focus the primary action button once it's ready,
+  // same as a native "default button" convention (its own Enter-activation
+  // then just works, like any other focused button).
+  const cloneButtonRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    if (activeView === 'git-results' && initCloneGitRepositoryFetcher.state === 'idle') {
+      cloneButtonRef.current?.focus();
+    }
+  }, [activeView, initCloneGitRepositoryFetcher.state]);
+
   return (
     <>
       {/* Content */}
@@ -187,29 +243,32 @@ export const ProjectCreateForm: FC<Props> = ({
         <div
           className={`flex w-full flex-col justify-start gap-4 pb-2 text-left ${activeView === 'project' ? '' : 'hidden'}`}
         >
-          <TextField
-            autoFocus
-            name="name"
-            value={projectData.name}
-            onChange={name => setProjectData({ ...projectData, name })}
-            className="group relative flex flex-col gap-2 px-0.5"
-          >
-            <Label className="pt-0 text-sm text-(--color-font)">Project name</Label>
-            <Input
-              placeholder={defaultProjectName}
-              className="w-full rounded-xs border border-solid border-(--hl-sm) bg-(--color-bg) py-1 pr-7 pl-2 text-(--color-font) transition-colors placeholder:italic focus:ring-1 focus:ring-(--hl-md) focus:outline-hidden"
+          <Form id={UPSERT_FORM_ID} className="contents" onSubmit={handleUpsertFormSubmit}>
+            <TextField
+              autoFocus
+              name="name"
+              value={projectData.name}
+              onChange={name => setProjectData({ ...projectData, name })}
+              className="group relative flex flex-col gap-2 px-0.5"
+            >
+              <Label className="pt-0 text-sm text-(--color-font)">Project name</Label>
+              <Input
+                ref={nameInputRef}
+                placeholder={defaultProjectName}
+                className="w-full rounded-xs border border-solid border-(--hl-sm) bg-(--color-bg) py-1 pr-7 pl-2 text-(--color-font) transition-colors placeholder:italic focus:ring-1 focus:ring-(--hl-md) focus:outline-hidden"
+              />
+            </TextField>
+            <ProjectTypeSelect
+              storageRules={storageRules}
+              value={storageType}
+              onChange={v => setStorageType(v as ProjectType)}
             />
-          </TextField>
-          <ProjectTypeSelect
-            storageRules={storageRules}
-            value={storageType}
-            onChange={v => setStorageType(v as ProjectType)}
-          />
-          <ProjectTypeWarning
-            isGitSyncEnabled={isGitSyncEnabled}
-            storageType={storageType}
-            storageRules={storageRules}
-          />
+            <ProjectTypeWarning
+              isGitSyncEnabled={isGitSyncEnabled}
+              storageType={storageType}
+              storageRules={storageRules}
+            />
+          </Form>
           {storageType === 'git' && isGitSyncEnabled && (
             <>
               <div className="flex w-full gap-2">
@@ -320,14 +379,11 @@ export const ProjectCreateForm: FC<Props> = ({
                 Cancel
               </Button>
             )}
-            {storageType !== 'git' || projectData.connectRepositoryLater || isGitOpen ? (
+            {isUpsertPrimaryAction ? (
               <Button
-                onPress={onUpsertProject}
-                isDisabled={
-                  !storageType ||
-                  newProjectFetcher.state !== 'idle' ||
-                  (isGitOpen && (!openExistingDir || !!existingFolderProject))
-                }
+                type="submit"
+                form={UPSERT_FORM_ID}
+                isDisabled={!canUpsertProject}
                 className="flex h-full w-[10ch] items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
               >
                 {newProjectFetcher.state !== 'idle' && <Icon icon="spinner" className="animate-spin" />}
@@ -337,7 +393,7 @@ export const ProjectCreateForm: FC<Props> = ({
               <Button
                 type="submit"
                 form={FORMID}
-                isDisabled={!isGitSyncEnabled || isGitCredentialInvalid}
+                isDisabled={!canScanForFiles}
                 className="flex h-full items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
               >
                 <span>Scan for files</span>
@@ -350,7 +406,7 @@ export const ProjectCreateForm: FC<Props> = ({
       {activeView === 'git-results' && (
         <div className="flex items-center justify-end gap-2">
           <Button
-            isDisabled={newProjectFetcher.state !== 'idle' || initCloneGitRepositoryFetcher.state !== 'idle'}
+            isDisabled={!canCloneAfterScan}
             onPress={() => {
               setActiveView('project');
               setError(null);
@@ -370,6 +426,7 @@ export const ProjectCreateForm: FC<Props> = ({
             </Button>
           ) : (
             <Button
+              ref={cloneButtonRef}
               isDisabled={newProjectFetcher.state !== 'idle'}
               onPress={onUpsertProject}
               className="flex h-full items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -3,7 +3,7 @@ import type { GitCredentials, GitRepository, Project, ProviderEmail } from 'inso
 import { models } from 'insomnia-data';
 import { platform } from 'insomnia-data/common';
 import type { FC } from 'react';
-import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useEffect, useId, useMemo, useRef, useState } from 'react';
 import {
   Button,
   Form,
@@ -43,8 +43,6 @@ import { selectFileOrFolder } from '~/ui/utils/select-file-or-folder';
 import { useProjectUpdateActionFetcher } from '../../../routes/organization.$organizationId.project.$projectId.update';
 import { Icon } from '../icon';
 
-const FORMID = 'git-repo-form';
-const UPSERT_FORM_ID = 'project-upsert-form';
 const { isGitCredentialsV2, isOAuthCredential } = models.gitCredentials;
 
 function isSwitchingStorageType(project: Project, storageType: 'local' | 'remote' | 'git') {
@@ -87,6 +85,8 @@ export const ProjectSettingsForm: FC<Props> = ({
   onDirtyChange,
 }) => {
   const { organizationId } = useParams() as { organizationId: string };
+  const gitFormId = useId();
+  const upsertFormId = useId();
 
   const isGitSyncEnabled = useIsGitSyncEnabled(organizationId);
 
@@ -191,44 +191,26 @@ export const ProjectSettingsForm: FC<Props> = ({
     (isSwitchingStorageType(project!, storageType) ||
       project?.gitRepositoryId === models.project.EMPTY_GIT_PROJECT_ID ||
       !gitRepository?.credentialsId);
-  const canScanForFiles = !(
-    (!isGitSyncEnabled && isSwitchingStorageType(project!, storageType)) ||
-    isGitCredentialInvalid
-  );
-  const canUpsertProject = !(
-    updateProjectFetcher.state !== 'idle' ||
-    (!isSwitchingStorageType(project!, storageType) &&
-      project?.name.trim() === projectData.name.trim() &&
-      (gitRepository?.selectedAuthorEmail ?? null) === (projectData.selectedAuthorEmail ?? null))
-  );
+  const isGitSyncUnavailableForSwitch = !isGitSyncEnabled && isSwitchingStorageType(project!, storageType);
+  const canScanForFiles = !isGitSyncUnavailableForSwitch && !isGitCredentialInvalid;
+
+  const hasNoChangesToUpsert =
+    !isSwitchingStorageType(project!, storageType) &&
+    project?.name.trim() === projectData.name.trim() &&
+    (gitRepository?.selectedAuthorEmail ?? null) === (projectData.selectedAuthorEmail ?? null);
+  const canUpsertProject = updateProjectFetcher.state === 'idle' && !hasNoChangesToUpsert;
   const canCloneAfterScan = updateProjectFetcher.state === 'idle' && initCloneGitRepositoryFetcher.state === 'idle';
 
-  // React Aria's FocusScope can hand initial focus to the modal header's close
-  // button ahead of this field's `autoFocus`; claim it back once mounted.
   const nameInputRef = useRef<HTMLInputElement>(null);
-  useEffect(() => {
-    nameInputRef.current?.focus();
-  }, []);
-
-  // Choosing a type collapses the type list, unmounting the focused radio. The
-  // child restores focus to its collapsed summary, but Enter there would just
-  // reopen the list — put focus back on the name field so Enter runs the CTA.
-  // Child effects run before parent effects, so this wins.
   useEffect(() => {
     nameInputRef.current?.focus();
   }, [storageType]);
 
-  // The name field's correct submit-target is dynamic (Update vs. Scan for
-  // files), but that's fine inside a real <Form> — onSubmit is just a callback,
-  // it can dispatch on current state same as any other handler. This form wraps
-  // only the name field + type picker, stopping before the git-clone subtree:
-  // GitRepoForm owns its own separate, natively-submitting <Form id={FORMID}>,
-  // and nesting two <form> elements is invalid, so they must stay DOM siblings.
   const handleUpsertFormSubmit = (event: React.FormEvent) => {
     event.preventDefault();
     if (isScanForFilesPrimaryAction) {
       if (canScanForFiles) {
-        (document.getElementById(FORMID) as HTMLFormElement | null)?.requestSubmit();
+        (document.getElementById(gitFormId) as HTMLFormElement | null)?.requestSubmit();
       }
       return;
     }
@@ -237,10 +219,6 @@ export const ProjectSettingsForm: FC<Props> = ({
     }
   };
 
-  // No inputs on this results screen, so there's nothing for native form
-  // submission to key off — focus the primary action button once it's ready,
-  // same as a native "default button" convention (its own Enter-activation
-  // then just works, like any other focused button).
   const cloneButtonRef = useRef<HTMLButtonElement>(null);
   useEffect(() => {
     if (activeView === 'git-results' && initCloneGitRepositoryFetcher.state === 'idle') {
@@ -359,7 +337,7 @@ export const ProjectSettingsForm: FC<Props> = ({
         <div
           className={`flex w-full flex-col justify-start gap-4 pb-2 text-left ${activeView === 'project' ? '' : 'hidden'}`}
         >
-          <Form id={UPSERT_FORM_ID} className="contents" onSubmit={handleUpsertFormSubmit}>
+          <Form id={upsertFormId} className="contents" onSubmit={handleUpsertFormSubmit}>
             <TextField
               autoFocus
               name="name"
@@ -637,7 +615,7 @@ export const ProjectSettingsForm: FC<Props> = ({
               setActiveView={setActiveView}
               credentials={credentials}
               providers={providers}
-              formId={FORMID}
+              formId={gitFormId}
               onCredentialValidationChange={setIsGitCredentialInvalid}
             />
           )}
@@ -668,7 +646,7 @@ export const ProjectSettingsForm: FC<Props> = ({
             {isScanForFilesPrimaryAction ? (
               <Button
                 isDisabled={!canScanForFiles}
-                form={FORMID}
+                form={gitFormId}
                 type="submit"
                 className="flex h-full items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
               >
@@ -677,7 +655,7 @@ export const ProjectSettingsForm: FC<Props> = ({
             ) : (
               <Button
                 type="submit"
-                form={UPSERT_FORM_ID}
+                form={upsertFormId}
                 isDisabled={!canUpsertProject}
                 className="flex h-full w-[10ch] items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
               >

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -3,9 +3,10 @@ import type { GitCredentials, GitRepository, Project, ProviderEmail } from 'inso
 import { models } from 'insomnia-data';
 import { platform } from 'insomnia-data/common';
 import type { FC } from 'react';
-import { Fragment, useEffect, useMemo, useState } from 'react';
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Button,
+  Form,
   Input,
   Label,
   ListBox,
@@ -43,6 +44,7 @@ import { useProjectUpdateActionFetcher } from '../../../routes/organization.$org
 import { Icon } from '../icon';
 
 const FORMID = 'git-repo-form';
+const UPSERT_FORM_ID = 'project-upsert-form';
 const { isGitCredentialsV2, isOAuthCredential } = models.gitCredentials;
 
 function isSwitchingStorageType(project: Project, storageType: 'local' | 'remote' | 'git') {
@@ -181,6 +183,71 @@ export const ProjectSettingsForm: FC<Props> = ({
 
   const hideActionButtons = storageType === 'git' && !projectData.connectRepositoryLater && credentials.length === 0;
 
+  // Switching to git (or reconnecting an empty/unauthenticated git project) scans
+  // the remote for files first; every other case updates directly.
+  const isScanForFilesPrimaryAction =
+    storageType === 'git' &&
+    !projectData.connectRepositoryLater &&
+    (isSwitchingStorageType(project!, storageType) ||
+      project?.gitRepositoryId === models.project.EMPTY_GIT_PROJECT_ID ||
+      !gitRepository?.credentialsId);
+  const canScanForFiles = !(
+    (!isGitSyncEnabled && isSwitchingStorageType(project!, storageType)) ||
+    isGitCredentialInvalid
+  );
+  const canUpsertProject = !(
+    updateProjectFetcher.state !== 'idle' ||
+    (!isSwitchingStorageType(project!, storageType) &&
+      project?.name.trim() === projectData.name.trim() &&
+      (gitRepository?.selectedAuthorEmail ?? null) === (projectData.selectedAuthorEmail ?? null))
+  );
+  const canCloneAfterScan = updateProjectFetcher.state === 'idle' && initCloneGitRepositoryFetcher.state === 'idle';
+
+  // React Aria's FocusScope can hand initial focus to the modal header's close
+  // button ahead of this field's `autoFocus`; claim it back once mounted.
+  const nameInputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    nameInputRef.current?.focus();
+  }, []);
+
+  // Choosing a type collapses the type list, unmounting the focused radio. The
+  // child restores focus to its collapsed summary, but Enter there would just
+  // reopen the list — put focus back on the name field so Enter runs the CTA.
+  // Child effects run before parent effects, so this wins.
+  useEffect(() => {
+    nameInputRef.current?.focus();
+  }, [storageType]);
+
+  // The name field's correct submit-target is dynamic (Update vs. Scan for
+  // files), but that's fine inside a real <Form> — onSubmit is just a callback,
+  // it can dispatch on current state same as any other handler. This form wraps
+  // only the name field + type picker, stopping before the git-clone subtree:
+  // GitRepoForm owns its own separate, natively-submitting <Form id={FORMID}>,
+  // and nesting two <form> elements is invalid, so they must stay DOM siblings.
+  const handleUpsertFormSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (isScanForFilesPrimaryAction) {
+      if (canScanForFiles) {
+        (document.getElementById(FORMID) as HTMLFormElement | null)?.requestSubmit();
+      }
+      return;
+    }
+    if (canUpsertProject) {
+      onUpsertProject();
+    }
+  };
+
+  // No inputs on this results screen, so there's nothing for native form
+  // submission to key off — focus the primary action button once it's ready,
+  // same as a native "default button" convention (its own Enter-activation
+  // then just works, like any other focused button).
+  const cloneButtonRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    if (activeView === 'git-results' && initCloneGitRepositoryFetcher.state === 'idle') {
+      cloneButtonRef.current?.focus();
+    }
+  }, [activeView, initCloneGitRepositoryFetcher.state]);
+
   const showGitConnectionInfo =
     storageType === 'git' &&
     !isSwitchingStorageType(project!, storageType) &&
@@ -292,43 +359,46 @@ export const ProjectSettingsForm: FC<Props> = ({
         <div
           className={`flex w-full flex-col justify-start gap-4 pb-2 text-left ${activeView === 'project' ? '' : 'hidden'}`}
         >
-          <TextField
-            autoFocus
-            name="name"
-            value={projectData.name}
-            onChange={name => setProjectData({ ...projectData, name })}
-            className="group relative flex flex-col gap-2 px-0.5"
-          >
-            <Label className="pt-0 text-sm text-(--color-font)">Project name</Label>
-            <Input
-              placeholder="My project"
-              className="w-full rounded-xs border border-solid border-(--hl-sm) bg-(--color-bg) py-1 pr-7 pl-2 text-(--color-font) transition-colors placeholder:italic focus:ring-1 focus:ring-(--hl-md) focus:outline-hidden"
-            />
-          </TextField>
-          {project?.konnectControlPlaneId ? (
-            <div className="flex flex-col gap-2">
-              <Label aria-label="Project Type" className="p-0 text-sm text-(--color-font)">
-                Type
-              </Label>
-              <div className="flex h-7.5 items-center rounded-sm border border-(--hl-sm) px-2 opacity-75">
-                <div className="flex items-center gap-2">
-                  <Icon icon="laptop" />
-                  <span>Synced from Konnect</span>
+          <Form id={UPSERT_FORM_ID} className="contents" onSubmit={handleUpsertFormSubmit}>
+            <TextField
+              autoFocus
+              name="name"
+              value={projectData.name}
+              onChange={name => setProjectData({ ...projectData, name })}
+              className="group relative flex flex-col gap-2 px-0.5"
+            >
+              <Label className="pt-0 text-sm text-(--color-font)">Project name</Label>
+              <Input
+                ref={nameInputRef}
+                placeholder="My project"
+                className="w-full rounded-xs border border-solid border-(--hl-sm) bg-(--color-bg) py-1 pr-7 pl-2 text-(--color-font) transition-colors placeholder:italic focus:ring-1 focus:ring-(--hl-md) focus:outline-hidden"
+              />
+            </TextField>
+            {project?.konnectControlPlaneId ? (
+              <div className="flex flex-col gap-2">
+                <Label aria-label="Project Type" className="p-0 text-sm text-(--color-font)">
+                  Type
+                </Label>
+                <div className="flex h-7.5 items-center rounded-sm border border-(--hl-sm) px-2 opacity-75">
+                  <div className="flex items-center gap-2">
+                    <Icon icon="laptop" />
+                    <span>Synced from Konnect</span>
+                  </div>
                 </div>
               </div>
-            </div>
-          ) : (
-            <ProjectTypeSelect
+            ) : (
+              <ProjectTypeSelect
+                storageRules={storageRules}
+                value={storageType}
+                onChange={v => setStorageType(v as 'local' | 'remote' | 'git')}
+              />
+            )}
+            <ProjectTypeWarning
+              isGitSyncEnabled={isGitSyncEnabled}
+              storageType={storageType}
               storageRules={storageRules}
-              value={storageType}
-              onChange={v => setStorageType(v as 'local' | 'remote' | 'git')}
             />
-          )}
-          <ProjectTypeWarning
-            isGitSyncEnabled={isGitSyncEnabled}
-            storageType={storageType}
-            storageRules={storageRules}
-          />
+          </Form>
 
           {showSwitchBanner && storageType === 'remote' && (
             <Banner
@@ -595,15 +665,9 @@ export const ProjectSettingsForm: FC<Props> = ({
                 Cancel
               </Button>
             )}
-            {storageType === 'git' &&
-            !projectData.connectRepositoryLater &&
-            (isSwitchingStorageType(project!, storageType) ||
-              project?.gitRepositoryId === models.project.EMPTY_GIT_PROJECT_ID ||
-              !gitRepository?.credentialsId) ? (
+            {isScanForFilesPrimaryAction ? (
               <Button
-                isDisabled={
-                  (!isGitSyncEnabled && isSwitchingStorageType(project!, storageType)) || isGitCredentialInvalid
-                }
+                isDisabled={!canScanForFiles}
                 form={FORMID}
                 type="submit"
                 className="flex h-full items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
@@ -612,13 +676,9 @@ export const ProjectSettingsForm: FC<Props> = ({
               </Button>
             ) : (
               <Button
-                onPress={onUpsertProject}
-                isDisabled={
-                  updateProjectFetcher.state !== 'idle' ||
-                  (!isSwitchingStorageType(project!, storageType) &&
-                    project?.name.trim() === projectData.name.trim() &&
-                    (gitRepository?.selectedAuthorEmail ?? null) === (projectData.selectedAuthorEmail ?? null))
-                }
+                type="submit"
+                form={UPSERT_FORM_ID}
+                isDisabled={!canUpsertProject}
                 className="flex h-full w-[10ch] items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
               >
                 {updateProjectFetcher.state !== 'idle' && <Icon icon="spinner" className="animate-spin" />}
@@ -632,7 +692,7 @@ export const ProjectSettingsForm: FC<Props> = ({
       {activeView === 'git-results' && (
         <div className="flex items-center justify-end gap-2">
           <Button
-            isDisabled={updateProjectFetcher.state !== 'idle' || initCloneGitRepositoryFetcher.state !== 'idle'}
+            isDisabled={!canCloneAfterScan}
             onPress={() => {
               setActiveView('project');
               setError(null);
@@ -652,6 +712,7 @@ export const ProjectSettingsForm: FC<Props> = ({
             </Button>
           ) : (
             <Button
+              ref={cloneButtonRef}
               isDisabled={updateProjectFetcher.state !== 'idle'}
               onPress={onUpsertProject}
               className="flex h-full items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"

--- a/packages/insomnia/src/ui/components/project/project-type-select.tsx
+++ b/packages/insomnia/src/ui/components/project/project-type-select.tsx
@@ -1,7 +1,7 @@
 import type { IconProp } from '@fortawesome/fontawesome-svg-core';
 import type { StorageRules } from 'insomnia-api';
-import { useState } from 'react';
-import { Label, Radio, RadioGroup } from 'react-aria-components';
+import { useEffect, useRef, useState } from 'react';
+import { Button, Label, Radio, RadioGroup } from 'react-aria-components';
 
 import { Icon } from '~/basic-components/icon';
 import type { ProjectType } from '~/ui/components/project/utils';
@@ -47,10 +47,41 @@ export const ProjectTypeSelect = ({ value, onChange, storageRules }: Props) => {
 
   const currentType = typeList.find(item => item.type === value);
 
+  // Toggling between the radio list and the collapsed summary unmounts whichever
+  // one currently has focus. Without deliberately moving focus, it falls to the
+  // body, and an enclosing modal's FocusScope then yanks it to the first
+  // focusable element (the close button). Hand focus to whichever replaces it.
+  const summaryButtonRef = useRef<HTMLButtonElement>(null);
+  const radioGroupContainerRef = useRef<HTMLDivElement>(null);
+  const shouldFocusSummaryRef = useRef(false);
+  const shouldFocusRadioRef = useRef(false);
+
   const handleChange = (v: string) => {
+    shouldFocusSummaryRef.current = true;
     setListOpen(false);
     onChange(v);
   };
+
+  const handleChangePressed = () => {
+    shouldFocusRadioRef.current = true;
+    setListOpen(true);
+  };
+
+  useEffect(() => {
+    if (shouldFocusSummaryRef.current && !listOpen && currentType) {
+      shouldFocusSummaryRef.current = false;
+      summaryButtonRef.current?.focus();
+    }
+  }, [listOpen, currentType]);
+
+  useEffect(() => {
+    if (shouldFocusRadioRef.current && listOpen) {
+      shouldFocusRadioRef.current = false;
+      const checkedInput = radioGroupContainerRef.current?.querySelector<HTMLInputElement>('input:checked');
+      const firstInput = radioGroupContainerRef.current?.querySelector<HTMLInputElement>('input[type="radio"]');
+      (checkedInput || firstInput)?.focus();
+    }
+  }, [listOpen]);
 
   return (
     <div className="flex flex-col gap-2">
@@ -58,42 +89,58 @@ export const ProjectTypeSelect = ({ value, onChange, storageRules }: Props) => {
         Type
       </Label>
       {listOpen || !currentType ? (
-        <RadioGroup
-          aria-label="Project Type Radio"
-          className="flex flex-col rounded-sm border border-(--hl-md) p-1"
-          value={value}
-          onChange={handleChange}
-        >
-          {typeList.map(item => (
-            <Radio
-              onClick={() => setListOpen(false)}
-              key={item.name}
-              value={item.type}
-              isDisabled={item.isDisabled}
-              aria-label={`Project Type: ${item.type}`}
-              className="w-full rounded-sm border border-transparent pt-0 transition-colors hover:border-transparent hover:bg-(--hl-xs) data-disabled:cursor-not-allowed data-disabled:opacity-50 data-selected:border-(--color-surprise)"
-            >
-              <div aria-label={`Project Type Item: ${item.type}`} className="flex gap-2 p-2">
-                <Icon icon={item.icon} className="mt-1" />
-                <div>
-                  <div>{item.name}</div>
-                  <div className="text-sm text-(--hl)">{item.description}</div>
-                </div>
-              </div>
-            </Radio>
-          ))}
-        </RadioGroup>
-      ) : (
         <div
-          className="flex h-[30px] cursor-pointer items-center justify-between rounded-sm border border-(--hl-sm) px-2"
-          onClick={() => setListOpen(true)}
+          ref={radioGroupContainerRef}
+          onKeyDown={event => {
+            // Unlike text-like inputs, a focused radio button is spec'd to NOT
+            // trigger a form's implicit submission on Enter — so leaving the
+            // selection unchanged and pressing Enter here would otherwise do
+            // nothing at all. Restore parity with the rest of the form.
+            if (event.key === 'Enter') {
+              event.preventDefault();
+              (event.target as HTMLElement).closest('form')?.requestSubmit();
+            }
+          }}
+        >
+          <RadioGroup
+            aria-label="Project Type Radio"
+            className="flex flex-col rounded-sm border border-(--hl-md) p-1"
+            value={value}
+            onChange={handleChange}
+          >
+            {typeList.map(item => (
+              <Radio
+                onClick={() => setListOpen(false)}
+                key={item.name}
+                value={item.type}
+                isDisabled={item.isDisabled}
+                aria-label={`Project Type: ${item.type}`}
+                className="w-full rounded-sm border border-transparent pt-0 transition-colors hover:border-transparent hover:bg-(--hl-xs) data-disabled:cursor-not-allowed data-disabled:opacity-50 data-selected:border-(--color-surprise)"
+              >
+                <div aria-label={`Project Type Item: ${item.type}`} className="flex gap-2 p-2">
+                  <Icon icon={item.icon} className="mt-1" />
+                  <div>
+                    <div>{item.name}</div>
+                    <div className="text-sm text-(--hl)">{item.description}</div>
+                  </div>
+                </div>
+              </Radio>
+            ))}
+          </RadioGroup>
+        </div>
+      ) : (
+        <Button
+          ref={summaryButtonRef}
+          aria-label={`Project type: ${currentType.name}. Change`}
+          className="flex h-[30px] w-full cursor-pointer items-center justify-between rounded-sm border border-solid border-(--hl-sm) px-2 text-(--color-font) ring-1 ring-transparent transition-colors hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:outline-hidden focus:ring-inset"
+          onPress={handleChangePressed}
         >
           <div className="flex items-center gap-2">
-            <Icon icon={currentType?.icon} />
-            <span>{currentType?.name}</span>
+            <Icon icon={currentType.icon} />
+            <span>{currentType.name}</span>
           </div>
           <span>Change</span>
-        </div>
+        </Button>
       )}
     </div>
   );

--- a/packages/insomnia/src/ui/components/project/project-type-select.tsx
+++ b/packages/insomnia/src/ui/components/project/project-type-select.tsx
@@ -67,6 +67,8 @@ export const ProjectTypeSelect = ({ value, onChange, storageRules }: Props) => {
     setListOpen(true);
   };
 
+  // Picking a type unmounts the RadioGroup; claim focus on the summary button
+  // that replaces it before FocusScope's fallback grabs the modal's close button.
   useEffect(() => {
     if (shouldFocusSummaryRef.current && !listOpen && currentType) {
       shouldFocusSummaryRef.current = false;
@@ -74,6 +76,8 @@ export const ProjectTypeSelect = ({ value, onChange, storageRules }: Props) => {
     }
   }, [listOpen, currentType]);
 
+  // Clicking "Change" unmounts the summary button; claim focus on the radio
+  // list that replaces it before FocusScope's fallback grabs the modal's close button.
   useEffect(() => {
     if (shouldFocusRadioRef.current && listOpen) {
       shouldFocusRadioRef.current = false;
@@ -91,11 +95,8 @@ export const ProjectTypeSelect = ({ value, onChange, storageRules }: Props) => {
       {listOpen || !currentType ? (
         <div
           ref={radioGroupContainerRef}
-          onKeyDown={event => {
-            // Unlike text-like inputs, a focused radio button is spec'd to NOT
-            // trigger a form's implicit submission on Enter — so leaving the
-            // selection unchanged and pressing Enter here would otherwise do
-            // nothing at all. Restore parity with the rest of the form.
+          // Capture phase so we can intercept Enter before React Aria's own Radio handles it.
+          onKeyDownCapture={event => {
             if (event.key === 'Enter') {
               event.preventDefault();
               (event.target as HTMLElement).closest('form')?.requestSubmit();


### PR DESCRIPTION
This PR introduces functionality to trigger primary CTA buttons when pressing Enter within select modals. The approach used: 

1. If a modal has no input fields, we autoFocus the primary CTA button so when the modal pops up the user presses Enter and the primary CTA is triggered. 
2. If a modal has input fields, we wrap them in a form. Pressing enter when a form input field is focused triggers the form onSubmit callback. 

[Jira](https://konghq.atlassian.net/browse/INS-3072)