### PR TITLE
fix(main): compare full origin, not string prefix, for renderer nav guard

### DIFF
--- a/packages/insomnia/src/main/trusted-origin.test.ts
+++ b/packages/insomnia/src/main/trusted-origin.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { isTrustedAppOrigin } from './trusted-origin';
+
+// Guards against regressing to a raw string-prefix comparison.
+describe('isTrustedAppOrigin', () => {
+  const appUrl = 'https://insomnia-app.local';
+
+  it('trusts the exact app origin', () => {
+    expect(isTrustedAppOrigin('https://insomnia-app.local', appUrl)).toBe(true);
+  });
+
+  it('trusts the app origin with a different path or query', () => {
+    expect(isTrustedAppOrigin('https://insomnia-app.local/some/path?x=1', appUrl)).toBe(true);
+  });
+
+  it('rejects a hostname with an extra dot-separated suffix sharing the app origin as a prefix', () => {
+    expect(isTrustedAppOrigin('https://insomnia-app.local.example.com/', appUrl)).toBe(false);
+  });
+
+  it('rejects a hostname extended with extra characters and no separator', () => {
+    expect(isTrustedAppOrigin('https://insomnia-app.localexample.com/', appUrl)).toBe(false);
+  });
+
+  it('rejects userinfo-style prefix tricks', () => {
+    expect(isTrustedAppOrigin('https://insomnia-app.local@example.com/', appUrl)).toBe(false);
+  });
+
+  it('rejects a different scheme even with the same host', () => {
+    expect(isTrustedAppOrigin('http://insomnia-app.local/', appUrl)).toBe(false);
+  });
+
+  it('rejects a different port', () => {
+    expect(isTrustedAppOrigin('https://insomnia-app.local:8443/', appUrl)).toBe(false);
+  });
+
+  it('is not fooled when the app origin appears in the path/query instead of the host', () => {
+    expect(isTrustedAppOrigin('https://example.com/https://insomnia-app.local', appUrl)).toBe(false);
+  });
+
+  it('treats an unparsable URL as untrusted rather than throwing', () => {
+    expect(isTrustedAppOrigin('not-a-valid-url', appUrl)).toBe(false);
+  });
+
+  it('applies the same suffix-bypass check against a non-default appUrl (e.g. dev server)', () => {
+    const devAppUrl = 'http://localhost:3334';
+    expect(isTrustedAppOrigin('http://localhost:3334', devAppUrl)).toBe(true);
+    expect(isTrustedAppOrigin('http://localhost:33340/', devAppUrl)).toBe(false);
+    expect(isTrustedAppOrigin('http://localhost:3334@example.com/', devAppUrl)).toBe(false);
+  });
+});

--- a/packages/insomnia/src/main/trusted-origin.test.ts
+++ b/packages/insomnia/src/main/trusted-origin.test.ts
@@ -42,6 +42,10 @@ describe('isTrustedAppOrigin', () => {
     expect(isTrustedAppOrigin('not-a-valid-url', appUrl)).toBe(false);
   });
 
