### PR TITLE
chore(settings): remove dead Write() permission rule

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,8 +2,7 @@
   "permissions": {
     "deny": [
       "Read(packages/insomnia/bin/yarn-standalone.js)",
-      "Edit(packages/insomnia/bin/yarn-standalone.js)",
-      "Write(packages/insomnia/bin/yarn-standalone.js)"
+      "Edit(packages/insomnia/bin/yarn-standalone.js)"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- `.claude/settings.json` had a `Write(packages/insomnia/bin/yarn-standalone.js)` deny rule that never matches — file-editing tools only match `Edit(path)` rules, not a separate `Write(path)` type.
- `Edit(...)` rule for the same path already covers this. Removed the dead line.

## Test plan
- [x] Confirmed `Edit(...)` rule remains for the same path