### PR TITLE
fix(sandbox): guard keys in QuickJS env/var bridge

### DIFF
--- a/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
+++ b/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { RequestContext } from '../../../insomnia-scripting-environment/src/objects/interfaces';
+import { getQuickJSModule } from '../templating/sandbox/quickjs-runtime';
 import { runScriptInQuickJs } from './quickjs-script-engine';
 
 const baseContext = (): RequestContext => ({
@@ -94,5 +95,107 @@ describe('runScriptInQuickJs', () => {
     const context = baseContext();
 
     await expect(runScriptInQuickJs({ script: 'throw new Error("boom");', context })).rejects.toThrow('boom');
+  });
+
+  it('does not let a "__proto__" key rewire the returned environment data\'s own prototype', async () => {
+    const context = baseContext();
+
+    const result = await runScriptInQuickJs({
+      script: `
+        insomnia.environment.set('__proto__', { polluted: true });
+        insomnia.environment.set('after', 'marker');
+      `,
+      context,
+    });
+
+    expect(Object.getPrototypeOf(result.environment.data)).toBe(Object.prototype);
+    expect((result.environment.data as Record<string, unknown>).polluted).toBeUndefined();
+    expect((result.environment.data as Record<string, unknown>).after).toBe('marker');
+    // The shared Object.prototype itself stays untouched.
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it('does not let a "constructor"/"prototype" key rewire the returned environment data', async () => {
+    const context = baseContext();
+
+    const result = await runScriptInQuickJs({
+      script: `
+        insomnia.environment.set('constructor', { polluted: true });
+        insomnia.environment.set('prototype', { polluted: true });
+      `,
+      context,
+    });
+
+    expect(typeof result.environment.data.constructor).not.toBe('object');
+    expect((result.environment.data as Record<string, unknown>).prototype).toBeUndefined();
+  });
+
+  it('keeps globalThis limited to standard intrinsics and this sandbox\'s own bridged names', async () => {
+    const context = baseContext();
+
+    // Reports host globals and the full globalThis property list back through
+    // insomnia.environment.set — the only channel available — for the assertions below.
+    const result = await runScriptInQuickJs({
+      script: `
+        const hostGlobals = [
+          'require', 'process', 'module', 'exports', '__dirname', '__filename',
+          'Deno', 'Bun', 'window', 'document', 'fetch', 'XMLHttpRequest', 'WebSocket',
+          'Buffer', 'setTimeout', 'setInterval', 'setImmediate', 'WebAssembly',
+          'importScripts', 'postMessage',
+        ];
+        const leaked = hostGlobals.filter(name => typeof globalThis[name] !== 'undefined');
+        insomnia.environment.set('leakedHostGlobals', leaked);
+        insomnia.environment.set('sandboxGlobalNames', Object.getOwnPropertyNames(globalThis));
+      `,
+      context,
+    });
+
+    const data = result.environment.data as Record<string, unknown>;
+    expect(data.leakedHostGlobals).toEqual([]);
+
+    // Baseline: what a bare QuickJS context exposes on globalThis with no bootstrap, derived
+    // dynamically so it can't go stale as the vendored QuickJS version changes.
+    const QuickJS = await getQuickJSModule();
+    const bareVm = QuickJS.newContext();
+    let bareGlobalNames: string[];
+    try {
+      const dumped = bareVm.evalCode('Object.getOwnPropertyNames(globalThis)');
+      if (dumped.error) {
+        dumped.error.dispose();
+        throw new Error('failed to enumerate a bare QuickJS context\'s globals');
+      }
+      bareGlobalNames = bareVm.dump(dumped.value) as string[];
+      dumped.value.dispose();
+    } finally {
+      bareVm.dispose();
+    }
+    const baseline = new Set(bareGlobalNames);
+
+    // Anything else reachable on globalThis fails this assertion instead of shipping silently.
+    const ALLOWED_EXTRA_GLOBALS = new Set([
+      'console', '__envGet', '__envSet', '__varGet', '__varSet', '__requestJSON', '__task',
+      'insomnia', '$',
+    ]);
+    const unexpectedGlobals = (data.sandboxGlobalNames as string[]).filter(
+      name => !baseline.has(name) && !ALLOWED_EXTRA_GLOBALS.has(name),
+    );
+    expect(unexpectedGlobals).toEqual([]);
+  });
+
+  it('produces the intended timeout error, not a crash, when a script awaits a promise that never resolves', async () => {
+    const context = baseContext();
+    context.settings = { timeout: 30 } as any;
+
+    await expect(
+      runScriptInQuickJs({ script: 'await new Promise(() => {});', context }),
+    ).rejects.toThrow(/Executing script timeout: 30/);
+
+    // A later, unrelated run must still complete normally afterward.
+    const laterContext = baseContext();
+    const laterResult = await runScriptInQuickJs({
+      script: `insomnia.environment.set('ranCleanly', true);`,
+      context: laterContext,
+    });
+    expect((laterResult.environment.data as Record<string, unknown>).ranCleanly).toBe(true);
   });
 });

--- a/packages/insomnia/src/scripting/quickjs-script-engine.ts
+++ b/packages/insomnia/src/scripting/quickjs-script-engine.ts
@@ -114,6 +114,10 @@ const installConsole = (vm: QuickJSContext, scriptConsole: Console): void => {
   consoleHandle.dispose();
 };
 
+// Using one of these as a bracket-assignment key on a plain object rewires its prototype or
+// shadows the name instead of setting an ordinary property.
+const DANGEROUS_BRIDGE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 /** Registers `<getName>(key)`/`<setName>(key, jsonValue)` host functions backed by a plain object. */
 const installKeyValueBridge = (
   vm: QuickJSContext,
@@ -130,6 +134,9 @@ const installKeyValueBridge = (
 
   const setFn = vm.newFunction(setName, (keyHandle, valueHandle) => {
     const key = vm.getString(keyHandle);
+    if (DANGEROUS_BRIDGE_KEYS.has(key)) {
+      return;
+    }
     const rawValue = vm.getString(valueHandle);
     try {
       store[key] = JSON.parse(rawValue);


### PR DESCRIPTION
## What this PR does

Both `insomnia.environment.set()`/`insomnia.variables.set()` pass a script-supplied key straight into a bracket assignment on the bridge's store object. A key of `"__proto__"` rewires that object's own prototype instead of setting an ordinary property, and `"constructor"`/`"prototype"` get silently shadowed the same way. 

The impact is contained to the single per-call store object (it never reaches the real `Object.prototype` and doesn't survive the worker's `postMessage` boundary), but it's still an unintended prototype-chain side effect. We can  reject these three keys before the assignment happens. 