### PR TITLE
fix(release): resolve previous tag by semver precedence

### DIFF
--- a/.github/scripts/resolve-previous-release-tag.js
+++ b/.github/scripts/resolve-previous-release-tag.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// Resolves the previous core@ tag for release notes by semver precedence, excluding a release's own beta versions.
+const { execSync } = require('child_process');
+
+function parseTag(tag) {
+  const version = tag.replace(/^core@/, '');
+  // build metadata doesn't affect precedence and is discarded
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-([^+]+))?(?:\+.+)?$/);
+  if (!match) return null;
+  const [, major, minor, patch, prerelease] = match;
+  return { tag, major: +major, minor: +minor, patch: +patch, prerelease: prerelease || null };
+}
+
+function comparePrerelease(a, b) {
+  if (a === null && b === null) return 0;
+  if (a === null) return 1; // no prerelease outranks any prerelease
+  if (b === null) return -1;
+  const aParts = a.split('.');
+  const bParts = b.split('.');
+  const length = Math.max(aParts.length, bParts.length);
+  for (let i = 0; i < length; i++) {
+    const x = aParts[i];
+    const y = bParts[i];
+    if (x === undefined) return -1;
+    if (y === undefined) return 1;
+    const xIsNumeric = /^\d+$/.test(x);
+    const yIsNumeric = /^\d+$/.test(y);
+    if (xIsNumeric && yIsNumeric) {
+      const diff = Number(x) - Number(y);
+      if (diff) return diff;
+    } else if (xIsNumeric !== yIsNumeric) {
+      return xIsNumeric ? -1 : 1; // numeric identifiers always rank below alphanumeric ones
+    } else {
+      const diff = x.localeCompare(y);
+      if (diff) return diff;
+    }
+  }
+  return 0;
+}
+
+function compareVersions(a, b) {
+  return (
+    a.major - b.major ||
+    a.minor - b.minor ||
+    a.patch - b.patch ||
+    comparePrerelease(a.prerelease, b.prerelease)
+  );
+}
+
+function resolvePreviousTag(tags, current) {
+  const previous = tags
+    .map(parseTag)
+    .filter(Boolean)
+    .filter(parsed => parsed.major < 1000) // exclude legacy CalVer tags (2020.x-2023.x era)
+    .filter(parsed => parsed.tag !== current.tag)
+    .filter(parsed => (current.prerelease === null ? parsed.prerelease === null : true))
+    .filter(parsed => compareVersions(parsed, current) < 0)
+    .sort(compareVersions)
+    .pop();
+
+  return previous ? previous.tag : null;
+}
+
+if (require.main === module) {
+  const currentTag = process.argv[2];
+  if (!currentTag) {
+    console.error('Usage: resolve-previous-release-tag.js <current-tag>');
+    process.exit(1);
+  }
+
+  const current = parseTag(currentTag);
+  if (!current) {
+    console.error(`Could not parse current tag: ${currentTag}`);
+    process.exit(1);
+  }
+
+  const tags = execSync("git tag --list 'core@*'").toString().split('\n').filter(Boolean);
+  const previous = resolvePreviousTag(tags, current);
+
+  process.stdout.write(previous || '');
+}
+
+module.exports = { parseTag, comparePrerelease, compareVersions, resolvePreviousTag };

--- a/.github/scripts/resolve-previous-release-tag.test.js
+++ b/.github/scripts/resolve-previous-release-tag.test.js
@@ -1,0 +1,61 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { parseTag, comparePrerelease, resolvePreviousTag } = require('./resolve-previous-release-tag');
+
+// spans the CalVer/SemVer boundary, a beta->stable line, and an out-of-order hotfix
+const FIXTURE_TAGS = [
+  'core@2023.5.8',
+  'core@8.0.0-beta.1',
+  'core@8.0.0',
+  'core@13.0.2',
+  'core@13.1.0-beta.0',
+  'core@13.1.0-beta.1',
+  'core@13.1.0',
+  'core@13.1.1',
+  'core@13.2.0-beta.0',
+];
+
+function resolve(currentTag, tags = FIXTURE_TAGS) {
+  return resolvePreviousTag(tags, parseTag(currentTag));
+}
+
+test('legacy CalVer tags are never selected as the previous tag', () => {
+  assert.equal(resolve('core@8.0.0', ['core@2023.5.8']), null);
+});
+
+test('a stable release resolves to the prior stable release, not its own beta', () => {
+  assert.equal(resolve('core@13.1.0'), 'core@13.0.2');
+});
+
+test('a beta resolves to the prior beta of the same version', () => {
+  assert.equal(resolve('core@13.1.0-beta.1'), 'core@13.1.0-beta.0');
+});
+
+test('an out-of-order hotfix stays scoped to its own release line', () => {
+  // core@13.2.0-beta.0 postdates 13.1.1 in precedence despite tagging order
+  assert.equal(resolve('core@13.1.1'), 'core@13.1.0');
+});
+
+test('returns null when no qualifying previous tag exists (first-ever release)', () => {
+  assert.equal(resolvePreviousTag([], parseTag('core@1.0.0')), null);
+});
+
+test('malformed tags are skipped rather than breaking resolution', () => {
+  assert.equal(resolve('core@13.1.0', ['not-a-real-tag', 'core@garbage', 'core@13.0.0']), 'core@13.0.0');
+});
+
+test('parseTag discards build metadata without dropping the tag', () => {
+  assert.deepEqual(parseTag('core@13.1.0+build.5'), {
+    tag: 'core@13.1.0+build.5',
+    major: 13,
+    minor: 1,
+    patch: 0,
+    prerelease: null,
+  });
+  assert.equal(parseTag('core@13.1.0-beta.1+build.5').prerelease, 'beta.1');
+});
+
+test('comparePrerelease ranks numeric identifiers below alphanumeric ones regardless of value', () => {
+  assert.ok(comparePrerelease('99', '8a') < 0);
+  assert.ok(comparePrerelease('8a', '99') > 0);
+});

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -133,13 +133,46 @@ jobs:
         with:
           path: ${{ env.ELECTRON_ARTIFACT_BASE64_FILE }}
 
