### PR TITLE
fix(ui): center button label

### DIFF
--- a/packages/insomnia/src/ui/components/settings/general.tsx
+++ b/packages/insomnia/src/ui/components/settings/general.tsx
@@ -222,7 +222,7 @@ export const General: FC = () => {
           help="If checked, clears the OAuth session every time Insomnia is relaunched."
         />
         <button
-          className="pointer h-(--line-height-xs) rounded-md border border-solid border-(--hl-lg) px-(--padding-sm) hover:bg-(--hl-xs)"
+          className="pointer flex h-(--line-height-xs) items-center justify-center rounded-md border border-solid border-(--hl-lg) px-(--padding-sm) hover:bg-(--hl-xs)"
           onClick={clearOAuthWindowSessionId}
         >
           Clear OAuth 2 session


### PR DESCRIPTION
duplicate of #10285

~~Center the button label `Clear OAuth 2 session`~~
|before|after|
|-|-|
|<img width="730" height="130" alt="image" src="https://github.com/user-attachments/assets/ac7a19b7-d51b-41a9-9b63-98e0eabc3e32" />|<img width="700" height="151" alt="image" src="https://github.com/user-attachments/assets/5d246085-6100-4ce5-b4ad-018c5685155b" />|
