### PR TITLE
fix(git): return success:true after a completed pull in GitProjectSyncDropdown

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
@@ -487,7 +487,7 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository, activeProject
         revalidate();
 
         return {
-          success: false,
+          success: true,
         };
       }
     } catch (err) {


### PR DESCRIPTION
## What
Fixes the return value of the git pull handler in `GitProjectSyncDropdown`. When a pull completes successfully (no merge conflicts), the function showed a "Pull completed" success toast but still returned `{ success: false }`.

## Why
Callers relying on the resolved value of this handler (e.g. for chaining follow-up actions or UI state) were receiving a `false` success flag despite the pull actually succeeding, which is misleading and could cause incorrect downstream behavior.

## Change
- `packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx`: changed the return value in the successful-pull branch from `{ success: false }` to `{ success: true }`.

## Testing
- Manually verified a successful pull with no conflicts now resolves with `success: true`.

Closes: INS-3527
