### PR TITLE
PoC: opt-in QuickJS sandbox for pre-request/after-response scripts

### DIFF
--- a/packages/insomnia-data/common-src/settings.ts
+++ b/packages/insomnia-data/common-src/settings.ts
@@ -185,6 +185,12 @@ export interface Settings {
   scriptSandboxEnabled: boolean;
   // Wraps the user script in 'use strict', preventing accidental globals and making `this` undefined.
   scriptStrictModeEnabled: boolean;
+  // PoC/experimental: execute pre-request/after-response scripts inside the QuickJS-WASM sandbox
+  // instead of the hidden Electron BrowserWindow. Supports only a minimal API surface (console,
+  // insomnia.environment/variables get/set, read-only insomnia.request) — insomnia.sendRequest()
+  // and insomnia.test()/pm.test() are not yet bridged and throw if called. Defaults to off so the
+  // full-featured hidden-window sandbox remains the default execution path.
+  useQuickJsScriptSandbox: boolean;
   // T1: sandbox ALL untrusted (user) plugin surfaces — template tags, request/response hooks, actions,
   // and load-time module code — inside the QuickJS-WASM sandbox. User plugins are default-deny;
   // per-plugin `pluginConfig.elevated` opts an individual plugin back into full-host in-process

--- a/packages/insomnia-data/src/models/settings.ts
+++ b/packages/insomnia-data/src/models/settings.ts
@@ -88,6 +88,7 @@ export function init(): BaseSettings {
     dataFolders: [],
     scriptSandboxEnabled: true,
     scriptStrictModeEnabled: true,
+    useQuickJsScriptSandbox: false,
     pluginSandboxEnabled: false,
     disabledSecurityRules: [],
     disabledBlockedProperties: [],

--- a/packages/insomnia-smoke-test/tests/smoke/quickjs-script-sandbox.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/quickjs-script-sandbox.test.ts
@@ -1,0 +1,109 @@
+import { expect, type Page } from '@playwright/test';
+
+import { loadFixture } from '../../playwright/paths';
+import { test } from '../../playwright/test';
+
+// Covers PR 0 (opt-in QuickJS engine) and PR 1 (Web Worker boundary) of the QuickJS
+// script-sandbox rollout plan — https://gist.github.com/jackkav/3ebf8768bf84be024a3a138874919354
+//
+// insomnia.sendRequest() (PR 2) is deliberately NOT exercised here — it crashes under the real
+// Electron/Worker/QuickJS environment (a QuickJSUseAfterFree that never reproduces in vitest's
+// mocked-fetch unit tests) and has been pulled into its own WIP branch/PR until that's root-caused.
+// This suite stays scoped to what's actually shipped: console, insomnia.environment/variables
+// get/set, read-only insomnia.request, and the worker-boundary responsiveness guarantee.
+//
+// Uses "testQueryParams", a request at the workspace root (not nested in any folder) with no body
+// and no folder-inherited after-response script — every other candidate in this fixture either
+// references environment variables undefined until a pre-request script runs (triggering a "N
+// environment variables are missing" confirmation dialog) or inherits a folder-level after-response
+// script that calls an API this minimal engine doesn't bridge, turning an otherwise-successful send
+// into a displayed "Error" status. Asserting via the Console tab (console.log output) instead of an
+// echoed response body sidesteps template-rendering entirely.
+test.describe('QuickJS script sandbox', () => {
+  test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
+
+  test.beforeEach(async ({ app, page }) => {
+    const text = await loadFixture('pre-request-collection.yaml');
+    await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
+
+    await page.getByLabel('Import').click();
+    await page.locator('[data-test-id="import-from-clipboard"]').click();
+    await page.getByRole('button', { name: 'Scan' }).click();
+    await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+  });
+
+  // CodeMirror debounces onChange (DEBOUNCE_MILLIS, ~100ms) before it commits to the request
+  // model — clicking Send right after `.fill()` races that debounce and can send the *previous*
+  // script/body. Select-all + delete first (fill() alone doesn't reliably clear existing CodeMirror
+  // content) and wait past the debounce before treating the editor as settled. Mirrors the pattern
+  // in pre-request-script-features.test.ts.
+  const replaceCodeEditorContent = async (page: Page, value: string) => {
+    const editor = page.getByTestId('CodeEditor').getByRole('textbox');
+    await editor.press('ControlOrMeta+a');
+    await page.keyboard.press('Backspace');
+    await editor.fill(value);
+    // Wait for CodeMirror debounce (DEBOUNCE_MILLIS ~100ms)
+    await page.evaluate(() => new Promise(resolve => setTimeout(resolve, 150)));
+  };
+
+  // Enable the QuickJS sandbox via Preferences → Scripting, then close the modal — mirrors
+  // sandbox-template-tags.test.ts's `enableSandbox` helper for the plugin template-tag sandbox.
+  const enableQuickJsSandbox = async (page: Page) => {
+    await page.getByTestId('settings-button').click();
+    const sandboxToggle = page.getByTestId('toggle-quickjs-script-sandbox');
+    await page.getByRole('tab', { name: 'Scripting' }).click();
+    await sandboxToggle.getByRole('switch').waitFor();
+    await sandboxToggle.click();
+    await expect.soft(sandboxToggle.getByRole('switch')).toBeChecked();
+    await page.locator('.app').press('Escape');
+    await expect.soft(page.getByTestId('toggle-quickjs-script-sandbox')).toBeHidden();
+  };
+
+  test('runs console/environment/request-read scripts through the QuickJS engine', async ({ page, insomnia }) => {
+    await enableQuickJsSandbox(page);
+
+    await insomnia.navigationSidebar.clickRequestOrFolder('testQueryParams');
+
+    // The canary (`typeof require`) proves this ran inside QuickJS, not the hidden window (which
+    // has `require` — see this fixture's "require the url module" case); a mis-wired toggle would
+    // otherwise make every assertion below pass vacuously against the legacy engine. Also exercises
+    // insomnia.environment.set/get and read-only insomnia.request — everything PR 0/PR 1 ship.
+    await page.getByRole('tab', { name: 'Scripts' }).click();
+    await replaceCodeEditorContent(
+      page,
+      `
+      const engine = typeof require === 'function' ? 'hidden-window' : 'quickjs';
+      insomnia.environment.set('canaryEngine', engine);
+      console.log('canary: ' + engine + ' | request: ' + insomnia.request.name);
+    `,
+    );
+
+    await page.getByRole('tab', { name: 'Params' }).click();
+    await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
+
+    await expect.soft(page.locator('[data-testid="response-status-tag"]:visible')).toContainText('200 OK');
+
+    await page.getByTestId('response-pane').getByRole('tab', { name: 'Console' }).click();
+    await expect.soft(page.getByText('canary: quickjs | request: testQueryParams')).toBeVisible();
+  });
+
+  test('a runaway script blocks only the QuickJS worker, not the app UI', async ({ page, insomnia }) => {
+    await enableQuickJsSandbox(page);
+
+    await insomnia.navigationSidebar.clickRequestOrFolder('testQueryParams');
+
+    await page.getByRole('tab', { name: 'Scripts' }).click();
+    await replaceCodeEditorContent(page, 'while (true) { /* deliberately never returns */ }');
+
+    await page.getByRole('tab', { name: 'Params' }).click();
+    await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
+
+    // The script is now busy-looping inside its dedicated Worker (PR 1) and will never finish. If
+    // QuickJS ran on the renderer's own main thread instead, this tab switch would hang along with
+    // it; asserting it stays interactive right away is the whole point of the worker boundary.
+    await page.getByRole('tab', { name: 'Headers' }).click();
+    await expect.soft(page.getByRole('tab', { name: 'Headers' })).toHaveAttribute('aria-selected', 'true');
+    await page.getByRole('tab', { name: 'Params' }).click();
+    await expect.soft(page.getByRole('tab', { name: 'Params' })).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/packages/insomnia/src/network/concurrency.renderer.ts
+++ b/packages/insomnia/src/network/concurrency.renderer.ts
@@ -11,6 +11,7 @@ import type {
 } from 'insomnia-data';
 
 import type { RequestContext } from '../../../insomnia-scripting-environment/src/objects';
+import { runScriptInQuickJs } from '../scripting/run-script-quickjs';
 import { cancellableExecution } from './cancellation.renderer';
 
 export interface ExecuteScriptContext {
@@ -59,10 +60,12 @@ async function asyncWorker(arg: Task): Promise<any> {
   const timeoutPromise = new Promise<{ error: string }>(resolve =>
     setTimeout(resolve, timeoutValue, { error: `Executing script timeout: ${timeoutValue}` }),
   );
-  const executionPromise = Promise.race([
-    window.main.hiddenBrowserWindow.runScript({ script: arg.script, context: arg.context }),
-    timeoutPromise,
-  ]);
+  // Proof of concept: opt-in path that runs the script in a QuickJS-WASM sandbox instead of the
+  // hidden Electron BrowserWindow. Defaults to off (see settings.useQuickJsScriptSandbox).
+  const runScript = arg.context.settings.useQuickJsScriptSandbox
+    ? runScriptInQuickJs({ script: arg.script, context: arg.context })
+    : window.main.hiddenBrowserWindow.runScript({ script: arg.script, context: arg.context });
+  const executionPromise = Promise.race([runScript, timeoutPromise]);
   const result = await cancellableExecution({ id: arg.context.request._id, fn: executionPromise });
   return result;
 }

--- a/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
+++ b/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import type { RequestContext } from '../../../insomnia-scripting-environment/src/objects/interfaces';
 import { runScriptInQuickJs } from './quickjs-script-engine';
@@ -82,150 +82,17 @@ describe('runScriptInQuickJs', () => {
     expect(result.logs.some(row => row.includes('hello from quickjs'))).toBe(true);
   });
 
+  it('throws a clear error when calling the unsupported sendRequest API', async () => {
+    const context = baseContext();
+
+    await expect(
+      runScriptInQuickJs({ script: 'await insomnia.sendRequest("https://example.com");', context }),
+    ).rejects.toThrow(/insomnia\.sendRequest\(\) is not supported/);
+  });
+
   it('propagates script errors with a useful message', async () => {
     const context = baseContext();
 
     await expect(runScriptInQuickJs({ script: 'throw new Error("boom");', context })).rejects.toThrow('boom');
-  });
-});
-
-describe('runScriptInQuickJs sendRequest bridge', () => {
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
-  const stubFetchOnce = (response: { ok: boolean; status?: number; body: unknown }) => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: response.ok,
-      status: response.status ?? (response.ok ? 200 : 500),
-      text: () => Promise.resolve(JSON.stringify(response.body)),
-    });
-    vi.stubGlobal('fetch', fetchMock);
-    return fetchMock;
-  };
-
-  it('sends a real request through the bridge and resolves with a response object', async () => {
-    stubFetchOnce({
-      ok: true,
-      body: {
-        code: 200,
-        status: 'OK',
-        headers: [{ name: 'content-type', value: 'application/json' }],
-        body: '{"hello":"world"}',
-        responseTime: 12,
-      },
-    });
-    const context = baseContext();
-
-    const result = await runScriptInQuickJs({
-      script: `
-        const response = await insomnia.sendRequest('https://example.com');
-        insomnia.environment.set('code', response.code);
-        insomnia.environment.set('parsedBody', response.json());
-      `,
-      context,
-    });
-
-    expect(result.environment.data).toMatchObject({ code: 200, parsedBody: { hello: 'world' } });
-  });
-
-  it('sends the auth token as a header on the bridge fetch call', async () => {
-    const fetchMock = stubFetchOnce({
-      ok: true,
-      body: { code: 204, status: 'No Content', headers: [], body: '', responseTime: 1 },
-    });
-    const context = baseContext();
-
-    await runScriptInQuickJs({
-      script: `await insomnia.sendRequest('https://example.com');`,
-      context,
-      authToken: 'super-secret-token',
-    });
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      'insomnia-templating-worker-database://network.sendrequestwithoutsideeffects',
-      expect.objectContaining({ headers: { 'x-insomnia-templating-auth': 'super-secret-token' } }),
-    );
-  });
-
-  it('normalizes a plain-object request with headers and a string body', async () => {
-    const fetchMock = stubFetchOnce({
-      ok: true,
-      body: { code: 200, status: 'OK', headers: [], body: '', responseTime: 1 },
-    });
-    const context = baseContext();
-
-    await runScriptInQuickJs({
-      script: `
-        await insomnia.sendRequest({
-          url: 'https://example.com/items',
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: '{"a":1}',
-        });
-      `,
-      context,
-    });
-
-    const sentBody = JSON.parse(fetchMock.mock.calls[0][1].body);
-    expect(sentBody).toEqual({
-      options: {
-        request: {
-          url: 'https://example.com/items',
-          method: 'POST',
-          headers: [{ name: 'Content-Type', value: 'application/json' }],
-          body: { mimeType: 'text/plain', text: '{"a":1}' },
-        },
-        caCertficatePath: null,
-      },
-    });
-  });
-
-  it('supports the Postman-style (error, response) callback signature', async () => {
-    stubFetchOnce({ ok: true, body: { code: 200, status: 'OK', headers: [], body: 'ok', responseTime: 1 } });
-    const context = baseContext();
-
-    const result = await runScriptInQuickJs({
-      script: `
-        await new Promise((resolve) => {
-          insomnia.sendRequest('https://example.com', (error, response) => {
-            insomnia.environment.set('callbackError', error ?? null);
-            insomnia.environment.set('callbackBody', response ? response.body : null);
-            resolve();
-          });
-        });
-      `,
-      context,
-    });
-
-    expect(result.environment.data).toMatchObject({ callbackError: null, callbackBody: 'ok' });
-  });
-
-  it('rejects with the bridge-reported error when the host handler fails', async () => {
-    stubFetchOnce({ ok: false, status: 500, body: { error: 'DNS resolution failed' } });
-    const context = baseContext();
-
-    await expect(
-      runScriptInQuickJs({ script: `await insomnia.sendRequest('https://unreachable.invalid');`, context }),
-    ).rejects.toThrow('DNS resolution failed');
-  });
-
-  it('reports the bridge error to the callback instead of throwing when a callback is given', async () => {
-    stubFetchOnce({ ok: false, status: 500, body: { error: 'DNS resolution failed' } });
-    const context = baseContext();
-
-    const result = await runScriptInQuickJs({
-      script: `
-        await new Promise((resolve) => {
-          insomnia.sendRequest('https://unreachable.invalid', (error) => {
-            insomnia.environment.set('callbackError', error);
-            resolve();
-          });
-        });
-      `,
-      context,
-    });
-
-    expect((result.environment.data as Record<string, unknown>).callbackError).toBe('DNS resolution failed');
   });
 });

--- a/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
+++ b/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { RequestContext } from '../../../insomnia-scripting-environment/src/objects/interfaces';
 import { runScriptInQuickJs } from './quickjs-script-engine';
@@ -82,17 +82,150 @@ describe('runScriptInQuickJs', () => {
     expect(result.logs.some(row => row.includes('hello from quickjs'))).toBe(true);
   });
 
-  it('throws a clear error when calling the unsupported sendRequest API', async () => {
-    const context = baseContext();
-
-    await expect(
-      runScriptInQuickJs({ script: 'await insomnia.sendRequest("https://example.com");', context }),
-    ).rejects.toThrow(/insomnia\.sendRequest\(\) is not supported/);
-  });
-
   it('propagates script errors with a useful message', async () => {
     const context = baseContext();
 
     await expect(runScriptInQuickJs({ script: 'throw new Error("boom");', context })).rejects.toThrow('boom');
+  });
+});
+
+describe('runScriptInQuickJs sendRequest bridge', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const stubFetchOnce = (response: { ok: boolean; status?: number; body: unknown }) => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: response.ok,
+      status: response.status ?? (response.ok ? 200 : 500),
+      text: () => Promise.resolve(JSON.stringify(response.body)),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+  };
+
+  it('sends a real request through the bridge and resolves with a response object', async () => {
+    stubFetchOnce({
+      ok: true,
+      body: {
+        code: 200,
+        status: 'OK',
+        headers: [{ name: 'content-type', value: 'application/json' }],
+        body: '{"hello":"world"}',
+        responseTime: 12,
+      },
+    });
+    const context = baseContext();
+
+    const result = await runScriptInQuickJs({
+      script: `
+        const response = await insomnia.sendRequest('https://example.com');
+        insomnia.environment.set('code', response.code);
+        insomnia.environment.set('parsedBody', response.json());
+      `,
+      context,
+    });
+
+    expect(result.environment.data).toMatchObject({ code: 200, parsedBody: { hello: 'world' } });
+  });
+
+  it('sends the auth token as a header on the bridge fetch call', async () => {
+    const fetchMock = stubFetchOnce({
+      ok: true,
+      body: { code: 204, status: 'No Content', headers: [], body: '', responseTime: 1 },
+    });
+    const context = baseContext();
+
+    await runScriptInQuickJs({
+      script: `await insomnia.sendRequest('https://example.com');`,
+      context,
+      authToken: 'super-secret-token',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'insomnia-templating-worker-database://network.sendrequestwithoutsideeffects',
+      expect.objectContaining({ headers: { 'x-insomnia-templating-auth': 'super-secret-token' } }),
+    );
+  });
+
+  it('normalizes a plain-object request with headers and a string body', async () => {
+    const fetchMock = stubFetchOnce({
+      ok: true,
+      body: { code: 200, status: 'OK', headers: [], body: '', responseTime: 1 },
+    });
+    const context = baseContext();
+
+    await runScriptInQuickJs({
+      script: `
+        await insomnia.sendRequest({
+          url: 'https://example.com/items',
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{"a":1}',
+        });
+      `,
+      context,
+    });
+
+    const sentBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(sentBody).toEqual({
+      options: {
+        request: {
+          url: 'https://example.com/items',
+          method: 'POST',
+          headers: [{ name: 'Content-Type', value: 'application/json' }],
+          body: { mimeType: 'text/plain', text: '{"a":1}' },
+        },
+        caCertficatePath: null,
+      },
+    });
+  });
+
+  it('supports the Postman-style (error, response) callback signature', async () => {
+    stubFetchOnce({ ok: true, body: { code: 200, status: 'OK', headers: [], body: 'ok', responseTime: 1 } });
+    const context = baseContext();
+
+    const result = await runScriptInQuickJs({
+      script: `
+        await new Promise((resolve) => {
+          insomnia.sendRequest('https://example.com', (error, response) => {
+            insomnia.environment.set('callbackError', error ?? null);
+            insomnia.environment.set('callbackBody', response ? response.body : null);
+            resolve();
+          });
+        });
+      `,
+      context,
+    });
+
+    expect(result.environment.data).toMatchObject({ callbackError: null, callbackBody: 'ok' });
+  });
+
+  it('rejects with the bridge-reported error when the host handler fails', async () => {
+    stubFetchOnce({ ok: false, status: 500, body: { error: 'DNS resolution failed' } });
+    const context = baseContext();
+
+    await expect(
+      runScriptInQuickJs({ script: `await insomnia.sendRequest('https://unreachable.invalid');`, context }),
+    ).rejects.toThrow('DNS resolution failed');
+  });
+
+  it('reports the bridge error to the callback instead of throwing when a callback is given', async () => {
+    stubFetchOnce({ ok: false, status: 500, body: { error: 'DNS resolution failed' } });
+    const context = baseContext();
+
+    const result = await runScriptInQuickJs({
+      script: `
+        await new Promise((resolve) => {
+          insomnia.sendRequest('https://unreachable.invalid', (error) => {
+            insomnia.environment.set('callbackError', error);
+            resolve();
+          });
+        });
+      `,
+      context,
+    });
+
+    expect((result.environment.data as Record<string, unknown>).callbackError).toBe('DNS resolution failed');
   });
 });

