### PR TITLE
feat(quickjs): insomnia.sendRequest() bridge for the QuickJS script sandbox

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/quickjs-sendrequest-bridge.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/quickjs-sendrequest-bridge.test.ts
@@ -1,0 +1,77 @@
+import { expect, type Page } from '@playwright/test';
+
+import { loadFixture } from '../../playwright/paths';
+import { test } from '../../playwright/test';
+
+// PR 2 of the QuickJS script-sandbox rollout plan —
+// https://gist.github.com/jackkav/3ebf8768bf84be024a3a138874919354
+//
+// KNOWN BUG (unresolved): insomnia.sendRequest() crashes under the real Electron/Worker/QuickJS
+// environment with `Aborted(Assertion failed: list_empty(&rt->gc_obj_list), at:
+// .../quickjs.c,2036,JS_FreeRuntime)` on the first real network round trip, even after three
+// targeted fixes (see quickjs-script-engine.ts's module doc comment and installSendRequestBridge).
+// This never reproduces in vitest (mocked fetch, or a plain Node http server) — only real Electron
+// fetch() timing inside the dedicated Worker reproduces it. `test.fail()` marks this as an expected
+// failure: CI stays green while the bug is open, and flips red (telling us to remove the
+// annotation) the moment someone actually fixes it.
+test.describe('QuickJS sendRequest bridge (known bug)', () => {
+  test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
+
+  test.beforeEach(async ({ app, page }) => {
+    const text = await loadFixture('pre-request-collection.yaml');
+    await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
+
+    await page.getByLabel('Import').click();
+    await page.locator('[data-test-id="import-from-clipboard"]').click();
+    await page.getByRole('button', { name: 'Scan' }).click();
+    await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+  });
+
+  // Same pattern as quickjs-script-sandbox.test.ts's helper.
+  const replaceCodeEditorContent = async (page: Page, value: string) => {
+    const editor = page.getByTestId('CodeEditor').getByRole('textbox');
+    await editor.press('ControlOrMeta+a');
+    await page.keyboard.press('Backspace');
+    await editor.fill(value);
+    await page.evaluate(() => new Promise(resolve => setTimeout(resolve, 150)));
+  };
+
+  const enableQuickJsSandbox = async (page: Page) => {
+    await page.getByTestId('settings-button').click();
+    const sandboxToggle = page.getByTestId('toggle-quickjs-script-sandbox');
+    await page.getByRole('tab', { name: 'Scripting' }).click();
+    await sandboxToggle.getByRole('switch').waitFor();
+    await sandboxToggle.click();
+    await expect.soft(sandboxToggle.getByRole('switch')).toBeChecked();
+    await page.locator('.app').press('Escape');
+    await expect.soft(page.getByTestId('toggle-quickjs-script-sandbox')).toBeHidden();
+  };
+
+  test('runs a real sendRequest() round trip through the QuickJS engine', async ({ page, insomnia }) => {
+    test.fail(true, 'insomnia.sendRequest() crashes under real Electron/Worker timing — see file header comment');
+
+    await enableQuickJsSandbox(page);
+
+    // "testQueryParams" has no body and no folder-inherited after-response script — see
+    // quickjs-script-sandbox.test.ts's header comment for why every other candidate in this
+    // fixture is unsuitable. console.log sidesteps template-rendering entirely.
+    await insomnia.navigationSidebar.clickRequestOrFolder('testQueryParams');
+
+    await page.getByRole('tab', { name: 'Scripts' }).click();
+    await replaceCodeEditorContent(
+      page,
+      `
+      const response = await insomnia.sendRequest('http://127.0.0.1:4010/echo');
+      console.log('sendRequest status: ' + response.code + ' method: ' + JSON.parse(response.body).method);
+    `,
+    );
+
+    await page.getByRole('tab', { name: 'Params' }).click();
+    await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
+
+    await expect.soft(page.locator('[data-testid="response-status-tag"]:visible')).toContainText('200 OK');
+
+    await page.getByTestId('response-pane').getByRole('tab', { name: 'Console' }).click();
+    await expect.soft(page.getByText('sendRequest status: 200 method: GET')).toBeVisible();
+  });
+});

--- a/packages/insomnia-smoke-test/tests/smoke/quickjs-sendrequest-bridge.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/quickjs-sendrequest-bridge.test.ts
@@ -6,15 +6,13 @@ import { test } from '../../playwright/test';
 // PR 2 of the QuickJS script-sandbox rollout plan —
 // https://gist.github.com/jackkav/3ebf8768bf84be024a3a138874919354
 //
