### PR TITLE
fix(ui): restore h-fit on cookies modal

### DIFF
--- a/packages/insomnia/src/ui/components/modals/cookies-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/cookies-modal.tsx
@@ -166,7 +166,7 @@ export const CookiesModal = ({ setIsOpen }: Props) => {
       onOpenChange={setIsOpen}
       className="fixed top-0 left-0 z-10 flex h-(--visual-viewport-height) w-full justify-center bg-black/30 py-[100px]"
     >
-      <Modal className="max-h-full w-full max-w-[900px] overflow-y-auto rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) p-(--padding-lg) text-(--color-font)">
+      <Modal className="h-fit max-h-full w-full max-w-[900px] overflow-y-auto rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) p-(--padding-lg) text-(--color-font)">
         <Dialog className="relative outline-hidden" aria-label="Cookies Modal">
           {({ close }) => (
             <>


### PR DESCRIPTION
## Summary
- PR #10097 dropped `h-fit` from the `Modal` className in `cookies-modal.tsx` as an unrelated side effect of a class rewrite (bg/padding tokens), unrelated to that PR's actual feature.
- Without `h-fit`, the modal inherits `align-items: stretch` from the parent flex overlay and stretches to the overlay's full height, leaving empty space below the cookie list content.
- Restores `h-fit` on the `Modal` element.

## Test plan
- [x] Open cookies modal, confirm it sizes to content height instead of stretching with empty space below