--- a/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
+++ b/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { RequestContext } from '../../../insomnia-scripting-environment/src/objects/interfaces';
+import { getQuickJSModule } from '../templating/sandbox/quickjs-runtime';
 import { runScriptInQuickJs } from './quickjs-script-engine';
 
 const baseContext = (): RequestContext => ({
@@ -94,5 +95,107 @@ describe('runScriptInQuickJs', () => {
     const context = baseContext();
 
     await expect(runScriptInQuickJs({ script: 'throw new Error("boom");', context })).rejects.toThrow('boom');
+  });
+
+  it('does not let a "__proto__" key rewire the returned environment data\'s own prototype', async () => {
+    const context = baseContext();
+
+    const result = await runScriptInQuickJs({
+      script: `
+        insomnia.environment.set('__proto__', { polluted: true });
+        insomnia.environment.set('after', 'marker');
+      `,
+      context,
+    });
+
+    expect(Object.getPrototypeOf(result.environment.data)).toBe(Object.prototype);
+    expect((result.environment.data as Record<string, unknown>).polluted).toBeUndefined();
+    expect((result.environment.data as Record<string, unknown>).after).toBe('marker');
+    // The shared Object.prototype itself stays untouched.
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it('does not let a "constructor"/"prototype" key rewire the returned environment data', async () => {
+    const context = baseContext();
+
+    const result = await runScriptInQuickJs({
+      script: `
+        insomnia.environment.set('constructor', { polluted: true });
+        insomnia.environment.set('prototype', { polluted: true });
+      `,
+      context,
+    });
+
+    expect(typeof result.environment.data.constructor).not.toBe('object');
+    expect((result.environment.data as Record<string, unknown>).prototype).toBeUndefined();
+  });
+
+  it('keeps globalThis limited to standard intrinsics and this sandbox\'s own bridged names', async () => {
+    const context = baseContext();
+
+    // Reports host globals and the full globalThis property list back through
+    // insomnia.environment.set — the only channel available — for the assertions below.
+    const result = await runScriptInQuickJs({
+      script: `
+        const hostGlobals = [
+          'require', 'process', 'module', 'exports', '__dirname', '__filename',
+          'Deno', 'Bun', 'window', 'document', 'fetch', 'XMLHttpRequest', 'WebSocket',
+          'Buffer', 'setTimeout', 'setInterval', 'setImmediate', 'WebAssembly',
+          'importScripts', 'postMessage',
+        ];
+        const leaked = hostGlobals.filter(name => typeof globalThis[name] !== 'undefined');
+        insomnia.environment.set('leakedHostGlobals', leaked);
+        insomnia.environment.set('sandboxGlobalNames', Object.getOwnPropertyNames(globalThis));
+      `,
+      context,
+    });
+
+    const data = result.environment.data as Record<string, unknown>;
+    expect(data.leakedHostGlobals).toEqual([]);
+
+    // Baseline: what a bare QuickJS context exposes on globalThis with no bootstrap, derived
+    // dynamically so it can't go stale as the vendored QuickJS version changes.
+    const QuickJS = await getQuickJSModule();
+    const bareVm = QuickJS.newContext();
+    let bareGlobalNames: string[];
+    try {
+      const dumped = bareVm.evalCode('Object.getOwnPropertyNames(globalThis)');
+      if (dumped.error) {
+        dumped.error.dispose();
+        throw new Error('failed to enumerate a bare QuickJS context\'s globals');
+      }
+      bareGlobalNames = bareVm.dump(dumped.value) as string[];
+      dumped.value.dispose();
+    } finally {
+      bareVm.dispose();
+    }
+    const baseline = new Set(bareGlobalNames);
+
+    // Anything else reachable on globalThis fails this assertion instead of shipping silently.
+    const ALLOWED_EXTRA_GLOBALS = new Set([
+      'console', '__envGet', '__envSet', '__varGet', '__varSet', '__requestJSON', '__task',
+      'insomnia', '$',
+    ]);
+    const unexpectedGlobals = (data.sandboxGlobalNames as string[]).filter(
+      name => !baseline.has(name) && !ALLOWED_EXTRA_GLOBALS.has(name),
+    );
+    expect(unexpectedGlobals).toEqual([]);
+  });
+
+  it('produces the intended timeout error, not a crash, when a script awaits a promise that never resolves', async () => {
+    const context = baseContext();
+    context.settings = { timeout: 30 } as any;
+
+    await expect(
+      runScriptInQuickJs({ script: 'await new Promise(() => {});', context }),
+    ).rejects.toThrow(/Executing script timeout: 30/);
+
+    // A later, unrelated run must still complete normally afterward.
+    const laterContext = baseContext();
+    const laterResult = await runScriptInQuickJs({
+      script: `insomnia.environment.set('ranCleanly', true);`,
+      context: laterContext,
+    });
+    expect((laterResult.environment.data as Record<string, unknown>).ranCleanly).toBe(true);
   });
 });

--- a/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
+++ b/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import type { RequestContext } from '../../../insomnia-scripting-environment/src/objects/interfaces';
+import { runScriptInQuickJs } from './quickjs-script-engine';
+
+const baseContext = (): RequestContext => ({
+  request: { _id: 'req_1', name: 'Test request', url: 'https://example.com' } as any,
+  timelinePath: '',
+  environment: { id: 'env_1', name: 'Base Environment', data: { foo: 'bar' } },
+  baseEnvironment: { id: 'env_1', name: 'Base Environment', data: {} },
+  timeout: 30_000,
+  settings: { timeout: 30_000 } as any,
+  clientCertificates: [],
+  cookieJar: { cookies: [] } as any,
+  requestInfo: {} as any,
+  execution: {} as any,
+  logs: [],
+  transientVariables: { name: 'transientVariables', data: {} },
+  parentFolders: [],
+});
+
+describe('runScriptInQuickJs', () => {
+  it('reads and writes environment variables', async () => {
+    const context = baseContext();
+
+    const result = await runScriptInQuickJs({
+      script: `
+        const current = insomnia.environment.get('foo');
+        insomnia.environment.set('foo', current + '-updated');
+        insomnia.environment.set('newKey', 42);
+      `,
+      context,
+    });
+
+    expect(result.environment.data).toEqual({ foo: 'bar-updated', newKey: 42 });
+  });
+
+  it('reads and writes transient variables', async () => {
+    const context = baseContext();
+
+    const result = await runScriptInQuickJs({
+      script: `insomnia.variables.set('count', (insomnia.variables.get('count') ?? 0) + 1);`,
+      context,
+    });
+
+    expect(result.transientVariables?.data).toEqual({ count: 1 });
+  });
+
+  it('exposes a read-only insomnia.request', async () => {
+    const context = baseContext();
+
+    const result = await runScriptInQuickJs({
+      script: `insomnia.environment.set('requestName', insomnia.request.name);`,
+      context,
+    });
+
+    expect((result.environment.data as Record<string, unknown>).requestName).toBe('Test request');
+  });
+
+  it('silently ignores attempts to mutate insomnia.request instead of faking success', async () => {
+    const context = baseContext();
+
+    const result = await runScriptInQuickJs({
+      script: `
+        insomnia.request.name = 'mutated';
+        insomnia.environment.set('nameAfterMutationAttempt', insomnia.request.name);
+      `,
+      context,
+    });
+
+    expect((result.environment.data as Record<string, unknown>).nameAfterMutationAttempt).toBe('Test request');
+  });
+
+  it('captures console output into logs', async () => {
+    const context = baseContext();
+
+    const result = await runScriptInQuickJs({
+      script: `console.log('hello from quickjs');`,
+      context,
+    });
+
+    expect(result.logs.some(row => row.includes('hello from quickjs'))).toBe(true);
+  });
+
+  it('throws a clear error when calling the unsupported sendRequest API', async () => {
+    const context = baseContext();
+
+    await expect(
+      runScriptInQuickJs({ script: 'await insomnia.sendRequest("https://example.com");', context }),
+    ).rejects.toThrow(/insomnia\.sendRequest\(\) is not supported/);
+  });
+
+  it('propagates script errors with a useful message', async () => {
+    const context = baseContext();
+
+    await expect(runScriptInQuickJs({ script: 'throw new Error("boom");', context })).rejects.toThrow('boom');
+  });
+});

--- a/packages/insomnia/src/scripting/quickjs-script-engine.ts
+++ b/packages/insomnia/src/scripting/quickjs-script-engine.ts
@@ -1,0 +1,208 @@
+import type { QuickJSContext, QuickJSHandle } from 'quickjs-emscripten';
+
+import { Console } from '../../../insomnia-scripting-environment/src/objects/console';
+import type { RequestContext } from '../../../insomnia-scripting-environment/src/objects/interfaces';
+import { getQuickJSModule } from '../templating/sandbox/quickjs-runtime';
+
+/**
+ * The actual QuickJS execution engine — creates a fresh VM, bridges in the minimal API surface, runs
+ * the script, and tears the VM down. Runs wherever it's called from (today: inside
+ * `quickjs-script.worker.ts`, off the renderer's main thread — see `run-script-quickjs.ts` for the
+ * client side of that boundary). Has no knowledge of workers/messaging; callers own that.
+ *
+ * PoC/experimental alternative to `run-script.ts`'s hidden-`BrowserWindow` execution path. Only a
+ * minimal API surface is bridged in — enough to demonstrate the architecture, not enough to replace
+ * the hidden-window sandbox yet. Gated behind `settings.useQuickJsScriptSandbox` (default off).
+ *
+ * Not supported (throws inside the script if called): insomnia.sendRequest(), insomnia.test()/
+ * pm.test(), collectionVariables, vault, cookies, client certificates, and mutating the request.
+ */
+export const runScriptInQuickJs = async ({
+  script,
+  context,
+}: {
+  script: string;
+  context: RequestContext;
+}): Promise<RequestContext> => {
+  const QuickJS = await getQuickJSModule();
+  const vm = QuickJS.newContext();
+  const scriptConsole = new Console();
+  const timeoutMs = context.settings.timeout && context.settings.timeout > 0 ? context.settings.timeout : 30_000;
+  const deadline = Date.now() + timeoutMs;
+
+  // Copied in up front and mutated in place by the environment/variables bridges below; whatever
+  // is left in these objects when the script finishes becomes the updated context.
+  const environmentData: Record<string, unknown> = { ...context.environment.data };
+  const variablesData: Record<string, unknown> = { ...context.transientVariables?.data };
+
+  try {
+    // Polled during synchronous execution so a tight sync loop in the script can't bypass the timeout.
+    vm.runtime.setInterruptHandler(() => Date.now() > deadline);
+    vm.runtime.setMemoryLimit(32 * 1024 * 1024);
+
+    installConsole(vm, scriptConsole);
+    installKeyValueBridge(vm, '__envGet', '__envSet', environmentData);
+    installKeyValueBridge(vm, '__varGet', '__varSet', variablesData);
+    setGlobalString(vm, '__requestJSON', JSON.stringify(context.request ?? {}));
+
+    evalOrThrow(vm, BOOTSTRAP, '<quickjs-script-bootstrap>');
+    evalOrThrow(vm, wrapUserScript(script), '<user-script>');
+
+    await driveTaskToCompletion(vm, deadline, timeoutMs);
+  } finally {
+    vm.dispose();
+  }
+
+  return {
+    ...context,
+    environment: {
+      id: context.environment.id,
+      name: context.environment.name,
+      data: environmentData,
+    },
+    transientVariables: {
+      name: context.transientVariables?.name || 'transientVariables',
+      data: variablesData,
+    },
+    logs: scriptConsole.dumpLogsAsArray(),
+  };
+};
+
+const unsupportedApiMessage = (name: string): string =>
+  `${name} is not supported yet by the QuickJS sandbox (proof of concept). Disable "Use QuickJS sandbox for scripts" in Settings > Scripting to use it.`;
+
+const BOOTSTRAP = `
+globalThis.insomnia = {
+  environment: {
+    get: (key) => JSON.parse(__envGet(key)),
+    set: (key, value) => { __envSet(key, JSON.stringify(value === undefined ? null : value)); },
+  },
+  variables: {
+    get: (key) => JSON.parse(__varGet(key)),
+    set: (key, value) => { __varSet(key, JSON.stringify(value === undefined ? null : value)); },
+  },
+  request: (function deepFreeze(value) {
+    if (value && typeof value === 'object') {
+      Object.values(value).forEach(deepFreeze);
+      return Object.freeze(value);
+    }
+    return value;
+  })(JSON.parse(__requestJSON)),
+  sendRequest: () => { throw new Error(${JSON.stringify(unsupportedApiMessage('insomnia.sendRequest()'))}); },
+  test: () => { throw new Error(${JSON.stringify(unsupportedApiMessage('insomnia.test()/pm.test()'))}); },
+};
+globalThis.$ = globalThis.insomnia;
+`;
+
+const wrapUserScript = (script: string): string => `
+globalThis.__task = (async () => {
+  ${script}
+})();
+`;
+
+const installConsole = (vm: QuickJSContext, scriptConsole: Console): void => {
+  const consoleHandle = vm.newObject();
+  (['log', 'warn', 'error', 'info', 'debug'] as const).forEach(level => {
+    const fn = vm.newFunction(level, (...argHandles: QuickJSHandle[]) => {
+      const values = argHandles.map(handle => vm.dump(handle));
+      scriptConsole[level](...values);
+    });
+    vm.setProp(consoleHandle, level, fn);
+    fn.dispose();
+  });
+  vm.setProp(vm.global, 'console', consoleHandle);
+  consoleHandle.dispose();
+};
+
+/** Registers `<getName>(key)`/`<setName>(key, jsonValue)` host functions backed by a plain object. */
+const installKeyValueBridge = (
+  vm: QuickJSContext,
+  getName: string,
+  setName: string,
+  store: Record<string, unknown>,
+): void => {
+  const getFn = vm.newFunction(getName, keyHandle => {
+    const key = vm.getString(keyHandle);
+    const value = Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null;
+    return vm.newString(JSON.stringify(value));
+  });
+  setGlobal(vm, getName, getFn);
+
+  const setFn = vm.newFunction(setName, (keyHandle, valueHandle) => {
+    const key = vm.getString(keyHandle);
+    const rawValue = vm.getString(valueHandle);
+    try {
+      store[key] = JSON.parse(rawValue);
+    } catch {
+      store[key] = rawValue;
+    }
+  });
+  setGlobal(vm, setName, setFn);
+};
+
+const setGlobal = (vm: QuickJSContext, name: string, handle: QuickJSHandle): void => {
+  // setProp does NOT take ownership of handle — it must still be disposed here, or the VM leaks
+  // it and asserts ("gc_obj_list" non-empty) when the runtime is later disposed.
+  vm.setProp(vm.global, name, handle);
+  handle.dispose();
+};
+
+const setGlobalString = (vm: QuickJSContext, name: string, value: string): void => {
+  const handle = vm.newString(value);
+  setGlobal(vm, name, handle);
+};
+
+const evalOrThrow = (vm: QuickJSContext, code: string, filename: string): void => {
+  const result = vm.evalCode(code, filename);
+  if (result.error) {
+    const errData = vm.dump(result.error);
+    result.error.dispose();
+    throw toError(errData);
+  }
+  result.value.dispose();
+};
+
+/** Drives `globalThis.__task` (a VM promise wrapping the user script) to completion. */
+const driveTaskToCompletion = async (vm: QuickJSContext, deadline: number, timeoutMs: number): Promise<void> => {
+  const taskHandle = vm.getProp(vm.global, '__task');
+  const resultPromise = vm.resolvePromise(taskHandle);
+  taskHandle.dispose();
+
+  let settled: Awaited<typeof resultPromise> | undefined;
+  resultPromise.then(result => {
+    settled = result;
+  });
+
+  while (!settled) {
+    vm.runtime.executePendingJobs();
+    if (settled) {
+      break;
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`Executing script timeout: ${timeoutMs}`);
+    }
+    await new Promise(resolve => setTimeout(resolve, 0));
+  }
+
+  if (settled.error) {
+    const errData = vm.dump(settled.error);
+    settled.error.dispose();
+    throw toError(errData);
+  }
+  settled.value.dispose();
+};
+
+const toError = (data: unknown): Error => {
+  if (data && typeof data === 'object' && 'message' in data) {
+    const { message, name, stack } = data as { message?: string; name?: string; stack?: string };
+    const err = new Error(message ?? 'QuickJS sandbox error');
+    if (name) {
+      err.name = name;
+    }
+    if (stack) {
+      err.stack = stack;
+    }
+    return err;
+  }
+  return new Error(typeof data === 'string' ? data : JSON.stringify(data));
+};

--- a/packages/insomnia/src/scripting/quickjs-script-engine.ts
+++ b/packages/insomnia/src/scripting/quickjs-script-engine.ts
@@ -14,26 +14,15 @@ import { getQuickJSModule } from '../templating/sandbox/quickjs-runtime';
  * minimal API surface is bridged in — enough to demonstrate the architecture, not enough to replace
  * the hidden-window sandbox yet. Gated behind `settings.useQuickJsScriptSandbox` (default off).
  *
- * insomnia.sendRequest() bridges to the real `network.sendRequestWithoutSideEffects` host handler
- * (the same one the template-tag sandbox uses) over the `insomnia-templating-worker-database://`
- * fetch-based protocol — see `installSendRequestBridge` below. It supports only a minimal request
- * shape (a URL string, or `{ url, method, headers, body }` with a plain string body) — no auth,
- * client certificates, cookies, or multipart/urlencoded bodies yet, and the response object exposes
- * only `code`/`status`/`headers`/`body`/`responseTime`/`json()`/`text()` (no chai assertions, no
- * `originalRequest`). Full parity with the hidden-window `Response` class is deferred.
- *
- * Not supported (throws inside the script if called): insomnia.test()/pm.test(), collectionVariables,
- * vault, cookies, client certificates, and mutating the request.
+ * Not supported (throws inside the script if called): insomnia.sendRequest(), insomnia.test()/
+ * pm.test(), collectionVariables, vault, cookies, client certificates, and mutating the request.
  */
 export const runScriptInQuickJs = async ({
   script,
   context,
-  authToken,
 }: {
   script: string;
   context: RequestContext;
-  /** Auth token for the `insomnia-templating-worker-database://` bridge — required for sendRequest. */
-  authToken?: string;
 }): Promise<RequestContext> => {
   const QuickJS = await getQuickJSModule();
   const vm = QuickJS.newContext();
@@ -54,7 +43,6 @@ export const runScriptInQuickJs = async ({
     installConsole(vm, scriptConsole);
     installKeyValueBridge(vm, '__envGet', '__envSet', environmentData);
     installKeyValueBridge(vm, '__varGet', '__varSet', variablesData);
-    installSendRequestBridge(vm, authToken);
     setGlobalString(vm, '__requestJSON', JSON.stringify(context.request ?? {}));
 
     evalOrThrow(vm, BOOTSTRAP, '<quickjs-script-bootstrap>');
@@ -100,43 +88,7 @@ globalThis.insomnia = {
     }
     return value;
   })(JSON.parse(__requestJSON)),
-  sendRequest: (request, callback) => {
-    const normalized = typeof request === 'string'
-      ? { url: request, method: 'GET' }
-      : {
-          url: request.url,
-          method: request.method || 'GET',
-          headers: Array.isArray(request.headers)
-            ? request.headers
-            : Object.entries(request.headers || {}).map(([name, value]) => ({ name, value: String(value) })),
-          body: request.body !== undefined ? { mimeType: 'text/plain', text: String(request.body) } : undefined,
-        };
-    const bodyJson = JSON.stringify({ options: { request: normalized, caCertficatePath: null } });
-    const promise = __sendRequest(bodyJson).then((envelopeJson) => {
-      const envelope = JSON.parse(envelopeJson);
-      if (!envelope.ok) {
-        throw new Error(envelope.error);
-      }
-      const result = envelope.value;
-      return {
-        code: result.code,
-        status: result.status,
-        headers: result.headers,
-        body: result.body,
-        responseTime: result.responseTime,
-        json: () => JSON.parse(result.body),
-        text: () => result.body,
-      };
-    });
-    if (typeof callback === 'function') {
-      promise.then(
-        (response) => callback(undefined, response),
-        (err) => callback(err.message),
-      );
-      return undefined;
-    }
-    return promise;
-  },
+  sendRequest: () => { throw new Error(${JSON.stringify(unsupportedApiMessage('insomnia.sendRequest()'))}); },
   test: () => { throw new Error(${JSON.stringify(unsupportedApiMessage('insomnia.test()/pm.test()'))}); },
 };
 globalThis.$ = globalThis.insomnia;
@@ -160,57 +112,6 @@ const installConsole = (vm: QuickJSContext, scriptConsole: Console): void => {
   });
   vm.setProp(vm.global, 'console', consoleHandle);
   consoleHandle.dispose();
