### PR TITLE
fix: apply proxy setting to SSE requests

### DIFF
--- a/packages/insomnia/src/main/api.protocol.ts
+++ b/packages/insomnia/src/main/api.protocol.ts
@@ -5,6 +5,7 @@ import { parse as urlParse } from 'node:url';
 import { Curl, CurlAuth, CurlFeature, CurlSslOpt, type HeaderInfo } from '@getinsomnia/node-libcurl';
 import { app, net, protocol, session } from 'electron';
 import { services } from 'insomnia-data';
+import { ProxyScopes } from 'insomnia-data/common';
 
 import { getApiBaseURL } from '../common/constants';
 import { parseResolvedProxy, setDefaultProtocol, shouldBypassProxyForHost } from './network/libcurl-promise';
@@ -81,6 +82,8 @@ export async function registerInsomniaProtocols() {
             } else {
               curl.setOpt(Curl.option.PROXY, '');
             }
+          } else if (settings.proxyScope !== ProxyScopes.all) {
+            curl.setOpt(Curl.option.PROXY, '');
           } else {
             const { protocol, hostname } = urlParse(urlStr);
             const { httpProxy, httpsProxy, noProxy } = settings;


### PR DESCRIPTION
SSE requests (presence, etc.) were being routed through the configured proxy since it uses `node-libcurl`. Added a clause to prevent routing if the `All traffic sent by Insomnia` option is not chosen