+  it('rejects a blob URL that merely embeds the app origin in its text', () => {
+    expect(isTrustedAppOrigin('blob:https://insomnia-app.local/9a1c-uuid', appUrl)).toBe(false);
+  });
+
   it('applies the same suffix-bypass check against a non-default appUrl (e.g. dev server)', () => {
     const devAppUrl = 'http://localhost:3334';
     expect(isTrustedAppOrigin('http://localhost:3334', devAppUrl)).toBe(true);

--- a/packages/insomnia/src/main/trusted-origin.ts
+++ b/packages/insomnia/src/main/trusted-origin.ts
@@ -1,7 +1,12 @@
 // Ensure trusted origin insomnia-app.local.
 export function isTrustedAppOrigin(url: string, appUrl: string): boolean {
   try {
-    return new URL(url).origin === new URL(appUrl).origin;
+    const parsed = new URL(url);
+    // blob:/data:/javascript: report a spoofable .origin string, not a real match.
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return false;
+    }
+    return parsed.origin === new URL(appUrl).origin;
   } catch {
     return false;
   }

--- a/packages/insomnia/src/main/trusted-origin.ts
+++ b/packages/insomnia/src/main/trusted-origin.ts
@@ -1,0 +1,8 @@
+// Ensure trusted origin insomnia-app.local.
+export function isTrustedAppOrigin(url: string, appUrl: string): boolean {
+  try {
+    return new URL(url).origin === new URL(appUrl).origin;
+  } catch {
+    return false;
+  }
+}

--- a/packages/insomnia/src/main/window-navigation-guard.test.ts
+++ b/packages/insomnia/src/main/window-navigation-guard.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+// Scans source as text; window-utils.ts can't be imported here (pulls in electron).
+describe('main window navigation guard', () => {
+  const source = readFileSync(path.join(__dirname, 'window-utils.ts'), 'utf8');
+
+  it('gates both will-navigate and will-redirect through the same origin check', () => {
+    const start = source.indexOf('const guardNavigation = ');
+    const end = source.indexOf('setWindowOpenHandler', start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const block = source.slice(start, end);
+
+    expect(block).toContain('isTrustedAppOrigin(url, appUrl)');
+    // Must not regress to a raw prefix check.
+    expect(block).not.toMatch(/url\.startsWith\(appUrl\)/);
+
+    expect(block).toContain("webContents.on('will-navigate', guardNavigation)");
+    expect(block).toContain("webContents.on('will-redirect', guardNavigation)");
+  });
+
+  it('unconditionally denies new-window/popup requests', () => {
+    expect(source).toMatch(/setWindowOpenHandler\(\(\) => \{\s*return \{ action: 'deny' \};\s*\}\)/);
+  });
+});

--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -26,6 +26,7 @@ import { getElectronStorage } from './electron-storage';
 import { ipcMainOn } from './ipc/electron';
 import { getLogDirectory } from './log';
 import { createPluginWindow, destroyPluginWindow, getPluginWindow } from './plugin-window';
+import { isTrustedAppOrigin } from './trusted-origin';
 import { MAIN_WINDOW_SECURITY } from './window-security';
 
 const DEFAULT_WIDTH = 1280;
@@ -227,10 +228,10 @@ export function createWindow(): ElectronBrowserWindow {
     showUnresponsiveModal();
   });
 
-  // Open generic links (<a .../>) in default browser
-  mainBrowserWindow.webContents.on('will-navigate', (event, url) => {
+  // Open generic links (<a .../>) in default browser; also covers redirects.
+  const guardNavigation = (event: Electron.Event, url: string) => {
     // Prevents local dev full-reload events from opening browser window, see https://github.com/Kong/insomnia/pull/4925
-    if (url.startsWith(appUrl)) {
+    if (isTrustedAppOrigin(url, appUrl)) {
       return;
     }
 
@@ -240,7 +241,9 @@ export function createWindow(): ElectronBrowserWindow {
     if (protocol === 'http:' || protocol === 'https:') {
       shell.openExternal(url);
     }
-  });
+  };
+  mainBrowserWindow.webContents.on('will-navigate', guardNavigation);
+  mainBrowserWindow.webContents.on('will-redirect', guardNavigation);
 
   mainBrowserWindow.webContents.setWindowOpenHandler(() => {
     return { action: 'deny' };


### PR DESCRIPTION
## Summary
- Replace the raw `url.startsWith(appUrl)` prefix check with a proper   parsed-origin comparison (`isTrustedAppOrigin`) before allowing   in-app navigation on the main window.
- Apply the same check to `will-redirect`, not just `will-navigate`.
- Reject non-http(s) schemes (e.g. `blob:`) in the origin check, since   their `.origin` can embed arbitrary text rather than reflecting the actual creating context.

## Test plan
- [x] `trusted-origin.test.ts` — origin-comparison unit tests
- [x] `window-navigation-guard.test.ts` — asserts both nav events are gated through `isTrustedAppOrigin` and popups stay denied
- [x] `npm run lint` / `npm run type-check` clean on touched files