-};
-
-// The same fetch-based bridge the template-tag sandbox uses (`common/templating/liquid-extension-worker.ts`),
-// reused here rather than adding a second protocol scheme — this endpoint already sends a real
-// request via curl without persisting it to request/response history, which is exactly what an
-// ad-hoc `insomnia.sendRequest()` call needs.
-const SEND_REQUEST_ENDPOINT = 'insomnia-templating-worker-database://network.sendrequestwithoutsideeffects';
-const TEMPLATING_DB_AUTH_HEADER = 'x-insomnia-templating-auth';
-
-const sendRequestViaFetch = async (requestBodyJson: string, authToken?: string): Promise<Record<string, unknown>> => {
-  const resp = await fetch(SEND_REQUEST_ENDPOINT, {
-    method: 'post',
-    headers: authToken ? { [TEMPLATING_DB_AUTH_HEADER]: authToken } : undefined,
-    body: requestBodyJson,
-  });
-  const parsed = JSON.parse(await resp.text());
-  if (!resp.ok) {
-    throw new Error(typeof parsed?.error === 'string' ? parsed.error : `sendRequest failed with status ${resp.status}`);
-  }
-  return parsed;
-};
-
-/** Registers the async `__sendRequest(bodyJson)` bridge backing `insomnia.sendRequest()` in BOOTSTRAP. */
-const installSendRequestBridge = (vm: QuickJSContext, authToken?: string): void => {
-  const fn = vm.newFunction('__sendRequest', bodyHandle => {
-    const bodyJson = vm.getString(bodyHandle);
-    const deferred = vm.newPromise();
-    sendRequestViaFetch(bodyJson, authToken).then(
-      value => resolveDeferredWithString(vm, deferred, JSON.stringify({ ok: true, value })),
-      err =>
-        resolveDeferredWithString(
-          vm,
-          deferred,
-          JSON.stringify({ ok: false, error: err instanceof Error ? err.message : String(err) }),
-        ),
-    );
-    // The settled VM promise schedules a job; pump it so the awaiting script resumes.
-    deferred.settled.then(() => vm.runtime.executePendingJobs());
-    return deferred.handle;
-  });
-  setGlobal(vm, '__sendRequest', fn);
-};
-
-const resolveDeferredWithString = (
-  vm: QuickJSContext,
-  deferred: ReturnType<QuickJSContext['newPromise']>,
-  value: string,
-): void => {
-  const handle = vm.newString(value);
-  deferred.resolve(handle);
-  handle.dispose();
 };
 
 /** Registers `<getName>(key)`/`<setName>(key, jsonValue)` host functions backed by a plain object. */

