### PR TITLE
fix: validate paths stay within their intended base directory

### DIFF
--- a/packages/insomnia/src/main/__tests__/backup.test.ts
+++ b/packages/insomnia/src/main/__tests__/backup.test.ts
@@ -1,0 +1,58 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  default: {
+    app: {
+      getPath: vi.fn(() => process.env['INSOMNIA_DATA_PATH']),
+      relaunch: vi.fn(),
+      exit: vi.fn(),
+    },
+  },
+}));
+
+import { restoreBackup } from '../backup';
+
+describe('restoreBackup', () => {
+  let dataPath: string;
+  let originalDataPath: string | undefined;
+
+  beforeEach(() => {
+    dataPath = fs.mkdtempSync(path.join(os.tmpdir(), 'insomnia-backup-test-'));
+    originalDataPath = process.env['INSOMNIA_DATA_PATH'];
+    process.env['INSOMNIA_DATA_PATH'] = dataPath;
+  });
+
+  afterEach(() => {
+    process.env['INSOMNIA_DATA_PATH'] = originalDataPath;
+    fs.rmSync(dataPath, { recursive: true, force: true });
+  });
+
+  it('restores a .db file from a real backup version', async () => {
+    const versionDir = path.join(dataPath, 'backups', '1.0.0');
+    fs.mkdirSync(versionDir, { recursive: true });
+    fs.writeFileSync(path.join(versionDir, 'insomnia.Request.db'), 'backed-up-content');
+
+    await restoreBackup('1.0.0');
+
+    expect(fs.readFileSync(path.join(dataPath, 'insomnia.Request.db'), 'utf8')).toBe('backed-up-content');
+  });
+
+  it('refuses a version that escapes the backups directory', async () => {
+    const secretPath = path.join(dataPath, 'insomnia.Secret.db');
+    fs.writeFileSync(secretPath, 'do-not-touch');
+
+    await restoreBackup('../');
+
+    expect(fs.readFileSync(secretPath, 'utf8')).toBe('do-not-touch');
+  });
+
+  it('refuses a deeply nested traversal version', async () => {
+    fs.mkdirSync(path.join(dataPath, 'backups'), { recursive: true });
+
+    await expect(restoreBackup('../../../../etc')).resolves.toBeUndefined();
+  });
+});

