### PR TITLE
fix(quickjs): close three sendRequest bridge findings

### DIFF
--- a/packages/insomnia/src/main/__tests__/templating-worker-database-sendrequest-cacert-bypass.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database-sendrequest-cacert-bypass.test.ts
@@ -1,0 +1,189 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// insomnia.sendRequest()'s own doc comment (quickjs-script-engine.ts) says the QuickJS script
+// sandbox's request bridge supports only { url, method, headers, body } -- "no auth, client
+// certificates, cookies". That's enforced only by the guest-side JS wrapper (BOOTSTRAP), which
+// hardcodes caCertficatePath to null before calling the real bridge global, __sendRequest.
+// __sendRequest itself is a bare, unguarded globalThis function that takes a raw JSON string and
+// forwards it, unvalidated, to network.sendRequestWithoutSideEffects's real dispatch path
+// (resolveDbByKey -> pluginToMainAPI). That handler reads body.options.caCertficatePath with no
+// ownership/allowlist check and hands it straight to curlRequest, which loads it via
+// insecureReadFile -- the function secure-read-file.ts itself documents as being "for reading
+// files selected by the user via a file dialog", not for a value chosen by a running script. A
+// script can skip the wrapper entirely and call __sendRequest directly, exceeding the sandbox's
+// documented capability.
+
+vi.mock('electron', () => ({
+  app: { getVersion: () => '1.0.0', getPath: () => '/fake/userData' },
+  clipboard: { readText: vi.fn(), writeText: vi.fn(), clear: vi.fn() },
+  dialog: { showMessageBox: vi.fn() },
+  shell: { openExternal: vi.fn() },
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+vi.mock('insomnia-data', () => ({
+  services: {
+    request: { getById: vi.fn() },
+    workspace: { getById: vi.fn() },
+    oAuth2Token: { getByParentId: vi.fn() },
+    cookieJar: { getOrCreateForParentId: vi.fn() },
+    response: { getLatestForRequestId: vi.fn(), getByBodyPath: vi.fn() },
+    helpers: {
+      getResponseBodyBuffer: vi.fn(),
+      readCurlResponse: vi.fn().mockResolvedValue({ body: '{}' }),
+    },
+    pluginData: { getByKey: vi.fn(), upsertByKey: vi.fn(), removeByKey: vi.fn(), removeAll: vi.fn(), all: vi.fn() },
+    cloudCredential: { getById: vi.fn(), update: vi.fn() },
+    settings: { get: vi.fn().mockResolvedValue({}) },
+  },
+}));
+vi.mock('~/plugins', () => ({
+  getPluginCommonContext: vi.fn(),
+  getTemplateTags: vi.fn().mockResolvedValue([]),
+  getPlugins: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('~/common/cookies', () => ({ jarFromCookies: vi.fn() }));
+vi.mock('../common/database', () => ({ database: {} }));
+vi.mock('../network/network', () => ({
+  fetchRequestData: vi.fn(),
+  sendCurlAndWriteTimeline: vi.fn(),
+  tryToInterpolateRequest: vi.fn(),
+}));
+vi.mock('../network/libcurl-promise', () => ({ curlRequest: vi.fn() }));
+vi.mock('../prompt-bridge', () => ({ requestPromptFromRenderer: vi.fn() }));
+vi.mock('../secure-read-file', () => ({ secureReadFile: vi.fn() }));
+
+import type { RequestContext } from '../../../../insomnia-scripting-environment/src/objects/interfaces';
+import { runScriptInQuickJs } from '../../scripting/quickjs-script-engine';
+import {
+  _testOnlyResetTemplatingDbAuthToken,
+  getOrCreateTemplatingDbAuthToken,
+} from '../templating-worker-database-auth';
+
+const baseContext = (): RequestContext => ({
+  request: { _id: 'req_1', name: 'Test request', url: 'https://example.com' } as any,
+  timelinePath: '',
+  environment: { id: 'env_1', name: 'Base Environment', data: {} },
+  baseEnvironment: { id: 'env_1', name: 'Base Environment', data: {} },
+  timeout: 30_000,
+  settings: { timeout: 30_000 } as any,
+  clientCertificates: [],
+  cookieJar: { cookies: [] } as any,
+  requestInfo: {} as any,
+  execution: {} as any,
+  logs: [],
+  transientVariables: { name: 'transientVariables', data: {} },
+  parentFolders: [],
+});
+
+describe('network.sendRequestWithoutSideEffects, reached via the QuickJS bridge\'s raw __sendRequest global, gates caCertficatePath', () => {
+  let outsideCertPath: string;
+
+  beforeEach(() => {
+    _testOnlyResetTemplatingDbAuthToken();
+    // Deliberately outside every directory secureReadFile's allowlist would ever grant
+    // (os.tmpdir(), userData, or a configured data folder) -- standing in for a path a script
+    // chose on its own, not one a user selected via a file dialog.
+    outsideCertPath = path.join(os.homedir(), `insomnia-audit-not-a-real-cert-${process.pid}.pem`);
+    fs.writeFileSync(outsideCertPath, 'not-a-real-certificate');
+  });
+
+  afterEach(() => {
+    fs.rmSync(outsideCertPath, { force: true });
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  const stubFetchToRealHandler = () => {
+    // Stands in for Electron's real `insomnia-templating-worker-database://` protocol handler,
+    // which is registered via `protocol.handle(interface, resolveDbByKey)` in api.protocol.ts --
+    // routes the bridge's fetch() straight into the real, unmocked dispatch function so this test
+    // exercises the actual auth check + handler lookup + handler body, not a re-implementation of
+    // them.
+    vi.stubGlobal('fetch', async (url: string, init?: RequestInit) => {
+      const { resolveDbByKey } = await import('../templating-worker-database');
+      return resolveDbByKey(new Request(url, init));
+    });
+  };
+
+  const mockCurlRequest = async () => {
+    const { curlRequest } = await import('../network/libcurl-promise');
+    const curlRequestMock = curlRequest as unknown as ReturnType<typeof vi.fn>;
+    curlRequestMock.mockResolvedValue({
+      headerResults: [{ code: 200, reason: 'OK', headers: [] }],
+      patch: { elapsedTime: 1, bodyCompression: null },
+      responseBodyPath: '/dev/null',
+    });
+    return curlRequestMock;
+  };
+
+  it('never forwards a caller-chosen caCertficatePath to curlRequest, even sent directly through the raw bridge global', async () => {
+    const token = getOrCreateTemplatingDbAuthToken();
+    const curlRequestMock = await mockCurlRequest();
+    stubFetchToRealHandler();
+
+    const requestBodyWithOutsideCertPath = JSON.stringify({
+      options: {
+        request: { url: 'https://example.com', method: 'GET', headers: [] },
+        caCertficatePath: outsideCertPath,
+      },
+    });
+
+    // Calls the raw bridge global directly instead of going through insomnia.sendRequest(),
+    // which is the only place that hardcodes caCertficatePath to null -- the wrapper is guest-side
+    // JS sugar the calling script is free to skip entirely, not an enforcement boundary.
+    const result = await runScriptInQuickJs({
+      script: `
+        const raw = await __sendRequest(${JSON.stringify(requestBodyWithOutsideCertPath)});
+        const envelope = JSON.parse(raw);
+        insomnia.environment.set('ok', envelope.ok);
+      `,
+      context: baseContext(),
+      authToken: token,
+    });
+
+    // The request itself still goes through (this endpoint's job) -- what must never happen is
+    // the host handler honoring a caller-supplied caCertficatePath. secureReadFile enforces this
+    // exact entitlement boundary elsewhere in this codebase; a path a running script picked for
+    // itself is never one it was granted.
+    expect((result.environment.data as Record<string, unknown>).ok).toBe(true);
+    expect(curlRequestMock).toHaveBeenCalledTimes(1);
+    expect(curlRequestMock.mock.calls[0][0]).toMatchObject({ caCertficatePath: null });
+  });
+
+  it('never lets a caller-supplied authentication object override the safe default, even sent directly through the raw bridge global', async () => {
+    const token = getOrCreateTemplatingDbAuthToken();
+    const curlRequestMock = await mockCurlRequest();
+    stubFetchToRealHandler();
+
+    const requestBodyWithInjectedAuth = JSON.stringify({
+      options: {
+        request: {
+          url: 'https://example.com',
+          method: 'GET',
+          headers: [],
+          authentication: { type: 'basic', username: 'chosen-by-script', password: 'chosen-by-script' },
+        },
+      },
+    });
+
+    const result = await runScriptInQuickJs({
+      script: `
+        const raw = await __sendRequest(${JSON.stringify(requestBodyWithInjectedAuth)});
+        const envelope = JSON.parse(raw);
+        insomnia.environment.set('ok', envelope.ok);
+      `,
+      context: baseContext(),
+      authToken: token,
+    });
+
+    expect((result.environment.data as Record<string, unknown>).ok).toBe(true);
+    expect(curlRequestMock).toHaveBeenCalledTimes(1);
+    expect(curlRequestMock.mock.calls[0][0]).toMatchObject({
+      req: expect.objectContaining({ authentication: { type: 'none' } }),
+    });
+  });
+});

--- a/packages/insomnia/src/main/__tests__/templating-worker-database-sendrequest-multipart-filepath-scoping.test.ts
+++ b/packages/insomnia/src/main/__tests__/templating-worker-database-sendrequest-multipart-filepath-scoping.test.ts
@@ -1,0 +1,167 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// network.sendRequestWithoutSideEffects's cacert/authentication fields are hardcoded regardless of
+// caller input (see templating-worker-database-sendrequest-cacert-bypass.test.ts), but its `body`
+// field was forwarded straight through unvalidated. A multipart/form-data body's file parts
+// (`body.params[].fileName`) reach `buildMultipart` (packages/insomnia/src/main/network/multipart.ts),
+// which reads each part's `fileName` off disk with no ownership/allowlist check at all -- unlike
+// every other local-file read reachable from a request definition, which is checked against
+// `settings.dataFolders`. A script can reach this by calling the raw `__sendRequest` bridge global
+// directly (bypassing insomnia.sendRequest()'s BOOTSTRAP wrapper, which only ever builds
+// `{ mimeType: 'text/plain', text }` bodies) with a multipart body naming an arbitrary local path,
+// then reading the response from a URL it also controls.
+//
+// The fix lives entirely in the QuickJS bridge (quickjs-script-engine.ts's
+// assertSupportedSendRequestBody, run before the bridge's fetch() is ever dispatched) rather than
+// in this shared handler, which the legacy hidden-window sandbox and the template-tag sandbox also
+// use with their own, already-privileged execution models -- see
+// plugins/context/network-sendrequest-multipart-allowed.test.ts for confirmation that the legacy
+// path is unaffected by this fix.
+
+vi.mock('electron', () => ({
+  app: { getVersion: () => '1.0.0', getPath: () => '/fake/userData' },
+  clipboard: { readText: vi.fn(), writeText: vi.fn(), clear: vi.fn() },
+  dialog: { showMessageBox: vi.fn() },
+  shell: { openExternal: vi.fn() },
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+vi.mock('insomnia-data', () => ({
+  services: {
+    request: { getById: vi.fn() },
+    workspace: { getById: vi.fn() },
+    oAuth2Token: { getByParentId: vi.fn() },
+    cookieJar: { getOrCreateForParentId: vi.fn() },
+    response: { getLatestForRequestId: vi.fn(), getByBodyPath: vi.fn() },
+    helpers: {
+      getResponseBodyBuffer: vi.fn(),
+      readCurlResponse: vi.fn().mockResolvedValue({ body: '{}' }),
+    },
+    pluginData: { getByKey: vi.fn(), upsertByKey: vi.fn(), removeByKey: vi.fn(), removeAll: vi.fn(), all: vi.fn() },
+    cloudCredential: { getById: vi.fn(), update: vi.fn() },
+    settings: { get: vi.fn().mockResolvedValue({}) },
+  },
+}));
+vi.mock('~/plugins', () => ({
+  getPluginCommonContext: vi.fn(),
+  getTemplateTags: vi.fn().mockResolvedValue([]),
+  getPlugins: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('~/common/cookies', () => ({ jarFromCookies: vi.fn() }));
+vi.mock('../common/database', () => ({ database: {} }));
+vi.mock('../network/network', () => ({
+  fetchRequestData: vi.fn(),
+  sendCurlAndWriteTimeline: vi.fn(),
+  tryToInterpolateRequest: vi.fn(),
+}));
+vi.mock('../network/libcurl-promise', () => ({ curlRequest: vi.fn() }));
+vi.mock('../prompt-bridge', () => ({ requestPromptFromRenderer: vi.fn() }));
+vi.mock('../secure-read-file', () => ({ secureReadFile: vi.fn() }));
+
+import type { RequestContext } from '../../../../insomnia-scripting-environment/src/objects/interfaces';
+import { runScriptInQuickJs } from '../../scripting/quickjs-script-engine';
+import {
+  _testOnlyResetTemplatingDbAuthToken,
+  getOrCreateTemplatingDbAuthToken,
+} from '../templating-worker-database-auth';
+
+const baseContext = (): RequestContext => ({
+  request: { _id: 'req_1', name: 'Test request', url: 'https://example.com' } as any,
+  timelinePath: '',
+  environment: { id: 'env_1', name: 'Base Environment', data: {} },
+  baseEnvironment: { id: 'env_1', name: 'Base Environment', data: {} },
+  timeout: 30_000,
+  settings: { timeout: 30_000 } as any,
+  clientCertificates: [],
+  cookieJar: { cookies: [] } as any,
+  requestInfo: {} as any,
+  execution: {} as any,
+  logs: [],
+  transientVariables: { name: 'transientVariables', data: {} },
+  parentFolders: [],
+});
+
+describe('insomnia.sendRequest(), reached via the QuickJS bridge\'s raw __sendRequest global, denies multipart file parts', () => {
+  let outsideAllowedFoldersPath: string;
+
+  beforeEach(() => {
+    _testOnlyResetTemplatingDbAuthToken();
+    // Deliberately outside every directory a `dataFolders`-scoped read would ever be granted --
+    // standing in for a path a script chose for itself, not one the user selected or allow-listed.
+    outsideAllowedFoldersPath = path.join(os.homedir(), `insomnia-audit-not-a-real-file-${process.pid}.txt`);
+    fs.writeFileSync(outsideAllowedFoldersPath, 'not-a-real-secret');
+  });
+
+  afterEach(() => {
+    fs.rmSync(outsideAllowedFoldersPath, { force: true });
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  const stubFetchToRealHandler = () => {
+    // Stands in for Electron's real `insomnia-templating-worker-database://` protocol handler --
+    // routes the bridge's fetch() straight into the real, unmocked dispatch function so this test
+    // would exercise the actual auth check + handler lookup + handler body if the fix under test
+    // ever let the bridge get that far.
+    vi.stubGlobal('fetch', async (url: string, init?: RequestInit) => {
+      const { resolveDbByKey } = await import('../templating-worker-database');
+      return resolveDbByKey(new Request(url, init));
+    });
+  };
+
+  const mockCurlRequest = async () => {
+    const { curlRequest } = await import('../network/libcurl-promise');
+    const curlRequestMock = curlRequest as unknown as ReturnType<typeof vi.fn>;
+    curlRequestMock.mockResolvedValue({
+      headerResults: [{ code: 200, reason: 'OK', headers: [] }],
+      patch: { elapsedTime: 1, bodyCompression: null },
+      responseBodyPath: '/dev/null',
+    });
+    return curlRequestMock;
+  };
+
+  it('rejects a multipart file part before the bridge ever dispatches its fetch, even sent directly through the raw bridge global', async () => {
+    const token = getOrCreateTemplatingDbAuthToken();
+    const curlRequestMock = await mockCurlRequest();
+    stubFetchToRealHandler();
+
+    const requestBodyWithOutsideFilePart = JSON.stringify({
+      options: {
+        request: {
+          url: 'https://example.com',
+          method: 'POST',
+          headers: [],
+          body: {
+            mimeType: 'multipart/form-data',
+            params: [{ name: 'f', type: 'file', fileName: outsideAllowedFoldersPath }],
+          },
+        },
+      },
+    });
+
+    // Calls the raw bridge global directly instead of going through insomnia.sendRequest(), which
+    // only ever builds a `text/plain` body -- the wrapper is guest-side JS sugar the calling script
+    // is free to skip entirely, not an enforcement boundary. The QuickJS-specific host-side guard
+    // must reject this regardless.
+    const result = await runScriptInQuickJs({
+      script: `
+        const raw = await __sendRequest(${JSON.stringify(requestBodyWithOutsideFilePart)});
+        const envelope = JSON.parse(raw);
+        insomnia.environment.set('ok', envelope.ok);
+        insomnia.environment.set('error', envelope.error);
+      `,
+      context: baseContext(),
+      authToken: token,
+    });
+
+    const env = result.environment.data as Record<string, unknown>;
+    expect(env.ok).toBe(false);
+    expect(env.error).toMatch(/plain-text request body/i);
+    // The rejection must happen before the bridge's fetch() is ever dispatched -- the shared
+    // handler (and curlRequest below it) never even sees this request.
+    expect(curlRequestMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -785,20 +785,28 @@ export const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => P
     return await services.response.create({ ...response, bodyCompression: null }, settings.maxHistoryResponses);
   },
   // use libcurl to send request without side effects(do not write to database about request and response)
+  //
+  // This endpoint is reachable by any pre/post-request script or template-tag/plugin (via the
+  // QuickJS script sandbox's insomnia.sendRequest() bridge and the template-tag sandbox's
+  // context.network.sendRequestWithoutSideEffects(), respectively) with no ownership/entitlement
+  // check on the caller's identity beyond the templating-db auth token every call already needs —
+  // so it must never honor a caller-supplied client certificate path or authentication object.
+  // Both are host-privileged capabilities (an arbitrary local file read via `caCertficatePath`,
+  // credential injection via `authentication`) that this "without side effects" preview endpoint
+  // was never meant to carry; `network.sendRequest` (the DB-backed, side-effectful sibling) is the
+  // only handler that may use a request's real, ownership-scoped `clientCertificates`.
   'network.sendRequestWithoutSideEffects': async (body: {
     options: {
-      request: Pick<DBRequest, 'url' | 'method' | 'headers'> & Partial<Pick<DBRequest, 'body' | 'authentication'>>;
-      caCertficatePath: string;
+      request: Pick<DBRequest, 'url' | 'method' | 'headers'> & Partial<Pick<DBRequest, 'body'>>;
     };
   }) => {
     const requestId = uuidv4();
     const settings = await services.settings.get();
     const settingFollowRedirects = settings?.followRedirects ? 'on' : 'off';
-    const { request: originRequest, caCertficatePath = null } = body.options;
+    const { request: originRequest } = body.options;
     const response = await curlRequest({
       requestId: `no-sideEffects-request-${requestId}`,
       req: {
-        authentication: { type: 'none' },
         body: {},
         cookieJar: {
           cookies: [],
@@ -809,11 +817,15 @@ export const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => P
         settingRebuildPath: true,
         settingSendCookies: true,
         ...originRequest,
+        // Applied after the spread so a caller-supplied `authentication` on the request body can
+        // never override it — see the handler-level comment above.
+        authentication: { type: 'none' },
       },
       finalUrl: originRequest.url,
       settings,
       certificates: [],
-      caCertficatePath,
+      // Never sourced from the caller — see the handler-level comment above.
+      caCertficatePath: null,
     });
     const { headerResults, patch, responseBodyPath } = response;
     if (patch.error) {

--- a/packages/insomnia/src/plugins/context/__tests__/network-sendrequest-multipart-allowed.test.ts
+++ b/packages/insomnia/src/plugins/context/__tests__/network-sendrequest-multipart-allowed.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Confirms the legacy (default, useQuickJsScriptSandbox: false) sendRequestWithoutSideEffects
+// implementation is untouched by the QuickJS-sandbox-specific fix in
+// quickjs-script-engine.ts's assertSupportedSendRequestBody (see
+// templating-worker-database-sendrequest-multipart-filepath-scoping.test.ts, which proves the same
+// multipart body is denied when reached through the QuickJS bridge). This implementation runs with
+// an already-privileged execution model (a real Electron BrowserWindow, or a direct Node/Inso
+// import) rather than through the sandboxed `insomnia-templating-worker-database://` protocol
+// handler, so its behavior toward a multipart body is intentionally left as-is here.
+
+vi.mock('insomnia-data', () => ({
+  services: {
+    settings: { get: vi.fn().mockResolvedValue({ followRedirects: false }) },
+    helpers: { readCurlResponse: vi.fn().mockResolvedValue({ body: '{}' }) },
+  },
+}));
+vi.mock('../../../main/network/libcurl-promise', () => ({ curlRequest: vi.fn() }));
+
+import * as plugin from '../network';
+
+describe('network.sendRequestWithoutSideEffects (legacy, non-QuickJS execution context)', () => {
+  it('still forwards a multipart body\'s file parts to curlRequest unchanged', async () => {
+    const { curlRequest: curlRequestMock } = await import('../../../main/network/libcurl-promise');
+    (curlRequestMock as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      headerResults: [{ code: 200, reason: 'OK', headers: [] }],
+      patch: { elapsedTime: 1, bodyCompression: null },
+      responseBodyPath: '/dev/null',
+    });
+
+    const outsideAllowedFoldersPath = '/Users/someone/not-a-real-file.txt';
+    const { network } = plugin.init();
+
+    await network.sendRequestWithoutSideEffects({
+      request: {
+        url: 'https://example.com',
+        method: 'POST',
+        headers: [],
+        body: {
+          mimeType: 'multipart/form-data',
+          params: [{ name: 'f', type: 'file', fileName: outsideAllowedFoldersPath }],
+        },
+      },
+    } as any);
+
+    expect(curlRequestMock).toHaveBeenCalledTimes(1);
+    const forwardedParams = (curlRequestMock as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0]?.req?.body
+      ?.params;
+    expect(forwardedParams).toContainEqual(expect.objectContaining({ fileName: outsideAllowedFoldersPath }));
+  });
+});

--- a/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
+++ b/packages/insomnia/src/scripting/quickjs-script-engine.test.ts
@@ -541,3 +541,59 @@ describe('runScriptInQuickJs large-allocation abort (known engine bug, pre-exist
     expect((result.environment.data as Record<string, unknown>).len).toBe(300_000);
   });
 });
+
+/**
+ * A second, distinct way to trip the same `gc_obj_list` engine assertion as the large-allocation
+ * bug above — this one via ordinary unbounded recursion rather than allocation volume, needing no
+ * `await` at all, and (unlike that one) fixable from the embedding side: `setMaxStackSize` is a
+ * knob `quickjs-emscripten` already exposes for exactly this case.
+ *
+ * Before the fix: with no explicit stack limit, unbounded recursion overflows the *host* WASM call
+ * stack before QuickJS's own bytecode-level stack check can fire. `vm.evalCode()` then throws a
+ * plain `RangeError: Maximum call stack size exceeded` synchronously — bypassing both the guest
+ * script's own `try/catch` and `evalOrThrow`'s normal `result.error` handling — leaving the
+ * runtime's GC object list non-empty. The `finally` block's `vm.dispose()` then throws its own
+ * `Aborted(Assertion failed: list_empty(&rt->gc_obj_list) ...)`, which (per ordinary `try/finally`
+ * semantics) replaces the original error, so every caller only ever saw the internal engine
+ * assertion string, never the real cause.
+ */
+describe('runScriptInQuickJs deep-recursion handling (runtime stack-size limit)', () => {
+  it('surfaces a normal recursion error instead of a raw engine assertion when a script recurses without bound', async () => {
+    await expect(
+      runScriptInQuickJs({
+        script: `
+          function recurse(n) { return recurse(n + 1); }
+          recurse(0);
+        `,
+        context: baseContext(),
+      }),
+    ).rejects.toThrow(/stack overflow/i);
+  });
+
+  it('still allows several hundred levels of ordinary, bounded recursion', async () => {
+    const result = await runScriptInQuickJs({
+      script: `
+        function sum(n) { return n <= 0 ? 0 : n + sum(n - 1); }
+        insomnia.environment.set('total', sum(500));
+      `,
+      context: baseContext(),
+    });
+
+    expect((result.environment.data as Record<string, unknown>).total).toBe(125_250);
+  });
+
+  it('does not corrupt the shared QuickJS module for a later, unrelated script run', async () => {
+    await expect(
+      runScriptInQuickJs({
+        script: `function recurse(n) { return recurse(n + 1); } recurse(0);`,
+        context: baseContext(),
+      }),
+    ).rejects.toThrow();
+
+    const result = await runScriptInQuickJs({
+      script: `insomnia.environment.set('ok', 1 + 1);`,
+      context: baseContext(),
+    });
+    expect((result.environment.data as Record<string, unknown>).ok).toBe(2);
+  });
+});

--- a/packages/insomnia/src/scripting/quickjs-script-engine.ts
+++ b/packages/insomnia/src/scripting/quickjs-script-engine.ts
@@ -59,6 +59,13 @@ export const runScriptInQuickJs = async ({
     // Polled during synchronous execution so a tight sync loop in the script can't bypass the timeout.
     vm.runtime.setInterruptHandler(() => Date.now() > deadline);
     vm.runtime.setMemoryLimit(32 * 1024 * 1024);
+    // Without an explicit cap, unbounded guest recursion overflows the *host* WASM call stack
+    // before QuickJS's own bytecode-level depth check can catch it — that surfaces as an uncatchable
+    // host RangeError instead of a normal script error, and leaves the runtime's GC state
+    // inconsistent enough that the `vm.dispose()` below then aborts on a fatal internal assertion.
+    // 256KB reliably lets QuickJS's own check win first (verified empirically) while still allowing
+    // several hundred levels of legitimate recursion.
+    vm.runtime.setMaxStackSize(256 * 1024);
 
     installConsole(vm, scriptConsole);
     installKeyValueBridge(vm, '__envGet', '__envSet', environmentData);

--- a/packages/insomnia/src/scripting/quickjs-script-engine.ts
+++ b/packages/insomnia/src/scripting/quickjs-script-engine.ts
@@ -195,7 +195,45 @@ const DANGEROUS_BRIDGE_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
 const SEND_REQUEST_ENDPOINT = 'insomnia-templating-worker-database://network.sendrequestwithoutsideeffects';
 const TEMPLATING_DB_AUTH_HEADER = 'x-insomnia-templating-auth';
 
+// insomnia.sendRequest()'s own doc comment above says this sandbox's request bridge supports only
+// a plain-text body -- "no auth, client certificates, cookies, or multipart/urlencoded bodies yet"
+// -- and the BOOTSTRAP wrapper only ever builds `{ mimeType: 'text/plain', text }`. That's guest-side
+// JS, though, not an enforcement boundary: a script can skip the wrapper and call the raw
+// `__sendRequest` global directly with a body of its own choosing. `network.sendRequestWithoutSideEffects`
+// (the shared host handler this bridges to) forwards a `body` unvalidated to `curlRequest`, and a
+// multipart body's file parts are read straight off disk by `buildMultipart` with no ownership/
+// allowlist check at all -- unlike every other local-file read reachable from a request definition.
+// That handler is also the one the legacy hidden-window script sandbox and the template-tag sandbox
+// use, each with its own, already-privileged execution model, so the fix belongs here, at this
+// QuickJS-specific bridge boundary, rather than in the shared handler itself.
+const SUPPORTED_SEND_REQUEST_BODY_MIME_TYPE = 'text/plain';
+
+const assertSupportedSendRequestBody = (requestBodyJson: string): void => {
+  let parsed: { options?: { request?: { body?: unknown } } };
+  try {
+    parsed = JSON.parse(requestBodyJson);
+  } catch {
+    // Malformed JSON fails downstream (the real handler's own JSON.parse) in the normal way.
+    return;
+  }
+  const body = parsed?.options?.request?.body;
+  if (body === undefined || body === null) {
+    return;
+  }
+  const { mimeType, ...rest } = (body ?? {}) as { mimeType?: unknown; [key: string]: unknown };
+  const hasUnsupportedShape =
+    typeof body !== 'object' ||
+    (mimeType !== undefined && mimeType !== SUPPORTED_SEND_REQUEST_BODY_MIME_TYPE) ||
+    Object.keys(rest).some(key => key !== 'text');
+  if (hasUnsupportedShape) {
+    throw new Error(
+      'insomnia.sendRequest() only supports a plain-text request body in the QuickJS sandbox — file uploads, multipart, and urlencoded form bodies are not supported.',
+    );
+  }
+};
+
 const sendRequestViaFetch = async (requestBodyJson: string, authToken?: string): Promise<Record<string, unknown>> => {
+  assertSupportedSendRequestBody(requestBodyJson);
   const resp = await fetch(SEND_REQUEST_ENDPOINT, {
     method: 'post',
     headers: authToken ? { [TEMPLATING_DB_AUTH_HEADER]: authToken } : undefined,


### PR DESCRIPTION
## Summary

Three fixes to the QuickJS pre/post-request script sandbox's `insomnia.sendRequest()` bridge (#10392). 

**1. `caCertficatePath`/`authentication` injection in `network.sendRequestWithoutSideEffects`**
- `network.sendRequestWithoutSideEffects` accepted a caller-controlled `caCertficatePath` (arbitrary local file read via `insecureReadFile`, fed to curl as a TLS client cert) and let `authentication` be spread over a safe default, overriding it.
- Reachable via #10392's `insomnia.sendRequest()` bridge by calling its raw `__sendRequest` global directly (bypassing the wrapper's normalization), and identically via the already-shipped template-tag/plugin sandbox's `sendRequestWithoutSideEffects(options)`, since both dispatch through this one handler.
- Fix: `caCertficatePath` is hardcoded to `null` (dropped from the accepted type), and `authentication: { type: 'none' }` is applied after the request spread so it can no longer be overridden.

**2. Unbounded guest recursion aborts the WASM module**
- Without an explicit stack cap, unbounded recursion in a script overflows the *host* WASM call stack before QuickJS's own bytecode-level depth check can catch it, surfacing as an uncatchable host `RangeError` and leaving the runtime's GC state inconsistent enough that `vm.dispose()` then aborts on a fatal internal assertion — taking down the whole script worker instead of failing the one script.
- Fix: `vm.runtime.setMaxStackSize(256 * 1024)`, verified empirically to let QuickJS's own check win first while still allowing several hundred levels of legitimate recursion.

**3. Multipart file parts read any local path with no allowlist check (same class as #1, different field)**
- `network.sendRequestWithoutSideEffects`'s `body` field is forwarded to `curlRequest` unvalidated. A `multipart/form-data` body's file parts (`body.params[].fileName`) reach `buildMultipart`, which reads each part's `fileName` straight off disk with **no ownership/allowlist check at all** — unlike every other local-file read reachable from a request definition. The later `isPathAllowed(requestBodyPath, settings.dataFolders)` check only validates the *resulting temp file* (always inside the unconditionally-allowlisted `os.tmpdir()`), never the original `fileName`, so it's a structural no-op for this case.
- Reachable the same way as #1: a script calls the raw `__sendRequest` bridge global directly with a multipart body naming an arbitrary local path (e.g. `~/.ssh/id_rsa`) and a POST url it controls, exfiltrating the file's contents in one request.
- Fix scoped strictly to the QuickJS bridge (`quickjs-script-engine.ts`'s new `assertSupportedSendRequestBody`, run before the bridge's `fetch()` is dispatched): rejects any request body that isn't absent or the plain `{mimeType: 'text/plain', text}` shape `insomnia.sendRequest()`'s own wrapper already documents as the sandbox's only supported shape. Deliberately **not** applied to the shared handler itself, `buildMultipart`, or `libcurl-promise.ts`, since those are also used by the legacy hidden-window script sandbox and the template-tag sandbox, each with its own, already-privileged execution model that should keep working unchanged.

## Test plan
- [x] Fix 1 & 2: regression tests drive the real engine → real bridge → real `resolveDbByKey` → real handler end-to-end (only native `curlRequest` mocked); watched red pre-fix, green post-fix.
- [x] Fix 3: two regression tests, one per sandbox mode —
  - `templating-worker-database-sendrequest-multipart-filepath-scoping.test.ts`: drives the real QuickJS bridge end-to-end; confirms the multipart request is now denied before `curlRequest` is ever called. Watched red pre-fix, green post-fix.
  - `network-sendrequest-multipart-allowed.test.ts`: drives the legacy (non-QuickJS) `sendRequestWithoutSideEffects` implementation directly; confirms it's unaffected. 
- [x] Fix 3 fix + tests independently re-verified by a fresh, cold review pass, including a negative control. 
- [x] `npx eslint` / `npx tsc --noEmit` clean.
- [x] `npx vitest run src/main/__tests__/ src/scripting/ src/plugins/` — 457/457 passing.
