### PR TITLE
fix(network): send fully rendered request for SSE connections

### DIFF
--- a/packages/insomnia/setup-vitest.ts
+++ b/packages/insomnia/setup-vitest.ts
@@ -14,7 +14,8 @@ await initDatabase(mainDatabase, { inMemoryOnly: true }, true);
 await initServices(servicesNodeImpl);
 initRuntime(nodeRuntime);
 
-vi.mock('electron', () => ({ default: electronMock }));
+// spread as named exports too, so `import { ipcMain, BrowserWindow, app } from 'electron'` resolves
+vi.mock('electron', () => ({ default: electronMock, ...electronMock }));
 
 vi.mock('uuid', () => ({
   v4: () => v4Mock(),

--- a/packages/insomnia/src/__mocks__/electron.ts
+++ b/packages/insomnia/src/__mocks__/electron.ts
@@ -19,6 +19,7 @@ const remote = {
     },
 
     exit: vi.fn(),
+    on: vi.fn(),
   },
   net: {
     request() {

--- a/packages/insomnia/src/main/network/curl.test.ts
+++ b/packages/insomnia/src/main/network/curl.test.ts
@@ -1,0 +1,112 @@
+// @ts-nocheck
+import { Curl } from '@getinsomnia/node-libcurl';
+import electron from 'electron';
+import { services } from 'insomnia-data';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { registerCurlHandlers } from './curl';
+
+// `openCurlConnection` isn't exported (it's only wired up via `ipcMainHandle`), so we
+// register the real handlers once and pull the handler function out of the mocked
+// `electron.ipcMain.handle` calls instead of exporting an internal for tests only.
+let openCurlConnection: (event: unknown, options: unknown) => Promise<void>;
+
+beforeAll(() => {
+  registerCurlHandlers();
+  const call = electron.ipcMain.handle.mock.calls.find(([channel]) => channel === 'curl.open');
+  openCurlConnection = call[1];
+});
+
+const baseRenderedRequest = (overrides: Record<string, unknown> = {}) => ({
+  _id: `req_curl_test_${Math.random().toString(36).slice(2)}`,
+  parentId: 'wrk_curl_test',
+  name: 'Test',
+  method: 'GET',
+  url: 'https://example.com',
+  headers: [],
+  body: {},
+  authentication: { type: 'none' },
+  parameters: [],
+  pathParameters: [],
+  settingSendCookies: false,
+  settingStoreCookies: false,
+  settingFollowRedirects: 'global',
+  settingRebuildPath: true,
+  cookies: [],
+  cookieJar: { cookies: [] },
+  suppressUserAgent: false,
+  ...overrides,
+});
+
+describe('openCurlConnection', () => {
+  let workspaceId: string;
+
+  beforeEach(async () => {
+    await services.settings.getOrCreate();
+    const workspace = await services.workspace.create();
+    workspaceId = workspace._id;
+  });
+
+  const setOptCallsFor = (spy: ReturnType<typeof vi.spyOn>, option: string) =>
+    spy.mock.calls.filter(([name]) => name === option);
+
+  it('sends exactly the headers on the rendered request, without re-reading a separate stored copy', async () => {
+    const setOptSpy = vi.spyOn(Curl.prototype, 'setOpt');
+    vi.spyOn(Curl.prototype, 'perform').mockImplementation(() => {});
+
+    await openCurlConnection({}, {
+      workspaceId,
+      renderedRequest: baseRenderedRequest({
+        headers: [{ name: 'Accept', value: 'text/event-stream' }],
+      }),
+    });
+
+    const httpHeaderCalls = setOptCallsFor(setOptSpy, Curl.option.HTTPHEADER);
+    expect(httpHeaderCalls).toHaveLength(1);
+    const headers: string[] = httpHeaderCalls[0][1];
+    expect(headers.filter(h => h.startsWith('Accept:'))).toEqual(['Accept: text/event-stream']);
+  });
+
+  it('signs the request using the authentication on the rendered request', async () => {
+    const setOptSpy = vi.spyOn(Curl.prototype, 'setOpt');
+    vi.spyOn(Curl.prototype, 'perform').mockImplementation(() => {});
+
+    await openCurlConnection({}, {
+      workspaceId,
+      renderedRequest: baseRenderedRequest({
+        authentication: { type: 'basic', username: 'render-user', password: 'render-pass' },
+      }),
+    });
+
+    const headers: string[] = setOptCallsFor(setOptSpy, Curl.option.HTTPHEADER)[0][1];
+    const expectedAuth = `Basic ${Buffer.from('render-user:render-pass').toString('base64')}`;
+    expect(headers).toEqual(expect.arrayContaining([`Authorization: ${expectedAuth}`]));
+  });
+
+  it('sends the body text from the rendered request as POSTFIELDS', async () => {
+    const setOptSpy = vi.spyOn(Curl.prototype, 'setOpt');
+    vi.spyOn(Curl.prototype, 'perform').mockImplementation(() => {});
+
+    await openCurlConnection({}, {
+      workspaceId,
+      renderedRequest: baseRenderedRequest({
+        method: 'POST',
+        body: { mimeType: 'application/json', text: '{"hello":"world"}' },
+      }),
+    });
+
+    const postFieldsCalls = setOptCallsFor(setOptSpy, Curl.option.POSTFIELDS);
+    expect(postFieldsCalls[0][1]).toBe('{"hello":"world"}');
+  });
+
+  it('keys the connection registry by the rendered request id, rejecting a second connect for the same id', async () => {
+    const setOptSpy = vi.spyOn(Curl.prototype, 'setOpt');
+    vi.spyOn(Curl.prototype, 'perform').mockImplementation(() => {});
+    const renderedRequest = baseRenderedRequest();
+
+    await openCurlConnection({}, { workspaceId, renderedRequest });
+    await openCurlConnection({}, { workspaceId, renderedRequest });
+
+    expect(setOptCallsFor(setOptSpy, Curl.option.HTTPHEADER)).toHaveLength(1);
+  });
+});

--- a/packages/insomnia/src/main/network/curl.ts
+++ b/packages/insomnia/src/main/network/curl.ts
@@ -4,11 +4,12 @@ import type { Readable } from 'node:stream';
 
 import { Curl, CurlFeature, CurlInfoDebug, type HeaderInfo } from '@getinsomnia/node-libcurl';
 import electron, { BrowserWindow } from 'electron';
-import type { CookieJar, RequestAuthentication, RequestHeader, Response } from 'insomnia-data';
+import type { Response } from 'insomnia-data';
 import { services } from 'insomnia-data';
 import { v4 as uuidV4 } from 'uuid';
 
 import { REALTIME_EVENTS_CHANNELS } from '~/common/constants';
+import type { RenderedRequest } from '~/common/templating/types';
 import { invariant } from '~/common/utils/invariant';
 import { insecureReadFile } from '~/main/secure-read-file';
 
@@ -17,6 +18,7 @@ import { filterClientCertificates } from '../../network/certificate';
 import { parseHeaderStrings } from '../../network/parse-header-strings';
 import { addSetCookiesToToughCookieJar } from '../../network/set-cookie-util';
 import { ipcMainHandle, ipcMainOn } from '../ipc/electron';
+import { getAuthHeader } from './get-auth-header';
 import { createConfiguredCurlInstance } from './libcurl-promise';
 
 export interface CurlConnection extends Curl {
@@ -105,90 +107,85 @@ const parseHeadersAndBuildTimeline = (url: string, headersWithStatus: HeaderInfo
   return { timeline, responseHeaders, statusCode, statusMessage, httpVersion };
 };
 interface OpenCurlRequestOptions {
-  requestId: string;
   workspaceId: string;
-  url: string;
-  headers: RequestHeader[];
-  authHeader?: { name: string; value: string };
-  authentication: RequestAuthentication;
-  cookieJar: CookieJar;
+  renderedRequest: RenderedRequest;
   initialPayload?: string;
-  suppressUserAgent: boolean;
 }
 const openCurlConnection = async (
   _event: Electron.IpcMainInvokeEvent,
   options: OpenCurlRequestOptions,
 ): Promise<void> => {
-  const existingConnection = CurlConnections.get(options.requestId);
+  const { workspaceId, renderedRequest: req } = options;
+  const requestId = req._id;
+  const existingConnection = CurlConnections.get(requestId);
 
   if (existingConnection) {
     console.warn('Connection still open to ' + existingConnection.getInfo(Curl.info.EFFECTIVE_URL));
     return;
   }
-  const request = await services.request.getById(options.requestId);
   const responseId = generateId('res');
-  if (!request) {
-    console.warn('Could not find request for ' + options.requestId);
-    return;
-  }
 
   const responsesDir = path.join(process.env['INSOMNIA_DATA_PATH'] || electron.app.getPath('userData'), 'responses');
 
   const responseBodyPath = path.join(responsesDir, uuidV4() + '.response');
-  eventLogFileStreams.set(options.requestId, fs.createWriteStream(responseBodyPath));
+  eventLogFileStreams.set(requestId, fs.createWriteStream(responseBodyPath));
   const timelinePath = path.join(responsesDir, responseId + '.timeline');
-  timelineFileStreams.set(options.requestId, fs.createWriteStream(timelinePath));
-  requestIdToResponseIdMap.set(options.requestId, responseId);
+  timelineFileStreams.set(requestId, fs.createWriteStream(timelinePath));
+  requestIdToResponseIdMap.set(requestId, responseId);
 
-  const workspaceMeta = await services.workspaceMeta.getOrCreateByParentId(options.workspaceId);
+  const workspaceMeta = await services.workspaceMeta.getOrCreateByParentId(workspaceId);
   const environmentId: string = workspaceMeta.activeEnvironmentId || 'n/a';
   const environment = await services.environment.getById(environmentId || 'n/a');
   const responseEnvironmentId = environment ? environment._id : null;
 
-  const caCert = await services.caCertificate.getByParentId(options.workspaceId);
+  const caCert = await services.caCertificate.getByParentId(workspaceId);
   const caCertficatePath = caCert?.path || null;
   const caCertificate = caCertficatePath && (await insecureReadFile(caCertficatePath));
 
   try {
-    invariant(options.url, 'URL must be defined');
-    invariant(!options.url.startsWith('file://'), 'Local file URIs are not supported');
+    invariant(req.url, 'URL must be defined');
+    invariant(!req.url.startsWith('file://'), 'Local file URIs are not supported');
 
-    const readyStateChannel = `${protocolName}.${request._id}.${REALTIME_EVENTS_CHANNELS.READY_STATE}`;
+    const readyStateChannel = `${protocolName}.${requestId}.${REALTIME_EVENTS_CHANNELS.READY_STATE}`;
 
     const settings = await services.settings.get();
     const start = performance.now();
-    const clientCertificates = await services.clientCertificate.findByParentId(options.workspaceId);
-    const filteredClientCertificates = filterClientCertificates(clientCertificates, options.url, 'https:');
+    const clientCertificates = await services.clientCertificate.findByParentId(workspaceId);
+    const filteredClientCertificates = filterClientCertificates(clientCertificates, req.url, 'https:');
 
+    const { header: authHeader, timeline: authTimeline } = await getAuthHeader(req, req.url);
+    authTimeline?.forEach(entry => timelineFileStreams.get(requestId)?.write(JSON.stringify(entry) + '\n'));
+
+    // request-level `cookies` aren't resolved for realtime connections (unlike the plain HTTP
+    // send path), so cookie sending relies entirely on the cookie jar file below.
     const { curl, debugTimeline } = await createConfiguredCurlInstance({
-      req: { ...request, cookieJar: options.cookieJar, cookies: [], suppressUserAgent: options.suppressUserAgent },
-      finalUrl: options.url,
+      req: { ...req, cookies: [] },
       settings,
       caCert: caCertificate,
       certificates: filteredClientCertificates,
     });
     // set method
-    curl.setOpt(Curl.option.CUSTOMREQUEST, request.method);
+    curl.setOpt(Curl.option.CUSTOMREQUEST, req.method);
     // TODO: support all post data content types
-    curl.setOpt(Curl.option.POSTFIELDS, request.body?.text || '');
-    debugTimeline.forEach(entry => timelineFileStreams.get(options.requestId)?.write(JSON.stringify(entry) + '\n'));
-    CurlConnections.set(options.requestId, curl);
-    CurlConnections.get(options.requestId)?.enable(CurlFeature.StreamResponse);
-    const headerStrings = parseHeaderStrings({ req: request, finalUrl: options.url, authHeader: options.authHeader });
+    curl.setOpt(Curl.option.POSTFIELDS, req.body?.text || '');
+    debugTimeline.forEach(entry => timelineFileStreams.get(requestId)?.write(JSON.stringify(entry) + '\n'));
+    CurlConnections.set(requestId, curl);
+    CurlConnections.get(requestId)?.enable(CurlFeature.StreamResponse);
+    const headerStrings = parseHeaderStrings({ req, finalUrl: req.url, authHeader });
 
-    CurlConnections.get(options.requestId)?.setOpt(Curl.option.HTTPHEADER, headerStrings);
-    CurlConnections.get(options.requestId)?.on('error', async (error, errorCode) => {
+    CurlConnections.get(requestId)?.setOpt(Curl.option.HTTPHEADER, headerStrings);
+    CurlConnections.get(requestId)?.on('error', async (error, errorCode) => {
       const errorEvent: CurlErrorEvent = {
         _id: uuidV4(),
-        requestId: options.requestId,
+        requestId,
         message: error.message,
         type: 'error',
         error,
         timestamp: Date.now(),
       };
       console.error('curl - error:', error, errorCode);
-      CurlConnections.get(options.requestId)?.close();
-      deleteRequestMaps(request._id, error.message, errorEvent);
+      CurlConnections.get(requestId)?.close();
+      deleteRequestMaps(requestId, error.message, errorEvent);
       for (const window of BrowserWindow.getAllWindows()) {
         window.webContents.send(readyStateChannel, false);
       }
@@ -197,7 +194,7 @@ const openCurlConnection = async (
         if (!res) {
           createErrorResponse(
             responseId,
-            request._id,
+            requestId,
             responseEnvironmentId,
             timelinePath,
             error.message || 'Something went wrong creating curl response',
@@ -206,7 +203,7 @@ const openCurlConnection = async (
       }
     });
 
-    CurlConnections.get(options.requestId)?.setOpt(Curl.option.DEBUGFUNCTION, (infoType, buffer) => {
+    CurlConnections.get(requestId)?.setOpt(Curl.option.DEBUGFUNCTION, (infoType, buffer) => {
       const isSSLData = infoType === CurlInfoDebug.SslDataIn || infoType === CurlInfoDebug.SslDataOut;
       const isEmpty = buffer.length === 0;
       // Don't show cookie setting because this will display every domain in the jar
@@ -230,80 +227,80 @@ const openCurlConnection = async (
         name = 'Text';
       }
       const value = timelineMessage || buffer.toString('utf8');
-      timelineFileStreams.get(options.requestId)?.write(JSON.stringify({ name, value, timestamp: Date.now() }) + '\n');
+      timelineFileStreams.get(requestId)?.write(JSON.stringify({ name, value, timestamp: Date.now() }) + '\n');
       return 0;
     });
 
-    CurlConnections.get(options.requestId)?.on(
+    CurlConnections.get(requestId)?.on(
       'stream',
       async (stream: Readable, _code: number, [headersWithStatus]: HeaderInfo[]) => {
         for (const window of BrowserWindow.getAllWindows()) {
           window.webContents.send(readyStateChannel, true);
         }
         const { timeline, responseHeaders, statusCode, statusMessage, httpVersion } = parseHeadersAndBuildTimeline(
-          options.url,
+          req.url,
           headersWithStatus,
         );
 
         const responsePatch: Partial<Response> = {
           _id: responseId,
-          parentId: request._id,
+          parentId: requestId,
           environmentId: responseEnvironmentId,
           headers: responseHeaders,
-          url: options.url,
+          url: req.url,
           statusCode,
           statusMessage,
           httpVersion,
           elapsedTime: performance.now() - start,
           timelinePath,
           bodyPath: responseBodyPath,
-          settingSendCookies: request.settingSendCookies,
-          settingStoreCookies: request.settingStoreCookies,
+          settingSendCookies: req.settingSendCookies,
+          settingStoreCookies: req.settingStoreCookies,
           bodyCompression: null,
         };
         const settings = await services.settings.get();
         const res = await services.response.create(responsePatch, settings.maxHistoryResponses);
-        services.requestMeta.updateOrCreateByParentId(request._id, { activeResponseId: res._id });
+        services.requestMeta.updateOrCreateByParentId(requestId, { activeResponseId: res._id });
 
-        if (request.settingStoreCookies) {
+        if (req.settingStoreCookies) {
           const setCookieStrings: string[] = getSetCookieHeaders(responseHeaders).map(h => h.value);
           const totalSetCookies = setCookieStrings.length;
           if (totalSetCookies) {
-            const currentUrl = request.url;
+            const currentUrl = req.url;
             const { cookies, rejectedCookies } = await addSetCookiesToToughCookieJar({
               setCookieStrings,
               currentUrl,
-              cookieJar: options.cookieJar,
+              cookieJar: req.cookieJar,
             });
             rejectedCookies.forEach(errorMessage =>
               timeline.push({ value: `Rejected cookie: ${errorMessage}`, name: 'Text', timestamp: Date.now() }),
             );
             const hasCookiesToPersist = totalSetCookies > rejectedCookies.length;
             if (hasCookiesToPersist) {
-              await services.cookieJar.update(options.cookieJar, { cookies });
+              await services.cookieJar.update(req.cookieJar, { cookies });
               timeline.push({ value: `Saved ${totalSetCookies} cookies`, name: 'Text', timestamp: Date.now() });
             }
           }
         }
-        timeline.map(t => timelineFileStreams.get(options.requestId)?.write(JSON.stringify(t) + '\n'));
+        timeline.map(t => timelineFileStreams.get(requestId)?.write(JSON.stringify(t) + '\n'));
 
-        invariant(eventLogFileStreams.get(request._id), 'writableStream should be defined');
+        invariant(eventLogFileStreams.get(requestId), 'writableStream should be defined');
         for await (const chunk of stream) {
           const messageEvent: CurlMessageEvent = {
             _id: uuidV4(),
-            requestId: options.requestId,
+            requestId,
             data: new TextDecoder('utf-8').decode(chunk),
             type: 'message',
             timestamp: Date.now(),
             direction: 'INCOMING',
           };
-          writeEventLogAndNotify({ requestId: options.requestId, data: JSON.stringify(messageEvent) + '\n' });
+          writeEventLogAndNotify({ requestId, data: JSON.stringify(messageEvent) + '\n' });
         }
 
         // NOTE: when stream is closed by remote server
         const closeEvent: CurlCloseEvent = {
           _id: uuidV4(),
-          requestId: options.requestId,
+          requestId,
           type: 'close',
           timestamp: Date.now(),
           statusCode,
@@ -311,8 +308,8 @@ const openCurlConnection = async (
           code: 0,
           wasClean: true,
         };
-        CurlConnections.get(options.requestId)?.close();
-        deleteRequestMaps(options.requestId, 'Closing connection', closeEvent);
+        CurlConnections.get(requestId)?.close();
+        deleteRequestMaps(requestId, 'Closing connection', closeEvent);
         for (const window of BrowserWindow.getAllWindows()) {
           window.webContents.send(readyStateChannel, false);
         }
@@ -322,10 +319,10 @@ const openCurlConnection = async (
   } catch (e) {
     console.error('unhandled error:', e);
 
-    deleteRequestMaps(request._id, e.message || 'Something went wrong opening curl connection');
+    deleteRequestMaps(requestId, e.message || 'Something went wrong opening curl connection');
     createErrorResponse(
       responseId,
-      request._id,
+      requestId,
       responseEnvironmentId,
       timelinePath,
       e.message || 'Something went wrong creating curl connection',

--- a/packages/insomnia/src/main/network/libcurl-promise.test.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.test.ts
@@ -1,0 +1,59 @@
+// @ts-nocheck
+import { Curl } from '@getinsomnia/node-libcurl';
+import { describe, expect, it } from 'vitest';
+
+import { createConfiguredCurlInstance } from './libcurl-promise';
+
+const baseReq = (overrides: Record<string, unknown> = {}) => ({
+  headers: [],
+  method: 'GET',
+  body: {},
+  authentication: {},
+  settingFollowRedirects: 'global',
+  settingRebuildPath: true,
+  settingSendCookies: false,
+  url: 'https://api.example.com/v1/messages',
+  cookieJar: { cookies: [] },
+  cookies: [],
+  suppressUserAgent: false,
+  ...overrides,
+});
+
+const baseSettings = (overrides: Record<string, unknown> = {}) => ({
+  preferredHttpVersion: 'default',
+  maxRedirects: 10,
+  proxyEnabled: true,
+  timeout: 0,
+  validateSSL: true,
+  followRedirects: true,
+  maxTimelineDataSizeKB: 1,
+  httpProxy: 'http-proxy.local:1111',
+  httpsProxy: 'https-proxy.local:2222',
+  noProxy: '',
+  dataFolders: [],
+  ...overrides,
+});
+
+describe('createConfiguredCurlInstance', () => {
+  it('picks the manual proxy matching req.url\'s protocol', async () => {
+    const { curl } = await createConfiguredCurlInstance({
+      req: baseReq(),
+      settings: baseSettings(),
+      caCert: null,
+      certificates: [],
+    });
+
+    expect(curl._options[Curl.option.PROXY]).toBe('http://https-proxy.local:2222');
+  });
+
+  it('bypasses the manual proxy when req.url\'s host matches noProxy', async () => {
+    const { curl } = await createConfiguredCurlInstance({
+      req: baseReq(),
+      settings: baseSettings({ noProxy: 'api.example.com' }),
+      caCert: null,
+      certificates: [],
+    });
+
+    expect(curl._options[Curl.option.PROXY]).toBe('');
+  });
+});

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -125,8 +125,7 @@ export const curlRequest = (options: CurlRequestOptions) =>
       const caCert = caCertficatePath && (await insecureReadFile(caCertficatePath));
 
       const { curl, debugTimeline } = await createConfiguredCurlInstance({
-        req,
-        finalUrl,
+        req: { ...req, url: finalUrl },
         settings,
         caCert,
         certificates,
@@ -343,7 +342,6 @@ export function parseResolvedProxy(pacString: string | undefined): { proxyUrl: s
 
 export const createConfiguredCurlInstance = async ({
   req,
-  finalUrl,
   settings,
   caCert,
   certificates,
@@ -351,7 +349,6 @@ export const createConfiguredCurlInstance = async ({
   noDecompress = false,
 }: {
   req: RequestUsedHere;
-  finalUrl: string;
   settings: SettingsUsedHere;
   certificates: ClientCertificate[];
   caCert: string | null;
@@ -360,6 +357,7 @@ export const createConfiguredCurlInstance = async ({
 }) => {
   const debugTimeline: ResponseTimelineEntry[] = [];
   const curl = new Curl();
+  const finalUrl = req.url;
   curl.setOpt(Curl.option.URL, finalUrl);
   socketPath && curl.setOpt(Curl.option.UNIX_SOCKET_PATH, socketPath);
 
@@ -436,7 +434,7 @@ export const createConfiguredCurlInstance = async ({
       curl.setOpt(Curl.option.PROXY, '');
     }
   } else {
-    const { protocol, hostname } = urlParse(req.url);
+    const { protocol, hostname } = urlParse(finalUrl);
     const { httpProxy, httpsProxy, noProxy } = settings;
     const proxyHost = protocol === 'https:' ? httpsProxy : httpProxy;
     const proxy = !shouldBypassProxyForHost(hostname, noProxy) && proxyHost ? setDefaultProtocol(proxyHost) : '';

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.connect.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.connect.tsx
@@ -4,6 +4,7 @@ import type {
   CookieJar,
   McpTransportType,
   RequestAuthentication,
+  RequestBody,
   RequestHeader,
 } from 'insomnia-data';
 import { models, services } from 'insomnia-data';
@@ -23,6 +24,7 @@ export interface ConnectActionParams {
   url: string;
   headers: RequestHeader[];
   authentication: RequestAuthentication;
+  body?: RequestBody;
   cookieJar: CookieJar;
   suppressUserAgent: boolean;
   transportType?: McpTransportType;
@@ -84,17 +86,7 @@ export async function clientAction({ params, request }: Route.ClientActionArgs) 
   }
   if (isEventStreamRequest(req)) {
     const renderedRequest = { ...req, ...rendered } as RenderedRequest;
-    const { header: authHeader } = await window.main.getAuthHeader(renderedRequest, rendered.url);
-    window.main.curl.open({
-      requestId,
-      workspaceId,
-      url: rendered.url,
-      headers: rendered.headers,
-      authHeader,
-      authentication: rendered.authentication,
-      cookieJar: rendered.cookieJar,
-      suppressUserAgent: rendered.suppressUserAgent,
-    });
+    window.main.curl.open({ workspaceId, renderedRequest });
     window.main.trackAnalyticsEvent({
       event: AnalyticsEvent.requestExecuted,
       properties: { request_type: 'Event Stream' },

--- a/packages/insomnia/src/ui/components/request-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/request-url-bar.tsx
@@ -207,6 +207,7 @@ export const RequestUrlBar = forwardRef<RequestUrlBarHandle, Props>(
                 url: joinUrlAndQueryString(rendered.url, buildQueryStringFromParams(rendered.parameters)),
                 headers: rendered.headers,
                 authentication: rendered.authentication,
+                body: rendered.body,
                 cookieJar: rendered.workspaceCookieJar,
                 suppressUserAgent: rendered.suppressUserAgent,
               });

--- a/packages/insomnia/src/ui/utils/render-realtime-connect.ts
+++ b/packages/insomnia/src/ui/utils/render-realtime-connect.ts
@@ -1,4 +1,4 @@
-import type { CookieJar, Request, RequestAuthentication, RequestGroup, RequestHeader, RequestParameter, SocketIORequest, WebSocketRequest } from 'insomnia-data';
+import type { CookieJar, Request, RequestAuthentication, RequestBody, RequestGroup, RequestHeader, RequestParameter, SocketIORequest, WebSocketRequest } from 'insomnia-data';
 import { models, services } from 'insomnia-data';
 
 import { database as db } from '../../common/database';
@@ -13,6 +13,7 @@ export interface RenderedRealtimeConnectPayload {
   url: string;
   headers: RequestHeader[];
   authentication: RequestAuthentication;
+  body?: RequestBody;
   parameters: RequestParameter[];
   workspaceCookieJar: CookieJar;
   suppressUserAgent: boolean;
@@ -34,6 +35,7 @@ export async function renderRealtimeConnectPayload({
   const requestGroups = ancestors.filter(isRequestGroup);
   const headers = getOrInheritHeaders({ request, requestGroups });
   const authentication = getOrInheritAuthentication({ request, requestGroups });
+  const body = 'body' in request ? request.body : undefined;
 
   const rendered = await tryToInterpolateRequestOrShowRenderErrorModal({
     request,
@@ -42,6 +44,7 @@ export async function renderRealtimeConnectPayload({
       url: request.url,
       headers,
       authentication,
+      body,
       parameters: request.parameters.filter(p => !p.disabled),
       pathParameters: request.pathParameters,
       workspaceCookieJar,
@@ -60,6 +63,7 @@ export async function renderRealtimeConnectPayload({
     url,
     headers: rendered.headers,
     authentication: rendered.authentication,
+    body: rendered.body,
     parameters: rendered.parameters,
     workspaceCookieJar: rendered.workspaceCookieJar,
     suppressUserAgent,


### PR DESCRIPTION
[INS-3637](https://konghq.atlassian.net/browse/INS-3637)

## Summary
- SSE ("Event Stream") sends re-fetched the raw, unrendered request from the database instead of using the already-rendered/de-duplicated/interpolated request the renderer had computed, so headers/authentication/body reaching curl could diverge from what the user configured.
- `openCurlConnection` now takes one fully-rendered request object (`{ workspaceId, renderedRequest, initialPayload? }`) instead of piecemeal fields, drops the redundant DB read, and computes the auth header in-process via `getAuthHeader` instead of a separate IPC round trip.
- Fixed `createConfiguredCurlInstance`'s manual-proxy branch, which resolved protocol/hostname from the raw stored URL instead of the request's actual URL.
- Added `curl.test.ts` and `libcurl-promise.test.ts`; patched shared test infra (`setup-vitest.ts`, `src/__mocks__/electron.ts`) so named imports from `electron` resolve under the mock and `electron.app.on(...)` doesn't throw.

## Test plan
- [x] `npx tsc --noEmit` clean on changed files
- [x] `npx eslint` clean on changed files
- [x] `npx vitest run` — full suite: 162 files / 2244 passed, 15 pre-existing skips
- [x] Manually verify an SSE request (e.g. POST with `Accept: text/event-stream` to a streaming API) sends the expected single Accept header and correct body/auth

[INS-3637]: https://konghq.atlassian.net/browse/INS-3637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