### PR TITLE
fix(smoke-test): assert prompt template tag visibility

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/template-tags-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/template-tags-interactions.test.ts
@@ -148,6 +148,6 @@ test('Critical Path For Template Tags Interactions', async ({ page, app, insomni
   await insomnia.navigationSidebar.requestRow('Prompt Tag').click({ modifiers: ['ControlOrMeta'] });
   await page.getByText('Body', { exact: true }).click();
   const { tagPrefix } = templateTagTestCases.prompt[0];
-  await page.locator(`[data-template^="${tagPrefix}"]`).isVisible();
+  await expect(page.locator(`[data-template^="${tagPrefix}"]`)).toBeVisible();
   await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
 });


### PR DESCRIPTION
## Summary

The prompt-template section of the Playwright smoke test called `locator.isVisible()` and discarded the returned boolean. That line therefore passed whether or not the prompt template tag was rendered.

Replace the one-shot state read with Playwright's web-first `toBeVisible()` assertion so the critical-path test fails when the prompt template tag is missing or hidden before the request is sent.

## Verification

- Confirmed the defect against `Kong/insomnia@afaaec6` on 2026-08-15.
- `git diff --check` passed for the one-line patch.
- The local PR preflight reported no static failures: smell count `3 -> 2` and clean AST-artifact, diff-hygiene, and authoring checks.
- `npm ci --no-audit --no-fund` passed with Node 24.18.0.
- `npm run app-build` passed.
- `CI=1 npm run test:smoke:build -- tests/smoke/template-tags-interactions.test.ts` passed: 1 test in 19.9 seconds.

Found while reviewing the test suite with [`e2e-skills/e2e-reviewer`](https://github.com/voidmatcha/e2e-skills#skill-2-e2e-reviewer--quality-review).
