### PR TITLE
fix: JSON format vault config is showing in the tag when edit credential

### DIFF
--- a/packages/insomnia/src/ui/components/templating/external-vault/external-vault-form.tsx
+++ b/packages/insomnia/src/ui/components/templating/external-vault/external-vault-form.tsx
@@ -122,7 +122,7 @@ export const ExternalVaultForm = (props: ArgConfigFormProps) => {
           provider={provider}
           providerCredential={selectedCredentialDoc}
           onClose={() => setShowModal(false)}
-          onComplete={() => onChange(configValue)}
+          onComplete={() => onChange(btoa(configValue))}
         />
       )}
     </>

--- a/packages/insomnia/src/ui/components/templating/external-vault/external-vault-form.tsx
+++ b/packages/insomnia/src/ui/components/templating/external-vault/external-vault-form.tsx
@@ -122,7 +122,12 @@ export const ExternalVaultForm = (props: ArgConfigFormProps) => {
           provider={provider}
           providerCredential={selectedCredentialDoc}
           onClose={() => setShowModal(false)}
-          onComplete={() => onChange(btoa(configValue))}
+          onComplete={() =>
+            onChange(
+              // convert the configValue to base64 string to avoid special characters in the configValue
+              btoa(new TextEncoder().encode(configValue).reduce((data, byte) => data + String.fromCodePoint(byte), '')),
+            )
+          }
         />
       )}
     </>


### PR DESCRIPTION
Fix the issue that JSON format vault config is showing in the tag when edit credential

[INS-3522](https://konghq.atlassian.net/browse/INS-3522)


[INS-3522]: https://konghq.atlassian.net/browse/INS-3522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