### PR TITLE
fix(data-process): fix crash-loop detection and renderer hang on give-up

### DIFF
--- a/packages/insomnia/src/data-process/data-process-manager.ts
+++ b/packages/insomnia/src/data-process/data-process-manager.ts
@@ -134,6 +134,10 @@ function handleExit(dbPath: string): void {
   if (restartCount > MAX_RESTARTS) {
     console.error(`[data-process] exceeded ${MAX_RESTARTS} restarts within ${RESTART_WINDOW_MS / 1000}s - giving up`);
     mainRpc.invalidate('data-process crashed and could not be restarted');
+    // Renderer windows hold their own PortRpc instances (attached via attachDataPortRpc in
+    // preload). Without this, their pending/future invoke() calls hang forever instead of
+    // rejecting, since 'data-process.restarting' is the only signal that invalidates them.
+    BrowserWindow.getAllWindows().forEach(w => w.webContents.send('data-process.restarting'));
     return;
   }
 
@@ -146,7 +150,10 @@ function handleExit(dbPath: string): void {
     spawnDataProcess(dbPath)
       .then(() => {
         console.log('[data-process] restarted, re-issuing ports');
-        restartCount = 0;
+        // Don't reset restartCount here: a process that reaches 'ready' and then crashes
+        // again seconds later would otherwise reset the counter on every attempt, defeating
+        // MAX_RESTARTS for a ready-then-crash loop. The RESTART_WINDOW_MS check above already
+        // decays the count correctly for restarts that are spaced apart.
         BrowserWindow.getAllWindows().forEach(w => issuePort(w));
       })
       .catch(e => {


### PR DESCRIPTION
Feedback PR for #10259 — two related bugs in `data-process-manager.ts`'s `handleExit()`.

## 1. `restartCount` reset undermines `MAX_RESTARTS`

```js
spawnDataProcess(dbPath)
  .then(() => {
    console.log('[data-process] restarted, re-issuing ports');
    restartCount = 0; // <-- removed
    ...
```

`restartCount` was zeroed as soon as the child reached `ready`, regardless of how quickly it crashed afterwards. If the utility process crashes shortly *after* reaching ready every time (e.g. a bug that only manifests once init finishes), each restart attempt resets the counter before the next crash increments it again — so `restartCount` never climbs past 1 and `MAX_RESTARTS` (10) never trips. The app would restart the data process forever instead of giving up.

The existing `RESTART_WINDOW_MS` check in the same function already decays the counter correctly for restarts that are spaced more than 60s apart:

```js
if (now - lastRestartTime > RESTART_WINDOW_MS) {
  restartCount = 0;
}
```

Removing the extra reset-on-success lets that time-based logic do its job as intended, while still correctly capping tight ready-then-crash loops.

## 2. Renderer windows never learn the data process is permanently gone

When `MAX_RESTARTS` is exceeded, only `mainRpc` (the main process's own RPC client) was invalidated:

```js
if (restartCount > MAX_RESTARTS) {
  ...
  mainRpc.invalidate('data-process crashed and could not be restarted');
  return; // <-- no broadcast to renderer windows
}
```

Each `BrowserWindow`'s own `PortRpc` (attached via `attachDataPortRpc` in preload) is only invalidated when it receives the `'data-process.restarting'` IPC message — which is sent on every *retry* but not on the final give-up path. So once the data process is confirmed dead, any pending or future `database`/`services` call from a window would hang forever with no error, rather than rejecting with a clear message.

Fix: broadcast `'data-process.restarting'` to all windows on the give-up path too, so their pending/future `invoke()` calls reject instead of hanging.

## Testing

- `npx tsc --noEmit` and `npx eslint` clean on the changed file.
- `serialization.test.ts` passes; `port-rpc.test.ts` in this workspace currently fails locally due to an unrelated broken `electron` postinstall in my worktree, not this change (confirmed the same file's other test suite runs fine and the failure is `Electron failed to install correctly`, not a code issue).
- No behavior change for the common case (single crash, successful restart, no further crashes) — only the crash-loop and give-up paths differ.