### PR TITLE
fix(ui): wrap runner message

### DIFF
--- a/packages/insomnia/src/ui/components/panes/request-test-result-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-test-result-pane.tsx
@@ -126,8 +126,8 @@ export const RequestTestResultRows: FC<RequestTestResultRowsProps> = ({
             <div className="mx-1 leading-4">
               <span className="mr-2 ml-2">{statusTag}</span>
             </div>
-            <div className="mr-2 leading-4">
-              <div className="mt-1 mr-2 w-auto text-nowrap">{message}</div>
+            <div className="mr-2 min-w-0 leading-4">
+              <div className="mt-1 mr-2 w-auto break-words">{message}</div>
               <div className="mt-1 text-sm text-neutral-400">
                 {`${testCategory} (`}
                 {executionTime}


### PR DESCRIPTION
|before|after|
|-|-|
|<img width="866" height="210" alt="image" src="https://github.com/user-attachments/assets/8b07abe6-ad0f-4ff5-958e-96bac5e72dd8" />|<img width="803" height="243" alt="image" src="https://github.com/user-attachments/assets/5757568d-7938-4593-b7db-b8e76d10664b" />|