-// KNOWN BUG (unresolved): insomnia.sendRequest() crashes under the real Electron/Worker/QuickJS
-// environment with `Aborted(Assertion failed: list_empty(&rt->gc_obj_list), at:
-// .../quickjs.c,2036,JS_FreeRuntime)` on the first real network round trip, even after three
-// targeted fixes (see quickjs-script-engine.ts's module doc comment and installSendRequestBridge).
-// This never reproduces in vitest (mocked fetch, or a plain Node http server) — only real Electron
-// fetch() timing inside the dedicated Worker reproduces it. `test.fail()` marks this as an expected
-// failure: CI stays green while the bug is open, and flips red (telling us to remove the
-// annotation) the moment someone actually fixes it.
-test.describe('QuickJS sendRequest bridge (known bug)', () => {
+// End-to-end cover for the `insomnia.sendRequest()` bridge: the real Electron protocol handler, the
+// real auth token (forwarded by run-script-quickjs.ts), and real curl. The teardown hazard this used
+// to crash on is covered far more cheaply by
+// `packages/insomnia/src/scripting/quickjs-script-engine.test.ts`'s "sendRequest bridge teardown"
+// block, which reproduces the `gc_obj_list` abort in vitest by settling the mocked fetch on a later
+// macrotask.
+test.describe('QuickJS sendRequest bridge', () => {
   test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
 
   test.beforeEach(async ({ app, page }) => {
@@ -48,8 +46,6 @@ test.describe('QuickJS sendRequest bridge (known bug)', () => {
   };
 
   test('runs a real sendRequest() round trip through the QuickJS engine', async ({ page, insomnia }) => {
-    test.fail(true, 'insomnia.sendRequest() crashes under real Electron/Worker timing — see file header comment');
-
     await enableQuickJsSandbox(page);
 
     // "testQueryParams" has no body and no folder-inherited after-response script — see

--- a/packages/insomnia/src/main/__tests__/templating-worker-database-sendrequest-cacert-bypass.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database-sendrequest-cacert-bypass.test.ts
@@ -1,0 +1,189 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// insomnia.sendRequest()'s own doc comment (quickjs-script-engine.ts) says the QuickJS script
+// sandbox's request bridge supports only { url, method, headers, body } -- "no auth, client
+// certificates, cookies". That's enforced only by the guest-side JS wrapper (BOOTSTRAP), which
+// hardcodes caCertficatePath to null before calling the real bridge global, __sendRequest.
+// __sendRequest itself is a bare, unguarded globalThis function that takes a raw JSON string and
+// forwards it, unvalidated, to network.sendRequestWithoutSideEffects's real dispatch path
+// (resolveDbByKey -> pluginToMainAPI). That handler reads body.options.caCertficatePath with no
+// ownership/allowlist check and hands it straight to curlRequest, which loads it via
+// insecureReadFile -- the function secure-read-file.ts itself documents as being "for reading
+// files selected by the user via a file dialog", not for a value chosen by a running script. A
+// script can skip the wrapper entirely and call __sendRequest directly, exceeding the sandbox's
+// documented capability.
+
+vi.mock('electron', () => ({
+  app: { getVersion: () => '1.0.0', getPath: () => '/fake/userData' },
+  clipboard: { readText: vi.fn(), writeText: vi.fn(), clear: vi.fn() },
+  dialog: { showMessageBox: vi.fn() },
+  shell: { openExternal: vi.fn() },
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+vi.mock('insomnia-data', () => ({
+  services: {
+    request: { getById: vi.fn() },
+    workspace: { getById: vi.fn() },
+    oAuth2Token: { getByParentId: vi.fn() },
+    cookieJar: { getOrCreateForParentId: vi.fn() },
+    response: { getLatestForRequestId: vi.fn(), getByBodyPath: vi.fn() },
+    helpers: {
+      getResponseBodyBuffer: vi.fn(),
+      readCurlResponse: vi.fn().mockResolvedValue({ body: '{}' }),
+    },
+    pluginData: { getByKey: vi.fn(), upsertByKey: vi.fn(), removeByKey: vi.fn(), removeAll: vi.fn(), all: vi.fn() },
+    cloudCredential: { getById: vi.fn(), update: vi.fn() },
+    settings: { get: vi.fn().mockResolvedValue({}) },
+  },
+}));
+vi.mock('~/plugins', () => ({
+  getPluginCommonContext: vi.fn(),
+  getTemplateTags: vi.fn().mockResolvedValue([]),
+  getPlugins: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('~/common/cookies', () => ({ jarFromCookies: vi.fn() }));
+vi.mock('../common/database', () => ({ database: {} }));
+vi.mock('../network/network', () => ({
+  fetchRequestData: vi.fn(),
+  sendCurlAndWriteTimeline: vi.fn(),
+  tryToInterpolateRequest: vi.fn(),
+}));
+vi.mock('../network/libcurl-promise', () => ({ curlRequest: vi.fn() }));
+vi.mock('../prompt-bridge', () => ({ requestPromptFromRenderer: vi.fn() }));
+vi.mock('../secure-read-file', () => ({ secureReadFile: vi.fn() }));
+
+import type { RequestContext } from '../../../../insomnia-scripting-environment/src/objects/interfaces';
+import { runScriptInQuickJs } from '../../scripting/quickjs-script-engine';
+import {
+  _testOnlyResetTemplatingDbAuthToken,
+  getOrCreateTemplatingDbAuthToken,
+} from '../templating-worker-database-auth';
+
+const baseContext = (): RequestContext => ({
+  request: { _id: 'req_1', name: 'Test request', url: 'https://example.com' } as any,
+  timelinePath: '',
+  environment: { id: 'env_1', name: 'Base Environment', data: {} },
+  baseEnvironment: { id: 'env_1', name: 'Base Environment', data: {} },
+  timeout: 30_000,
+  settings: { timeout: 30_000 } as any,
+  clientCertificates: [],
+  cookieJar: { cookies: [] } as any,
+  requestInfo: {} as any,
+  execution: {} as any,
+  logs: [],
+  transientVariables: { name: 'transientVariables', data: {} },
+  parentFolders: [],
+});
+
+describe('network.sendRequestWithoutSideEffects, reached via the QuickJS bridge\'s raw __sendRequest global, gates caCertficatePath', () => {
+  let outsideCertPath: string;
+
+  beforeEach(() => {
+    _testOnlyResetTemplatingDbAuthToken();
+    // Deliberately outside every directory secureReadFile's allowlist would ever grant
+    // (os.tmpdir(), userData, or a configured data folder) -- standing in for a path a script
+    // chose on its own, not one a user selected via a file dialog.
+    outsideCertPath = path.join(os.homedir(), `insomnia-audit-not-a-real-cert-${process.pid}.pem`);
+    fs.writeFileSync(outsideCertPath, 'not-a-real-certificate');
+  });
+
+  afterEach(() => {
+    fs.rmSync(outsideCertPath, { force: true });
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  const stubFetchToRealHandler = () => {
+    // Stands in for Electron's real `insomnia-templating-worker-database://` protocol handler,
+    // which is registered via `protocol.handle(interface, resolveDbByKey)` in api.protocol.ts --
+    // routes the bridge's fetch() straight into the real, unmocked dispatch function so this test
+    // exercises the actual auth check + handler lookup + handler body, not a re-implementation of
+    // them.
+    vi.stubGlobal('fetch', async (url: string, init?: RequestInit) => {
+      const { resolveDbByKey } = await import('../templating-worker-database');
+      return resolveDbByKey(new Request(url, init));
+    });
+  };
+
+  const mockCurlRequest = async () => {
+    const { curlRequest } = await import('../network/libcurl-promise');
+    const curlRequestMock = curlRequest as unknown as ReturnType<typeof vi.fn>;
+    curlRequestMock.mockResolvedValue({
+      headerResults: [{ code: 200, reason: 'OK', headers: [] }],
+      patch: { elapsedTime: 1, bodyCompression: null },
+      responseBodyPath: '/dev/null',
+    });
+    return curlRequestMock;
+  };
+
+  it('never forwards a caller-chosen caCertficatePath to curlRequest, even sent directly through the raw bridge global', async () => {
+    const token = getOrCreateTemplatingDbAuthToken();
+    const curlRequestMock = await mockCurlRequest();
+    stubFetchToRealHandler();
+
+    const requestBodyWithOutsideCertPath = JSON.stringify({
+      options: {
+        request: { url: 'https://example.com', method: 'GET', headers: [] },
+        caCertficatePath: outsideCertPath,
+      },
+    });
+
+    // Calls the raw bridge global directly instead of going through insomnia.sendRequest(),
+    // which is the only place that hardcodes caCertficatePath to null -- the wrapper is guest-side
+    // JS sugar the calling script is free to skip entirely, not an enforcement boundary.
+    const result = await runScriptInQuickJs({
+      script: `
+        const raw = await __sendRequest(${JSON.stringify(requestBodyWithOutsideCertPath)});
+        const envelope = JSON.parse(raw);
+        insomnia.environment.set('ok', envelope.ok);
+      `,
+      context: baseContext(),
+      authToken: token,
+    });
+
+    // The request itself still goes through (this endpoint's job) -- what must never happen is
+    // the host handler honoring a caller-supplied caCertficatePath. secureReadFile enforces this
+    // exact entitlement boundary elsewhere in this codebase; a path a running script picked for
+    // itself is never one it was granted.
+    expect((result.environment.data as Record<string, unknown>).ok).toBe(true);
+    expect(curlRequestMock).toHaveBeenCalledTimes(1);
+    expect(curlRequestMock.mock.calls[0][0]).toMatchObject({ caCertficatePath: null });
+  });
+
+  it('never lets a caller-supplied authentication object override the safe default, even sent directly through the raw bridge global', async () => {
+    const token = getOrCreateTemplatingDbAuthToken();
+    const curlRequestMock = await mockCurlRequest();
+    stubFetchToRealHandler();
+
+    const requestBodyWithInjectedAuth = JSON.stringify({
+      options: {
+        request: {
+          url: 'https://example.com',
+          method: 'GET',
+          headers: [],
+          authentication: { type: 'basic', username: 'chosen-by-script', password: 'chosen-by-script' },
+        },
+      },
+    });
+
+    const result = await runScriptInQuickJs({
+      script: `
+        const raw = await __sendRequest(${JSON.stringify(requestBodyWithInjectedAuth)});
+        const envelope = JSON.parse(raw);
+        insomnia.environment.set('ok', envelope.ok);
+      `,
+      context: baseContext(),
+      authToken: token,
+    });
+
+    expect((result.environment.data as Record<string, unknown>).ok).toBe(true);
+    expect(curlRequestMock).toHaveBeenCalledTimes(1);
+    expect(curlRequestMock.mock.calls[0][0]).toMatchObject({
+      req: expect.objectContaining({ authentication: { type: 'none' } }),
+    });
+  });
+});

--- a/packages/insomnia/src/main/__tests__/templating-worker-database-sendrequest-multipart-filepath-scoping.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database-sendrequest-multipart-filepath-scoping.test.ts
@@ -1,0 +1,167 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// network.sendRequestWithoutSideEffects's cacert/authentication fields are hardcoded regardless of
+// caller input (see templating-worker-database-sendrequest-cacert-bypass.test.ts), but its `body`
+// field was forwarded straight through unvalidated. A multipart/form-data body's file parts
+// (`body.params[].fileName`) reach `buildMultipart` (packages/insomnia/src/main/network/multipart.ts),
+// which reads each part's `fileName` off disk with no ownership/allowlist check at all -- unlike
+// every other local-file read reachable from a request definition, which is checked against
+// `settings.dataFolders`. A script can reach this by calling the raw `__sendRequest` bridge global
+// directly (bypassing insomnia.sendRequest()'s BOOTSTRAP wrapper, which only ever builds
+// `{ mimeType: 'text/plain', text }` bodies) with a multipart body naming an arbitrary local path,
+// then reading the response from a URL it also controls.
+//
+// The fix lives entirely in the QuickJS bridge (quickjs-script-engine.ts's
+// assertSupportedSendRequestBody, run before the bridge's fetch() is ever dispatched) rather than
+// in this shared handler, which the legacy hidden-window sandbox and the template-tag sandbox also
+// use with their own, already-privileged execution models -- see
+// plugins/context/network-sendrequest-multipart-allowed.test.ts for confirmation that the legacy
+// path is unaffected by this fix.
+
+vi.mock('electron', () => ({
+  app: { getVersion: () => '1.0.0', getPath: () => '/fake/userData' },
+  clipboard: { readText: vi.fn(), writeText: vi.fn(), clear: vi.fn() },
+  dialog: { showMessageBox: vi.fn() },
+  shell: { openExternal: vi.fn() },
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+vi.mock('insomnia-data', () => ({
+  services: {
+    request: { getById: vi.fn() },
+    workspace: { getById: vi.fn() },
+    oAuth2Token: { getByParentId: vi.fn() },
+    cookieJar: { getOrCreateForParentId: vi.fn() },
+    response: { getLatestForRequestId: vi.fn(), getByBodyPath: vi.fn() },
+    helpers: {
+      getResponseBodyBuffer: vi.fn(),
+      readCurlResponse: vi.fn().mockResolvedValue({ body: '{}' }),
+    },
+    pluginData: { getByKey: vi.fn(), upsertByKey: vi.fn(), removeByKey: vi.fn(), removeAll: vi.fn(), all: vi.fn() },
+    cloudCredential: { getById: vi.fn(), update: vi.fn() },
+    settings: { get: vi.fn().mockResolvedValue({}) },
+  },
+}));
+vi.mock('~/plugins', () => ({
+  getPluginCommonContext: vi.fn(),
+  getTemplateTags: vi.fn().mockResolvedValue([]),
+  getPlugins: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('~/common/cookies', () => ({ jarFromCookies: vi.fn() }));
+vi.mock('../common/database', () => ({ database: {} }));
+vi.mock('../network/network', () => ({
+  fetchRequestData: vi.fn(),
+  sendCurlAndWriteTimeline: vi.fn(),
+  tryToInterpolateRequest: vi.fn(),
+}));
+vi.mock('../network/libcurl-promise', () => ({ curlRequest: vi.fn() }));
+vi.mock('../prompt-bridge', () => ({ requestPromptFromRenderer: vi.fn() }));
+vi.mock('../secure-read-file', () => ({ secureReadFile: vi.fn() }));
+
+import type { RequestContext } from '../../../../insomnia-scripting-environment/src/objects/interfaces';
+import { runScriptInQuickJs } from '../../scripting/quickjs-script-engine';
+import {
+  _testOnlyResetTemplatingDbAuthToken,
+  getOrCreateTemplatingDbAuthToken,
+} from '../templating-worker-database-auth';
+
+const baseContext = (): RequestContext => ({
+  request: { _id: 'req_1', name: 'Test request', url: 'https://example.com' } as any,
+  timelinePath: '',
+  environment: { id: 'env_1', name: 'Base Environment', data: {} },
+  baseEnvironment: { id: 'env_1', name: 'Base Environment', data: {} },
+  timeout: 30_000,
+  settings: { timeout: 30_000 } as any,
+  clientCertificates: [],
+  cookieJar: { cookies: [] } as any,
+  requestInfo: {} as any,
+  execution: {} as any,
+  logs: [],
+  transientVariables: { name: 'transientVariables', data: {} },
+  parentFolders: [],
+});
+
+describe('insomnia.sendRequest(), reached via the QuickJS bridge\'s raw __sendRequest global, denies multipart file parts', () => {
+  let outsideAllowedFoldersPath: string;
+
+  beforeEach(() => {
+    _testOnlyResetTemplatingDbAuthToken();
+    // Deliberately outside every directory a `dataFolders`-scoped read would ever be granted --
+    // standing in for a path a script chose for itself, not one the user selected or allow-listed.
+    outsideAllowedFoldersPath = path.join(os.homedir(), `insomnia-audit-not-a-real-file-${process.pid}.txt`);
+    fs.writeFileSync(outsideAllowedFoldersPath, 'not-a-real-secret');
+  });
+
+  afterEach(() => {
+    fs.rmSync(outsideAllowedFoldersPath, { force: true });
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  const stubFetchToRealHandler = () => {
+    // Stands in for Electron's real `insomnia-templating-worker-database://` protocol handler --
+    // routes the bridge's fetch() straight into the real, unmocked dispatch function so this test
+    // would exercise the actual auth check + handler lookup + handler body if the fix under test
+    // ever let the bridge get that far.
+    vi.stubGlobal('fetch', async (url: string, init?: RequestInit) => {
+      const { resolveDbByKey } = await import('../templating-worker-database');
+      return resolveDbByKey(new Request(url, init));
+    });
+  };
+
+  const mockCurlRequest = async () => {
+    const { curlRequest } = await import('../network/libcurl-promise');
+    const curlRequestMock = curlRequest as unknown as ReturnType<typeof vi.fn>;
+    curlRequestMock.mockResolvedValue({
+      headerResults: [{ code: 200, reason: 'OK', headers: [] }],
+      patch: { elapsedTime: 1, bodyCompression: null },
+      responseBodyPath: '/dev/null',
+    });
+    return curlRequestMock;
+  };
+
+  it('rejects a multipart file part before the bridge ever dispatches its fetch, even sent directly through the raw bridge global', async () => {
+    const token = getOrCreateTemplatingDbAuthToken();
+    const curlRequestMock = await mockCurlRequest();
+    stubFetchToRealHandler();
+
+    const requestBodyWithOutsideFilePart = JSON.stringify({
+      options: {
+        request: {
+          url: 'https://example.com',
+          method: 'POST',
+          headers: [],
+          body: {
+            mimeType: 'multipart/form-data',
+            params: [{ name: 'f', type: 'file', fileName: outsideAllowedFoldersPath }],
+          },
+        },
+      },
+    });
+
+    // Calls the raw bridge global directly instead of going through insomnia.sendRequest(), which
+    // only ever builds a `text/plain` body -- the wrapper is guest-side JS sugar the calling script
+    // is free to skip entirely, not an enforcement boundary. The QuickJS-specific host-side guard
+    // must reject this regardless.
+    const result = await runScriptInQuickJs({
+      script: `
+        const raw = await __sendRequest(${JSON.stringify(requestBodyWithOutsideFilePart)});
+        const envelope = JSON.parse(raw);
+        insomnia.environment.set('ok', envelope.ok);
+        insomnia.environment.set('error', envelope.error);
+      `,
+      context: baseContext(),
+      authToken: token,
+    });
+
+    const env = result.environment.data as Record<string, unknown>;
+    expect(env.ok).toBe(false);
+    expect(env.error).toMatch(/plain-text request body/i);
+    // The rejection must happen before the bridge's fetch() is ever dispatched -- the shared
+    // handler (and curlRequest below it) never even sees this request.
+    expect(curlRequestMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -785,20 +785,28 @@ export const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => P
     return await services.response.create({ ...response, bodyCompression: null }, settings.maxHistoryResponses);
   },
   // use libcurl to send request without side effects(do not write to database about request and response)
+  //
+  // This endpoint is reachable by any pre/post-request script or template-tag/plugin (via the
+  // QuickJS script sandbox's insomnia.sendRequest() bridge and the template-tag sandbox's
+  // context.network.sendRequestWithoutSideEffects(), respectively) with no ownership/entitlement
+  // check on the caller's identity beyond the templating-db auth token every call already needs —
+  // so it must never honor a caller-supplied client certificate path or authentication object.
+  // Both are host-privileged capabilities (an arbitrary local file read via `caCertficatePath`,
+  // credential injection via `authentication`) that this "without side effects" preview endpoint
+  // was never meant to carry; `network.sendRequest` (the DB-backed, side-effectful sibling) is the
+  // only handler that may use a request's real, ownership-scoped `clientCertificates`.
   'network.sendRequestWithoutSideEffects': async (body: {
     options: {
-      request: Pick<DBRequest, 'url' | 'method' | 'headers'> & Partial<Pick<DBRequest, 'body' | 'authentication'>>;
-      caCertficatePath: string;
+      request: Pick<DBRequest, 'url' | 'method' | 'headers'> & Partial<Pick<DBRequest, 'body'>>;
     };
   }) => {
     const requestId = uuidv4();
     const settings = await services.settings.get();
     const settingFollowRedirects = settings?.followRedirects ? 'on' : 'off';
-    const { request: originRequest, caCertficatePath = null } = body.options;
+    const { request: originRequest } = body.options;
     const response = await curlRequest({
       requestId: `no-sideEffects-request-${requestId}`,
       req: {
-        authentication: { type: 'none' },
         body: {},
         cookieJar: {
           cookies: [],
@@ -809,11 +817,15 @@ export const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => P
         settingRebuildPath: true,
         settingSendCookies: true,
         ...originRequest,
+        // Applied after the spread so a caller-supplied `authentication` on the request body can
+        // never override it — see the handler-level comment above.
+        authentication: { type: 'none' },
       },
       finalUrl: originRequest.url,
       settings,
       certificates: [],
-      caCertficatePath,
+      // Never sourced from the caller — see the handler-level comment above.
+      caCertficatePath: null,
     });
     const { headerResults, patch, responseBodyPath } = response;
     if (patch.error) {

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -846,7 +846,11 @@ export const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => P
         }
       },
     };
-    return new Response(JSON.stringify(result));
+    // Every other handler in this map returns a plain value and lets the caller wrap it.
+    // `resolveDbByKey` does `JSON.stringify(await handler(body))` and `createMapBridge` hands the
+    // value straight to the sandbox — so returning a `Response` here stringified to `"{}"` and every
+    // caller got an empty object instead of the response.
+    return result;
   },
   // used to generate the template tags for the bundle plugins and send back to the web worker
   'plugin.getBundlePluginTemplateTags': async () => {

--- a/packages/insomnia/src/plugins/context/__tests__/network-sendrequest-multipart-allowed.test.ts
+++ b/packages/insomnia/src/plugins/context/__tests__/network-sendrequest-multipart-allowed.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Confirms the legacy (default, useQuickJsScriptSandbox: false) sendRequestWithoutSideEffects
+// implementation is untouched by the QuickJS-sandbox-specific fix in
+// quickjs-script-engine.ts's assertSupportedSendRequestBody (see
+// templating-worker-database-sendrequest-multipart-filepath-scoping.test.ts, which proves the same
+// multipart body is denied when reached through the QuickJS bridge). This implementation runs with
+// an already-privileged execution model (a real Electron BrowserWindow, or a direct Node/Inso
+// import) rather than through the sandboxed `insomnia-templating-worker-database://` protocol
+// handler, so its behavior toward a multipart body is intentionally left as-is here.
+
+vi.mock('insomnia-data', () => ({
+  services: {
+    settings: { get: vi.fn().mockResolvedValue({ followRedirects: false }) },
+    helpers: { readCurlResponse: vi.fn().mockResolvedValue({ body: '{}' }) },
+  },
+}));
+vi.mock('../../../main/network/libcurl-promise', () => ({ curlRequest: vi.fn() }));
+
+import * as plugin from '../network';
+
+describe('network.sendRequestWithoutSideEffects (legacy, non-QuickJS execution context)', () => {
+  it('still forwards a multipart body\'s file parts to curlRequest unchanged', async () => {
+    const { curlRequest: curlRequestMock } = await import('../../../main/network/libcurl-promise');
+    (curlRequestMock as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      headerResults: [{ code: 200, reason: 'OK', headers: [] }],
+      patch: { elapsedTime: 1, bodyCompression: null },
+      responseBodyPath: '/dev/null',
+    });
+
+    const outsideAllowedFoldersPath = '/Users/someone/not-a-real-file.txt';
+    const { network } = plugin.init();
+
+    await network.sendRequestWithoutSideEffects({
+      request: {
+        url: 'https://example.com',
+        method: 'POST',
+        headers: [],
+        body: {
+          mimeType: 'multipart/form-data',
+          params: [{ name: 'f', type: 'file', fileName: outsideAllowedFoldersPath }],
+        },
+      },
+    } as any);
+
+    expect(curlRequestMock).toHaveBeenCalledTimes(1);
+    const forwardedParams = (curlRequestMock as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0]?.req?.body
+      ?.params;
+    expect(forwardedParams).toContainEqual(expect.objectContaining({ fileName: outsideAllowedFoldersPath }));
+  });
+});

--- a/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
+++ b/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
@@ -308,6 +308,78 @@ describe('runScriptInQuickJs sendRequest bridge', () => {
     });
   });
 
+  it('normalizes RequestOptions-shaped input: singular "header" with {key, value} entries and a Url-like object', async () => {
+    const fetchMock = stubFetchOnce({
+      ok: true,
+      body: { code: 200, status: 'OK', headers: [], body: '', responseTime: 1 },
+    });
+    const context = baseContext();
+
+    await runScriptInQuickJs({
+      script: `
+        await insomnia.sendRequest({
+          url: { toString: () => 'https://example.com/items' },
+          method: 'POST',
+          header: [{ key: 'Content-Type', value: 'application/json' }],
+        });
+      `,
+      context,
+    });
+
+    const sentBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(sentBody.options.request).toEqual({
+      url: 'https://example.com/items',
+      method: 'POST',
+      headers: [{ name: 'Content-Type', value: 'application/json' }],
+      body: undefined,
+    });
+  });
+
+  it('rejects with a clear error, not a raw SyntaxError, when the bridge returns a non-JSON body', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, text: () => Promise.resolve('not json') });
+    vi.stubGlobal('fetch', fetchMock);
+    const context = baseContext();
+
+    await expect(
+      runScriptInQuickJs({ script: `await insomnia.sendRequest('https://example.com');`, context }),
+    ).rejects.toThrow(/non-JSON response/);
+  });
+
+  it('rejects with a status-based error, not a raw SyntaxError, when a failed response has a non-JSON body', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: false, status: 502, text: () => Promise.resolve('<html>Bad Gateway</html>') });
+    vi.stubGlobal('fetch', fetchMock);
+    const context = baseContext();
+
+    await expect(
+      runScriptInQuickJs({ script: `await insomnia.sendRequest('https://example.com');`, context }),
+    ).rejects.toThrow(/sendRequest failed with status 502/);
+  });
+
+  it("reports a usable callback error message even when the rejection is a raw SyntaxError, not the bridge's own Error", async () => {
+    // The callback handler's `err && err.message` guard should hold for any thrown error shape, not
+    // just the bridge's own `throw new Error(envelope.error)` — exercise it via a JSON.parse failure
+    // on the envelope itself, a different error-generation path than the "bridge-reported error" test.
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, text: () => Promise.resolve('not json') });
+    vi.stubGlobal('fetch', fetchMock);
+    const context = baseContext();
+
+    const result = await runScriptInQuickJs({
+      script: `
+        await new Promise((resolve) => {
+          insomnia.sendRequest('https://example.com', (error) => {
+            insomnia.environment.set('callbackErrorIsNonEmptyString', typeof error === 'string' && error.length > 0);
+            resolve();
+          });
+        });
+      `,
+      context,
+    });
+
+    expect((result.environment.data as Record<string, unknown>).callbackErrorIsNonEmptyString).toBe(true);
+  });
+
   it('supports the Postman-style (error, response) callback signature', async () => {
     stubFetchOnce({ ok: true, body: { code: 200, status: 'OK', headers: [], body: 'ok', responseTime: 1 } });
     const context = baseContext();

--- a/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
+++ b/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
@@ -558,49 +558,69 @@ describe('runScriptInQuickJs sendRequest bridge teardown', () => {
 });
 
 /**
- * A SECOND, UNRELATED `gc_obj_list` abort that the teardown fix above does not address, and that
- * predates the sendRequest bridge — `git show develop:…/quickjs-script-engine.ts` aborts identically.
- *
  * Allocation-heavy work performed *inside* `runtime.executePendingJobs()` — i.e. anything after the
- * script's first `await` — leaves live GC objects behind, and `JS_FreeRuntime` then asserts. The same
- * work run synchronously (before any `await`) is clean at 6x the size, so it is the job context that
- * matters, not the volume alone. Reduced to a host-free reproducer with no bridge, no host functions,
- * no interrupt handler, no memory limit and no `resolvePromise`:
+ * script's first `await` — leaves QuickJS's runtime un-freeable, and `JS_FreeRuntime` then aborts the
+ * WASM module on `assert(list_empty(&rt->gc_obj_list))`. A multi-megabyte `insomnia.sendRequest()`
+ * response body reaches that size on its own, so it is ordinary usage, not a synthetic case.
+ *
+ * This is a defect in quickjs-emscripten's **WASM build**, not in QuickJS: the identical vendored
+ * engine source built natively is clean well past the failing size at `-O1`/`-O2`/`-Oz`, with and
+ * without `-fwrapv`, with `CONFIG_STACK_CHECK`, and with the same raw-context intrinsic subset the
+ * shim installs. The WASM builds abort on both the `quickjs` and `quickjs-ng` variants and at both
+ * optimization levels. Tracked upstream at
+ * https://github.com/justjake/quickjs-emscripten/issues/269. Reproducer, for reference:
  *
  *   const vm = QuickJS.newContext();
- *   vm.evalCode(`(async()=>{await Promise.resolve();` +
- *     `const a=[];for(let i=0;i<100000;i++){a.push({i});}` +
- *     `globalThis.__n=JSON.parse(JSON.stringify(a)).length;})();`);
+ *   vm.evalCode(`Promise.resolve().then(()=>{` +
+ *     `const a=[];for(let i=0;i<200000;i++){a.push({i});}globalThis.__n=a.length;});`);
  *   vm.runtime.executePendingJobs().dispose();
  *   vm.dispose();   // Aborted(Assertion failed: list_empty(&rt->gc_obj_list) …)
  *
- * Threshold is between 50k and 100k objects. Not fixable from the host: unaffected by removing the
- * memory limit or the interrupt handler, by polling `getPromiseState` instead of `resolvePromise`, by
- * extra `executePendingJobs()` passes, by `computeMemoryUsage()`, or by forcing further allocation to
- * provoke a GC — and it reproduces on both the RELEASE_SYNC and DEBUG_SYNC quickjs-emscripten
- * variants. It needs an upstream fix or an engine-version bump.
- *
- * Why it matters here: before the bridge existed, nothing put multi-megabyte host data into the VM.
- * `insomnia.sendRequest()` does, on every response, so this turns a latent engine bug into a routine
- * crash for any script that parses a large response body. Left as a `.fails()` test so it is tracked
- * and flips red the moment an engine bump fixes it.
+ * Until it is fixed upstream, the engine contains the damage rather than dying to it: the abort is
+ * caught at teardown, the run returns its (already complete, host-side) result, and the caller is
+ * told to replace the engine. These tests pin that behaviour.
  */
-describe('runScriptInQuickJs large-allocation abort (known engine bug, pre-existing)', () => {
-  it.fails('survives allocating ~100k objects after an await', async () => {
+describe('runScriptInQuickJs large-allocation engine fault', () => {
+  it('returns the script result and reports the fault instead of crashing', async () => {
+    const faults: Error[] = [];
+
     const result = await runScriptInQuickJs({
       script: `
         await Promise.resolve();
         const arr = [];
-        for (let i = 0; i < 100000; i++) { arr.push({ i }); }
+        for (let i = 0; i < 200000; i++) { arr.push({ i }); }
         insomnia.environment.set('len', JSON.parse(JSON.stringify(arr)).length);
+      `,
+      context: baseContext(),
+      onEngineFault: err => faults.push(err),
+    });
+
+    // The script's own output is intact — it had already finished before teardown.
+    expect((result.environment.data as Record<string, unknown>).len).toBe(200_000);
+
+    // If upstream #269 is fixed, `faults` is empty and this test should be simplified to assert only
+    // the result above. Until then the fault must be reported, and explained in the script's logs.
+    if (faults.length > 0) {
+      expect(faults[0].message).toMatch(/gc_obj_list|Aborted/);
+      expect(result.logs.some(row => row.includes('QuickJS engine faulted'))).toBe(true);
+    }
+  });
+
+  it('runs a later script correctly after a fault', async () => {
+    const result = await runScriptInQuickJs({
+      script: `
+        insomnia.environment.set('sum', [1, 2, 3].reduce((a, b) => a + b, 0));
+        insomnia.environment.set('parsed', JSON.parse('{"a":[1,"two"]}'));
       `,
       context: baseContext(),
     });
 
-    expect((result.environment.data as Record<string, unknown>).len).toBe(100_000);
+    expect(result.environment.data).toMatchObject({ sum: 6, parsed: { a: [1, 'two'] } });
   });
 
   it('is specific to the job context — the same work before any await is fine', async () => {
+    const faults: Error[] = [];
+
     const result = await runScriptInQuickJs({
       script: `
         const arr = [];
@@ -608,8 +628,10 @@ describe('runScriptInQuickJs large-allocation abort (known engine bug, pre-exist
         insomnia.environment.set('len', JSON.parse(JSON.stringify(arr)).length);
       `,
       context: baseContext(),
+      onEngineFault: err => faults.push(err),
     });
 
     expect((result.environment.data as Record<string, unknown>).len).toBe(300_000);
+    expect(faults).toEqual([]);
   });
 });

--- a/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
+++ b/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
@@ -416,7 +416,8 @@ describe('runScriptInQuickJs sendRequest bridge teardown', () => {
     // unhandled QuickJSUseAfterFree rejection out of the settle callback.
     await new Promise(resolve => setTimeout(resolve, 250));
 
-    // A later run proving the shared WASM module survived — after an Emscripten abort this throws.
+    // A later run still works. Note this is NOT what detects the abort — a fresh context on the same
+    // WASM module succeeds even after one, so only the assertions above are load-bearing here.
     const laterResult = await runScriptInQuickJs({
       script: 'insomnia.environment.set("ranCleanly", true);',
       context: baseContext(),
@@ -481,5 +482,62 @@ describe('runScriptInQuickJs sendRequest bridge teardown', () => {
       context: baseContext(),
     });
     expect((laterResult.environment.data as Record<string, unknown>).ranCleanly).toBe(true);
+  });
+});
+
+/**
+ * A SECOND, UNRELATED `gc_obj_list` abort that the teardown fix above does not address, and that
+ * predates the sendRequest bridge — `git show develop:…/quickjs-script-engine.ts` aborts identically.
+ *
+ * Allocation-heavy work performed *inside* `runtime.executePendingJobs()` — i.e. anything after the
+ * script's first `await` — leaves live GC objects behind, and `JS_FreeRuntime` then asserts. The same
+ * work run synchronously (before any `await`) is clean at 6x the size, so it is the job context that
+ * matters, not the volume alone. Reduced to a host-free reproducer with no bridge, no host functions,
+ * no interrupt handler, no memory limit and no `resolvePromise`:
+ *
+ *   const vm = QuickJS.newContext();
+ *   vm.evalCode(`(async()=>{await Promise.resolve();` +
+ *     `const a=[];for(let i=0;i<100000;i++){a.push({i});}` +
+ *     `globalThis.__n=JSON.parse(JSON.stringify(a)).length;})();`);
+ *   vm.runtime.executePendingJobs().dispose();
+ *   vm.dispose();   // Aborted(Assertion failed: list_empty(&rt->gc_obj_list) …)
+ *
+ * Threshold is between 50k and 100k objects. Not fixable from the host: unaffected by removing the
+ * memory limit or the interrupt handler, by polling `getPromiseState` instead of `resolvePromise`, by
+ * extra `executePendingJobs()` passes, by `computeMemoryUsage()`, or by forcing further allocation to
+ * provoke a GC — and it reproduces on both the RELEASE_SYNC and DEBUG_SYNC quickjs-emscripten
+ * variants. It needs an upstream fix or an engine-version bump.
+ *
+ * Why it matters here: before the bridge existed, nothing put multi-megabyte host data into the VM.
+ * `insomnia.sendRequest()` does, on every response, so this turns a latent engine bug into a routine
+ * crash for any script that parses a large response body. Left as a `.fails()` test so it is tracked
+ * and flips red the moment an engine bump fixes it.
+ */
+describe('runScriptInQuickJs large-allocation abort (known engine bug, pre-existing)', () => {
+  it.fails('survives allocating ~100k objects after an await', async () => {
+    const result = await runScriptInQuickJs({
+      script: `
+        await Promise.resolve();
+        const arr = [];
+        for (let i = 0; i < 100000; i++) { arr.push({ i }); }
+        insomnia.environment.set('len', JSON.parse(JSON.stringify(arr)).length);
+      `,
+      context: baseContext(),
+    });
+
+    expect((result.environment.data as Record<string, unknown>).len).toBe(100_000);
+  });
+
+  it('is specific to the job context — the same work before any await is fine', async () => {
+    const result = await runScriptInQuickJs({
+      script: `
+        const arr = [];
+        for (let i = 0; i < 300000; i++) { arr.push({ i }); }
+        insomnia.environment.set('len', JSON.parse(JSON.stringify(arr)).length);
+      `,
+      context: baseContext(),
+    });
+
+    expect((result.environment.data as Record<string, unknown>).len).toBe(300_000);
   });
 });

--- a/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
+++ b/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
@@ -635,3 +635,59 @@ describe('runScriptInQuickJs large-allocation engine fault', () => {
     expect(faults).toEqual([]);
   });
 });
+
+/**
+ * A second, distinct way to trip the same `gc_obj_list` engine assertion as the large-allocation
+ * bug above — this one via ordinary unbounded recursion rather than allocation volume, needing no
+ * `await` at all, and (unlike that one) fixable from the embedding side: `setMaxStackSize` is a
+ * knob `quickjs-emscripten` already exposes for exactly this case.
+ *
+ * Before the fix: with no explicit stack limit, unbounded recursion overflows the *host* WASM call
+ * stack before QuickJS's own bytecode-level stack check can fire. `vm.evalCode()` then throws a
+ * plain `RangeError: Maximum call stack size exceeded` synchronously — bypassing both the guest
+ * script's own `try/catch` and `evalOrThrow`'s normal `result.error` handling — leaving the
+ * runtime's GC object list non-empty. The `finally` block's `vm.dispose()` then throws its own
+ * `Aborted(Assertion failed: list_empty(&rt->gc_obj_list) ...)`, which (per ordinary `try/finally`
+ * semantics) replaces the original error, so every caller only ever saw the internal engine
+ * assertion string, never the real cause.
+ */
+describe('runScriptInQuickJs deep-recursion handling (runtime stack-size limit)', () => {
+  it('surfaces a normal recursion error instead of a raw engine assertion when a script recurses without bound', async () => {
+    await expect(
+      runScriptInQuickJs({
+        script: `
+          function recurse(n) { return recurse(n + 1); }
+          recurse(0);
+        `,
+        context: baseContext(),
+      }),
+    ).rejects.toThrow(/stack overflow/i);
+  });
+
+  it('still allows several hundred levels of ordinary, bounded recursion', async () => {
+    const result = await runScriptInQuickJs({
+      script: `
+        function sum(n) { return n <= 0 ? 0 : n + sum(n - 1); }
+        insomnia.environment.set('total', sum(500));
+      `,
+      context: baseContext(),
+    });
+
+    expect((result.environment.data as Record<string, unknown>).total).toBe(125_250);
+  });
+
+  it('does not corrupt the shared QuickJS module for a later, unrelated script run', async () => {
+    await expect(
+      runScriptInQuickJs({
+        script: `function recurse(n) { return recurse(n + 1); } recurse(0);`,
+        context: baseContext(),
+      }),
+    ).rejects.toThrow();
+
+    const result = await runScriptInQuickJs({
+      script: `insomnia.environment.set('ok', 1 + 1);`,
+      context: baseContext(),
+    });
+    expect((result.environment.data as Record<string, unknown>).ok).toBe(2);
+  });
+});

--- a/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
+++ b/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
@@ -170,6 +170,7 @@ describe('runScriptInQuickJs', () => {
       '__envSet',
       '__varGet',
       '__varSet',
+      '__sendRequest',
       '__requestJSON',
       '__task',
       'insomnia',

--- a/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
+++ b/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
@@ -200,12 +200,6 @@ describe('runScriptInQuickJs', () => {
   });
 });
 
-// KNOWN BUG (unresolved): a real sendRequest() round trip crashes under the real Electron/Worker
-// environment (see quickjs-script-engine.ts's module doc comment and
-// packages/insomnia-smoke-test/tests/smoke/quickjs-sendrequest-bridge.test.ts, which reproduces it
-// end to end). These unit tests mock `fetch` entirely, so they only cover the bridge's own request
-// normalization / response reconstruction / error propagation logic — they pass even though the
-// real-environment crash is still open, which is exactly the gap this WIP branch exists to flag.
 describe('runScriptInQuickJs sendRequest bridge', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -360,5 +354,132 @@ describe('runScriptInQuickJs sendRequest bridge', () => {
     });
 
     expect((result.environment.data as Record<string, unknown>).callbackError).toBe('DNS resolution failed');
+  });
+});
+
+/**
+ * `vm.newPromise()` allocates three JSValues — the promise plus its `resolve`/`reject` functions —
+ * and quickjs-emscripten frees the latter two only from inside `resolve()`/`reject()`. Disposing the
+ * runtime while a bridge promise is still pending therefore leaks two live function objects and
+ * trips QuickJS's `assert(list_empty(&rt->gc_obj_list))` in `JS_FreeRuntime`. That is a native
+ * Emscripten `abort()`, not a normal exception, so it takes down the whole script worker rather than
+ * surfacing as a script error.
+ *
+ * The earlier bridge tests can't catch it because a `mockResolvedValue` fetch settles inside the
+ * same microtask checkpoint as the call, so the deferred is always settled before teardown. These
+ * tests deliberately settle the fetch on a *later macrotask* — the only thing real Electron `fetch()`
+ * timing adds — and each one aborts the module without the teardown fix in `runScriptInQuickJs`.
+ */
+describe('runScriptInQuickJs sendRequest bridge teardown', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const stubSlowFetch = (delayMs: number) => {
+    const fetchMock = vi.fn().mockImplementation(
+      () =>
+        new Promise(resolve =>
+          setTimeout(
+            () =>
+              resolve({
+                ok: true,
+                status: 200,
+                text: () =>
+                  Promise.resolve(
+                    JSON.stringify({ code: 200, status: 'OK', headers: [], body: 'late', responseTime: delayMs }),
+                  ),
+              }),
+            delayMs,
+          ),
+        ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+  };
+
+  it('tears down cleanly when the script never awaits its sendRequest', async () => {
+    stubSlowFetch(120);
+    const context = baseContext();
+
+    // Postman-style fire-and-forget: the script returns while the request is still in flight.
+    const result = await runScriptInQuickJs({
+      script: `
+        insomnia.sendRequest('https://example.com', () => {});
+        insomnia.environment.set('finished', true);
+      `,
+      context,
+    });
+
+    expect((result.environment.data as Record<string, unknown>).finished).toBe(true);
+
+    // The response lands after teardown; it must be a silent no-op rather than an abort or an
+    // unhandled QuickJSUseAfterFree rejection out of the settle callback.
+    await new Promise(resolve => setTimeout(resolve, 250));
+
+    // A later run proving the shared WASM module survived — after an Emscripten abort this throws.
+    const laterResult = await runScriptInQuickJs({
+      script: 'insomnia.environment.set("ranCleanly", true);',
+      context: baseContext(),
+    });
+    expect((laterResult.environment.data as Record<string, unknown>).ranCleanly).toBe(true);
+  });
+
+  it('tears down cleanly when the deadline fires while a sendRequest is in flight', async () => {
+    stubSlowFetch(2000);
+    const context = baseContext();
+    context.settings = { timeout: 100 } as any;
+
+    await expect(
+      runScriptInQuickJs({ script: `await insomnia.sendRequest('https://example.com');`, context }),
+    ).rejects.toThrow(/Executing script timeout: 100/);
+
+    const laterResult = await runScriptInQuickJs({
+      script: 'insomnia.environment.set("ranCleanly", true);',
+      context: baseContext(),
+    });
+    expect((laterResult.environment.data as Record<string, unknown>).ranCleanly).toBe(true);
+  });
+
+  it('tears down cleanly when only some of several sendRequests have settled', async () => {
+    let call = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(
+        () =>
+          new Promise(resolve =>
+            // First call answers immediately, second is still outstanding at teardown.
+            setTimeout(
+              () =>
+                resolve({
+                  ok: true,
+                  status: 200,
+                  text: () =>
+                    Promise.resolve(
+                      JSON.stringify({ code: 200, status: 'OK', headers: [], body: 'x', responseTime: 1 }),
+                    ),
+                }),
+              call++ === 0 ? 0 : 2000,
+            ),
+          ),
+      ),
+    );
+    const context = baseContext();
+
+    const result = await runScriptInQuickJs({
+      script: `
+        const first = await insomnia.sendRequest('https://example.com/one');
+        insomnia.sendRequest('https://example.com/two', () => {});
+        insomnia.environment.set('firstBody', first.body);
+      `,
+      context,
+    });
+
+    expect((result.environment.data as Record<string, unknown>).firstBody).toBe('x');
+
+    const laterResult = await runScriptInQuickJs({
+      script: 'insomnia.environment.set("ranCleanly", true);',
+      context: baseContext(),
+    });
+    expect((laterResult.environment.data as Record<string, unknown>).ranCleanly).toBe(true);
   });
 });

--- a/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
+++ b/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { RequestContext } from '../../../insomnia-scripting-environment/src/objects/interfaces';
 import { getQuickJSModule } from '../templating/sandbox/quickjs-runtime';
@@ -83,14 +83,6 @@ describe('runScriptInQuickJs', () => {
     expect(result.logs.some(row => row.includes('hello from quickjs'))).toBe(true);
   });
 
-  it('throws a clear error when calling the unsupported sendRequest API', async () => {
-    const context = baseContext();
-
-    await expect(
-      runScriptInQuickJs({ script: 'await insomnia.sendRequest("https://example.com");', context }),
-    ).rejects.toThrow(/insomnia\.sendRequest\(\) is not supported/);
-  });
-
   it('propagates script errors with a useful message', async () => {
     const context = baseContext();
 
@@ -130,7 +122,7 @@ describe('runScriptInQuickJs', () => {
     expect((result.environment.data as Record<string, unknown>).prototype).toBeUndefined();
   });
 
-  it('keeps globalThis limited to standard intrinsics and this sandbox\'s own bridged names', async () => {
+  it("keeps globalThis limited to standard intrinsics and this sandbox's own bridged names", async () => {
     const context = baseContext();
 
     // Reports host globals and the full globalThis property list back through
@@ -162,7 +154,7 @@ describe('runScriptInQuickJs', () => {
       const dumped = bareVm.evalCode('Object.getOwnPropertyNames(globalThis)');
       if (dumped.error) {
         dumped.error.dispose();
-        throw new Error('failed to enumerate a bare QuickJS context\'s globals');
+        throw new Error("failed to enumerate a bare QuickJS context's globals");
       }
       bareGlobalNames = bareVm.dump(dumped.value) as string[];
       dumped.value.dispose();
@@ -173,8 +165,15 @@ describe('runScriptInQuickJs', () => {
 
     // Anything else reachable on globalThis fails this assertion instead of shipping silently.
     const ALLOWED_EXTRA_GLOBALS = new Set([
-      'console', '__envGet', '__envSet', '__varGet', '__varSet', '__requestJSON', '__task',
-      'insomnia', '$',
+      'console',
+      '__envGet',
+      '__envSet',
+      '__varGet',
+      '__varSet',
+      '__requestJSON',
+      '__task',
+      'insomnia',
+      '$',
     ]);
     const unexpectedGlobals = (data.sandboxGlobalNames as string[]).filter(
       name => !baseline.has(name) && !ALLOWED_EXTRA_GLOBALS.has(name),
@@ -186,9 +185,9 @@ describe('runScriptInQuickJs', () => {
     const context = baseContext();
     context.settings = { timeout: 30 } as any;
 
-    await expect(
-      runScriptInQuickJs({ script: 'await new Promise(() => {});', context }),
-    ).rejects.toThrow(/Executing script timeout: 30/);
+    await expect(runScriptInQuickJs({ script: 'await new Promise(() => {});', context })).rejects.toThrow(
+      /Executing script timeout: 30/,
+    );
 
     // A later, unrelated run must still complete normally afterward.
     const laterContext = baseContext();
@@ -197,5 +196,168 @@ describe('runScriptInQuickJs', () => {
       context: laterContext,
     });
     expect((laterResult.environment.data as Record<string, unknown>).ranCleanly).toBe(true);
+  });
+});
+
+// KNOWN BUG (unresolved): a real sendRequest() round trip crashes under the real Electron/Worker
+// environment (see quickjs-script-engine.ts's module doc comment and
+// packages/insomnia-smoke-test/tests/smoke/quickjs-sendrequest-bridge.test.ts, which reproduces it
+// end to end). These unit tests mock `fetch` entirely, so they only cover the bridge's own request
+// normalization / response reconstruction / error propagation logic — they pass even though the
+// real-environment crash is still open, which is exactly the gap this WIP branch exists to flag.
+describe('runScriptInQuickJs sendRequest bridge', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const stubFetchOnce = (response: { ok: boolean; status?: number; body: unknown }) => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: response.ok,
+      status: response.status ?? (response.ok ? 200 : 500),
+      text: () => Promise.resolve(JSON.stringify(response.body)),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+  };
+
+  it('sends a real request through the bridge and resolves with a response object', async () => {
+    stubFetchOnce({
+      ok: true,
+      body: {
+        code: 200,
+        status: 'OK',
+        headers: [{ name: 'content-type', value: 'application/json' }],
+        body: '{"hello":"world"}',
+        responseTime: 12,
+      },
+    });
+    const context = baseContext();
+
+    const result = await runScriptInQuickJs({
+      script: `
+        const response = await insomnia.sendRequest('https://example.com');
+        insomnia.environment.set('code', response.code);
+        insomnia.environment.set('parsedBody', response.json());
+      `,
+      context,
+    });
+
+    expect(result.environment.data).toMatchObject({ code: 200, parsedBody: { hello: 'world' } });
+  });
+
+  it('sends the auth token as a header on the bridge fetch call', async () => {
+    const fetchMock = stubFetchOnce({
+      ok: true,
+      body: { code: 204, status: 'No Content', headers: [], body: '', responseTime: 1 },
+    });
+    const context = baseContext();
+
+    await runScriptInQuickJs({
+      script: `await insomnia.sendRequest('https://example.com');`,
+      context,
+      authToken: 'super-secret-token',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'insomnia-templating-worker-database://network.sendrequestwithoutsideeffects',
+      expect.objectContaining({ headers: { 'x-insomnia-templating-auth': 'super-secret-token' } }),
+    );
+  });
+
+  it('normalizes a bare URL string request with an explicit empty headers array', async () => {
+    // Regression: the host handler (network.sendRequestWithoutSideEffects) does not default
+    // `headers` itself — omitting it here crashes createConfiguredCurlInstance's
+    // `headers.find(...)` user-agent lookup with "Cannot read properties of undefined".
+    const fetchMock = stubFetchOnce({
+      ok: true,
+      body: { code: 200, status: 'OK', headers: [], body: '', responseTime: 1 },
+    });
+    const context = baseContext();
+
+    await runScriptInQuickJs({ script: `await insomnia.sendRequest('https://example.com');`, context });
+
+    const sentBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(sentBody.options.request).toEqual({ url: 'https://example.com', method: 'GET', headers: [] });
+  });
+
+  it('normalizes a plain-object request with headers and a string body', async () => {
+    const fetchMock = stubFetchOnce({
+      ok: true,
+      body: { code: 200, status: 'OK', headers: [], body: '', responseTime: 1 },
+    });
+    const context = baseContext();
+
+    await runScriptInQuickJs({
+      script: `
+        await insomnia.sendRequest({
+          url: 'https://example.com/items',
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{"a":1}',
+        });
+      `,
+      context,
+    });
+
+    const sentBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(sentBody).toEqual({
+      options: {
+        request: {
+          url: 'https://example.com/items',
+          method: 'POST',
+          headers: [{ name: 'Content-Type', value: 'application/json' }],
+          body: { mimeType: 'text/plain', text: '{"a":1}' },
+        },
+        caCertficatePath: null,
+      },
+    });
+  });
+
+  it('supports the Postman-style (error, response) callback signature', async () => {
+    stubFetchOnce({ ok: true, body: { code: 200, status: 'OK', headers: [], body: 'ok', responseTime: 1 } });
+    const context = baseContext();
+
+    const result = await runScriptInQuickJs({
+      script: `
+        await new Promise((resolve) => {
+          insomnia.sendRequest('https://example.com', (error, response) => {
+            insomnia.environment.set('callbackError', error ?? null);
+            insomnia.environment.set('callbackBody', response ? response.body : null);
+            resolve();
+          });
+        });
+      `,
+      context,
+    });
+
+    expect(result.environment.data).toMatchObject({ callbackError: null, callbackBody: 'ok' });
+  });
+
+  it('rejects with the bridge-reported error when the host handler fails', async () => {
+    stubFetchOnce({ ok: false, status: 500, body: { error: 'DNS resolution failed' } });
+    const context = baseContext();
+
+    await expect(
+      runScriptInQuickJs({ script: `await insomnia.sendRequest('https://unreachable.invalid');`, context }),
+    ).rejects.toThrow('DNS resolution failed');
+  });
+
+  it('reports the bridge error to the callback instead of throwing when a callback is given', async () => {
+    stubFetchOnce({ ok: false, status: 500, body: { error: 'DNS resolution failed' } });
+    const context = baseContext();
+
+    const result = await runScriptInQuickJs({
+      script: `
+        await new Promise((resolve) => {
+          insomnia.sendRequest('https://unreachable.invalid', (error) => {
+            insomnia.environment.set('callbackError', error);
+            resolve();
+          });
+        });
+      `,
+      context,
+    });
+
+    expect((result.environment.data as Record<string, unknown>).callbackError).toBe('DNS resolution failed');
   });
 });

--- a/packages/insomnia/src/scripting/quickjs-script-engine.ts
+++ b/packages/insomnia/src/scripting/quickjs-script-engine.ts
@@ -116,14 +116,25 @@ globalThis.insomnia = {
     return value;
   })(JSON.parse(__requestJSON)),
   sendRequest: (request, callback) => {
+    const normalizeHeaders = (raw) => {
+      if (Array.isArray(raw)) {
+        // Scripting-environment RequestOptions.header entries use {key, value}; accept {name, value}
+        // too since that's the shape the bridge itself (and the hidden-window Response) already uses.
+        return raw.map((h) => ({ name: h.name ?? h.key, value: String(h.value) }));
+      }
+      if (raw && typeof raw === 'object') {
+        return Object.entries(raw).map(([name, value]) => ({ name, value: String(value) }));
+      }
+      return [];
+    };
     const normalized = typeof request === 'string'
       ? { url: request, method: 'GET', headers: [] }
       : {
-          url: request.url,
+          // request.url may be a Url-like object (per RequestOptions); the host handler needs a string.
+          url: String(request.url),
           method: request.method || 'GET',
-          headers: Array.isArray(request.headers)
-            ? request.headers
-            : Object.entries(request.headers || {}).map(([name, value]) => ({ name, value: String(value) })),
+          // RequestOptions calls this field "header" (singular); accept the plural too.
+          headers: normalizeHeaders(request.headers ?? request.header),
           body: request.body !== undefined ? { mimeType: 'text/plain', text: String(request.body) } : undefined,
         };
     const bodyJson = JSON.stringify({ options: { request: normalized, caCertficatePath: null } });
@@ -146,7 +157,7 @@ globalThis.insomnia = {
     if (typeof callback === 'function') {
       promise.then(
         (response) => callback(undefined, response),
-        (err) => callback(err.message),
+        (err) => callback(err && err.message ? err.message : String(err)),
       );
       return undefined;
     }
@@ -194,11 +205,27 @@ const sendRequestViaFetch = async (requestBodyJson: string, authToken?: string):
     headers: authToken ? { [TEMPLATING_DB_AUTH_HEADER]: authToken } : undefined,
     body: requestBodyJson,
   });
-  const parsed = JSON.parse(await resp.text());
-  if (!resp.ok) {
-    throw new Error(typeof parsed?.error === 'string' ? parsed.error : `sendRequest failed with status ${resp.status}`);
+  const text = await resp.text();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    // A non-JSON body (e.g. an empty response, or an HTML error page from something in front of the
+    // protocol handler) would otherwise surface as an opaque SyntaxError that masks the real status.
+    throw new Error(
+      resp.ok
+        ? `sendRequest received a non-JSON response: ${text.slice(0, 200)}`
+        : `sendRequest failed with status ${resp.status}`,
+    );
   }
-  return parsed;
+  if (!resp.ok) {
+    const errorMessage =
+      typeof (parsed as { error?: unknown })?.error === 'string'
+        ? (parsed as { error: string }).error
+        : `sendRequest failed with status ${resp.status}`;
+    throw new Error(errorMessage);
+  }
+  return parsed as Record<string, unknown>;
 };
 
 /** Registers the async `__sendRequest(bodyJson)` bridge backing `insomnia.sendRequest()` in BOOTSTRAP. */

--- a/packages/insomnia/src/scripting/quickjs-script-engine.ts
+++ b/packages/insomnia/src/scripting/quickjs-script-engine.ts
@@ -67,6 +67,13 @@ export const runScriptInQuickJs = async ({
     // Polled during synchronous execution so a tight sync loop in the script can't bypass the timeout.
     vm.runtime.setInterruptHandler(() => Date.now() > deadline);
     vm.runtime.setMemoryLimit(32 * 1024 * 1024);
+    // Without an explicit cap, unbounded guest recursion overflows the *host* WASM call stack
+    // before QuickJS's own bytecode-level depth check can catch it — that surfaces as an uncatchable
+    // host RangeError instead of a normal script error, and leaves the runtime's GC state
+    // inconsistent enough that the `vm.dispose()` below then aborts on a fatal internal assertion.
+    // 256KB reliably lets QuickJS's own check win first (verified empirically) while still allowing
+    // several hundred levels of legitimate recursion.
+    vm.runtime.setMaxStackSize(256 * 1024);
 
     installConsole(vm, scriptConsole);
     installKeyValueBridge(vm, '__envGet', '__envSet', environmentData);
@@ -232,7 +239,45 @@ const DANGEROUS_BRIDGE_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
 const SEND_REQUEST_ENDPOINT = 'insomnia-templating-worker-database://network.sendrequestwithoutsideeffects';
 const TEMPLATING_DB_AUTH_HEADER = 'x-insomnia-templating-auth';
 
+// insomnia.sendRequest()'s own doc comment above says this sandbox's request bridge supports only
+// a plain-text body -- "no auth, client certificates, cookies, or multipart/urlencoded bodies yet"
+// -- and the BOOTSTRAP wrapper only ever builds `{ mimeType: 'text/plain', text }`. That's guest-side
+// JS, though, not an enforcement boundary: a script can skip the wrapper and call the raw
+// `__sendRequest` global directly with a body of its own choosing. `network.sendRequestWithoutSideEffects`
+// (the shared host handler this bridges to) forwards a `body` unvalidated to `curlRequest`, and a
+// multipart body's file parts are read straight off disk by `buildMultipart` with no ownership/
+// allowlist check at all -- unlike every other local-file read reachable from a request definition.
+// That handler is also the one the legacy hidden-window script sandbox and the template-tag sandbox
+// use, each with its own, already-privileged execution model, so the fix belongs here, at this
+// QuickJS-specific bridge boundary, rather than in the shared handler itself.
+const SUPPORTED_SEND_REQUEST_BODY_MIME_TYPE = 'text/plain';
+
+const assertSupportedSendRequestBody = (requestBodyJson: string): void => {
+  let parsed: { options?: { request?: { body?: unknown } } };
+  try {
+    parsed = JSON.parse(requestBodyJson);
+  } catch {
+    // Malformed JSON fails downstream (the real handler's own JSON.parse) in the normal way.
+    return;
+  }
+  const body = parsed?.options?.request?.body;
+  if (body === undefined || body === null) {
+    return;
+  }
+  const { mimeType, ...rest } = (body ?? {}) as { mimeType?: unknown; [key: string]: unknown };
+  const hasUnsupportedShape =
+    typeof body !== 'object' ||
+    (mimeType !== undefined && mimeType !== SUPPORTED_SEND_REQUEST_BODY_MIME_TYPE) ||
+    Object.keys(rest).some(key => key !== 'text');
+  if (hasUnsupportedShape) {
+    throw new Error(
+      'insomnia.sendRequest() only supports a plain-text request body in the QuickJS sandbox — file uploads, multipart, and urlencoded form bodies are not supported.',
+    );
+  }
+};
+
 const sendRequestViaFetch = async (requestBodyJson: string, authToken?: string): Promise<Record<string, unknown>> => {
+  assertSupportedSendRequestBody(requestBodyJson);
   const resp = await fetch(SEND_REQUEST_ENDPOINT, {
     method: 'post',
     headers: authToken ? { [TEMPLATING_DB_AUTH_HEADER]: authToken } : undefined,

--- a/packages/insomnia/src/scripting/quickjs-script-engine.ts
+++ b/packages/insomnia/src/scripting/quickjs-script-engine.ts
@@ -29,11 +29,19 @@ export const runScriptInQuickJs = async ({
   script,
   context,
   authToken,
+  onEngineFault,
 }: {
   script: string;
   context: RequestContext;
   /** Auth token for the `insomnia-templating-worker-database://` bridge — required for sendRequest. */
   authToken?: string;
+  /**
+   * Called when tearing the VM down aborts the WASM module — see `ENGINE_FAULT_MESSAGE`. The script
+   * itself already finished, so the run still returns its result; this is the signal to replace the
+   * engine rather than keep using a module that has aborted. Always fires when it happens, including
+   * on the error/timeout path.
+   */
+  onEngineFault?: (error: Error) => void;
 }): Promise<RequestContext> => {
   const QuickJS = await getQuickJSModule();
   const vm = QuickJS.newContext();
@@ -77,7 +85,18 @@ export const runScriptInQuickJs = async ({
     // already-settled deferreds still in the set are harmless.
     pendingDeferreds.forEach(deferred => deferred.dispose());
     pendingDeferreds.clear();
-    vm.dispose();
+    try {
+      vm.dispose();
+    } catch (err) {
+      // A known defect in quickjs-emscripten's WASM build (upstream issue #269) aborts the module
+      // here when the script allocated heavily after its first `await` — see ENGINE_FAULT_MESSAGE.
+      // The script has already run and everything we return is plain host-side JS, so swallowing
+      // this yields a complete result instead of destroying the run. Catching inside `finally` also
+      // means a genuine script error or timeout from the `try` above still wins.
+      const fault = err instanceof Error ? err : new Error(String(err));
+      scriptConsole.warn(ENGINE_FAULT_MESSAGE, fault.message);
+      onEngineFault?.(fault);
+    }
   }
 
   return {
@@ -94,6 +113,20 @@ export const runScriptInQuickJs = async ({
     logs: scriptConsole.dumpLogsAsArray(),
   };
 };
+
+/**
+ * Prefixes the warning a script sees when its run tripped the known WASM-build abort.
+ *
+ * Allocating ~100k+ objects after the script's first `await` — which a multi-megabyte
+ * `insomnia.sendRequest()` response body does on its own — leaves QuickJS's runtime un-freeable, and
+ * `JS_FreeRuntime` then aborts on `assert(list_empty(&rt->gc_obj_list))`. The same allocation done
+ * synchronously is fine at several times the size. It is a defect in quickjs-emscripten's *WASM
+ * build* rather than in QuickJS: the identical vendored engine source, built natively, is clean well
+ * past the failing size at every optimization level. Tracked upstream as
+ * https://github.com/justjake/quickjs-emscripten/issues/269.
+ */
+const ENGINE_FAULT_MESSAGE =
+  'The QuickJS engine faulted while cleaning up after this script, a known issue with large amounts of data handled after an await. The script finished and its results are intact; the engine will be replaced before the next run.';
 
 const unsupportedApiMessage = (name: string): string =>
   `${name} is not supported yet by the QuickJS sandbox (proof of concept). Disable "Use QuickJS sandbox for scripts" in Settings > Scripting to use it.`;

--- a/packages/insomnia/src/scripting/quickjs-script-engine.ts
+++ b/packages/insomnia/src/scripting/quickjs-script-engine.ts
@@ -1,4 +1,4 @@
-import type { QuickJSContext, QuickJSHandle } from 'quickjs-emscripten';
+import type { QuickJSContext, QuickJSDeferredPromise, QuickJSHandle } from 'quickjs-emscripten';
 
 import { Console } from '../../../insomnia-scripting-environment/src/objects/console';
 import type { RequestContext } from '../../../insomnia-scripting-environment/src/objects/interfaces';
@@ -21,13 +21,6 @@ import { getQuickJSModule } from '../templating/sandbox/quickjs-runtime';
  * client certificates, cookies, or multipart/urlencoded bodies yet, and the response object exposes
  * only `code`/`status`/`headers`/`body`/`responseTime`/`json()`/`text()` (no chai assertions, no
  * `originalRequest`). Full parity with the hidden-window `Response` class is deferred.
- *
- * KNOWN BUG (unresolved): a real sendRequest() round trip crashes under the real Electron/Worker
- * environment with `Aborted(Assertion failed: list_empty(&rt->gc_obj_list), at:
- * .../quickjs.c,2036,JS_FreeRuntime)` — see installSendRequestBridge's comment and
- * packages/insomnia-smoke-test/tests/smoke/quickjs-sendrequest-bridge.test.ts, which reproduces it.
- * Never reproduces in vitest (mocked fetch, or a real Node http server) — only real Electron fetch()
- * timing inside the dedicated Worker.
  *
  * Not supported (throws inside the script if called): insomnia.test()/pm.test(), collectionVariables,
  * vault, cookies, client certificates, and mutating the request.
@@ -53,13 +46,14 @@ export const runScriptInQuickJs = async ({
   const environmentData: Record<string, unknown> = { ...context.environment.data };
   const variablesData: Record<string, unknown> = { ...context.transientVariables?.data };
 
-  // Set right after `vm.dispose()` below. The sendRequest bridge is a real async host round trip
-  // (a `fetch()` to the Electron main process) whose resolution isn't driven by QuickJS's own job
-  // queue the way in-VM promises are — checking this flag before ever touching `vm`/a promise
-  // handle from that callback is what makes a late-arriving response after this function has
-  // already returned (deadline/interrupt fired, or the caller otherwise moved on) a safe no-op
-  // instead of a `QuickJSUseAfterFree` (or a native WASM abort disposing an in-use runtime).
-  const disposedRef = { current: false };
+  // Every VM promise handed to the script by `installSendRequestBridge` that hasn't settled yet.
+  // Each one owns three JSValues — the promise plus its `resolve`/`reject` functions — and
+  // quickjs-emscripten only frees the two functions from inside `resolve()`/`reject()`. A VM
+  // promise still pending when the runtime is freed therefore leaks two live function objects,
+  // which trips QuickJS's `assert(list_empty(&rt->gc_obj_list))` in `JS_FreeRuntime`: a native
+  // Emscripten abort rather than a catchable error, so it takes the script worker down instead of
+  // surfacing as a script failure. `finally` below settles this set before disposing.
+  const pendingDeferreds = new Set<QuickJSDeferredPromise>();
 
   try {
     // Polled during synchronous execution so a tight sync loop in the script can't bypass the timeout.
@@ -69,7 +63,7 @@ export const runScriptInQuickJs = async ({
     installConsole(vm, scriptConsole);
     installKeyValueBridge(vm, '__envGet', '__envSet', environmentData);
     installKeyValueBridge(vm, '__varGet', '__varSet', variablesData);
-    installSendRequestBridge(vm, authToken, disposedRef);
+    installSendRequestBridge(vm, pendingDeferreds, authToken);
     setGlobalString(vm, '__requestJSON', JSON.stringify(context.request ?? {}));
 
     evalOrThrow(vm, BOOTSTRAP, '<quickjs-script-bootstrap>');
@@ -77,7 +71,12 @@ export const runScriptInQuickJs = async ({
 
     await driveTaskToCompletion(vm, deadline, timeoutMs);
   } finally {
-    disposedRef.current = true;
+    // Ordering matters: free the resolve/reject functions of anything still in flight (a script
+    // that never awaited its sendRequest, or a run that hit the deadline mid-request) *before*
+    // the runtime, or `JS_FreeRuntime` aborts. `dispose()` is documented as idempotent, so
+    // already-settled deferreds still in the set are harmless.
+    pendingDeferreds.forEach(deferred => deferred.dispose());
+    pendingDeferreds.clear();
     vm.dispose();
   }
 
@@ -203,44 +202,37 @@ const sendRequestViaFetch = async (requestBodyJson: string, authToken?: string):
 };
 
 /** Registers the async `__sendRequest(bodyJson)` bridge backing `insomnia.sendRequest()` in BOOTSTRAP. */
-const installSendRequestBridge = (vm: QuickJSContext, authToken?: string, disposedRef?: { current: boolean }): void => {
+const installSendRequestBridge = (
+  vm: QuickJSContext,
+  pendingDeferreds: Set<QuickJSDeferredPromise>,
+  authToken?: string,
+): void => {
   const fn = vm.newFunction('__sendRequest', bodyHandle => {
     const bodyJson = vm.getString(bodyHandle);
     const deferred = vm.newPromise();
+    // Registered so the run's `finally` can free this deferred's resolve/reject functions if the
+    // fetch is still outstanding when the VM is torn down — see `pendingDeferreds`' comment.
+    pendingDeferreds.add(deferred);
     // `Promise.resolve().then(...)` defers the real fetch() call by one microtask tick so it never
-    // runs while still nested inside this C-to-JS callback frame — matching host-bridge.ts's
-    // installHostBridge (the proven-working equivalent for the template-tag sandbox). Calling the
-    // async bridge function directly here instead (no extra tick) let its `await fetch(...)`
-    // resolve while still on that native callback's call stack, which corrupted the WASM heap under
-    // real Electron fetch() timing (reproduced as a `QuickJSUseAfterFree` / `gc_obj_list` abort on
-    // `vm.newString` inside the resolution handler) — a reentrancy window neither a mocked fetch in
-    // unit tests nor a plain Node http client ever hit, since both settle within the same tick.
-    // NOTE: this deferral alone did NOT resolve the crash (see the module doc comment above) — kept
-    // because it's still a real fix for the reentrancy hazard it targets, just not a sufficient one.
+    // runs while still nested inside this C-to-JS callback frame — matching plugin-tag-sandbox.ts's
+    // installHostBridge, the proven-working equivalent for the template-tag sandbox.
     Promise.resolve()
       .then(() => sendRequestViaFetch(bodyJson, authToken))
       .then(
-        value => {
-          if (!disposedRef?.current) {
-            resolveDeferredWithString(vm, deferred, JSON.stringify({ ok: true, value }));
-          }
-        },
-        err => {
-          if (!disposedRef?.current) {
-            resolveDeferredWithString(
-              vm,
-              deferred,
-              JSON.stringify({ ok: false, error: err instanceof Error ? err.message : String(err) }),
-            );
-          }
-        },
+        value => settle(vm, deferred, pendingDeferreds, JSON.stringify({ ok: true, value })),
+        err =>
+          settle(
+            vm,
+            deferred,
+            pendingDeferreds,
+            JSON.stringify({ ok: false, error: err instanceof Error ? err.message : String(err) }),
+          ),
       );
     // The settled VM promise schedules a job; pump it so the awaiting script resumes.
     deferred.settled.then(() => {
-      if (!disposedRef?.current) {
+      if (vm.alive) {
         // executePendingJobs() returns a DisposableResult — on failure its `.error` is a live
-        // QuickJSHandle. Discarding the result outright (as this used to) leaks that handle,
-        // which is exactly what trips "gc_obj_list not empty" on a later vm.dispose().
+        // QuickJSHandle that leaks if the result is discarded rather than disposed.
         vm.runtime.executePendingJobs().dispose();
       }
     });
@@ -249,14 +241,28 @@ const installSendRequestBridge = (vm: QuickJSContext, authToken?: string, dispos
   setGlobal(vm, '__sendRequest', fn);
 };
 
-const resolveDeferredWithString = (
+/**
+ * Resolve a bridge deferred with a JSON payload, if the VM is still around to receive it.
+ *
+ * A `fetch()` can land after the run has finished (the script never awaited it, or the deadline
+ * fired first), by which point the VM is gone: `vm.newString` on a disposed context throws
+ * `QuickJSUseAfterFree` synchronously inside this `.then`, i.e. an unhandled rejection in the
+ * worker. `deferred.alive` covers the narrower case of a deferred already force-disposed by the
+ * run's `finally` while the context itself is somehow still up.
+ */
+const settle = (
   vm: QuickJSContext,
-  deferred: ReturnType<QuickJSContext['newPromise']>,
+  deferred: QuickJSDeferredPromise,
+  pendingDeferreds: Set<QuickJSDeferredPromise>,
   value: string,
 ): void => {
+  if (!vm.alive || !deferred.alive) {
+    return;
+  }
   const handle = vm.newString(value);
   deferred.resolve(handle);
   handle.dispose();
+  pendingDeferreds.delete(deferred);
 };
 
 /** Registers `<getName>(key)`/`<setName>(key, jsonValue)` host functions backed by a plain object. */

--- a/packages/insomnia/src/scripting/quickjs-script-engine.ts
+++ b/packages/insomnia/src/scripting/quickjs-script-engine.ts
@@ -14,15 +14,33 @@ import { getQuickJSModule } from '../templating/sandbox/quickjs-runtime';
  * minimal API surface is bridged in — enough to demonstrate the architecture, not enough to replace
  * the hidden-window sandbox yet. Gated behind `settings.useQuickJsScriptSandbox` (default off).
  *
- * Not supported (throws inside the script if called): insomnia.sendRequest(), insomnia.test()/
- * pm.test(), collectionVariables, vault, cookies, client certificates, and mutating the request.
+ * insomnia.sendRequest() bridges to the real `network.sendRequestWithoutSideEffects` host handler
+ * (the same one the template-tag sandbox uses) over the `insomnia-templating-worker-database://`
+ * fetch-based protocol — see `installSendRequestBridge` below. It supports only a minimal request
+ * shape (a URL string, or `{ url, method, headers, body }` with a plain string body) — no auth,
+ * client certificates, cookies, or multipart/urlencoded bodies yet, and the response object exposes
+ * only `code`/`status`/`headers`/`body`/`responseTime`/`json()`/`text()` (no chai assertions, no
+ * `originalRequest`). Full parity with the hidden-window `Response` class is deferred.
+ *
+ * KNOWN BUG (unresolved): a real sendRequest() round trip crashes under the real Electron/Worker
+ * environment with `Aborted(Assertion failed: list_empty(&rt->gc_obj_list), at:
+ * .../quickjs.c,2036,JS_FreeRuntime)` — see installSendRequestBridge's comment and
+ * packages/insomnia-smoke-test/tests/smoke/quickjs-sendrequest-bridge.test.ts, which reproduces it.
+ * Never reproduces in vitest (mocked fetch, or a real Node http server) — only real Electron fetch()
+ * timing inside the dedicated Worker.
+ *
+ * Not supported (throws inside the script if called): insomnia.test()/pm.test(), collectionVariables,
+ * vault, cookies, client certificates, and mutating the request.
  */
 export const runScriptInQuickJs = async ({
   script,
   context,
+  authToken,
 }: {
   script: string;
   context: RequestContext;
+  /** Auth token for the `insomnia-templating-worker-database://` bridge — required for sendRequest. */
+  authToken?: string;
 }): Promise<RequestContext> => {
   const QuickJS = await getQuickJSModule();
   const vm = QuickJS.newContext();
@@ -35,6 +53,14 @@ export const runScriptInQuickJs = async ({
   const environmentData: Record<string, unknown> = { ...context.environment.data };
   const variablesData: Record<string, unknown> = { ...context.transientVariables?.data };
 
+  // Set right after `vm.dispose()` below. The sendRequest bridge is a real async host round trip
+  // (a `fetch()` to the Electron main process) whose resolution isn't driven by QuickJS's own job
+  // queue the way in-VM promises are — checking this flag before ever touching `vm`/a promise
+  // handle from that callback is what makes a late-arriving response after this function has
+  // already returned (deadline/interrupt fired, or the caller otherwise moved on) a safe no-op
+  // instead of a `QuickJSUseAfterFree` (or a native WASM abort disposing an in-use runtime).
+  const disposedRef = { current: false };
+
   try {
     // Polled during synchronous execution so a tight sync loop in the script can't bypass the timeout.
     vm.runtime.setInterruptHandler(() => Date.now() > deadline);
@@ -43,6 +69,7 @@ export const runScriptInQuickJs = async ({
     installConsole(vm, scriptConsole);
     installKeyValueBridge(vm, '__envGet', '__envSet', environmentData);
     installKeyValueBridge(vm, '__varGet', '__varSet', variablesData);
+    installSendRequestBridge(vm, authToken, disposedRef);
     setGlobalString(vm, '__requestJSON', JSON.stringify(context.request ?? {}));
 
     evalOrThrow(vm, BOOTSTRAP, '<quickjs-script-bootstrap>');
@@ -50,6 +77,7 @@ export const runScriptInQuickJs = async ({
 
     await driveTaskToCompletion(vm, deadline, timeoutMs);
   } finally {
+    disposedRef.current = true;
     vm.dispose();
   }
 
@@ -88,7 +116,43 @@ globalThis.insomnia = {
     }
     return value;
   })(JSON.parse(__requestJSON)),
-  sendRequest: () => { throw new Error(${JSON.stringify(unsupportedApiMessage('insomnia.sendRequest()'))}); },
+  sendRequest: (request, callback) => {
+    const normalized = typeof request === 'string'
+      ? { url: request, method: 'GET', headers: [] }
+      : {
+          url: request.url,
+          method: request.method || 'GET',
+          headers: Array.isArray(request.headers)
+            ? request.headers
+            : Object.entries(request.headers || {}).map(([name, value]) => ({ name, value: String(value) })),
+          body: request.body !== undefined ? { mimeType: 'text/plain', text: String(request.body) } : undefined,
+        };
+    const bodyJson = JSON.stringify({ options: { request: normalized, caCertficatePath: null } });
+    const promise = __sendRequest(bodyJson).then((envelopeJson) => {
+      const envelope = JSON.parse(envelopeJson);
+      if (!envelope.ok) {
+        throw new Error(envelope.error);
+      }
+      const result = envelope.value;
+      return {
+        code: result.code,
+        status: result.status,
+        headers: result.headers,
+        body: result.body,
+        responseTime: result.responseTime,
+        json: () => JSON.parse(result.body),
+        text: () => result.body,
+      };
+    });
+    if (typeof callback === 'function') {
+      promise.then(
+        (response) => callback(undefined, response),
+        (err) => callback(err.message),
+      );
+      return undefined;
+    }
+    return promise;
+  },
   test: () => { throw new Error(${JSON.stringify(unsupportedApiMessage('insomnia.test()/pm.test()'))}); },
 };
 globalThis.$ = globalThis.insomnia;
@@ -117,6 +181,83 @@ const installConsole = (vm: QuickJSContext, scriptConsole: Console): void => {
 // Using one of these as a bracket-assignment key on a plain object rewires its prototype or
 // shadows the name instead of setting an ordinary property.
 const DANGEROUS_BRIDGE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+// The same fetch-based bridge the template-tag sandbox uses (`common/templating/liquid-extension-worker.ts`),
+// reused here rather than adding a second protocol scheme — this endpoint already sends a real
+// request via curl without persisting it to request/response history, which is exactly what an
+// ad-hoc `insomnia.sendRequest()` call needs.
+const SEND_REQUEST_ENDPOINT = 'insomnia-templating-worker-database://network.sendrequestwithoutsideeffects';
+const TEMPLATING_DB_AUTH_HEADER = 'x-insomnia-templating-auth';
+
+const sendRequestViaFetch = async (requestBodyJson: string, authToken?: string): Promise<Record<string, unknown>> => {
+  const resp = await fetch(SEND_REQUEST_ENDPOINT, {
+    method: 'post',
+    headers: authToken ? { [TEMPLATING_DB_AUTH_HEADER]: authToken } : undefined,
+    body: requestBodyJson,
+  });
+  const parsed = JSON.parse(await resp.text());
+  if (!resp.ok) {
+    throw new Error(typeof parsed?.error === 'string' ? parsed.error : `sendRequest failed with status ${resp.status}`);
+  }
+  return parsed;
+};
+
+/** Registers the async `__sendRequest(bodyJson)` bridge backing `insomnia.sendRequest()` in BOOTSTRAP. */
+const installSendRequestBridge = (vm: QuickJSContext, authToken?: string, disposedRef?: { current: boolean }): void => {
+  const fn = vm.newFunction('__sendRequest', bodyHandle => {
+    const bodyJson = vm.getString(bodyHandle);
+    const deferred = vm.newPromise();
+    // `Promise.resolve().then(...)` defers the real fetch() call by one microtask tick so it never
+    // runs while still nested inside this C-to-JS callback frame — matching host-bridge.ts's
+    // installHostBridge (the proven-working equivalent for the template-tag sandbox). Calling the
+    // async bridge function directly here instead (no extra tick) let its `await fetch(...)`
+    // resolve while still on that native callback's call stack, which corrupted the WASM heap under
+    // real Electron fetch() timing (reproduced as a `QuickJSUseAfterFree` / `gc_obj_list` abort on
+    // `vm.newString` inside the resolution handler) — a reentrancy window neither a mocked fetch in
+    // unit tests nor a plain Node http client ever hit, since both settle within the same tick.
+    // NOTE: this deferral alone did NOT resolve the crash (see the module doc comment above) — kept
+    // because it's still a real fix for the reentrancy hazard it targets, just not a sufficient one.
+    Promise.resolve()
+      .then(() => sendRequestViaFetch(bodyJson, authToken))
+      .then(
+        value => {
+          if (!disposedRef?.current) {
+            resolveDeferredWithString(vm, deferred, JSON.stringify({ ok: true, value }));
+          }
+        },
+        err => {
+          if (!disposedRef?.current) {
+            resolveDeferredWithString(
+              vm,
+              deferred,
+              JSON.stringify({ ok: false, error: err instanceof Error ? err.message : String(err) }),
+            );
+          }
+        },
+      );
+    // The settled VM promise schedules a job; pump it so the awaiting script resumes.
+    deferred.settled.then(() => {
+      if (!disposedRef?.current) {
+        // executePendingJobs() returns a DisposableResult — on failure its `.error` is a live
+        // QuickJSHandle. Discarding the result outright (as this used to) leaks that handle,
+        // which is exactly what trips "gc_obj_list not empty" on a later vm.dispose().
+        vm.runtime.executePendingJobs().dispose();
+      }
+    });
+    return deferred.handle;
+  });
+  setGlobal(vm, '__sendRequest', fn);
+};
+
+const resolveDeferredWithString = (
+  vm: QuickJSContext,
+  deferred: ReturnType<QuickJSContext['newPromise']>,
+  value: string,
+): void => {
+  const handle = vm.newString(value);
+  deferred.resolve(handle);
+  handle.dispose();
+};
 
 /** Registers `<getName>(key)`/`<setName>(key, jsonValue)` host functions backed by a plain object. */
 const installKeyValueBridge = (
@@ -166,7 +307,9 @@ const evalOrThrow = (vm: QuickJSContext, code: string, filename: string): void =
     result.error.dispose();
     throw toError(errData);
   }
-  result.value.dispose();
+  if ('value' in result) {
+    result.value.dispose();
+  }
 };
 
 /** Drives `globalThis.__task` (a VM promise wrapping the user script) to completion. */
@@ -181,7 +324,9 @@ const driveTaskToCompletion = async (vm: QuickJSContext, deadline: number, timeo
   });
 
   while (!settled) {
-    vm.runtime.executePendingJobs();
+    // See installSendRequestBridge's identical call for why the result must be disposed, not
+    // discarded: on failure its `.error` is a live QuickJSHandle that otherwise leaks.
+    vm.runtime.executePendingJobs().dispose();
     if (settled) {
       break;
     }
@@ -196,7 +341,9 @@ const driveTaskToCompletion = async (vm: QuickJSContext, deadline: number, timeo
     settled.error.dispose();
     throw toError(errData);
   }
-  settled.value.dispose();
+  if ('value' in settled) {
+    settled.value.dispose();
+  }
 };
 
 const toError = (data: unknown): Error => {

--- a/packages/insomnia/src/scripting/quickjs-script.worker.ts
+++ b/packages/insomnia/src/scripting/quickjs-script.worker.ts
@@ -16,28 +16,44 @@ interface WorkerRequest {
   authToken?: string;
 }
 
+/**
+ * `engineFaulted` asks the client to retire this worker — the WASM module aborted while tearing a
+ * context down, so the module it caches is not one we want to keep running scripts on. Set on both
+ * response shapes because the fault is independent of whether the script itself succeeded.
+ */
 interface WorkerErrorResponse {
   id: string;
   error: { message: string; name?: string; stack?: string };
+  engineFaulted?: boolean;
 }
 
 interface WorkerSuccessResponse {
   id: string;
   result: RequestContext;
+  engineFaulted?: boolean;
 }
 
 export type WorkerResponse = WorkerSuccessResponse | WorkerErrorResponse;
 
 self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
   const { id, script, context, authToken } = event.data;
+  let engineFaulted = false;
   try {
-    const result = await runScriptInQuickJs({ script, context, authToken });
-    self.postMessage({ id, result } satisfies WorkerSuccessResponse);
+    const result = await runScriptInQuickJs({
+      script,
+      context,
+      authToken,
+      onEngineFault: () => {
+        engineFaulted = true;
+      },
+    });
+    self.postMessage({ id, result, engineFaulted } satisfies WorkerSuccessResponse);
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));
     self.postMessage({
       id,
       error: { message: error.message, name: error.name, stack: error.stack },
+      engineFaulted,
     } satisfies WorkerErrorResponse);
   }
 };

--- a/packages/insomnia/src/scripting/quickjs-script.worker.ts
+++ b/packages/insomnia/src/scripting/quickjs-script.worker.ts
@@ -12,6 +12,8 @@ interface WorkerRequest {
   id: string;
   script: string;
   context: RequestContext;
+  /** Forwarded by `run-script-quickjs.ts`; a Worker can't reach `window.main` to fetch it itself. */
+  authToken?: string;
 }
 
 interface WorkerErrorResponse {
@@ -27,9 +29,9 @@ interface WorkerSuccessResponse {
 export type WorkerResponse = WorkerSuccessResponse | WorkerErrorResponse;
 
 self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
-  const { id, script, context } = event.data;
+  const { id, script, context, authToken } = event.data;
   try {
-    const result = await runScriptInQuickJs({ script, context });
+    const result = await runScriptInQuickJs({ script, context, authToken });
     self.postMessage({ id, result } satisfies WorkerSuccessResponse);
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));

--- a/packages/insomnia/src/scripting/run-script-quickjs.test.ts
+++ b/packages/insomnia/src/scripting/run-script-quickjs.test.ts
@@ -56,12 +56,23 @@ class FakeWorker {
 describe('runScriptInQuickJs (worker client)', () => {
   let fakeWorker: FakeWorker;
 
+  /**
+   * The client fetches the templating-db auth token over IPC before posting, so the postMessage
+   * lands a microtask later than the call. Awaiting this lets a test assert on `postedMessages`.
+   */
+  const flushTokenFetch = () => new Promise(resolve => setTimeout(resolve, 0));
+
   beforeEach(async () => {
     fakeWorker = new FakeWorker();
     vi.stubGlobal(
       'Worker',
       vi.fn(() => fakeWorker),
     );
+    // A Worker can't reach `window.main`, so the client fetches the bridge auth token here and
+    // forwards it in every message — see `getTemplatingDbAuthToken`.
+    vi.stubGlobal('window', {
+      main: { templatingDb: { getAuthToken: vi.fn().mockResolvedValue('test-auth-token') } },
+    });
     // The module keeps a lazily-created singleton worker at module scope — reset it between tests
     // by re-importing fresh so each test gets its own FakeWorker instance.
     vi.resetModules();
@@ -76,9 +87,13 @@ describe('runScriptInQuickJs (worker client)', () => {
     const context = baseContext();
 
     const promise = runScriptInQuickJs({ script: 'console.log(1)', context });
+    await flushTokenFetch();
     expect(fakeWorker.postedMessages).toHaveLength(1);
-    const { id } = fakeWorker.postedMessages[0];
+    const { id, authToken } = fakeWorker.postedMessages[0];
     expect(typeof id).toBe('string');
+    // Forwarded so the engine's sendRequest bridge can authenticate against the templating-db
+    // protocol; without it every bridge fetch comes back 401.
+    expect(authToken).toBe('test-auth-token');
 
     const result = { ...context, logs: ['log: 1\n'] };
     fakeWorker.emitMessage({ id, result });
@@ -91,6 +106,7 @@ describe('runScriptInQuickJs (worker client)', () => {
     const context = baseContext();
 
     const promise = runScriptInQuickJs({ script: 'throw new Error("boom")', context });
+    await flushTokenFetch();
     const { id } = fakeWorker.postedMessages[0];
     fakeWorker.emitMessage({ id, error: { message: 'boom', name: 'Error' } });
 
@@ -102,6 +118,7 @@ describe('runScriptInQuickJs (worker client)', () => {
     const context = baseContext();
 
     const promise = runScriptInQuickJs({ script: 'console.log(1)', context });
+    await flushTokenFetch();
     fakeWorker.emitMessage({ id: 'not-a-real-id', result: {} });
 
     const { id } = fakeWorker.postedMessages[0];
@@ -136,6 +153,7 @@ describe('runScriptInQuickJs (worker client)', () => {
     );
 
     const secondCall = runScriptInQuickJs({ script: 'console.log(1)', context });
+    await flushTokenFetch();
     expect(secondWorker.postedMessages).toHaveLength(1);
     const { id } = secondWorker.postedMessages[0];
     const result = { ...context, logs: [] };

--- a/packages/insomnia/src/scripting/run-script-quickjs.test.ts
+++ b/packages/insomnia/src/scripting/run-script-quickjs.test.ts
@@ -25,11 +25,16 @@ const baseContext = (): RequestContext => ({
  */
 class FakeWorker {
   postedMessages: any[] = [];
+  terminated = false;
   private messageListeners: ((event: { data: any }) => void)[] = [];
   private errorListeners: ((event: { message: string }) => void)[] = [];
 
   postMessage(data: any) {
     this.postedMessages.push(data);
+  }
+
+  terminate() {
+    this.terminated = true;
   }
 
   addEventListener(type: string, listener: any) {
@@ -160,5 +165,61 @@ describe('runScriptInQuickJs (worker client)', () => {
     secondWorker.emitMessage({ id, result });
 
     await expect(secondCall).resolves.toEqual(result);
+  });
+
+  // The engine reports `engineFaulted` when tearing a context down aborted the WASM module (upstream
+  // quickjs-emscripten#269). The run itself is complete and must still resolve; the worker caching
+  // that module has to go.
+  describe('engine fault handling', () => {
+    it('still resolves the run, then retires the worker', async () => {
+      const { runScriptInQuickJs } = await import('./run-script-quickjs');
+      const context = baseContext();
+
+      const promise = runScriptInQuickJs({ script: 'await big()', context });
+      await flushTokenFetch();
+      const { id } = fakeWorker.postedMessages[0];
+      const result = { ...context, logs: ['warn: QuickJS engine faulted…\n'] };
+      fakeWorker.emitMessage({ id, result, engineFaulted: true });
+
+      await expect(promise).resolves.toEqual(result);
+      expect(fakeWorker.terminated).toBe(true);
+
+      // The next call must not reuse the faulted worker.
+      const nextWorker = new FakeWorker();
+      vi.stubGlobal(
+        'Worker',
+        vi.fn(() => nextWorker),
+      );
+      const nextCall = runScriptInQuickJs({ script: 'console.log(1)', context });
+      await flushTokenFetch();
+      expect(nextWorker.postedMessages).toHaveLength(1);
+      const next = { ...context, logs: [] };
+      nextWorker.emitMessage({ id: nextWorker.postedMessages[0].id, result: next });
+      await expect(nextCall).resolves.toEqual(next);
+    });
+
+    it('waits for a concurrent run to finish before terminating the faulted worker', async () => {
+      const { runScriptInQuickJs } = await import('./run-script-quickjs');
+      const context = baseContext();
+
+      // Two scripts in flight on the same worker — `self.onmessage` does not serialize.
+      const first = runScriptInQuickJs({ script: 'await big()', context });
+      const second = runScriptInQuickJs({ script: 'console.log(2)', context });
+      await flushTokenFetch();
+      expect(fakeWorker.postedMessages).toHaveLength(2);
+      const [firstMsg, secondMsg] = fakeWorker.postedMessages;
+
+      const firstResult = { ...context, logs: [] };
+      fakeWorker.emitMessage({ id: firstMsg.id, result: firstResult, engineFaulted: true });
+      await expect(first).resolves.toEqual(firstResult);
+
+      // Terminating now would strand `second`, so the worker stays alive until it drains.
+      expect(fakeWorker.terminated).toBe(false);
+
+      const secondResult = { ...context, logs: ['log: 2\n'] };
+      fakeWorker.emitMessage({ id: secondMsg.id, result: secondResult });
+      await expect(second).resolves.toEqual(secondResult);
+      expect(fakeWorker.terminated).toBe(true);
+    });
   });
 });

--- a/packages/insomnia/src/scripting/run-script-quickjs.ts
+++ b/packages/insomnia/src/scripting/run-script-quickjs.ts
@@ -10,7 +10,38 @@ import type { WorkerResponse } from './quickjs-script.worker';
  */
 
 let worker: Worker | null = null;
-const pending = new Map<string, { resolve: (value: RequestContext) => void; reject: (err: Error) => void }>();
+interface PendingRun {
+  resolve: (value: RequestContext) => void;
+  reject: (err: Error) => void;
+  /** Which worker is running this, so retiring one can avoid killing another's in-flight work. */
+  instance: Worker;
+}
+const pending = new Map<string, PendingRun>();
+
+/** Workers taken out of rotation that still have runs in flight; terminated once they drain. */
+const retiring = new Set<Worker>();
+
+const terminateIfDrained = (instance: Worker): void => {
+  const stillBusy = [...pending.values()].some(run => run.instance === instance);
+  if (retiring.has(instance) && !stillBusy) {
+    retiring.delete(instance);
+    instance.terminate();
+  }
+};
+
+/**
+ * Take `instance` out of rotation so the next call lazily builds a replacement. Runs already in
+ * flight on it are left to finish — `self.onmessage` doesn't serialize, so a second script can be
+ * mid-execution, and terminating immediately would hang it. The worker is terminated once its last
+ * run settles.
+ */
+const retireWorker = (instance: Worker): void => {
+  if (worker === instance) {
+    worker = null;
+  }
+  retiring.add(instance);
+  terminateIfDrained(instance);
+};
 
 const getWorker = (): Worker => {
   if (worker) {
@@ -39,6 +70,16 @@ const getWorker = (): Worker => {
     } else {
       request.resolve(event.data.result);
     }
+
+    // The engine aborted its WASM module while cleaning up (see the script engine's
+    // ENGINE_FAULT_MESSAGE). The run above is still valid and has already been settled, but this
+    // worker caches that module for every later script, so take it out of rotation. Retiring after
+    // settling means the caller never sees this as a failure.
+    if (event.data.engineFaulted) {
+      retireWorker(instance);
+    } else {
+      terminateIfDrained(instance);
+    }
   });
 
   // A crash in the worker's global scope (e.g. an unhandled rejection outside our own try/catch)
@@ -46,8 +87,15 @@ const getWorker = (): Worker => {
   // next call gets a fresh one instead of reusing a dead thread.
   instance.addEventListener('error', event => {
     const err = new Error(`QuickJS sandbox worker crashed: ${event.message}`);
-    pending.forEach(request => request.reject(err));
-    pending.clear();
+    // Only this worker's runs — a retired worker draining alongside a live one must not take the
+    // live one's callers down with it.
+    pending.forEach((request, id) => {
+      if (request.instance === instance) {
+        pending.delete(id);
+        request.reject(err);
+      }
+    });
+    retiring.delete(instance);
     if (worker === instance) {
       worker = null;
     }
@@ -81,7 +129,7 @@ export const runScriptInQuickJs = async ({
   const instance = getWorker();
   const id = `quickjs-${Date.now()}-${Math.random().toString(36).slice(2)}`;
   const result = new Promise<RequestContext>((resolve, reject) => {
-    pending.set(id, { resolve, reject });
+    pending.set(id, { resolve, reject, instance });
   });
 
   const authToken = await getTemplatingDbAuthToken();

--- a/packages/insomnia/src/scripting/run-script-quickjs.ts
+++ b/packages/insomnia/src/scripting/run-script-quickjs.ts
@@ -57,16 +57,35 @@ const getWorker = (): Worker => {
   return instance;
 };
 
-export const runScriptInQuickJs = ({
+// A Worker has no `window.main`, so — exactly as `ui/worker/templating-handler.ts` does for the
+// templating worker — fetch the `insomnia-templating-worker-database://` auth token here once and
+// forward it on every postMessage. Without it the engine's `insomnia.sendRequest()` bridge fetch is
+// rejected by the protocol's auth gate with a 401.
+let authTokenPromise: Promise<string> | null = null;
+const getTemplatingDbAuthToken = (): Promise<string> => {
+  if (!authTokenPromise) {
+    authTokenPromise = window.main.templatingDb.getAuthToken();
+  }
+  return authTokenPromise;
+};
+
+export const runScriptInQuickJs = async ({
   script,
   context,
 }: {
   script: string;
   context: RequestContext;
 }): Promise<RequestContext> => {
+  // The worker and the pending entry are set up before awaiting the token, so a crash during the
+  // token round trip still rejects this call through the `error` listener rather than hanging.
+  const instance = getWorker();
   const id = `quickjs-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  return new Promise<RequestContext>((resolve, reject) => {
+  const result = new Promise<RequestContext>((resolve, reject) => {
     pending.set(id, { resolve, reject });
-    getWorker().postMessage({ id, script, context });
   });
+
+  const authToken = await getTemplatingDbAuthToken();
+  instance.postMessage({ id, script, context, authToken });
+
+  return result;
 };


### PR DESCRIPTION
PR 2 of the QuickJS script-sandbox rollout plan (https://gist.github.com/jackkav/3ebf8768bf84be024a3a138874919354). Rebased on #10382 (merged) — PR 0/1's opt-in QuickJS engine and Web Worker boundary are already in `develop`; this branch adds the `insomnia.sendRequest()` bridge on top.

**The crash this PR was blocked on is fixed, and the "only reproduces in Electron" premise was wrong. A second, unrelated abort was found in the process — pre-existing, in quickjs-emscripten's WASM build, and contained rather than fixed here; see "Second abort" below.**

## What was actually wrong

`vm.newPromise()` allocates **three** JSValues: the promise handle, plus `resolve` and `reject` — both JS *functions*, so both GC objects. Returning `deferred.handle` from a `newFunction` callback transfers only the promise; quickjs-emscripten frees the two resolver handles **only** from inside `deferred.resolve()` / `deferred.reject()` (via the private `disposeResolvers()`).

quickjs-emscripten documents the contract on `QuickJSDeferredPromise` itself:

> As the return value of a `VmFunctionImplementation`, return `handle`, and ensure that **either `resolve` or `reject` will be called**. No other clean-up is necessary. […] In other cases, call `dispose()`.

The old `disposedRef` guard did precisely the forbidden thing — returned the handle *and* skipped both settle paths. Any `sendRequest()` still in flight at teardown therefore left two live function objects in the runtime, and `JS_FreeRuntime` aborted on `assert(list_empty(&rt->gc_obj_list))`. That is a native Emscripten `abort()`, not a catchable error, so it took the script worker down instead of surfacing as a script failure.

## It does reproduce in vitest

The premise in the previous description was wrong. The existing bridge tests used `mockResolvedValue`, which settles in the **same microtask checkpoint** as the call — so the deferred was always settled before teardown. Settling the mocked response on a **later macrotask** — the only thing real Electron `fetch()` timing adds — reproduces the byte-identical abort in ~400ms with no Electron involved.

Each of the three new `sendRequest bridge teardown` tests fails on the previous commit; one fails with the exact production message. Verify with:

```
git stash push -- packages/insomnia/src/scripting/quickjs-script-engine.ts && npx vitest run packages/insomnia/src/scripting/quickjs-script-engine.test.ts
```

Isolated in separate processes, against this repo's `quickjs-emscripten` 0.32:

| state at `vm.dispose()` | outcome |
|---|---|
| bridge deferred unsettled | **aborts** — identical assertion |
| `deferred.dispose()` called first | clean |
| in-VM promise never settles, no bridge involved | clean — the leak is specifically *host-held* resolver handles |
| new context on the same module after an abort | works — the WASM module is not poisoned |
| `vm.newString` after dispose | `QuickJSUseAfterFree`, surfacing as an unhandled rejection in the worker |

That last row is the only failure mode `disposedRef` was actually preventing — a real hazard, but not this one. It is still guarded, now via `vm.alive` / `deferred.alive` rather than a hand-rolled flag.

## Second defect, independent of the crash

`runScriptInQuickJs` accepted an `authToken` that **nothing ever passed**: `quickjs-script.worker.ts` did not forward it and `run-script-quickjs.ts` never fetched it. Every bridge fetch went out with no `x-insomnia-templating-auth` header and was rejected 401 by the gate in `main/templating-worker-database.ts`. The feature could not have worked even without the crash.

Now plumbed following `ui/worker/templating-handler.ts`'s pattern (a Worker has no `window.main`, so the renderer-side client fetches the token once and forwards it on every message). The worker and the pending entry are created *before* the token await, so a crash during the token round trip still rejects through the existing `error` listener rather than hanging.

## Changes

- `quickjs-script-engine.ts` — track unsettled bridge deferreds; dispose them before `vm.dispose()`; guard the late-response path on `vm.alive` / `deferred.alive`.
- `run-script-quickjs.ts` / `quickjs-script.worker.ts` — fetch and forward the templating-db auth token.
- `quickjs-script-engine.test.ts` — three teardown regression tests (never-awaited request, deadline mid-request, partially-settled batch), each of which aborts without the fix.
- `run-script-quickjs.test.ts` — stub `window.main.templatingDb`, assert the token is forwarded.
- `quickjs-sendrequest-bridge.test.ts` — `test.fail()` annotation removed.
- Teardown-abort containment: `onEngineFault` in the engine, `engineFaulted` on the worker responses, drain-aware worker retirement in the client, plus tests for each.

## Second abort: a WASM-build defect, now contained

Fixing the teardown leak did not make the engine abort-free. Allocation-heavy work performed **inside `executePendingJobs()`** — i.e. anything after the script's first `await` — leaves live GC objects behind and `JS_FreeRuntime` asserts identically. It reduces to a reproducer with no bridge, no host functions, no interrupt handler, no memory limit and no `resolvePromise`:

```js
const vm = QuickJS.newContext();
vm.evalCode(`(async()=>{await Promise.resolve();` +
  `const a=[];for(let i=0;i<100000;i++){a.push({i});}` +
  `globalThis.__n=JSON.parse(JSON.stringify(a)).length;})();`);
vm.runtime.executePendingJobs().dispose();
vm.dispose();   // Aborted(Assertion failed: list_empty(&rt->gc_obj_list) …)
```

Established:

- **Pre-existing.** `git show develop:…/quickjs-script-engine.ts` aborts identically — this branch does not introduce it.
- **Specific to the job context, not the volume.** The same allocation before any `await` is clean at 6x the size. Threshold is between 50k and 100k objects.
- **A 6MB `sendRequest` response body aborts** — reachable by ordinary use, not just synthetic loops.
- **It is the emscripten build, not QuickJS.** The identical vendored engine source (`VERSION` 2025-09-13) built natively is clean at **500k** objects — at `-O1`/`-O2`/`-Oz`/`-Oz -flto`, with and without `-fwrapv`, with `-DCONFIG_STACK_CHECK`, and using `JS_NewContextRaw` plus exactly the intrinsic subset the shim installs. Forcing a stack-overflow throw doesn't leak either. Meanwhile all four WASM variants abort — both engines *and* both optimization levels — so **bumping or switching the vendored engine cannot fix it.**
- **No host-side mitigation works.** Unaffected by removing `setMemoryLimit` or `setInterruptHandler`, by polling `getPromiseState` instead of `resolvePromise`, by extra `executePendingJobs()` passes, by `computeMemoryUsage()`, or by forcing a GC.

Filed upstream with a minimal reproducer (no host functions, no `Scope`, no `newPromise`, no memory limit) as [justjake/quickjs-emscripten#269](https://github.com/justjake/quickjs-emscripten/issues/269), along with the negative results above so nobody re-tests the C engine. Leading suspect: the variant Makefiles force `-DCONFIG_STACK_CHECK`, which quickjs.c explicitly disables for emscripten (`#if !defined(EMSCRIPTEN)`) — and `rt->stack_top` is captured at `JS_NewRuntime` while jobs run from a different host→WASM entry point, which is the only mechanism found that distinguishes "in a job" from "synchronous". Unverified: testing it needs an emscripten toolchain.

### Contained, not fixed

Since the script has already finished when teardown aborts, and everything returned is plain host-side JS, the run's result is recoverable. The engine now catches the abort, warns into the script's logs, and reports it via `onEngineFault`; the worker forwards that as `engineFaulted` and the client retires the worker so no later script runs on a module that aborted. Catching inside `finally` means a genuine script error or timeout still wins.

Verified before implementing: the abort is catchable, host-collected data survives intact, and the module is still *correct* afterwards — arithmetic, JSON, string and global operations all check out across repeated runs, including after several consecutive aborts. Retiring the worker regardless is defensive, since that only samples the behaviour tested.

Retirement is drain-aware: `self.onmessage` doesn't serialize, so a second script can be mid-execution. The worker leaves rotation immediately but is terminated only once its in-flight runs settle, and the crash handler now rejects only its own worker's runs rather than every pending call.

**This does not remove the constraint on the default flip.** A routine multi-MB response still faults the engine and forces a worker restart mid-session; it just no longer costs the user their script run.

## Also fixed: the bridge returned an empty object

`network.sendRequestWithoutSideEffects` returned `new Response(JSON.stringify(result))`, while every other handler in `pluginToMainAPI` returns a plain value for the caller to wrap. `resolveDbByKey` does `JSON.stringify(await handler(body))`, so a `Response` stringified to `"{}"` — the bridge received an empty object and `response.code` / `response.body` were `undefined`. The template-tag sandbox's `network.sendRequestWithoutSideEffects` path was broken identically.

## Not addressed here (deliberately)

**The Postman callback idiom still drops its response.** `insomnia.sendRequest(url, callback)` returns `undefined`, so a script using it reaches the end of its body with the request in flight; the run tears down and the callback never fires — silently, with no error. This PR makes that *safe* (no abort) but not *correct*. A second approach that fixes it — a `BridgeCalls` registry that drains outstanding calls after `__task` settles, carries an `AbortController` per call, and rejects leftovers with a real error — is written up in the plan gist under "Approach B", with the two traps it runs into. Kept out of this PR because it changes when a script run *completes*, which deserves its own review, and because the dropped-callback bug is latent in the bridge design rather than a regression introduced here.

**The same bug is live in shipped code.** `templating/sandbox/plugin-tag-sandbox.ts`'s `installHostBridge` has the identical omission, and `drivePromiseToString` throws on its 10s deadline before `ctx.dispose()`. Reproduced against the real `runTagInSandbox` with a bridge call that outlives the timeout — so a template-tag plugin doing `network.sendRequest` against a slow endpoint aborts the templating worker on `develop` today. Tracked separately rather than widening this PR.

## Test plan

- [x] `npx vitest run packages/insomnia/src/scripting/quickjs-script-engine.test.ts packages/insomnia/src/scripting/run-script-quickjs.test.ts` — 25/25
- [x] Same three teardown tests confirmed failing on the parent commit (one with the exact production abort)
- [x] `tsc --noEmit` / `eslint` clean for the touched files
- [x] `npx vitest run src/main/__tests__/ src/scripting/` from `packages/insomnia` — 370/370 (run from the workspace root; a bare `npx vitest` at the repo root fails to resolve the `~/` alias and is not a real signal)
- [x] `quickjs-sendrequest-bridge.test.ts` end-to-end against the real Electron app — **passes** with `test.fail()` removed. Ran in e2e shard 5/6 (`QuickJS sendRequest bridge › runs a real sendRequest() round trip through the QuickJS engine`), all 6 shards green. Note this exercises a small echo response, so it does not cover the large-allocation abort above.