--- a/packages/insomnia/src/scripting/quickjs-script-engine.ts
+++ b/packages/insomnia/src/scripting/quickjs-script-engine.ts
@@ -14,15 +14,26 @@ import { getQuickJSModule } from '../templating/sandbox/quickjs-runtime';
  * minimal API surface is bridged in — enough to demonstrate the architecture, not enough to replace
  * the hidden-window sandbox yet. Gated behind `settings.useQuickJsScriptSandbox` (default off).
  *
- * Not supported (throws inside the script if called): insomnia.sendRequest(), insomnia.test()/
- * pm.test(), collectionVariables, vault, cookies, client certificates, and mutating the request.
+ * insomnia.sendRequest() bridges to the real `network.sendRequestWithoutSideEffects` host handler
+ * (the same one the template-tag sandbox uses) over the `insomnia-templating-worker-database://`
+ * fetch-based protocol — see `installSendRequestBridge` below. It supports only a minimal request
+ * shape (a URL string, or `{ url, method, headers, body }` with a plain string body) — no auth,
+ * client certificates, cookies, or multipart/urlencoded bodies yet, and the response object exposes
+ * only `code`/`status`/`headers`/`body`/`responseTime`/`json()`/`text()` (no chai assertions, no
+ * `originalRequest`). Full parity with the hidden-window `Response` class is deferred.
+ *
+ * Not supported (throws inside the script if called): insomnia.test()/pm.test(), collectionVariables,
+ * vault, cookies, client certificates, and mutating the request.
  */
 export const runScriptInQuickJs = async ({
   script,
   context,
+  authToken,
 }: {
   script: string;
   context: RequestContext;
+  /** Auth token for the `insomnia-templating-worker-database://` bridge — required for sendRequest. */
+  authToken?: string;
 }): Promise<RequestContext> => {
   const QuickJS = await getQuickJSModule();
   const vm = QuickJS.newContext();
@@ -43,6 +54,7 @@ export const runScriptInQuickJs = async ({
     installConsole(vm, scriptConsole);
     installKeyValueBridge(vm, '__envGet', '__envSet', environmentData);
     installKeyValueBridge(vm, '__varGet', '__varSet', variablesData);
+    installSendRequestBridge(vm, authToken);
     setGlobalString(vm, '__requestJSON', JSON.stringify(context.request ?? {}));
 
     evalOrThrow(vm, BOOTSTRAP, '<quickjs-script-bootstrap>');
@@ -88,7 +100,43 @@ globalThis.insomnia = {
     }
     return value;
   })(JSON.parse(__requestJSON)),
-  sendRequest: () => { throw new Error(${JSON.stringify(unsupportedApiMessage('insomnia.sendRequest()'))}); },
+  sendRequest: (request, callback) => {
+    const normalized = typeof request === 'string'
+      ? { url: request, method: 'GET' }
+      : {
+          url: request.url,
+          method: request.method || 'GET',
+          headers: Array.isArray(request.headers)
+            ? request.headers
+            : Object.entries(request.headers || {}).map(([name, value]) => ({ name, value: String(value) })),
+          body: request.body !== undefined ? { mimeType: 'text/plain', text: String(request.body) } : undefined,
+        };
+    const bodyJson = JSON.stringify({ options: { request: normalized, caCertficatePath: null } });
+    const promise = __sendRequest(bodyJson).then((envelopeJson) => {
+      const envelope = JSON.parse(envelopeJson);
+      if (!envelope.ok) {
+        throw new Error(envelope.error);
+      }
+      const result = envelope.value;
+      return {
+        code: result.code,
+        status: result.status,
+        headers: result.headers,
+        body: result.body,
+        responseTime: result.responseTime,
+        json: () => JSON.parse(result.body),
+        text: () => result.body,
+      };
+    });
+    if (typeof callback === 'function') {
+      promise.then(
+        (response) => callback(undefined, response),
+        (err) => callback(err.message),
+      );
+      return undefined;
+    }
+    return promise;
+  },
   test: () => { throw new Error(${JSON.stringify(unsupportedApiMessage('insomnia.test()/pm.test()'))}); },
 };
 globalThis.$ = globalThis.insomnia;
@@ -112,6 +160,57 @@ const installConsole = (vm: QuickJSContext, scriptConsole: Console): void => {
   });
   vm.setProp(vm.global, 'console', consoleHandle);
   consoleHandle.dispose();
+};
+
+// The same fetch-based bridge the template-tag sandbox uses (`common/templating/liquid-extension-worker.ts`),
+// reused here rather than adding a second protocol scheme — this endpoint already sends a real
+// request via curl without persisting it to request/response history, which is exactly what an
+// ad-hoc `insomnia.sendRequest()` call needs.
+const SEND_REQUEST_ENDPOINT = 'insomnia-templating-worker-database://network.sendrequestwithoutsideeffects';
+const TEMPLATING_DB_AUTH_HEADER = 'x-insomnia-templating-auth';
+
+const sendRequestViaFetch = async (requestBodyJson: string, authToken?: string): Promise<Record<string, unknown>> => {
+  const resp = await fetch(SEND_REQUEST_ENDPOINT, {
+    method: 'post',
+    headers: authToken ? { [TEMPLATING_DB_AUTH_HEADER]: authToken } : undefined,
+    body: requestBodyJson,
+  });
+  const parsed = JSON.parse(await resp.text());
+  if (!resp.ok) {
+    throw new Error(typeof parsed?.error === 'string' ? parsed.error : `sendRequest failed with status ${resp.status}`);
+  }
+  return parsed;
+};
+
+/** Registers the async `__sendRequest(bodyJson)` bridge backing `insomnia.sendRequest()` in BOOTSTRAP. */
+const installSendRequestBridge = (vm: QuickJSContext, authToken?: string): void => {
+  const fn = vm.newFunction('__sendRequest', bodyHandle => {
+    const bodyJson = vm.getString(bodyHandle);
+    const deferred = vm.newPromise();
+    sendRequestViaFetch(bodyJson, authToken).then(
+      value => resolveDeferredWithString(vm, deferred, JSON.stringify({ ok: true, value })),
+      err =>
+        resolveDeferredWithString(
+          vm,
+          deferred,
+          JSON.stringify({ ok: false, error: err instanceof Error ? err.message : String(err) }),
+        ),
+    );
+    // The settled VM promise schedules a job; pump it so the awaiting script resumes.
+    deferred.settled.then(() => vm.runtime.executePendingJobs());
+    return deferred.handle;
+  });
+  setGlobal(vm, '__sendRequest', fn);
+};
+
+const resolveDeferredWithString = (
+  vm: QuickJSContext,
+  deferred: ReturnType<QuickJSContext['newPromise']>,
+  value: string,
+): void => {
+  const handle = vm.newString(value);
+  deferred.resolve(handle);
+  handle.dispose();
 };
 
 /** Registers `<getName>(key)`/`<setName>(key, jsonValue)` host functions backed by a plain object. */

--- a/packages/insomnia/src/scripting/quickjs-script-engine.ts
+++ b/packages/insomnia/src/scripting/quickjs-script-engine.ts
@@ -114,6 +114,10 @@ const installConsole = (vm: QuickJSContext, scriptConsole: Console): void => {
   consoleHandle.dispose();
 };
 
