### PR TITLE
fix(ui): re-render url bar templates on project environment switch

### DIFF
--- a/packages/insomnia/src/ui/components/mcp/mcp-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/mcp/mcp-url-bar.tsx
@@ -63,10 +63,10 @@ export const McpUrlActionBar = ({
   const requestTransportType = request.transportType;
   const requestTransportTypeLabel = getTransportLabel(requestTransportType);
   const modalRef = useRef<MCPStdioAccessModalHandle>(null);
-  const { activeEnvironment, vcsVersion } = useWorkspaceLoaderData()!;
+  const { activeEnvironment, activeGlobalEnvironment, vcsVersion } = useWorkspaceLoaderData()!;
   const gitVersion = useGitVCSVersion();
   // Force re-render when we switch requests, the environment gets modified, or the (Git|Sync)VCS version changes
-  const uniqueKey = `${activeEnvironment?.modified}::${requestId}::${gitVersion}::${vcsVersion}`;
+  const uniqueKey = `${activeEnvironment?._id}::${activeEnvironment?.modified}::${activeGlobalEnvironment?._id}::${activeGlobalEnvironment?.modified}::${requestId}::${gitVersion}::${vcsVersion}`;
 
   useLayoutEffect(() => {
     oneLineEditorRef.current?.focusEnd();

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -109,7 +109,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(
       setSearchParams({});
     }, [searchParams, setSearchParams]);
 
-    const { activeWorkspace, activeEnvironment } = useWorkspaceLoaderData()!;
+    const { activeWorkspace, activeEnvironment, activeGlobalEnvironment } = useWorkspaceLoaderData()!;
     const { settings } = useRootLoaderData()!;
     const { hotKeyRegistry } = settings;
     const {
@@ -317,7 +317,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(
             // Remount on request switch or environment change (switch/edit) so nunjucks
             // previews refresh. Excludes the response id / sync versions that churn on
             // send and local edits, which used to remount and blur the editor mid-edit.
-            key={`${requestId}::${activeEnvironment?._id}::${activeEnvironment?.modified}`}
+            key={`${requestId}::${activeEnvironment?._id}::${activeEnvironment?.modified}::${activeGlobalEnvironment?._id}::${activeGlobalEnvironment?.modified}`}
             // Stable across that remount, so undo history is restored from the cache.
             historyKey={historyKey}
             ref={inputRef}


### PR DESCRIPTION
[INS-2791](https://konghq.atlassian.net/browse/INS-2791)

## Summary
- Switching a request's project environment (activeGlobalEnvironment) left the URL bar's nunjucks template values stale, since its remount `key` only tracked the workspace environment (activeEnvironment). Switching workspace environment worked fine, as did the URL preview popup (which re-renders on any loader revalidation and refetches its render context fresh from the DB).
- Added the project environment id/modified timestamp to the URL bar's remount key so it also refreshes on project environment switch.

## Test plan
- [x] Open a request, switch project environment, confirm URL bar template tags update live (matching URL preview behavior)
- [x] Switch workspace environment, confirm URL bar still updates as before (no regression)

[INS-2791]: https://konghq.atlassian.net/browse/INS-2791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Out of Scope

- WebSocket has the same issue, but in the long term, we should use a controlled input instead of a magic react key, leave it for now.