+      - name: Determine previous release tag
+        id: previous_tag
+        run: |
+          PREVIOUS_TAG=$(node ./.github/scripts/resolve-previous-release-tag.js "${RELEASE_CORE_TAG}")
+          echo "Resolved previous tag for changelog diff: ${PREVIOUS_TAG:-<none, will omit>}"
+          echo "PREVIOUS_TAG=${PREVIOUS_TAG}" >> "$GITHUB_ENV"
+
+      - name: Generate release notes scoped to this branch's history
+        id: generated_notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -n "${PREVIOUS_TAG}" ]; then
+            PAYLOAD=$(jq -n --arg tag "$RELEASE_CORE_TAG" --arg target "$RELEASE_BRANCH" --arg prev "$PREVIOUS_TAG" \
+              '{tag_name: $tag, target_commitish: $target, previous_tag_name: $prev}')
+          else
+            PAYLOAD=$(jq -n --arg tag "$RELEASE_CORE_TAG" --arg target "$RELEASE_BRANCH" \
+              '{tag_name: $tag, target_commitish: $target}')
+          fi
+
+          BODY=$(curl -sSL --fail \
+            -X POST \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            -d "$PAYLOAD" | jq -r '.body')
+
+          {
+            echo "body<<RELEASE_NOTES_EOF"
+            echo "$BODY"
+            echo "RELEASE_NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Create Tag and Release
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         id: core_tag_and_release
         with:
           tag: ${{ env.RELEASE_CORE_TAG }}
           name: '${{ env.RELEASE_VERSION }} 📦'
-          generateReleaseNotes: true
+          body: ${{ steps.generated_notes.outputs.body }}
           commit: ${{ env.RELEASE_BRANCH }}
           prerelease: ${{ env.IS_PRERELEASE }}
           draft: false

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -140,39 +140,14 @@ jobs:
           echo "Resolved previous tag for changelog diff: ${PREVIOUS_TAG:-<none, will omit>}"
           echo "PREVIOUS_TAG=${PREVIOUS_TAG}" >> "$GITHUB_ENV"
 
-      - name: Generate release notes scoped to this branch's history
-        id: generated_notes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ -n "${PREVIOUS_TAG}" ]; then
-            PAYLOAD=$(jq -n --arg tag "$RELEASE_CORE_TAG" --arg target "$RELEASE_BRANCH" --arg prev "$PREVIOUS_TAG" \
-              '{tag_name: $tag, target_commitish: $target, previous_tag_name: $prev}')
-          else
-            PAYLOAD=$(jq -n --arg tag "$RELEASE_CORE_TAG" --arg target "$RELEASE_BRANCH" \
-              '{tag_name: $tag, target_commitish: $target}')
-          fi
-
-          BODY=$(curl -sSL --fail \
-            -X POST \
-            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
-            -d "$PAYLOAD" | jq -r '.body')
-
-          {
-            echo "body<<RELEASE_NOTES_EOF"
-            echo "$BODY"
-            echo "RELEASE_NOTES_EOF"
-          } >> "$GITHUB_OUTPUT"
-
       - name: Create Tag and Release
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         id: core_tag_and_release
         with:
           tag: ${{ env.RELEASE_CORE_TAG }}
           name: '${{ env.RELEASE_VERSION }} 📦'
-          body: ${{ steps.generated_notes.outputs.body }}
+          generateReleaseNotes: true
+          generateReleaseNotesPreviousTag: ${{ env.PREVIOUS_TAG }}
           commit: ${{ env.RELEASE_BRANCH }}
           prerelease: ${{ env.IS_PRERELEASE }}
           draft: false


### PR DESCRIPTION
Release notes generation was picking the wrong "previous tag" to diff against — GitHub's auto-detection has no notion of this repo's per-line `release/*` branches, so tags published out of order (a hotfix on an older line after a newer line's beta already shipped) could resolve to an unrelated release, pulling its PRs into the wrong changelog.

This replaces auto-detection with a script that computes the previous `core@` tag from real semver precedence: highest existing tag with strictly lower precedence than the one being cut, ignoring publish order and legacy CalVer tags. For a stable release it also excludes that version's own prereleases, so it diffs against the prior stable release rather than its own beta.