### PR TITLE
Fix: Secret type environment input hanging and data update issue

### DIFF
--- a/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
@@ -109,11 +109,12 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
     const { settings } = useRootLoaderData()!;
     const { isOwner, isEnterprisePlan } = usePlanData();
     const { handleRender, handleGetRenderContext } = useNunjucks();
+    const isPasswordEditor = type?.toLowerCase() === 'password';
 
     // Update the tooltip value, including rendering the value of a nunjucks tag if necessary
     const updateTooltipValue = useCallback(
       async (rawValue: string) => {
-        if (type?.toLowerCase() === 'password') {
+        if (isPasswordEditor) {
           return;
         }
         if (!handleRender || !/{{|{%/.test(rawValue)) {
@@ -127,7 +128,7 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
           setTooltipValue(rawValue);
         }
       },
-      [handleRender, type],
+      [handleRender, isPasswordEditor],
     );
 
     const getKeyMap = useCallback(() => {
@@ -563,7 +564,9 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
         delay={1000}
         className="h-full w-full"
         followCursor
-        shouldShow={() => Boolean(tooltipValue) && !isPointerOverNunjucksTag.current && isContentTruncated()}
+        shouldShow={() =>
+          Boolean(tooltipValue) && !isPasswordEditor && !isPointerOverNunjucksTag.current && isContentTruncated()
+        }
       >
         <div
           className={classnames('editor--single-line', {

--- a/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
@@ -438,6 +438,17 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
     }, [defaultValue, historyKey, type, updateTooltipValue]);
 
     useEffect(() => {
+      // Type password will apply the `-webkit-text-security` CSS on .CodeMirror-line, which changes glyph widths.
+      // CodeMirror isn't aware of it, so the cursor/selection stay positioned using stale widths until a manual re-measure.
+      const cm = codeMirror.current;
+      if (!cm) {
+        return;
+      }
+      const raf = requestAnimationFrame(() => cm.refresh());
+      return () => cancelAnimationFrame(raf);
+    }, [type]);
+
+    useEffect(() => {
       // Prevent these things if we're type === "password"
       const preventDefault = (_: CodeMirror.Editor, event: Event) =>
         type?.toLowerCase() === 'password' && event.preventDefault();

--- a/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
@@ -446,6 +446,7 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
       }
       const raf = requestAnimationFrame(() => cm.refresh());
       return () => cancelAnimationFrame(raf);
+      // `type` is intentionally included here to make sure the re-measure triggers when the type changes
     }, [type]);
 
     useEffect(() => {

--- a/packages/insomnia/src/ui/components/editors/environment-key-value-editor/key-value-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/environment-key-value-editor/key-value-editor.tsx
@@ -561,7 +561,7 @@ export const EnvironmentKVEditor = ({
         aria-label="Environment Key Value Pair"
         selectionMode="none"
         dragAndDropHooks={dragAndDropHooks}
-        dependencies={[kvPairError, data, symmetricKey, blankId]}
+        dependencies={[kvPairError, data, symmetricKey, blankId, decryptedValues]}
         className="h-full w-full overflow-y-auto p-(--padding-sm)"
         items={kvPairs}
         // Let React Aria place focus on the trailing blank row so the editor is ready to type into on

--- a/packages/insomnia/src/ui/components/editors/environment-key-value-editor/password-input.tsx
+++ b/packages/insomnia/src/ui/components/editors/environment-key-value-editor/password-input.tsx
@@ -30,25 +30,15 @@ export const PasswordInput = (props: PasswordInputProps) => {
   return (
     <div className={`flex h-full w-full items-center justify-between ${className}`}>
       <div className="h-full w-full flex-1">
-        {isHidden ? (
-          <input
-            value={value}
-            className="h-full w-full placeholder-(--hl-lg)"
-            onChange={event => onChange(event.target.value)}
-            placeholder={placeholder}
-            readOnly={!enabled}
-            type={'password'}
-          />
-        ) : (
-          <OneLineEditor
-            id={`environment-kv-editor-value-${itemId}`}
-            historyKey={`environment-kv-editor-value-${itemId}`}
-            placeholder={placeholder}
-            defaultValue={value}
-            readOnly={!enabled}
-            onChange={newValue => onChange(newValue)}
-          />
-        )}
+        <OneLineEditor
+          id={`environment-kv-editor-value-${itemId}`}
+          historyKey={`environment-kv-editor-value-${itemId}`}
+          type={isHidden ? 'password' : 'text'}
+          placeholder={placeholder}
+          defaultValue={value}
+          readOnly={!enabled}
+          onChange={onChange}
+        />
       </div>
       <button className="m-0 h-full items-center px-1" onClick={handleShowHidePassword}>
         {isHidden ? <i className="fa fa-eye-slash" /> : <i className="fa fa-eye" />}


### PR DESCRIPTION
# Changes
- Use `one-line-editor` to hide password
- Re-calculate the editor when editor type changes to avoid stale cursor position issue
- Update the ListBox `dependencies` property to update item value when decryptedValues are updated

[INS-3599](https://konghq.atlassian.net/browse/INS-3599)

[INS-3599]: https://konghq.atlassian.net/browse/INS-3599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