### PR TITLE
fix: change tanstack query option

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.tsx
@@ -121,6 +121,8 @@ const Component = ({ loaderData }: Route.ComponentProps) => {
     queryKey: ['learning-feature'],
     queryFn: getLearningFeature,
     enabled: !isLearningFeatureDismissed,
+    staleTime: 1000 * 60 * 60 * 24, // 1 day
+    refetchOnWindowFocus: true,
   });
   const sidebarPanelRef = useRef<ImperativePanelHandle>(null);
   const { isSidebarCollapsed } = useSidebarContext();

--- a/packages/insomnia/src/ui/context/app/insomnia-app-data-context.tsx
+++ b/packages/insomnia/src/ui/context/app/insomnia-app-data-context.tsx
@@ -13,6 +13,7 @@ const createAppDataQueryClient = () =>
         retry: false,
         // Local database queries should always be fetched regardless of network connectivity.
         networkMode: 'always',
+        refetchOnWindowFocus: false,
       },
     },
   });

--- a/packages/insomnia/src/ui/context/app/server-data-context.tsx
+++ b/packages/insomnia/src/ui/context/app/server-data-context.tsx
@@ -11,7 +11,7 @@ const createServerDataQueryClient = () =>
     defaultOptions: {
       queries: {
         retry: 2,
-        staleTime: Infinity,
+        refetchOnWindowFocus: false,
       },
     },
   });


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

- Change TanStack Server QueryClient default option so that it can refresh data every time the queryKey changes.
- Add staleTime for learning feature fetching scenario (keep consistent with the origin logic #10421 )