+// Using one of these as a bracket-assignment key on a plain object rewires its prototype or
+// shadows the name instead of setting an ordinary property.
+const DANGEROUS_BRIDGE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 /** Registers `<getName>(key)`/`<setName>(key, jsonValue)` host functions backed by a plain object. */
 const installKeyValueBridge = (
   vm: QuickJSContext,
@@ -130,6 +134,9 @@ const installKeyValueBridge = (
 
   const setFn = vm.newFunction(setName, (keyHandle, valueHandle) => {
     const key = vm.getString(keyHandle);
+    if (DANGEROUS_BRIDGE_KEYS.has(key)) {
+      return;
+    }
     const rawValue = vm.getString(valueHandle);
     try {
       store[key] = JSON.parse(rawValue);

--- a/packages/insomnia/src/scripting/quickjs-script.worker.ts
+++ b/packages/insomnia/src/scripting/quickjs-script.worker.ts
@@ -12,6 +12,8 @@ interface WorkerRequest {
   id: string;
   script: string;
   context: RequestContext;
+  /** Auth token for the `insomnia-templating-worker-database://` bridge — see run-script-quickjs.ts. */
+  authToken?: string;
 }
 
 interface WorkerErrorResponse {
@@ -27,9 +29,9 @@ interface WorkerSuccessResponse {
 export type WorkerResponse = WorkerSuccessResponse | WorkerErrorResponse;
 
 self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
-  const { id, script, context } = event.data;
+  const { id, script, context, authToken } = event.data;
   try {
-    const result = await runScriptInQuickJs({ script, context });
+    const result = await runScriptInQuickJs({ script, context, authToken });
     self.postMessage({ id, result } satisfies WorkerSuccessResponse);
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));

--- a/packages/insomnia/src/scripting/quickjs-script.worker.ts
+++ b/packages/insomnia/src/scripting/quickjs-script.worker.ts
@@ -1,0 +1,41 @@
+import type { RequestContext } from '../../../insomnia-scripting-environment/src/objects/interfaces';
+import { runScriptInQuickJs } from './quickjs-script-engine';
+
+/**
+ * Web Worker entry point for the QuickJS script engine — moves execution off the renderer's main
+ * thread (see `run-script-quickjs.ts`, this worker's client), so a runaway script blocks only this
+ * disposable worker, never the UI. One message in, one response out; no persistent VM state is kept
+ * between messages (`quickjs-script-engine.ts` creates and disposes a fresh QuickJS context per call).
+ */
+
+interface WorkerRequest {
+  id: string;
+  script: string;
+  context: RequestContext;
+}
+
+interface WorkerErrorResponse {
+  id: string;
+  error: { message: string; name?: string; stack?: string };
+}
+
+interface WorkerSuccessResponse {
+  id: string;
+  result: RequestContext;
+}
+
+export type WorkerResponse = WorkerSuccessResponse | WorkerErrorResponse;
+
+self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
+  const { id, script, context } = event.data;
+  try {
+    const result = await runScriptInQuickJs({ script, context });
+    self.postMessage({ id, result } satisfies WorkerSuccessResponse);
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    self.postMessage({
+      id,
+      error: { message: error.message, name: error.name, stack: error.stack },
+    } satisfies WorkerErrorResponse);
+  }
+};

--- a/packages/insomnia/src/scripting/quickjs-script.worker.ts
+++ b/packages/insomnia/src/scripting/quickjs-script.worker.ts
@@ -12,8 +12,6 @@ interface WorkerRequest {
   id: string;
   script: string;
   context: RequestContext;
-  /** Auth token for the `insomnia-templating-worker-database://` bridge — see run-script-quickjs.ts. */
-  authToken?: string;
 }
 
 interface WorkerErrorResponse {
@@ -29,9 +27,9 @@ interface WorkerSuccessResponse {
 export type WorkerResponse = WorkerSuccessResponse | WorkerErrorResponse;
 
 self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
-  const { id, script, context, authToken } = event.data;
+  const { id, script, context } = event.data;
   try {
-    const result = await runScriptInQuickJs({ script, context, authToken });
+    const result = await runScriptInQuickJs({ script, context });
     self.postMessage({ id, result } satisfies WorkerSuccessResponse);
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));

--- a/packages/insomnia/src/scripting/run-script-quickjs.test.ts
+++ b/packages/insomnia/src/scripting/run-script-quickjs.test.ts
@@ -53,10 +53,6 @@ class FakeWorker {
   }
 }
 
-// runScriptInQuickJs now awaits the (mocked) auth token before touching the worker, so callers must
-// let that microtask resolve before inspecting postedMessages or emitting worker events.
-const flushMicrotasks = (): Promise<void> => new Promise(resolve => setTimeout(resolve, 0));
-
 describe('runScriptInQuickJs (worker client)', () => {
   let fakeWorker: FakeWorker;
 
@@ -66,9 +62,6 @@ describe('runScriptInQuickJs (worker client)', () => {
       'Worker',
       vi.fn(() => fakeWorker),
     );
-    vi.stubGlobal('window', {
-      main: { templatingDb: { getAuthToken: vi.fn().mockResolvedValue('test-token') } },
-    });
     // The module keeps a lazily-created singleton worker at module scope — reset it between tests
     // by re-importing fresh so each test gets its own FakeWorker instance.
     vi.resetModules();
@@ -83,11 +76,9 @@ describe('runScriptInQuickJs (worker client)', () => {
     const context = baseContext();
 
     const promise = runScriptInQuickJs({ script: 'console.log(1)', context });
-    await flushMicrotasks();
     expect(fakeWorker.postedMessages).toHaveLength(1);
-    const { id, authToken } = fakeWorker.postedMessages[0];
+    const { id } = fakeWorker.postedMessages[0];
     expect(typeof id).toBe('string');
-    expect(authToken).toBe('test-token');
 
     const result = { ...context, logs: ['log: 1\n'] };
     fakeWorker.emitMessage({ id, result });
@@ -100,7 +91,6 @@ describe('runScriptInQuickJs (worker client)', () => {
     const context = baseContext();
 
     const promise = runScriptInQuickJs({ script: 'throw new Error("boom")', context });
-    await flushMicrotasks();
     const { id } = fakeWorker.postedMessages[0];
     fakeWorker.emitMessage({ id, error: { message: 'boom', name: 'Error' } });
 
@@ -112,7 +102,6 @@ describe('runScriptInQuickJs (worker client)', () => {
     const context = baseContext();
 
     const promise = runScriptInQuickJs({ script: 'console.log(1)', context });
-    await flushMicrotasks();
     fakeWorker.emitMessage({ id: 'not-a-real-id', result: {} });
 
     const { id } = fakeWorker.postedMessages[0];
@@ -127,7 +116,6 @@ describe('runScriptInQuickJs (worker client)', () => {
     const context = baseContext();
 
     const promise = runScriptInQuickJs({ script: 'while(true){}', context });
-    await flushMicrotasks();
     fakeWorker.emitError('script execution context has been aborted');
 
     await expect(promise).rejects.toThrow(/QuickJS sandbox worker crashed/);
@@ -138,7 +126,6 @@ describe('runScriptInQuickJs (worker client)', () => {
     const context = baseContext();
 
     const firstCall = runScriptInQuickJs({ script: 'while(true){}', context });
-    await flushMicrotasks();
     fakeWorker.emitError('boom');
     await expect(firstCall).rejects.toThrow();
 
@@ -149,7 +136,6 @@ describe('runScriptInQuickJs (worker client)', () => {
     );
 
     const secondCall = runScriptInQuickJs({ script: 'console.log(1)', context });
-    await flushMicrotasks();
     expect(secondWorker.postedMessages).toHaveLength(1);
     const { id } = secondWorker.postedMessages[0];
     const result = { ...context, logs: [] };

--- a/packages/insomnia/src/scripting/run-script-quickjs.test.ts
+++ b/packages/insomnia/src/scripting/run-script-quickjs.test.ts
@@ -1,12 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { RequestContext } from '../../../insomnia-scripting-environment/src/objects/interfaces';
-import { runScriptInQuickJs } from './run-script-quickjs';
 
 const baseContext = (): RequestContext => ({
   request: { _id: 'req_1', name: 'Test request', url: 'https://example.com' } as any,
   timelinePath: '',
-  environment: { id: 'env_1', name: 'Base Environment', data: { foo: 'bar' } },
+  environment: { id: 'env_1', name: 'Base Environment', data: {} },
   baseEnvironment: { id: 'env_1', name: 'Base Environment', data: {} },
   timeout: 30_000,
   settings: { timeout: 30_000 } as any,
@@ -19,80 +18,123 @@ const baseContext = (): RequestContext => ({
   parentFolders: [],
 });
 
-describe('runScriptInQuickJs', () => {
-  it('reads and writes environment variables', async () => {
-    const context = baseContext();
+/**
+ * A minimal stand-in for the DOM `Worker` API, driven manually from the test — this suite verifies
+ * the message-correlation contract between `run-script-quickjs.ts` and `quickjs-script.worker.ts`
+ * without needing a real Worker runtime (not available in the Vitest/Node test environment).
+ */
+class FakeWorker {
+  postedMessages: any[] = [];
+  private messageListeners: ((event: { data: any }) => void)[] = [];
+  private errorListeners: ((event: { message: string }) => void)[] = [];
 
-    const result = await runScriptInQuickJs({
-      script: `
-        const current = insomnia.environment.get('foo');
-        insomnia.environment.set('foo', current + '-updated');
-        insomnia.environment.set('newKey', 42);
-      `,
-      context,
-    });
+  postMessage(data: any) {
+    this.postedMessages.push(data);
+  }
 
-    expect(result.environment.data).toEqual({ foo: 'bar-updated', newKey: 42 });
+  addEventListener(type: string, listener: any) {
+    if (type === 'message') {
+      this.messageListeners.push(listener);
+    } else if (type === 'error') {
+      this.errorListeners.push(listener);
+    }
+  }
+
+  removeEventListener() {
+    // not used by the client today
+  }
+
+  emitMessage(data: any) {
+    this.messageListeners.forEach(listener => listener({ data }));
+  }
+
+  emitError(message: string) {
+    this.errorListeners.forEach(listener => listener({ message }));
+  }
+}
+
+describe('runScriptInQuickJs (worker client)', () => {
+  let fakeWorker: FakeWorker;
+
+  beforeEach(async () => {
+    fakeWorker = new FakeWorker();
+    vi.stubGlobal('Worker', vi.fn(() => fakeWorker));
+    // The module keeps a lazily-created singleton worker at module scope — reset it between tests
+    // by re-importing fresh so each test gets its own FakeWorker instance.
+    vi.resetModules();
   });
 
-  it('reads and writes transient variables', async () => {
-    const context = baseContext();
-
-    const result = await runScriptInQuickJs({
-      script: `insomnia.variables.set('count', (insomnia.variables.get('count') ?? 0) + 1);`,
-      context,
-    });
-
-    expect(result.transientVariables?.data).toEqual({ count: 1 });
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
-  it('exposes a read-only insomnia.request', async () => {
+  it('posts a message and resolves with the worker\'s result for the matching id', async () => {
+    const { runScriptInQuickJs } = await import('./run-script-quickjs');
     const context = baseContext();
 
-    const result = await runScriptInQuickJs({
-      script: `insomnia.environment.set('requestName', insomnia.request.name);`,
-      context,
-    });
+    const promise = runScriptInQuickJs({ script: 'console.log(1)', context });
+    expect(fakeWorker.postedMessages).toHaveLength(1);
+    const { id } = fakeWorker.postedMessages[0];
+    expect(typeof id).toBe('string');
 
-    expect((result.environment.data as Record<string, unknown>).requestName).toBe('Test request');
+    const result = { ...context, logs: ['log: 1\n'] };
+    fakeWorker.emitMessage({ id, result });
+
+    await expect(promise).resolves.toEqual(result);
   });
 
-  it('silently ignores attempts to mutate insomnia.request instead of faking success', async () => {
+  it('rejects with the worker-reported error for the matching id', async () => {
+    const { runScriptInQuickJs } = await import('./run-script-quickjs');
     const context = baseContext();
 
-    const result = await runScriptInQuickJs({
-      script: `
-        insomnia.request.name = 'mutated';
-        insomnia.environment.set('nameAfterMutationAttempt', insomnia.request.name);
-      `,
-      context,
-    });
+    const promise = runScriptInQuickJs({ script: 'throw new Error("boom")', context });
+    const { id } = fakeWorker.postedMessages[0];
+    fakeWorker.emitMessage({ id, error: { message: 'boom', name: 'Error' } });
 
-    expect((result.environment.data as Record<string, unknown>).nameAfterMutationAttempt).toBe('Test request');
+    await expect(promise).rejects.toThrow('boom');
   });
 
-  it('captures console output into logs', async () => {
+  it('ignores a message whose id does not match any pending request', async () => {
+    const { runScriptInQuickJs } = await import('./run-script-quickjs');
     const context = baseContext();
 
-    const result = await runScriptInQuickJs({
-      script: `console.log('hello from quickjs');`,
-      context,
-    });
+    const promise = runScriptInQuickJs({ script: 'console.log(1)', context });
+    fakeWorker.emitMessage({ id: 'not-a-real-id', result: {} });
 
-    expect(result.logs.some(row => row.includes('hello from quickjs'))).toBe(true);
+    const { id } = fakeWorker.postedMessages[0];
+    const result = { ...context, logs: [] };
+    fakeWorker.emitMessage({ id, result });
+
+    await expect(promise).resolves.toEqual(result);
   });
 
-  it('throws a clear error when calling the unsupported sendRequest API', async () => {
+  it('rejects every in-flight call when the worker crashes', async () => {
+    const { runScriptInQuickJs } = await import('./run-script-quickjs');
     const context = baseContext();
 
-    await expect(
-      runScriptInQuickJs({ script: 'await insomnia.sendRequest("https://example.com");', context }),
-    ).rejects.toThrow(/insomnia\.sendRequest\(\) is not supported/);
+    const promise = runScriptInQuickJs({ script: 'while(true){}', context });
+    fakeWorker.emitError('script execution context has been aborted');
+
+    await expect(promise).rejects.toThrow(/QuickJS sandbox worker crashed/);
   });
 
-  it('propagates script errors with a useful message', async () => {
+  it('creates a fresh worker for the next call after a crash', async () => {
+    const { runScriptInQuickJs } = await import('./run-script-quickjs');
     const context = baseContext();
 
-    await expect(runScriptInQuickJs({ script: 'throw new Error("boom");', context })).rejects.toThrow('boom');
+    const firstCall = runScriptInQuickJs({ script: 'while(true){}', context });
+    fakeWorker.emitError('boom');
+    await expect(firstCall).rejects.toThrow();
+
+    const secondWorker = new FakeWorker();
+    vi.stubGlobal('Worker', vi.fn(() => secondWorker));
+
+    const secondCall = runScriptInQuickJs({ script: 'console.log(1)', context });
+    expect(secondWorker.postedMessages).toHaveLength(1);
+    const { id } = secondWorker.postedMessages[0];
+    const result = { ...context, logs: [] };
+    secondWorker.emitMessage({ id, result });
+
+    await expect(secondCall).resolves.toEqual(result);
   });
 });

--- a/packages/insomnia/src/scripting/run-script-quickjs.test.ts
+++ b/packages/insomnia/src/scripting/run-script-quickjs.test.ts
@@ -58,7 +58,10 @@ describe('runScriptInQuickJs (worker client)', () => {
 
   beforeEach(async () => {
     fakeWorker = new FakeWorker();
-    vi.stubGlobal('Worker', vi.fn(() => fakeWorker));
+    vi.stubGlobal(
+      'Worker',
+      vi.fn(() => fakeWorker),
+    );
     // The module keeps a lazily-created singleton worker at module scope — reset it between tests
     // by re-importing fresh so each test gets its own FakeWorker instance.
     vi.resetModules();
@@ -68,7 +71,7 @@ describe('runScriptInQuickJs (worker client)', () => {
     vi.unstubAllGlobals();
   });
 
-  it('posts a message and resolves with the worker\'s result for the matching id', async () => {
+  it("posts a message and resolves with the worker's result for the matching id", async () => {
     const { runScriptInQuickJs } = await import('./run-script-quickjs');
     const context = baseContext();
 
@@ -127,7 +130,10 @@ describe('runScriptInQuickJs (worker client)', () => {
     await expect(firstCall).rejects.toThrow();
 
     const secondWorker = new FakeWorker();
-    vi.stubGlobal('Worker', vi.fn(() => secondWorker));
+    vi.stubGlobal(
+      'Worker',
+      vi.fn(() => secondWorker),
+    );
 
     const secondCall = runScriptInQuickJs({ script: 'console.log(1)', context });
     expect(secondWorker.postedMessages).toHaveLength(1);

--- a/packages/insomnia/src/scripting/run-script-quickjs.test.ts
+++ b/packages/insomnia/src/scripting/run-script-quickjs.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import type { RequestContext } from '../../../insomnia-scripting-environment/src/objects/interfaces';
+import { runScriptInQuickJs } from './run-script-quickjs';
+
+const baseContext = (): RequestContext => ({
+  request: { _id: 'req_1', name: 'Test request', url: 'https://example.com' } as any,
+  timelinePath: '',
+  environment: { id: 'env_1', name: 'Base Environment', data: { foo: 'bar' } },
+  baseEnvironment: { id: 'env_1', name: 'Base Environment', data: {} },
+  timeout: 30_000,
+  settings: { timeout: 30_000 } as any,
+  clientCertificates: [],
+  cookieJar: { cookies: [] } as any,
+  requestInfo: {} as any,
+  execution: {} as any,
+  logs: [],
+  transientVariables: { name: 'transientVariables', data: {} },
+  parentFolders: [],
+});
+
+describe('runScriptInQuickJs', () => {
+  it('reads and writes environment variables', async () => {
+    const context = baseContext();
+
+    const result = await runScriptInQuickJs({
+      script: `
+        const current = insomnia.environment.get('foo');
+        insomnia.environment.set('foo', current + '-updated');
+        insomnia.environment.set('newKey', 42);
+      `,
+      context,
+    });
+
+    expect(result.environment.data).toEqual({ foo: 'bar-updated', newKey: 42 });
+  });
+
+  it('reads and writes transient variables', async () => {
+    const context = baseContext();
+
+    const result = await runScriptInQuickJs({
+      script: `insomnia.variables.set('count', insomnia.variables.get('count') ?? 0 + 1);`,
+      context,
+    });
+
+    expect(result.transientVariables?.data).toEqual({ count: 1 });
+  });
+
+  it('exposes a read-only insomnia.request', async () => {
+    const context = baseContext();
+
+    const result = await runScriptInQuickJs({
+      script: `insomnia.environment.set('requestName', insomnia.request.name);`,
+      context,
+    });
+
+    expect((result.environment.data as Record<string, unknown>).requestName).toBe('Test request');
+  });
+
+  it('captures console output into logs', async () => {
+    const context = baseContext();
+
+    const result = await runScriptInQuickJs({
+      script: `console.log('hello from quickjs');`,
+      context,
+    });
+
+    expect(result.logs.some(row => row.includes('hello from quickjs'))).toBe(true);
+  });
+
+  it('throws a clear error when calling the unsupported sendRequest API', async () => {
+    const context = baseContext();
+
+    await expect(
+      runScriptInQuickJs({ script: 'await insomnia.sendRequest("https://example.com");', context }),
+    ).rejects.toThrow(/insomnia\.sendRequest\(\) is not supported/);
+  });
+
+  it('propagates script errors with a useful message', async () => {
+    const context = baseContext();
+
+    await expect(runScriptInQuickJs({ script: 'throw new Error("boom");', context })).rejects.toThrow('boom');
+  });
+});

--- a/packages/insomnia/src/scripting/run-script-quickjs.test.ts
+++ b/packages/insomnia/src/scripting/run-script-quickjs.test.ts
@@ -39,7 +39,7 @@ describe('runScriptInQuickJs', () => {
     const context = baseContext();
 
     const result = await runScriptInQuickJs({
-      script: `insomnia.variables.set('count', insomnia.variables.get('count') ?? 0 + 1);`,
+      script: `insomnia.variables.set('count', (insomnia.variables.get('count') ?? 0) + 1);`,
       context,
     });
 
@@ -55,6 +55,20 @@ describe('runScriptInQuickJs', () => {
     });
 
     expect((result.environment.data as Record<string, unknown>).requestName).toBe('Test request');
+  });
+
+  it('silently ignores attempts to mutate insomnia.request instead of faking success', async () => {
+    const context = baseContext();
+
+    const result = await runScriptInQuickJs({
+      script: `
+        insomnia.request.name = 'mutated';
+        insomnia.environment.set('nameAfterMutationAttempt', insomnia.request.name);
+      `,
+      context,
+    });
+
+    expect((result.environment.data as Record<string, unknown>).nameAfterMutationAttempt).toBe('Test request');
   });
 
   it('captures console output into logs', async () => {

--- a/packages/insomnia/src/scripting/run-script-quickjs.test.ts
+++ b/packages/insomnia/src/scripting/run-script-quickjs.test.ts
@@ -53,6 +53,10 @@ class FakeWorker {
   }
 }
 
+// runScriptInQuickJs now awaits the (mocked) auth token before touching the worker, so callers must
+// let that microtask resolve before inspecting postedMessages or emitting worker events.
+const flushMicrotasks = (): Promise<void> => new Promise(resolve => setTimeout(resolve, 0));
+
 describe('runScriptInQuickJs (worker client)', () => {
   let fakeWorker: FakeWorker;
 
@@ -62,6 +66,9 @@ describe('runScriptInQuickJs (worker client)', () => {
       'Worker',
       vi.fn(() => fakeWorker),
     );
+    vi.stubGlobal('window', {
+      main: { templatingDb: { getAuthToken: vi.fn().mockResolvedValue('test-token') } },
+    });
     // The module keeps a lazily-created singleton worker at module scope — reset it between tests
     // by re-importing fresh so each test gets its own FakeWorker instance.
     vi.resetModules();
@@ -76,9 +83,11 @@ describe('runScriptInQuickJs (worker client)', () => {
     const context = baseContext();
 
     const promise = runScriptInQuickJs({ script: 'console.log(1)', context });
+    await flushMicrotasks();
     expect(fakeWorker.postedMessages).toHaveLength(1);
-    const { id } = fakeWorker.postedMessages[0];
+    const { id, authToken } = fakeWorker.postedMessages[0];
     expect(typeof id).toBe('string');
+    expect(authToken).toBe('test-token');
 
     const result = { ...context, logs: ['log: 1\n'] };
     fakeWorker.emitMessage({ id, result });
@@ -91,6 +100,7 @@ describe('runScriptInQuickJs (worker client)', () => {
     const context = baseContext();
 
     const promise = runScriptInQuickJs({ script: 'throw new Error("boom")', context });
+    await flushMicrotasks();
     const { id } = fakeWorker.postedMessages[0];
     fakeWorker.emitMessage({ id, error: { message: 'boom', name: 'Error' } });
 
@@ -102,6 +112,7 @@ describe('runScriptInQuickJs (worker client)', () => {
     const context = baseContext();
 
     const promise = runScriptInQuickJs({ script: 'console.log(1)', context });
+    await flushMicrotasks();
     fakeWorker.emitMessage({ id: 'not-a-real-id', result: {} });
 
     const { id } = fakeWorker.postedMessages[0];
@@ -116,6 +127,7 @@ describe('runScriptInQuickJs (worker client)', () => {
     const context = baseContext();
 
     const promise = runScriptInQuickJs({ script: 'while(true){}', context });
+    await flushMicrotasks();
     fakeWorker.emitError('script execution context has been aborted');
 
     await expect(promise).rejects.toThrow(/QuickJS sandbox worker crashed/);
@@ -126,6 +138,7 @@ describe('runScriptInQuickJs (worker client)', () => {
     const context = baseContext();
 
     const firstCall = runScriptInQuickJs({ script: 'while(true){}', context });
+    await flushMicrotasks();
     fakeWorker.emitError('boom');
     await expect(firstCall).rejects.toThrow();
 
@@ -136,6 +149,7 @@ describe('runScriptInQuickJs (worker client)', () => {
     );
 
     const secondCall = runScriptInQuickJs({ script: 'console.log(1)', context });
+    await flushMicrotasks();
     expect(secondWorker.postedMessages).toHaveLength(1);
     const { id } = secondWorker.postedMessages[0];
     const result = { ...context, logs: [] };

--- a/packages/insomnia/src/scripting/run-script-quickjs.ts
+++ b/packages/insomnia/src/scripting/run-script-quickjs.ts
@@ -1,0 +1,198 @@
+import type { QuickJSContext, QuickJSHandle } from 'quickjs-emscripten';
+
+import { Console } from '../../../insomnia-scripting-environment/src/objects/console';
+import type { RequestContext } from '../../../insomnia-scripting-environment/src/objects/interfaces';
+import { getQuickJSModule } from '../templating/sandbox/quickjs-runtime';
+
+/**
+ * PoC/experimental alternative to `run-script.ts`'s hidden-`BrowserWindow` execution path. Runs
+ * pre-request/after-response scripts inside a QuickJS-WASM VM instead. Only a minimal API surface
+ * is bridged in — enough to demonstrate the architecture, not enough to replace the hidden-window
+ * sandbox yet. Gated behind `settings.useQuickJsScriptSandbox` (default off).
+ *
+ * Not supported (throws inside the script if called): insomnia.sendRequest(), insomnia.test()/
+ * pm.test(), collectionVariables, vault, cookies, client certificates, and mutating the request.
+ */
+export const runScriptInQuickJs = async ({
+  script,
+  context,
+}: {
+  script: string;
+  context: RequestContext;
+}): Promise<RequestContext> => {
+  const QuickJS = await getQuickJSModule();
+  const vm = QuickJS.newContext();
+  const scriptConsole = new Console();
+  const timeoutMs = context.settings.timeout && context.settings.timeout > 0 ? context.settings.timeout : 30_000;
+  const deadline = Date.now() + timeoutMs;
+
+  // Copied in up front and mutated in place by the environment/variables bridges below; whatever
+  // is left in these objects when the script finishes becomes the updated context.
+  const environmentData: Record<string, unknown> = { ...context.environment.data };
+  const variablesData: Record<string, unknown> = { ...context.transientVariables?.data };
+
+  try {
+    // Polled during synchronous execution so a tight sync loop in the script can't bypass the timeout.
+    vm.runtime.setInterruptHandler(() => Date.now() > deadline);
+    vm.runtime.setMemoryLimit(32 * 1024 * 1024);
+
+    installConsole(vm, scriptConsole);
+    installKeyValueBridge(vm, '__envGet', '__envSet', environmentData);
+    installKeyValueBridge(vm, '__varGet', '__varSet', variablesData);
+    setGlobalString(vm, '__requestJSON', JSON.stringify(context.request ?? {}));
+
+    evalOrThrow(vm, BOOTSTRAP, '<quickjs-script-bootstrap>');
+    evalOrThrow(vm, wrapUserScript(script), '<user-script>');
+
+    await driveTaskToCompletion(vm, deadline);
+  } finally {
+    vm.dispose();
+  }
+
+  return {
+    ...context,
+    environment: {
+      id: context.environment.id,
+      name: context.environment.name,
+      data: environmentData,
+    },
+    transientVariables: {
+      name: context.transientVariables?.name || 'transientVariables',
+      data: variablesData,
+    },
+    logs: scriptConsole.dumpLogsAsArray(),
+  };
+};
+
+const unsupportedApiMessage = (name: string): string =>
+  `${name} is not supported yet by the QuickJS sandbox (proof of concept). Disable "Use QuickJS sandbox for scripts" in Settings > Scripting to use it.`;
+
+const BOOTSTRAP = `
+globalThis.insomnia = {
+  environment: {
+    get: (key) => JSON.parse(__envGet(key)),
+    set: (key, value) => { __envSet(key, JSON.stringify(value === undefined ? null : value)); },
+  },
+  variables: {
+    get: (key) => JSON.parse(__varGet(key)),
+    set: (key, value) => { __varSet(key, JSON.stringify(value === undefined ? null : value)); },
+  },
+  request: JSON.parse(__requestJSON),
+  sendRequest: () => { throw new Error(${JSON.stringify(unsupportedApiMessage('insomnia.sendRequest()'))}); },
+  test: () => { throw new Error(${JSON.stringify(unsupportedApiMessage('insomnia.test()/pm.test()'))}); },
+};
+globalThis.$ = globalThis.insomnia;
+`;
+
+const wrapUserScript = (script: string): string => `
+globalThis.__task = (async () => {
+  ${script}
+})();
+`;
+
+const installConsole = (vm: QuickJSContext, scriptConsole: Console): void => {
+  const consoleHandle = vm.newObject();
+  (['log', 'warn', 'error', 'info', 'debug'] as const).forEach(level => {
+    const fn = vm.newFunction(level, (...argHandles: QuickJSHandle[]) => {
+      const values = argHandles.map(handle => vm.dump(handle));
+      scriptConsole[level](...values);
+    });
+    vm.setProp(consoleHandle, level, fn);
+    fn.dispose();
+  });
+  vm.setProp(vm.global, 'console', consoleHandle);
+  consoleHandle.dispose();
+};
+
+/** Registers `<getName>(key)`/`<setName>(key, jsonValue)` host functions backed by a plain object. */
+const installKeyValueBridge = (
+  vm: QuickJSContext,
+  getName: string,
+  setName: string,
+  store: Record<string, unknown>,
+): void => {
+  const getFn = vm.newFunction(getName, keyHandle => {
+    const key = vm.getString(keyHandle);
+    const value = Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null;
+    return vm.newString(JSON.stringify(value));
+  });
+  setGlobal(vm, getName, getFn);
+
+  const setFn = vm.newFunction(setName, (keyHandle, valueHandle) => {
+    const key = vm.getString(keyHandle);
+    const rawValue = vm.getString(valueHandle);
+    try {
+      store[key] = JSON.parse(rawValue);
+    } catch {
+      store[key] = rawValue;
+    }
+  });
+  setGlobal(vm, setName, setFn);
+};
+
+const setGlobal = (vm: QuickJSContext, name: string, handle: QuickJSHandle): void => {
+  // setProp does NOT take ownership of handle — it must still be disposed here, or the VM leaks
+  // it and asserts ("gc_obj_list" non-empty) when the runtime is later disposed.
+  vm.setProp(vm.global, name, handle);
+  handle.dispose();
+};
+
+const setGlobalString = (vm: QuickJSContext, name: string, value: string): void => {
+  const handle = vm.newString(value);
+  setGlobal(vm, name, handle);
+};
+
+const evalOrThrow = (vm: QuickJSContext, code: string, filename: string): void => {
+  const result = vm.evalCode(code, filename);
+  if (result.error) {
+    const errData = vm.dump(result.error);
+    result.error.dispose();
+    throw toError(errData);
+  }
+  result.value.dispose();
+};
+
+/** Drives `globalThis.__task` (a VM promise wrapping the user script) to completion. */
+const driveTaskToCompletion = async (vm: QuickJSContext, deadline: number): Promise<void> => {
+  const taskHandle = vm.getProp(vm.global, '__task');
+  const resultPromise = vm.resolvePromise(taskHandle);
+  taskHandle.dispose();
+
+  let settled: Awaited<typeof resultPromise> | undefined;
+  resultPromise.then(result => {
+    settled = result;
+  });
+
+  while (!settled) {
+    vm.runtime.executePendingJobs();
+    if (settled) {
+      break;
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`Executing script timeout: ${deadline}`);
+    }
+    await new Promise(resolve => setTimeout(resolve, 0));
+  }
+
+  if (settled.error) {
+    const errData = vm.dump(settled.error);
+    settled.error.dispose();
+    throw toError(errData);
+  }
+  settled.value.dispose();
+};
+
+const toError = (data: unknown): Error => {
+  if (data && typeof data === 'object' && 'message' in data) {
+    const { message, name, stack } = data as { message?: string; name?: string; stack?: string };
+    const err = new Error(message ?? 'QuickJS sandbox error');
+    if (name) {
+      err.name = name;
+    }
+    if (stack) {
+      err.stack = stack;
+    }
+    return err;
+  }
+  return new Error(typeof data === 'string' ? data : JSON.stringify(data));
+};

--- a/packages/insomnia/src/scripting/run-script-quickjs.ts
+++ b/packages/insomnia/src/scripting/run-script-quickjs.ts
@@ -1,204 +1,72 @@
-import type { QuickJSContext, QuickJSHandle } from 'quickjs-emscripten';
-
-import { Console } from '../../../insomnia-scripting-environment/src/objects/console';
 import type { RequestContext } from '../../../insomnia-scripting-environment/src/objects/interfaces';
-import { getQuickJSModule } from '../templating/sandbox/quickjs-runtime';
+import type { WorkerResponse } from './quickjs-script.worker';
 
 /**
- * PoC/experimental alternative to `run-script.ts`'s hidden-`BrowserWindow` execution path. Runs
- * pre-request/after-response scripts inside a QuickJS-WASM VM instead. Only a minimal API surface
- * is bridged in — enough to demonstrate the architecture, not enough to replace the hidden-window
- * sandbox yet. Gated behind `settings.useQuickJsScriptSandbox` (default off).
- *
- * Not supported (throws inside the script if called): insomnia.sendRequest(), insomnia.test()/
- * pm.test(), collectionVariables, vault, cookies, client certificates, and mutating the request.
+ * Client side of the QuickJS-sandbox worker boundary. Runs a script by posting it to a dedicated
+ * Web Worker (`quickjs-script.worker.ts`) instead of calling the engine (`quickjs-script-engine.ts`)
+ * directly on the renderer's main thread — a runaway script blocks only that disposable worker, the
+ * app stays responsive. The worker is created lazily on first use, since most users never enable
+ * `settings.useQuickJsScriptSandbox` and shouldn't pay for a QuickJS-WASM load they never trigger.
  */
-export const runScriptInQuickJs = async ({
+
+let worker: Worker | null = null;
+const pending = new Map<string, { resolve: (value: RequestContext) => void; reject: (err: Error) => void }>();
+
+const getWorker = (): Worker => {
+  if (worker) {
+    return worker;
+  }
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- see templating-handler.ts's identical pattern
+  // @ts-ignore -- inso transpiles to commonjs so doesn't play nice with this
+  const instance = new Worker(new URL('quickjs-script.worker.ts', import.meta.url), { type: 'module' });
+
+  instance.addEventListener('message', (event: MessageEvent<WorkerResponse>) => {
+    const { id } = event.data;
+    const request = pending.get(id);
+    if (!request) {
+      return;
+    }
+    pending.delete(id);
+    if ('error' in event.data) {
+      const err = new Error(event.data.error.message);
+      if (event.data.error.name) {
+        err.name = event.data.error.name;
+      }
+      if (event.data.error.stack) {
+        err.stack = event.data.error.stack;
+      }
+      request.reject(err);
+    } else {
+      request.resolve(event.data.result);
+    }
+  });
+
+  // A crash in the worker's global scope (e.g. an unhandled rejection outside our own try/catch)
+  // otherwise leaves every in-flight caller hanging forever. Reject them and drop the worker so the
+  // next call gets a fresh one instead of reusing a dead thread.
+  instance.addEventListener('error', event => {
+    const err = new Error(`QuickJS sandbox worker crashed: ${event.message}`);
+    pending.forEach(request => request.reject(err));
+    pending.clear();
+    if (worker === instance) {
+      worker = null;
+    }
+  });
+
+  worker = instance;
+  return instance;
+};
+
+export const runScriptInQuickJs = ({
   script,
   context,
 }: {
   script: string;
   context: RequestContext;
 }): Promise<RequestContext> => {
-  const QuickJS = await getQuickJSModule();
-  const vm = QuickJS.newContext();
-  const scriptConsole = new Console();
-  const timeoutMs = context.settings.timeout && context.settings.timeout > 0 ? context.settings.timeout : 30_000;
-  const deadline = Date.now() + timeoutMs;
-
-  // Copied in up front and mutated in place by the environment/variables bridges below; whatever
-  // is left in these objects when the script finishes becomes the updated context.
-  const environmentData: Record<string, unknown> = { ...context.environment.data };
-  const variablesData: Record<string, unknown> = { ...context.transientVariables?.data };
-
-  try {
-    // Polled during synchronous execution so a tight sync loop in the script can't bypass the timeout.
-    vm.runtime.setInterruptHandler(() => Date.now() > deadline);
-    vm.runtime.setMemoryLimit(32 * 1024 * 1024);
-
-    installConsole(vm, scriptConsole);
-    installKeyValueBridge(vm, '__envGet', '__envSet', environmentData);
-    installKeyValueBridge(vm, '__varGet', '__varSet', variablesData);
-    setGlobalString(vm, '__requestJSON', JSON.stringify(context.request ?? {}));
-
-    evalOrThrow(vm, BOOTSTRAP, '<quickjs-script-bootstrap>');
-    evalOrThrow(vm, wrapUserScript(script), '<user-script>');
-
-    await driveTaskToCompletion(vm, deadline, timeoutMs);
-  } finally {
-    vm.dispose();
-  }
-
-  return {
-    ...context,
-    environment: {
-      id: context.environment.id,
-      name: context.environment.name,
-      data: environmentData,
-    },
-    transientVariables: {
-      name: context.transientVariables?.name || 'transientVariables',
-      data: variablesData,
-    },
-    logs: scriptConsole.dumpLogsAsArray(),
-  };
-};
-
-const unsupportedApiMessage = (name: string): string =>
-  `${name} is not supported yet by the QuickJS sandbox (proof of concept). Disable "Use QuickJS sandbox for scripts" in Settings > Scripting to use it.`;
-
-const BOOTSTRAP = `
-globalThis.insomnia = {
-  environment: {
-    get: (key) => JSON.parse(__envGet(key)),
-    set: (key, value) => { __envSet(key, JSON.stringify(value === undefined ? null : value)); },
-  },
-  variables: {
-    get: (key) => JSON.parse(__varGet(key)),
-    set: (key, value) => { __varSet(key, JSON.stringify(value === undefined ? null : value)); },
-  },
-  request: (function deepFreeze(value) {
-    if (value && typeof value === 'object') {
-      Object.values(value).forEach(deepFreeze);
-      return Object.freeze(value);
-    }
-    return value;
-  })(JSON.parse(__requestJSON)),
-  sendRequest: () => { throw new Error(${JSON.stringify(unsupportedApiMessage('insomnia.sendRequest()'))}); },
-  test: () => { throw new Error(${JSON.stringify(unsupportedApiMessage('insomnia.test()/pm.test()'))}); },
-};
-globalThis.$ = globalThis.insomnia;
-`;
-
-const wrapUserScript = (script: string): string => `
-globalThis.__task = (async () => {
-  ${script}
-})();
-`;
-
-const installConsole = (vm: QuickJSContext, scriptConsole: Console): void => {
-  const consoleHandle = vm.newObject();
-  (['log', 'warn', 'error', 'info', 'debug'] as const).forEach(level => {
-    const fn = vm.newFunction(level, (...argHandles: QuickJSHandle[]) => {
-      const values = argHandles.map(handle => vm.dump(handle));
-      scriptConsole[level](...values);
-    });
-    vm.setProp(consoleHandle, level, fn);
-    fn.dispose();
+  const id = `quickjs-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return new Promise<RequestContext>((resolve, reject) => {
+    pending.set(id, { resolve, reject });
+    getWorker().postMessage({ id, script, context });
   });
-  vm.setProp(vm.global, 'console', consoleHandle);
-  consoleHandle.dispose();
-};
-
-/** Registers `<getName>(key)`/`<setName>(key, jsonValue)` host functions backed by a plain object. */
-const installKeyValueBridge = (
-  vm: QuickJSContext,
-  getName: string,
-  setName: string,
-  store: Record<string, unknown>,
-): void => {
-  const getFn = vm.newFunction(getName, keyHandle => {
-    const key = vm.getString(keyHandle);
-    const value = Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null;
-    return vm.newString(JSON.stringify(value));
-  });
-  setGlobal(vm, getName, getFn);
-
-  const setFn = vm.newFunction(setName, (keyHandle, valueHandle) => {
-    const key = vm.getString(keyHandle);
-    const rawValue = vm.getString(valueHandle);
-    try {
-      store[key] = JSON.parse(rawValue);
-    } catch {
-      store[key] = rawValue;
-    }
-  });
-  setGlobal(vm, setName, setFn);
-};
-
-const setGlobal = (vm: QuickJSContext, name: string, handle: QuickJSHandle): void => {
-  // setProp does NOT take ownership of handle — it must still be disposed here, or the VM leaks
-  // it and asserts ("gc_obj_list" non-empty) when the runtime is later disposed.
-  vm.setProp(vm.global, name, handle);
-  handle.dispose();
-};
-
-const setGlobalString = (vm: QuickJSContext, name: string, value: string): void => {
-  const handle = vm.newString(value);
-  setGlobal(vm, name, handle);
-};
-
-const evalOrThrow = (vm: QuickJSContext, code: string, filename: string): void => {
-  const result = vm.evalCode(code, filename);
-  if (result.error) {
-    const errData = vm.dump(result.error);
-    result.error.dispose();
-    throw toError(errData);
-  }
-  result.value.dispose();
-};
-
-/** Drives `globalThis.__task` (a VM promise wrapping the user script) to completion. */
-const driveTaskToCompletion = async (vm: QuickJSContext, deadline: number, timeoutMs: number): Promise<void> => {
-  const taskHandle = vm.getProp(vm.global, '__task');
-  const resultPromise = vm.resolvePromise(taskHandle);
-  taskHandle.dispose();
-
-  let settled: Awaited<typeof resultPromise> | undefined;
-  resultPromise.then(result => {
-    settled = result;
-  });
-
-  while (!settled) {
-    vm.runtime.executePendingJobs();
-    if (settled) {
-      break;
-    }
-    if (Date.now() > deadline) {
-      throw new Error(`Executing script timeout: ${timeoutMs}`);
-    }
-    await new Promise(resolve => setTimeout(resolve, 0));
-  }
-
-  if (settled.error) {
-    const errData = vm.dump(settled.error);
-    settled.error.dispose();
-    throw toError(errData);
-  }
-  settled.value.dispose();
-};
-
-const toError = (data: unknown): Error => {
-  if (data && typeof data === 'object' && 'message' in data) {
-    const { message, name, stack } = data as { message?: string; name?: string; stack?: string };
-    const err = new Error(message ?? 'QuickJS sandbox error');
-    if (name) {
-      err.name = name;
-    }
-    if (stack) {
-      err.stack = stack;
-    }
-    return err;
-  }
-  return new Error(typeof data === 'string' ? data : JSON.stringify(data));
 };

--- a/packages/insomnia/src/scripting/run-script-quickjs.ts
+++ b/packages/insomnia/src/scripting/run-script-quickjs.ts
@@ -12,16 +12,6 @@ import type { WorkerResponse } from './quickjs-script.worker';
 let worker: Worker | null = null;
 const pending = new Map<string, { resolve: (value: RequestContext) => void; reject: (err: Error) => void }>();
 
-// The Worker has no window.main access, so this module fetches the auth token once (same pattern as
-// ui/worker/templating-handler.ts) and forwards it on every postMessage instead.
-let authTokenPromise: Promise<string> | null = null;
-const getAuthToken = (): Promise<string> => {
-  if (!authTokenPromise) {
-    authTokenPromise = window.main.templatingDb.getAuthToken();
-  }
-  return authTokenPromise;
-};
-
 const getWorker = (): Worker => {
   if (worker) {
     return worker;
@@ -67,17 +57,16 @@ const getWorker = (): Worker => {
   return instance;
 };
 
-export const runScriptInQuickJs = async ({
+export const runScriptInQuickJs = ({
   script,
   context,
 }: {
   script: string;
   context: RequestContext;
 }): Promise<RequestContext> => {
-  const authToken = await getAuthToken();
   const id = `quickjs-${Date.now()}-${Math.random().toString(36).slice(2)}`;
   return new Promise<RequestContext>((resolve, reject) => {
     pending.set(id, { resolve, reject });
-    getWorker().postMessage({ id, script, context, authToken });
+    getWorker().postMessage({ id, script, context });
   });
 };

--- a/packages/insomnia/src/scripting/run-script-quickjs.ts
+++ b/packages/insomnia/src/scripting/run-script-quickjs.ts
@@ -44,7 +44,7 @@ export const runScriptInQuickJs = async ({
     evalOrThrow(vm, BOOTSTRAP, '<quickjs-script-bootstrap>');
     evalOrThrow(vm, wrapUserScript(script), '<user-script>');
 
-    await driveTaskToCompletion(vm, deadline);
+    await driveTaskToCompletion(vm, deadline, timeoutMs);
   } finally {
     vm.dispose();
   }
@@ -77,7 +77,13 @@ globalThis.insomnia = {
     get: (key) => JSON.parse(__varGet(key)),
     set: (key, value) => { __varSet(key, JSON.stringify(value === undefined ? null : value)); },
   },
-  request: JSON.parse(__requestJSON),
+  request: (function deepFreeze(value) {
+    if (value && typeof value === 'object') {
+      Object.values(value).forEach(deepFreeze);
+      return Object.freeze(value);
+    }
+    return value;
+  })(JSON.parse(__requestJSON)),
   sendRequest: () => { throw new Error(${JSON.stringify(unsupportedApiMessage('insomnia.sendRequest()'))}); },
   test: () => { throw new Error(${JSON.stringify(unsupportedApiMessage('insomnia.test()/pm.test()'))}); },
 };
@@ -153,7 +159,7 @@ const evalOrThrow = (vm: QuickJSContext, code: string, filename: string): void =
 };
 
 /** Drives `globalThis.__task` (a VM promise wrapping the user script) to completion. */
-const driveTaskToCompletion = async (vm: QuickJSContext, deadline: number): Promise<void> => {
+const driveTaskToCompletion = async (vm: QuickJSContext, deadline: number, timeoutMs: number): Promise<void> => {
   const taskHandle = vm.getProp(vm.global, '__task');
   const resultPromise = vm.resolvePromise(taskHandle);
   taskHandle.dispose();
@@ -169,7 +175,7 @@ const driveTaskToCompletion = async (vm: QuickJSContext, deadline: number): Prom
       break;
     }
     if (Date.now() > deadline) {
-      throw new Error(`Executing script timeout: ${deadline}`);
+      throw new Error(`Executing script timeout: ${timeoutMs}`);
     }
     await new Promise(resolve => setTimeout(resolve, 0));
   }

--- a/packages/insomnia/src/scripting/run-script-quickjs.ts
+++ b/packages/insomnia/src/scripting/run-script-quickjs.ts
@@ -12,6 +12,16 @@ import type { WorkerResponse } from './quickjs-script.worker';
 let worker: Worker | null = null;
 const pending = new Map<string, { resolve: (value: RequestContext) => void; reject: (err: Error) => void }>();
 
+// The Worker has no window.main access, so this module fetches the auth token once (same pattern as
+// ui/worker/templating-handler.ts) and forwards it on every postMessage instead.
+let authTokenPromise: Promise<string> | null = null;
+const getAuthToken = (): Promise<string> => {
+  if (!authTokenPromise) {
+    authTokenPromise = window.main.templatingDb.getAuthToken();
+  }
+  return authTokenPromise;
+};
+
 const getWorker = (): Worker => {
   if (worker) {
     return worker;
@@ -57,16 +67,17 @@ const getWorker = (): Worker => {
   return instance;
 };
 
-export const runScriptInQuickJs = ({
+export const runScriptInQuickJs = async ({
   script,
   context,
 }: {
   script: string;
   context: RequestContext;
 }): Promise<RequestContext> => {
+  const authToken = await getAuthToken();
   const id = `quickjs-${Date.now()}-${Math.random().toString(36).slice(2)}`;
   return new Promise<RequestContext>((resolve, reject) => {
     pending.set(id, { resolve, reject });
-    getWorker().postMessage({ id, script, context });
+    getWorker().postMessage({ id, script, context, authToken });
   });
 };

--- a/packages/insomnia/src/ui/components/settings/scripting-settings.tsx
+++ b/packages/insomnia/src/ui/components/settings/scripting-settings.tsx
@@ -143,6 +143,7 @@ export const ScriptingSettings = () => {
 
   const sandboxEnabled = settings.scriptSandboxEnabled !== false;
   const strictModeEnabled = settings.scriptStrictModeEnabled !== false;
+  const useQuickJsScriptSandbox = settings.useQuickJsScriptSandbox === true;
   const pluginSandboxEnabled = settings.pluginSandboxEnabled === true;
   const disabledRules = settings.disabledSecurityRules ?? [];
   const disabledProperties = settings.disabledBlockedProperties ?? [];
@@ -316,6 +317,33 @@ export const ScriptingSettings = () => {
               onChange={enabled => patchSettings({ scriptStrictModeEnabled: enabled })}
             />
           </div>
+        </div>
+      </div>
+
+      <div className="rounded-md border border-solid border-(--hl-sm) bg-(--hl-xs) p-4">
+        <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-1">
+            <span className="text-sm font-medium text-(--color-font)">
+              Use QuickJS sandbox for scripts (proof of concept)
+            </span>
+            <p className="text-xs text-(--hl)">
+              Run pre-request and after-response scripts inside the QuickJS-WASM sandbox instead of the hidden browser
+              window. Only a minimal API is supported so far (console, insomnia.environment/variables get/set, read-only
+              insomnia.request) — scripts calling insomnia.sendRequest() or insomnia.test()/pm.test() will throw. Leave
+              this off to keep using the full-featured hidden-window sandbox.
+            </p>
+          </div>
+          <Switch
+            aria-label="Use QuickJS sandbox for scripts (proof of concept)"
+            data-testid="toggle-quickjs-script-sandbox"
+            isSelected={useQuickJsScriptSandbox}
+            onChange={enabled => patchSettings({ useQuickJsScriptSandbox: enabled })}
+            className="group flex items-center gap-2"
+          >
+            <div className="flex h-6 w-11 cursor-pointer items-center rounded-full border-2 border-solid border-transparent bg-(--hl-md) transition-colors group-data-selected:bg-(--color-surprise)">
+              <span className="h-5 w-5 translate-x-0 rounded-full bg-white transition-transform group-data-selected:translate-x-5" />
+            </div>
+          </Switch>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Proof of concept: run pre-request/after-response scripts in the QuickJS-WASM sandbox (already used for plugin template tags) instead of the hidden Electron `BrowserWindow`, gated behind a new **opt-in** setting.
- Adds `settings.useQuickJsScriptSandbox` (default `false`) and a toggle in Settings → Scripting.
- Single branch point: `concurrency.renderer.ts`'s existing script dispatch now checks the setting and calls either the QuickJS runner or the existing hidden-window path — no other call sites changed.

**PR 1 (worker boundary):** QuickJS execution runs in a dedicated Web Worker instead of the renderer's main thread, so a runaway/looping script blocks only that disposable worker, not the app UI — mirroring the existing `templating-handler.ts`/`templating.worker.ts` pattern used for template tags.
- `scripting/quickjs-script-engine.ts` — the pure QuickJS execution logic.
- `scripting/quickjs-script.worker.ts` — Web Worker entry point running the engine off-thread.
- `scripting/run-script-quickjs.ts` — thin client: lazily creates the worker and correlates postMessage/response pairs by id; a worker-level crash rejects in-flight calls and the next call gets a fresh worker.

**PR 2 (`insomnia.sendRequest()`) has been split out to #10392.** It hit a real `QuickJSUseAfterFree`/WASM heap crash under real Electron `fetch()` timing that only reproduces in the actual app, never in vitest's mocked unit tests, and needs further root-causing. This PR now contains **only PR 0 + PR 1**.

**E2E verification (new):** `packages/insomnia-smoke-test/tests/smoke/quickjs-script-sandbox.test.ts` proves PR 0 + PR 1 work end-to-end in the real Electron app — not just in mocked unit tests:
- `console.log`, `insomnia.environment.get/set`, and read-only `insomnia.request` all work through the real Worker/QuickJS pipeline (canary: `typeof require` confirms the script actually ran in QuickJS, not the hidden window).
- A runaway (`while(true){}`) script blocks only its dedicated Worker — the app UI stays responsive.

## Design doc

Full rollout plan (PR 0 → PR 12): https://gist.github.com/jackkav/3ebf8768bf84be024a3a138874919354

## Test plan
- [x] `npx vitest run packages/insomnia/src/scripting/` — 195/195 passing
- [x] `tsc --noEmit` clean for `insomnia` and `insomnia-data`
- [x] `eslint` clean for touched files
- [x] `packages/insomnia-smoke-test/tests/smoke/quickjs-script-sandbox.test.ts` — 2/2 passing against the real built app