### PR TITLE
fix: Plugin action no loaded in request/requestGroup context menu when right click 

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
@@ -90,8 +90,13 @@ export const RequestActionsDropdown = ({
   };
 
   const onOpen = useCallback(async () => {
-    const actionPlugins = await plugins.getRequestActions();
-    setActionPlugins(actionPlugins);
+    try {
+      const actionPlugins = await plugins.getRequestActions();
+      setActionPlugins(actionPlugins);
+    } catch (error) {
+      setActionPlugins([]);
+      console.error('Failed to get request plugin actions', error);
+    }
   }, []);
 
   useEffect(() => {

--- a/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/request-actions-dropdown.tsx
@@ -10,7 +10,7 @@ import type {
 } from 'insomnia-data';
 import { models, services } from 'insomnia-data';
 import type { PlatformKeyCombinations } from 'insomnia-data/common';
-import React, { Fragment, useCallback, useState } from 'react';
+import React, { Fragment, useCallback, useEffect, useState } from 'react';
 import { Button, Collection, Header, Menu, MenuItem, MenuSection, MenuTrigger, Popover } from 'react-aria-components';
 import { useParams } from 'react-router';
 
@@ -93,6 +93,13 @@ export const RequestActionsDropdown = ({
     const actionPlugins = await plugins.getRequestActions();
     setActionPlugins(actionPlugins);
   }, []);
+
+  useEffect(() => {
+    // Fetch the action plugins when the dropdown is opened
+    if (isOpen) {
+      onOpen();
+    }
+  }, [isOpen, onOpen]);
 
   const handleDuplicateRequest = () => {
     if (!request) {
@@ -321,13 +328,7 @@ export const RequestActionsDropdown = ({
 
   return (
     <Fragment>
-      <MenuTrigger
-        isOpen={isOpen}
-        onOpenChange={isOpen => {
-          isOpen && onOpen();
-          onOpenChange(isOpen);
-        }}
-      >
+      <MenuTrigger isOpen={isOpen} onOpenChange={onOpenChange}>
         <Button
           data-testid={`Dropdown-${toKebabCase(request.name)}`}
           aria-label="Request Actions"

--- a/packages/insomnia/src/ui/components/dropdowns/request-group-actions-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/request-group-actions-dropdown.tsx
@@ -85,8 +85,13 @@ export const RequestGroupActionsDropdown = ({
     });
 
   const onOpen = useCallback(async () => {
-    const actionPlugins = await plugins.getRequestGroupActions();
-    setActionPlugins(actionPlugins);
+    try {
+      const actionPlugins = await plugins.getRequestGroupActions();
+      setActionPlugins(actionPlugins);
+    } catch (error) {
+      setActionPlugins([]);
+      console.error('Failed to get request group plugin actions', error);
+    }
   }, []);
 
   useEffect(() => {

--- a/packages/insomnia/src/ui/components/dropdowns/request-group-actions-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/request-group-actions-dropdown.tsx
@@ -2,7 +2,7 @@ import type { IconName } from '@fortawesome/fontawesome-svg-core';
 import type { Project, Request, RequestGroup, Workspace } from 'insomnia-data';
 import { services } from 'insomnia-data';
 import type { PlatformKeyCombinations } from 'insomnia-data/common';
-import React, { Fragment, useRef, useState } from 'react';
+import React, { Fragment, useCallback, useEffect, useRef, useState } from 'react';
 import { Button, Collection, Header, Menu, MenuItem, MenuSection, MenuTrigger, Popover } from 'react-aria-components';
 import { useParams } from 'react-router';
 
@@ -84,10 +84,17 @@ export const RequestGroupActionsDropdown = ({
       },
     });
 
-  const onOpen = async () => {
+  const onOpen = useCallback(async () => {
     const actionPlugins = await plugins.getRequestGroupActions();
     setActionPlugins(actionPlugins);
-  };
+  }, []);
+
+  useEffect(() => {
+    // Fetch the action plugins when the dropdown is opened
+    if (isOpen) {
+      onOpen();
+    }
+  }, [isOpen, onOpen]);
 
   const handleRequestGroupDuplicate = () => {
     showModal(PromptModal, {
@@ -357,13 +364,7 @@ export const RequestGroupActionsDropdown = ({
 
   return (
     <Fragment>
-      <MenuTrigger
-        isOpen={isOpen}
-        onOpenChange={isOpen => {
-          isOpen && onOpen();
-          onOpenChange(isOpen);
-        }}
-      >
+      <MenuTrigger isOpen={isOpen} onOpenChange={onOpenChange}>
         <Button
           data-testid={`Dropdown-${toKebabCase(requestGroup.name)}`}
           aria-label="Request Group Actions"

--- a/packages/insomnia/src/ui/components/dropdowns/sidebar-workspace-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/sidebar-workspace-dropdown.tsx
@@ -136,7 +136,7 @@ export const SidebarWorkspaceDropdown = ({
       setActionPlugins(actionPlugins);
     } catch (error) {
       setActionPlugins([]);
-      console.error('Failed to get workspace action plugins', error);
+      console.error('Failed to get workspace plugin actions', error);
     }
   }, []);
 


### PR DESCRIPTION
Fix the issue that plugin actions are not loaded in request/requestGroup context menu when right click on it.

[INS-3521](https://konghq.atlassian.net/browse/INS-3521)

[INS-3521]: https://konghq.atlassian.net/browse/INS-3521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