--- a/packages/insomnia/src/main/backup.ts
+++ b/packages/insomnia/src/main/backup.ts
@@ -62,7 +62,14 @@ export async function backup() {
 export async function restoreBackup(version: string) {
   try {
     const dataPath = process.env['INSOMNIA_DATA_PATH'] || electron.app.getPath('userData');
-    const versionPath = path.join(dataPath, 'backups', version);
+    const backupsPath = path.join(dataPath, 'backups');
+    const versionPath = path.join(backupsPath, version);
+    // version must resolve inside backupsPath.
+    const rel = path.relative(backupsPath, versionPath);
+    if (rel.startsWith('..') || path.isAbsolute(rel)) {
+      console.log('[main] Refusing to restore backup outside of backups dir:', versionPath);
+      return;
+    }
     const files = await readdir(versionPath);
     if (!files.length) {
       console.log('[main] No backup found at:', versionPath);

--- a/packages/insomnia/src/main/ipc/__tests__/is-path-inside-dir.test.ts
+++ b/packages/insomnia/src/main/ipc/__tests__/is-path-inside-dir.test.ts
@@ -1,0 +1,30 @@
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { isPathInsideDir } from '../path-guard';
+
+describe('isPathInsideDir', () => {
+  const dir = path.join('/tmp', 'insomnia-user-data');
+
+  it('accepts a plain nested folder name', () => {
+    expect(isPathInsideDir('plugins', dir)).toBe(true);
+  });
+
+  it('accepts the dir itself', () => {
+    expect(isPathInsideDir('.', dir)).toBe(true);
+  });
+
+  it('rejects a path that escapes the dir', () => {
+    expect(isPathInsideDir('../', dir)).toBe(false);
+    expect(isPathInsideDir('../../etc', dir)).toBe(false);
+  });
+
+  it('rejects an absolute path outside the dir', () => {
+    expect(isPathInsideDir('/etc/passwd', dir)).toBe(false);
+  });
+
+  it('rejects a sibling directory with a matching prefix', () => {
+    expect(isPathInsideDir(path.join('..', 'insomnia-user-data-evil'), dir)).toBe(false);
+  });
+});

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -633,7 +633,12 @@ export function registerMainHandlers() {
   ipcMainHandle('readDir', readDir);
 
   ipcMainHandle('readOrCreateDataDir', async (_, options: { folder: string }) => {
-    const folderPath = path.join(app.getPath('userData'), options.folder);
+    // options.folder must resolve inside userData.
+    const userDataDir = app.getPath('userData');
+    const folderPath = path.resolve(userDataDir, options.folder);
+    if (!(folderPath + path.sep).startsWith(userDataDir + path.sep)) {
+      throw new Error('readOrCreateDataDir: folder is outside the allowed userData directory');
+    }
     mkdirSync(folderPath, { recursive: true });
     try {
       return await readDir(_, { path: folderPath });

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -90,6 +90,7 @@ import { ipcMainHandle, ipcMainOn, type RendererOnChannels } from './electron';
 import type { electronStorageBridgeAPI } from './electron-storage';
 import extractPostmanDataDumpHandler from './extract-postman-data-dump';
 import type { gRPCBridgeAPI } from './grpc';
+import { isPathInsideDir } from './path-guard';
 import type { secretStorageBridgeAPI } from './secret-storage';
 import { registerTemplatingDbAuthIpcHandler } from './templating-db-auth';
 
@@ -633,12 +634,11 @@ export function registerMainHandlers() {
   ipcMainHandle('readDir', readDir);
 
   ipcMainHandle('readOrCreateDataDir', async (_, options: { folder: string }) => {
-    // options.folder must resolve inside userData.
     const userDataDir = app.getPath('userData');
-    const folderPath = path.resolve(userDataDir, options.folder);
-    if (!(folderPath + path.sep).startsWith(userDataDir + path.sep)) {
+    if (!isPathInsideDir(options.folder, userDataDir)) {
       throw new Error('readOrCreateDataDir: folder is outside the allowed userData directory');
     }
+    const folderPath = path.resolve(userDataDir, options.folder);
     mkdirSync(folderPath, { recursive: true });
     try {
       return await readDir(_, { path: folderPath });

--- a/packages/insomnia/src/main/ipc/path-guard.ts
+++ b/packages/insomnia/src/main/ipc/path-guard.ts
@@ -1,0 +1,6 @@
+import path from 'node:path';
+
+export const isPathInsideDir = (candidatePath: string, dir: string): boolean => {
+  const resolved = path.resolve(dir, candidatePath);
+  return (resolved + path.sep).startsWith(path.resolve(dir) + path.sep);
+};

--- a/packages/insomnia/src/sync/git/__tests__/fs-client.test.ts
+++ b/packages/insomnia/src/sync/git/__tests__/fs-client.test.ts
@@ -35,9 +35,15 @@ describe('fsClient', () => {
     await expect(client.promises.readFile('../../../etc/passwd')).rejects.toThrow('escapes the repository directory');
   });
 
-  it('rejects a symlink target that resolves outside basePath', async () => {
+  it('rejects a symlink whose own location resolves outside basePath', async () => {
     const client = fsClient(basePath);
     await expect(client.promises.symlink('link', '..')).rejects.toThrow('escapes the repository directory');
+  });
+
+  it('allows a symlink whose target content points outside basePath', async () => {
+    const client = fsClient(basePath);
+    await client.promises.symlink('../shared/config.json', 'link');
+    expect(fs.readlinkSync(path.join(basePath, 'link'))).toBe('../shared/config.json');
   });
 
   it('still allows nested paths that stay inside basePath', async () => {

--- a/packages/insomnia/src/sync/git/__tests__/fs-client.test.ts
+++ b/packages/insomnia/src/sync/git/__tests__/fs-client.test.ts
@@ -1,0 +1,49 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { fsClient } from '../fs-client';
+
+describe('fsClient', () => {
+  let basePath: string;
+
+  beforeEach(() => {
+    basePath = fs.mkdtempSync(path.join(os.tmpdir(), 'insomnia-fs-client-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(basePath, { recursive: true, force: true });
+  });
+
+  it('reads and writes files relative to basePath', async () => {
+    const client = fsClient(basePath);
+    await client.promises.writeFile('foo.txt', 'hello');
+    expect((await client.promises.readFile('foo.txt')).toString()).toBe('hello');
+    expect(fs.readFileSync(path.join(basePath, 'foo.txt'), 'utf8')).toBe('hello');
+  });
+
+  it('rejects a path that resolves outside basePath', async () => {
+    const client = fsClient(basePath);
+    await expect(client.promises.readFile('..')).rejects.toThrow('escapes the repository directory');
+    await expect(client.promises.writeFile('../evil.txt', 'x')).rejects.toThrow('escapes the repository directory');
+  });
+
+  it('rejects a deep traversal path', async () => {
+    const client = fsClient(basePath);
+    await expect(client.promises.readFile('../../../etc/passwd')).rejects.toThrow('escapes the repository directory');
+  });
+
+  it('rejects a symlink target that resolves outside basePath', async () => {
+    const client = fsClient(basePath);
+    await expect(client.promises.symlink('link', '..')).rejects.toThrow('escapes the repository directory');
+  });
+
+  it('still allows nested paths that stay inside basePath', async () => {
+    const client = fsClient(basePath);
+    await client.promises.mkdir('nested', { recursive: true });
+    await client.promises.writeFile('nested/foo.txt', 'hello');
+    expect((await client.promises.readFile('nested/foo.txt')).toString()).toBe('hello');
+  });
+});

--- a/packages/insomnia/src/sync/git/fs-client.ts
+++ b/packages/insomnia/src/sync/git/fs-client.ts
@@ -13,6 +13,17 @@ type FSWraps =
   | typeof fs.promises.readlink
   | typeof fs.promises.symlink;
 
+// path.normalize() leaves a leading ".." untouched, so a bare ".." path must be rejected
+// explicitly to keep every resolved path inside basePath.
+const resolveWithinBase = (basePath: string, relativePath: string): string => {
+  const resolved = path.join(basePath, path.normalize(relativePath));
+  const relative = path.relative(basePath, resolved);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`fsClient: path "${relativePath}" escapes the repository directory`);
+  }
+  return resolved;
+};
+
 /** This is a client for isomorphic-git. {@link https://isomorphic-git.org/docs/en/fs} */
 export const fsClient = (basePath: string) => {
   console.log(`[fsClient] Created in ${basePath}`);
@@ -21,7 +32,7 @@ export const fsClient = (basePath: string) => {
   const wrap =
     (fn: FSWraps) =>
     async (filePath: string, ...args: any[]) => {
-      const modifiedPath = path.join(basePath, path.normalize(filePath));
+      const modifiedPath = resolveWithinBase(basePath, filePath);
 
       // @ts-expect-error -- TSCONVERSION
       return fn(modifiedPath, ...args);
@@ -30,8 +41,8 @@ export const fsClient = (basePath: string) => {
   const wrapSymlink =
     (fn: typeof fs.promises.symlink) =>
     async (filePath: string, target: string, ...args: any[]) => {
-      const modifiedPath = path.join(basePath, path.normalize(filePath));
-      const modifiedTarget = path.join(basePath, path.normalize(target));
+      const modifiedPath = resolveWithinBase(basePath, filePath);
+      const modifiedTarget = resolveWithinBase(basePath, target);
 
       return fn(modifiedPath, modifiedTarget, ...args);
     };

--- a/packages/insomnia/src/sync/git/fs-client.ts
+++ b/packages/insomnia/src/sync/git/fs-client.ts
@@ -40,11 +40,12 @@ export const fsClient = (basePath: string) => {
 
   const wrapSymlink =
     (fn: typeof fs.promises.symlink) =>
-    async (filePath: string, target: string, ...args: any[]) => {
+    // Node's symlink signature is (target, path): target is the arbitrary text stored as the
+    // link's contents (not itself a location to contain), path is where the link file is created.
+    async (target: string, filePath: string, ...args: any[]) => {
       const modifiedPath = resolveWithinBase(basePath, filePath);
-      const modifiedTarget = resolveWithinBase(basePath, target);
 
-      return fn(modifiedPath, modifiedTarget, ...args);
+      return fn(target, modifiedPath, ...args);
     };
 
   return {


### PR DESCRIPTION
## Summary
- Add containment checks to `restoreBackup`, the `readOrCreateDataDir` IPC handler, and the git fs client so a supplied path/segment can't resolve outside the directory each is meant to operate in.
- Extract the userData folder guard into its own module (`path-guard.ts`) so it's unit-testable without pulling in Electron.
- Fix the git fs client's symlink wrapper to only contain the link's own on-disk location, not its target content — the target is arbitrary stored text (e.g. `../shared/config.json`), not a location, so containing it broke legitimate repos with outward-pointing symlinks.

## Test plan
- [x] `npx eslint` clean on all changed files
- [x] `npx tsc --noEmit` clean
- [x] New regression tests added (`backup.test.ts`, `fs-client.test.ts`, `is-path-inside-dir.test.ts`) covering normal use, path traversal, and the outward-pointing symlink case
- [x] Full package test suite passes: 170 files / 2370 tests, 0 failures