### PR TITLE
fix(database): emit change notifications on document duplication

### DIFF
--- a/packages/insomnia-data/node-src/database/database-nedb.ts
+++ b/packages/insomnia-data/node-src/database/database-nedb.ts
@@ -102,58 +102,61 @@ export const createNedbDatabase = <O = initOptions>(
 
     /** duplicate doc and its descendents recursively */
     duplicate: async function <T extends BaseModel>(originalDoc: T, patch: Partial<T> = {}) {
-      const flushId = await database.bufferChanges();
-      const descendantMap = models.getAllDescendantMap();
+      const flushId = await database.bufferChangesIndefinitely();
+      try {
+        const descendantMap = models.getAllDescendantMap();
 
-      const idMapping = new Map<string, string>();
-      const allDocs: { doc: BaseModel; parentId: string }[] = [];
+        const idMapping = new Map<string, string>();
+        const allDocs: { doc: BaseModel; parentId: string }[] = [];
 
-      async function collectDescendants(doc: BaseModel): Promise<void> {
-        const model = models.mustGetModel(doc.type);
-        idMapping.set(doc._id, generateId(model.prefix));
+        async function collectDescendants(doc: BaseModel): Promise<void> {
+          const model = models.mustGetModel(doc.type);
+          idMapping.set(doc._id, generateId(model.prefix));
 
-        const validChildTypes = (descendantMap[doc.type] ?? []).filter(t => models.canDuplicate(t));
-        for (const childType of validChildTypes) {
-          for (const child of await database.find(childType, { parentId: doc._id })) {
-            allDocs.push({ doc: child, parentId: doc._id });
-            await collectDescendants(child);
+          const validChildTypes = (descendantMap[doc.type] ?? []).filter(t => models.canDuplicate(t));
+          for (const childType of validChildTypes) {
+            for (const child of await database.find(childType, { parentId: doc._id })) {
+              allDocs.push({ doc: child, parentId: doc._id });
+              await collectDescendants(child);
+            }
           }
         }
-      }
-      await collectDescendants(originalDoc);
+        await collectDescendants(originalDoc);
 
-      const updateTime = Date.now();
+        const updateTime = Date.now();
 
-      // Duplicate the root document
-      const rootRewritten: T = models.rewriteReferences(originalDoc, idMapping);
-      const rootDoc = {
-        ...rootRewritten,
-        ...patch,
-        _id: idMapping.get(originalDoc._id)!,
-        modified: updateTime,
-        created: updateTime,
-        type: originalDoc.type,
-      };
-      const createdDoc = (await nedbBucket[originalDoc.type].insertAsync(rootDoc)) as T;
-      notifyOfChange('insert', createdDoc);
-
-      // Duplicate all descendants
-      for (const { doc, parentId } of allDocs) {
-        const rewritten = models.rewriteReferences(doc, idMapping);
-        const newDoc = {
-          ...rewritten,
-          _id: idMapping.get(doc._id)!,
-          parentId: idMapping.get(parentId)!,
+        // Duplicate the root document
+        const rootRewritten: T = models.rewriteReferences(originalDoc, idMapping);
+        const rootDoc = {
+          ...rootRewritten,
+          ...patch,
+          _id: idMapping.get(originalDoc._id)!,
           modified: updateTime,
           created: updateTime,
-          type: doc.type,
+          type: originalDoc.type,
         };
-        const createdDescendant = await nedbBucket[doc.type].insertAsync(newDoc);
-        notifyOfChange('insert', createdDescendant);
-      }
+        const createdDoc = (await nedbBucket[originalDoc.type].insertAsync(rootDoc)) as T;
+        notifyOfChange('insert', createdDoc);
 
-      await database.flushChanges(flushId);
-      return createdDoc;
+        // Duplicate all descendants
+        for (const { doc, parentId } of allDocs) {
+          const rewritten = models.rewriteReferences(doc, idMapping);
+          const newDoc = {
+            ...rewritten,
+            _id: idMapping.get(doc._id)!,
+            parentId: idMapping.get(parentId)!,
+            modified: updateTime,
+            created: updateTime,
+            type: doc.type,
+          };
+          const createdDescendant = await nedbBucket[doc.type].insertAsync(newDoc);
+          notifyOfChange('insert', createdDescendant);
+        }
+
+        return createdDoc;
+      } finally {
+        await database.flushChanges(flushId);
+      }
     },
     findOne: async function <T extends BaseModel>(
       type: AllTypes,

--- a/packages/insomnia-data/node-src/database/database-nedb.ts
+++ b/packages/insomnia-data/node-src/database/database-nedb.ts
@@ -135,6 +135,7 @@ export const createNedbDatabase = <O = initOptions>(
         type: originalDoc.type,
       };
       const createdDoc = (await nedbBucket[originalDoc.type].insertAsync(rootDoc)) as T;
+      notifyOfChange('insert', createdDoc);
 
       // Duplicate all descendants
       for (const { doc, parentId } of allDocs) {
@@ -147,7 +148,8 @@ export const createNedbDatabase = <O = initOptions>(
           created: updateTime,
           type: doc.type,
         };
-        await nedbBucket[doc.type].insertAsync(newDoc);
+        const createdDescendant = await nedbBucket[doc.type].insertAsync(newDoc);
+        notifyOfChange('insert', createdDescendant);
       }
 
       await database.flushChanges(flushId);

--- a/packages/insomnia-data/node-src/database/database.test.ts
+++ b/packages/insomnia-data/node-src/database/database.test.ts
@@ -617,6 +617,22 @@ describe('duplicate()', () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
+  it('should emit insert changes when duplicating', async () => {
+    const workspace = await services.workspace.create({ name: 'Workspace' });
+    const folder = await services.requestGroup.create({ parentId: workspace._id, name: 'Folder' });
+    await services.request.create({ parentId: folder._id, name: 'Request' });
+    const changesSeen: ChangeBufferEvent<BaseModel>[][] = [];
+    db.onChange(changes => changesSeen.push(changes));
+
+    const duplicatedFolder = await db.duplicate(folder);
+
+    expect(changesSeen).toHaveLength(1);
+    expect(changesSeen[0]).toEqual([
+      ['insert', duplicatedFolder, []],
+      ['insert', expect.objectContaining({ parentId: duplicatedFolder._id, type: models.request.type }), []],
+    ]);
+  });
+
   it('should rewrite chained request references when duplicating a folder', async () => {
     const workspace = await services.workspace.create({ name: 'Workspace' });
     const folder = await services.requestGroup.create({ parentId: workspace._id, name: 'Folder' });


### PR DESCRIPTION
Duplicating a request from either sidebar (project-level, collection-focus) creates the new request + navigates to it, but that request is not visible or selected in the sidebar.

This change emits a notification on duplication to cause the app data to revalidate