### PR TITLE
feat(ui): split environment picker into project/collection dropdowns

### DIFF
--- a/packages/insomnia-data/common-src/hotkeys.ts
+++ b/packages/insomnia-data/common-src/hotkeys.ts
@@ -18,7 +18,8 @@ export const keyboardShortcutDescriptions: Record<KeyboardShortcut, string> = {
   request_send: 'Send Request',
   request_showOptions: 'Send Request (Options)',
   environment_showEditor: 'Show Environment Editor',
-  environment_showSwitchMenu: 'Switch Environments',
+  environment_showSwitchMenu: 'Switch Collection Environments',
+  environment_showSwitchProjectMenu: 'Switch Project Environments',
   request_toggleHttpMethodMenu: 'Change HTTP Method',
   request_toggleHistory: 'Show Request History',
   request_focusUrl: 'Focus URL',
@@ -98,6 +99,10 @@ const defaultRegistry: HotKeyRegistry = {
   environment_showSwitchMenu: {
     macKeys: [{ shift: true, meta: true, keyCode: keyboardKeys.e.keyCode }],
     winLinuxKeys: [{ ctrl: true, shift: true, keyCode: keyboardKeys.e.keyCode }],
+  },
+  environment_showSwitchProjectMenu: {
+    macKeys: [{ alt: true, meta: true, keyCode: keyboardKeys.e.keyCode }],
+    winLinuxKeys: [{ ctrl: true, alt: true, keyCode: keyboardKeys.e.keyCode }],
   },
   request_toggleHttpMethodMenu: {
     macKeys: [{ shift: true, meta: true, keyCode: keyboardKeys.l.keyCode }],

--- a/packages/insomnia-data/common-src/settings.ts
+++ b/packages/insomnia-data/common-src/settings.ts
@@ -40,6 +40,7 @@ export type KeyboardShortcut =
   | 'request_showOptions'
   | 'environment_showEditor'
   | 'environment_showSwitchMenu'
+  | 'environment_showSwitchProjectMenu'
   | 'request_toggleHttpMethodMenu'
   | 'request_toggleHistory'
   | 'request_focusUrl'

--- a/packages/insomnia-smoke-test/tests/migration/local-to-cloud-projects.test.ts
+++ b/packages/insomnia-smoke-test/tests/migration/local-to-cloud-projects.test.ts
@@ -30,7 +30,7 @@ testWithLegacyDatabase('Run data migration to version 8', async ({ page, userCon
 
   // Open migrated local migrated collection that should have Git Sync
   await page.getByLabel('Local Collection').click();
-  await page.getByRole('button', { name: 'Manage Environments' }).click();
+  await page.getByLabel('Select a Collection Environment').click();
   await page.getByLabel('Select a Collection').getByRole('option', { name: 'Mars' }).press('Enter');
   await page.locator('body').click();
   // The collection is moved to a local project

--- a/packages/insomnia-smoke-test/tests/smoke/after-response-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/after-response-script-features.test.ts
@@ -81,7 +81,7 @@ test.describe('after-response script features tests', () => {
     await expect.soft(statusTag1).toContainText('200 OK');
 
     // verify persisted environment
-    await page.getByRole('button', { name: 'Manage Environments' }).click();
+    await page.getByLabel('Select a Collection Environment').click();
     await page.getByRole('button', { name: 'Manage collection environments' }).click();
     const responseBody = page.getByRole('dialog').getByTestId('CodeEditor').locator('.CodeMirror-line');
     const rows1 = await responseBody.allInnerTexts();
@@ -100,9 +100,7 @@ test.describe('after-response script features tests', () => {
     await page.locator('body').click();
     await insomnia.navigationSidebar.clickRequestOrFolder('persist global environment');
     // activate global sub environment
-    await page.getByLabel('Manage Environments').click();
-    await page.getByPlaceholder('Choose a project environment').click();
-    await page.getByRole('option', { name: 'Script Environment' }).click();
+    await page.getByLabel('Select a Project Environment').click();
     await page.getByRole('option', { name: 'Sub Script Env' }).click();
     await page.locator('body').click();
     // send
@@ -119,8 +117,8 @@ test.describe('after-response script features tests', () => {
     await page.getByText('log: globals sub').click();
     await page.getByText('log: baseGlobals base').click();
     // view sub environment has been updated
-    await page.getByLabel('Manage Environments').click();
-    await page.getByLabel('Manage project environment').click();
+    await page.getByLabel('Select a Project Environment').click();
+    await page.getByLabel('Edit Script Environment').click();
     await page.getByLabel('Environment name').getByText('Sub Script Env').first().click();
     let globalSubEditor = page.getByTestId('CodeEditor').locator('.CodeMirror-line');
     let globalSubRows = await globalSubEditor.allInnerTexts();

--- a/packages/insomnia-smoke-test/tests/smoke/after-response-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/after-response-script-features.test.ts
@@ -6,7 +6,11 @@ import { test } from '../../playwright/test';
 test.describe('after-response script features tests', () => {
   test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
 
-  test('after-response scripts: transient vars, assertions, and environment/global persistence', async ({ page, app, insomnia }) => {
+  test('after-response scripts: transient vars, assertions, and environment/global persistence', async ({
+    page,
+    app,
+    insomnia,
+  }) => {
     // import global environment
     const globalEnvText = await loadFixture('script-global-environment.yaml');
     await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), globalEnvText);
@@ -118,6 +122,7 @@ test.describe('after-response script features tests', () => {
     await page.getByText('log: baseGlobals base').click();
     // view sub environment has been updated
     await page.getByLabel('Select a Project Environment').click();
+    await page.getByRole('option', { name: 'Script Environment', exact: true }).hover();
     await page.getByLabel('Edit Script Environment').click();
     await page.getByLabel('Environment name').getByText('Sub Script Env').first().click();
     let globalSubEditor = page.getByTestId('CodeEditor').locator('.CodeMirror-line');
@@ -139,7 +144,11 @@ test.describe('after-response script features tests', () => {
     });
   });
 
-  test('insomnia.expect covers each matcher (equal/property/lengthOf/include/within/keys) and test.skip is reported', async ({ page, app, insomnia }) => {
+  test('insomnia.expect covers each matcher (equal/property/lengthOf/include/within/keys) and test.skip is reported', async ({
+    page,
+    app,
+    insomnia,
+  }) => {
     const text = await loadFixture('after-response-collection.yaml');
     await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
 

--- a/packages/insomnia-smoke-test/tests/smoke/environment-cascade.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/environment-cascade.test.ts
@@ -41,7 +41,7 @@ test.describe('environment cascade / override', () => {
   };
 
   const selectEnvironment = async (page: Page, insomnia: any, environmentName: string, requestName: string) => {
-    await page.getByRole('button', { name: 'Manage Environments' }).click();
+    await page.getByLabel('Select a Collection Environment').click();
     // wait for the Manage Environments dialog to close before interacting with the picker
     await page.getByRole('heading', { name: 'Manage Environments' }).waitFor({ state: 'hidden' });
 

--- a/packages/insomnia-smoke-test/tests/smoke/environment-editor-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/environment-editor-interactions.test.ts
@@ -16,10 +16,9 @@ test.describe('Environment Editor', () => {
     await page.getByRole('dialog').waitFor({ state: 'hidden' });
 
     // create a new shared environment (becomes active on creation)
-    await page.getByRole('button', { name: 'Manage Environments' }).click();
+    await page.getByLabel('Select a Collection Environment').click();
     await page.getByRole('button', { name: 'Manage collection environments' }).click();
-    await page.getByTestId('CreateEnvironmentDropdown').click();
-    await page.getByRole('menuitemradio', { name: 'Shared Environment' }).press('Enter');
+    await page.getByTestId('AddSubEnvironment').click();
 
     // wait for the new row to appear before clicking it
     await page.getByRole('row', { name: 'New Environment' }).waitFor({ state: 'visible' });
@@ -44,7 +43,7 @@ test.describe('Environment Editor', () => {
     await expect.soft(page.getByText('baseenv1')).toBeVisible();
 
     // duplicate ExampleA and rename the copy to Gandalf
-    await page.getByRole('button', { name: 'Manage Environments' }).click();
+    await page.getByLabel('Select a Collection Environment').click();
     await page.getByRole('button', { name: 'Manage collection environments' }).click();
     await page.getByRole('row', { name: 'ExampleA' }).getByLabel('Environment Actions').click();
     await page.getByText('Duplicate').click();
@@ -81,7 +80,7 @@ test.describe('Environment Editor', () => {
     await expect.soft(page.getByText('subenvB1')).toBeVisible();
 
     // add new variables to Gandalf via JSON editor
-    await page.getByRole('button', { name: 'Manage Environments' }).click();
+    await page.getByLabel('Select a Collection Environment').click();
     await page.getByRole('button', { name: 'Manage collection environments' }).click();
     await page.locator('pre').filter({ hasText: '"exampleNumber": 2222,' }).click();
     const dialog = page.getByRole('dialog');
@@ -100,7 +99,7 @@ test.describe('Environment Editor', () => {
     await insomnia.navigationSidebar.clickRequestOrFolder('New Request');
 
     // switch to table view and edit Gandalf environment
-    await page.getByRole('button', { name: 'Manage Environments' }).click();
+    await page.getByLabel('Select a Collection Environment').click();
     await page.getByRole('button', { name: 'Manage collection environments' }).click();
 
     // explicitly select Gandalf so table edits target the correct sub-environment
@@ -217,7 +216,7 @@ test.describe('Environment Editor', () => {
     await page.getByRole('dialog').waitFor({ state: 'hidden' });
 
     // activate ExampleA environment
-    await page.getByRole('button', { name: 'Manage Environments' }).click();
+    await page.getByLabel('Select a Collection Environment').click();
     await page.getByRole('option', { name: 'ExampleA' }).press('Enter');
     await page.getByRole('option', { name: 'ExampleA' }).press('Escape');
 
@@ -230,7 +229,7 @@ test.describe('Environment Editor', () => {
     await expect.soft(page.getByText('subenvA0')).toBeVisible();
 
     // open env editor, select ExampleA, switch to table view, disable exampleString
-    await page.getByRole('button', { name: 'Manage Environments' }).click();
+    await page.getByLabel('Select a Collection Environment').click();
     await page.getByRole('button', { name: 'Manage collection environments' }).click();
     await page.getByLabel('Environments', { exact: true }).getByText('ExampleA').click();
     await page.getByRole('button', { name: 'Table Edit' }).click();
@@ -260,5 +259,67 @@ test.describe('Environment Editor', () => {
     await page.getByRole('tab', { name: 'Console' }).click();
     await expect.soft(page.getByText('baseenv0')).toBeVisible();
     await expect.soft(page.getByText('subenvA0')).toBeHidden();
+  });
+
+  test('project and collection environment dropdowns open and close independently', async ({ page }) => {
+    await page.getByRole('button', { name: 'Create request collection', exact: true }).click();
+
+    const projectListbox = page.getByRole('listbox', { name: 'Select a Project Environment' });
+    const collectionListbox = page.getByRole('listbox', { name: 'Select a Collection Environment' });
+
+    // opening the collection dropdown does not open the project dropdown
+    await page.getByLabel('Select a Collection Environment').click();
+    await expect.soft(collectionListbox).toBeVisible();
+    await expect.soft(projectListbox).toBeHidden();
+    await page.keyboard.press('Escape');
+    await expect.soft(collectionListbox).toBeHidden();
+
+    // opening the project dropdown does not open the collection dropdown
+    await page.getByLabel('Select a Project Environment').click();
+    await expect.soft(projectListbox).toBeVisible();
+    await expect.soft(collectionListbox).toBeHidden();
+    await page.keyboard.press('Escape');
+    await expect.soft(projectListbox).toBeHidden();
+  });
+
+  test('Add Project Environment creates a project environment without activating it', async ({ page, insomnia }) => {
+    await page.getByRole('button', { name: 'Create request collection', exact: true }).click();
+
+    // the "+" button in the project dropdown header opens the create-workspace modal
+    await page.getByLabel('Select a Project Environment').click();
+    await page.getByLabel('Add Project Environment').click();
+    await page.getByPlaceholder('Enter a name for your Environment').fill('My New Project Env');
+    await page.getByRole('button', { name: 'Create', exact: true }).click();
+
+    // creating navigates into the new environment's own page; go back to the collection
+    await insomnia.navigationSidebar.selectWorkspace('My first collection');
+
+    // the new environment shows up in the project dropdown's list, but is not auto-selected
+    await expect.soft(page.getByLabel('Select a Project Environment')).toContainText('No Project Environment');
+    await page.getByLabel('Select a Project Environment').click();
+    await expect.soft(page.getByRole('option', { name: 'My New Project Env' })).toBeVisible();
+  });
+
+  test('Add Sub Environment and Add Private Sub Environment create environments with the correct privacy', async ({ page }) => {
+    await page.getByRole('button', { name: 'Create request collection', exact: true }).click();
+
+    await page.getByLabel('Select a Collection Environment').click();
+    await page.getByRole('button', { name: 'Manage collection environments' }).click();
+
+    // create the shared sub-environment and rename it so it can be told apart from the private one
+    await page.getByTestId('AddSubEnvironment').click();
+    const sharedRow = page.getByRole('row', { name: 'New Environment' });
+    await sharedRow.waitFor({ state: 'visible' });
+    await sharedRow.locator('[data-editable=true]').dblclick();
+    await sharedRow.locator('input').fill('Shared Sub Env');
+    await sharedRow.locator('input').press('Enter');
+    await page.getByRole('row', { name: 'Shared Sub Env' }).waitFor({ state: 'visible' });
+    await expect.soft(page.getByRole('row', { name: 'Shared Sub Env' }).locator('.fa-lock')).toHaveCount(0);
+
+    // create the private sub-environment
+    await page.getByTestId('AddPrivateSubEnvironment').click();
+    const privateRow = page.getByRole('row', { name: 'New Environment' });
+    await privateRow.waitFor({ state: 'visible' });
+    await expect.soft(privateRow.locator('.fa-lock')).toBeVisible();
   });
 });

--- a/packages/insomnia-smoke-test/tests/smoke/environment-editor-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/environment-editor-interactions.test.ts
@@ -294,7 +294,7 @@ test.describe('Environment Editor', () => {
     await page.getByLabel('Add Project Environment').click();
     await page.getByPlaceholder('Enter a name for your Environment').fill('My New Project Env');
     await page.getByRole('button', { name: 'Create', exact: true }).click();
-    await expect.soft(insomnia.navigationSidebar.workspaceRow('My New Project Env')).toBeVisible();
+    await page.getByRole('dialog', { name: 'Create or update dialog' }).waitFor({ state: 'hidden' });
     await insomnia.pressEscape();
 
     // creating navigates into the new environment's own page; go back to the collection

--- a/packages/insomnia-smoke-test/tests/smoke/environment-editor-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/environment-editor-interactions.test.ts
@@ -24,7 +24,7 @@ test.describe('Environment Editor', () => {
     await page.getByRole('row', { name: 'New Environment' }).waitFor({ state: 'visible' });
     await page.getByRole('row', { name: 'New Environment' }).click();
     await page.getByRole('dialog').getByRole('button', { name: 'Close' }).click();
-    
+
     // wait for the Manage Environments dialog to close before interacting with the picker
     await page.getByRole('heading', { name: 'Manage Environments' }).waitFor({ state: 'hidden' });
 
@@ -35,7 +35,7 @@ test.describe('Environment Editor', () => {
     // send request: verify variables fall back to base env (new env is empty)
     await insomnia.navigationSidebar.clickRequestOrFolder('New Request');
     await page.getByRole('button', { name: 'Send' }).click();
-    
+
     // wait for a response before switching to console
     await page.locator('[data-testid="response-status-tag"]:visible').waitFor({ state: 'visible', timeout: 25_000 });
     await page.getByRole('tab', { name: 'Console' }).click();
@@ -91,7 +91,7 @@ test.describe('Environment Editor', () => {
 
     // blur the editor before closing so the debounce flush is triggered by the button's mousedown
     await dialog.getByRole('button', { name: 'Close' }).click();
-    
+
     // wait for the Manage Environments dialog to fully close before navigating
     await page.getByRole('heading', { name: 'Manage Environments' }).waitFor({ state: 'hidden' });
     await page.getByLabel('Manage collection environments').press('Escape');
@@ -166,14 +166,14 @@ test.describe('Environment Editor', () => {
     await page.getByRole('menuitemradio', { name: 'JSON' }).click();
     await waitForSync();
     await secondRow.getByRole('button', { name: 'Edit JSON' }).click();
-    
+
     // wait for the JSON modal before typing
     await page.getByRole('dialog').getByTestId('CodeEditor').waitFor({ state: 'visible' });
     const bodyEditor = page.getByRole('dialog').getByTestId('CodeEditor').getByRole('textbox');
     await bodyEditor.focus();
     await page.keyboard.press('ControlOrMeta+a');
     await page.keyboard.type('{"anotherString":"kvAnotherStr","anotherNumber": 12345}');
-    
+
     // submit and wait for the JSON modal to fully close before proceeding
     await page.getByRole('button', { name: 'Modal Submit' }).click();
     await page.getByRole('dialog', { name: 'Modal' }).waitFor({ state: 'hidden' });
@@ -186,7 +186,9 @@ test.describe('Environment Editor', () => {
     // dismiss the environment picker dropdown if it appeared
     await page.locator('body').click();
     try {
-      await page.getByRole('listbox', { name: 'Select a Collection Environment' }).waitFor({ state: 'hidden', timeout: 3000 });
+      await page
+        .getByRole('listbox', { name: 'Select a Collection Environment' })
+        .waitFor({ state: 'hidden', timeout: 3000 });
     } catch {
       await page.keyboard.press('Escape');
     }
@@ -245,7 +247,9 @@ test.describe('Environment Editor', () => {
     // dismiss the environment picker dropdown if it appeared
     await page.locator('body').click();
     try {
-      await page.getByRole('listbox', { name: 'Select a Collection Environment' }).waitFor({ state: 'hidden', timeout: 3000 });
+      await page
+        .getByRole('listbox', { name: 'Select a Collection Environment' })
+        .waitFor({ state: 'hidden', timeout: 3000 });
     } catch {
       await page.keyboard.press('Escape');
     }
@@ -290,6 +294,8 @@ test.describe('Environment Editor', () => {
     await page.getByLabel('Add Project Environment').click();
     await page.getByPlaceholder('Enter a name for your Environment').fill('My New Project Env');
     await page.getByRole('button', { name: 'Create', exact: true }).click();
+    await expect.soft(insomnia.navigationSidebar.workspaceRow('My New Project Env')).toBeVisible();
+    await insomnia.pressEscape();
 
     // creating navigates into the new environment's own page; go back to the collection
     await insomnia.navigationSidebar.selectWorkspace('My first collection');
@@ -300,7 +306,9 @@ test.describe('Environment Editor', () => {
     await expect.soft(page.getByRole('option', { name: 'My New Project Env' })).toBeVisible();
   });
 
-  test('Add Sub Environment and Add Private Sub Environment create environments with the correct privacy', async ({ page }) => {
+  test('Add Sub Environment and Add Private Sub Environment create environments with the correct privacy', async ({
+    page,
+  }) => {
     await page.getByRole('button', { name: 'Create request collection', exact: true }).click();
 
     await page.getByLabel('Select a Collection Environment').click();

--- a/packages/insomnia-smoke-test/tests/smoke/focus-and-keyboard.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/focus-and-keyboard.test.ts
@@ -52,10 +52,9 @@ test.describe('Focus and keyboard navigation', () => {
   test('the KV environment editor focuses the blank row Name', async ({ page }) => {
     await page.getByRole('button', { name: 'Create request collection', exact: true }).click();
 
-    await page.getByRole('button', { name: 'Manage Environments' }).click();
+    await page.getByLabel('Select a Collection Environment').click();
     await page.getByRole('button', { name: 'Manage collection environments' }).click();
-    await page.getByTestId('CreateEnvironmentDropdown').click();
-    await page.getByRole('menuitemradio', { name: 'Shared Environment' }).press('Enter');
+    await page.getByTestId('AddSubEnvironment').click();
 
     // New environments default to KV mode, so selecting the new (empty) environment renders the KV
     // editor whose trailing blank row's Name should be focused.

--- a/packages/insomnia-smoke-test/tests/smoke/global-environments.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/global-environments.test.ts
@@ -29,8 +29,7 @@ test.describe('Global Environments', () => {
     await page.getByRole('button', { name: 'Send' }).click();
     await page.getByRole('heading', { name: '2 environment variables are' }).click();
     await page.getByRole('button', { name: 'Cancel' }).click();
-    await page.getByLabel('Manage Environments').click();
-    await page.getByPlaceholder('Choose a project environment').click();
+    await page.getByLabel('Select a Project Environment').click();
     await page.getByRole('option', { name: 'global-environment' }).click();
     await page.getByText('New Environment').click();
     await page.locator('body').click();
@@ -49,8 +48,7 @@ test.describe('Global Environments', () => {
     await page.getByLabel('Create in project').click();
     await page.getByLabel('Create', { exact: true }).getByText('Environment').click();
     await page.getByRole('button', { name: 'Create', exact: true }).click();
-    await page.getByTestId('CreateEnvironmentDropdown').click();
-    await page.getByText('Private environment').click();
+    await page.getByTestId('AddPrivateSubEnvironment').click();
     await page.getByLabel('New Environment').click();
     await page.getByLabel('New Environment').getByLabel('Project Actions').click();
     await page.getByText('Duplicate').click();

--- a/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
@@ -96,8 +96,7 @@ test.describe('Check vault used in environment', () => {
     await page.getByLabel('Create', { exact: true }).getByText('Environment').click();
     await page.getByPlaceholder('Enter a name for your Environment').fill('New Global Vault Environment');
     await page.getByRole('button', { name: 'Create', exact: true }).click();
-    await page.getByTestId('CreateEnvironmentDropdown').click();
-    await page.getByText('Private environment').click();
+    await page.getByTestId('AddPrivateSubEnvironment').click();
     // activate created private environment
     await page.getByRole('grid', { name: 'Environments' }).getByText('New Environment').click();
 
@@ -153,10 +152,10 @@ test.describe('Check vault used in environment', () => {
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
     // activate existing global private vault environment from import
-    await page.getByLabel('Manage Environments').click();
-    await page.getByPlaceholder('Choose a project environment').click();
-    await page.getByRole('option', { name: 'New Global Vault Environment' }).click();
+    await page.getByLabel('Select a Project Environment').click();
     await page.getByRole('option', { name: 'New Environment' }).click();
+    await page.keyboard.press('Escape');
+    await page.getByLabel('Select a Collection Environment').click();
     await page.getByText('Base Environment1').click();
     await page.locator('body').click();
 
@@ -176,12 +175,12 @@ test.describe('Check vault used in environment', () => {
     await page.locator('.app').press('Escape');
 
     // activate global private vault environment from import
-    await page.getByLabel('Manage Environments').click();
-    await page.getByPlaceholder('Choose a project environment').click();
-    await page.getByRole('option', { name: 'Global env workspace with secret vault' }).click();
+    await page.getByLabel('Select a Project Environment').click();
     await page.getByText('global vault env with secret').click();
+    await page.keyboard.press('Escape');
 
     // activate legacy array vault environment
+    await page.getByLabel('Select a Collection Environment').click();
     await page.getByText('legacy vault value array').click();
     await page.locator('body').click();
     // activate request
@@ -201,7 +200,7 @@ test.describe('Check vault used in environment', () => {
     await page.getByText('vault_array_b').click();
 
     // activate legacy object vault environment
-    await page.getByLabel('Manage Environments').click();
+    await page.getByLabel('Select a Collection Environment').click();
     await page.getByText('legacy vault value object').click();
     await page.locator('body').click();
     // activate request
@@ -219,7 +218,7 @@ test.describe('Check vault used in environment', () => {
     await page.getByText('world').click();
 
     // activate invalid vault environment
-    await page.getByLabel('Manage Environments').click();
+    await page.getByLabel('Select a Collection Environment').click();
     await page.getByText('base with vault').click();
     await page.locator('body').click();
     // activate request

--- a/packages/insomnia-smoke-test/tests/smoke/key-value-editor-blank-row.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/key-value-editor-blank-row.test.ts
@@ -66,7 +66,7 @@ test.describe('Key-value editor blank row', () => {
     await page.getByRole('dialog').waitFor({ state: 'hidden' });
 
     // Open the table editor for the ExampleA sub-environment.
-    await page.getByRole('button', { name: 'Manage Environments' }).click();
+    await page.getByLabel('Select a Collection Environment').click();
     await page.getByRole('button', { name: 'Manage collection environments' }).click();
     await page.getByLabel('Environments', { exact: true }).getByText('ExampleA').click();
     await page.getByRole('button', { name: 'Table Edit' }).click();
@@ -95,7 +95,7 @@ test.describe('Key-value editor blank row', () => {
     await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
     await page.getByRole('dialog').waitFor({ state: 'hidden' });
 
-    await page.getByRole('button', { name: 'Manage Environments' }).click();
+    await page.getByLabel('Select a Collection Environment').click();
     await page.getByRole('button', { name: 'Manage collection environments' }).click();
     await page.getByLabel('Environments', { exact: true }).getByText('ExampleA').click();
     await page.getByRole('button', { name: 'Table Edit' }).click();

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -529,7 +529,7 @@ test.describe('pre-request features tests', () => {
 
     // activate global environment
     await page.getByLabel('Select a Project Environment').click();
-    await page.getByRole('option', { name: 'Base Script Env' }).click();
+    await page.getByRole('option', { name: 'Script Environment', exact: true }).click();
     await page.locator('body').click();
     // send
     await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
@@ -539,6 +539,7 @@ test.describe('pre-request features tests', () => {
     await page.getByText('log: baseGlobals base').click();
     // view base environment has been updated
     await page.getByLabel('Select a Project Environment').click();
+    await page.getByRole('option', { name: 'Script Environment', exact: true }).hover();
     await page.getByLabel('Edit Script Environment').click();
     await page.getByLabel('Environment name').getByText('Base Script Env').click();
     const globalBaseEditor = page.getByTestId('CodeEditor').locator('.CodeMirror-line');
@@ -565,6 +566,7 @@ test.describe('pre-request features tests', () => {
     await page.getByText('log: baseGlobals base').click();
     // view sub environment has been updated
     await page.getByLabel('Select a Project Environment').click();
+    await page.getByRole('option', { name: 'Script Environment', exact: true }).hover();
     await page.getByLabel('Edit Script Environment').click();
     await page.getByLabel('Environment name').getByText('Sub Script Env').first().click();
     const globalSubEditor = page.getByTestId('CodeEditor').locator('.CodeMirror-line');

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -486,7 +486,7 @@ test.describe('pre-request features tests', () => {
     await expect.soft(statusTag).toContainText('200 OK');
 
     // verify persisted environment
-    await page.getByRole('button', { name: 'Manage Environments' }).click();
+    await page.getByLabel('Select a Collection Environment').click();
     await page.getByRole('button', { name: 'Manage collection environments' }).click();
     const responseBody = page.getByRole('dialog').getByTestId('CodeEditor').locator('.CodeMirror-line');
     const rows = await responseBody.allInnerTexts();
@@ -528,9 +528,7 @@ test.describe('pre-request features tests', () => {
     });
 
     // activate global environment
-    await page.getByLabel('Manage Environments').click();
-    await page.getByPlaceholder('Choose a project environment').click();
-    await page.getByRole('option', { name: 'Script Environment' }).click();
+    await page.getByLabel('Select a Project Environment').click();
     await page.getByRole('option', { name: 'Base Script Env' }).click();
     await page.locator('body').click();
     // send
@@ -540,8 +538,8 @@ test.describe('pre-request features tests', () => {
     await page.getByText('log: globals base').click();
     await page.getByText('log: baseGlobals base').click();
     // view base environment has been updated
-    await page.getByLabel('Manage Environments').click();
-    await page.getByLabel('Manage project environment').click();
+    await page.getByLabel('Select a Project Environment').click();
+    await page.getByLabel('Edit Script Environment').click();
     await page.getByLabel('Environment name').getByText('Base Script Env').click();
     const globalBaseEditor = page.getByTestId('CodeEditor').locator('.CodeMirror-line');
     const globalBaseRows = await globalBaseEditor.allInnerTexts();
@@ -556,7 +554,7 @@ test.describe('pre-request features tests', () => {
     // switch back to request collection tab
     await page.getByLabel('Insomnia Tabs').getByLabel('persist global environment').first().click();
     // activate global sub environment
-    await page.getByLabel('Manage Environments').click();
+    await page.getByLabel('Select a Project Environment').click();
     await page.getByRole('option', { name: 'Sub Script Env' }).click();
     await page.locator('body').click();
     // send
@@ -566,8 +564,8 @@ test.describe('pre-request features tests', () => {
     await page.getByText('log: globals sub').click();
     await page.getByText('log: baseGlobals base').click();
     // view sub environment has been updated
-    await page.getByLabel('Manage Environments').click();
-    await page.getByLabel('Manage project environment').click();
+    await page.getByLabel('Select a Project Environment').click();
+    await page.getByLabel('Edit Script Environment').click();
     await page.getByLabel('Environment name').getByText('Sub Script Env').first().click();
     const globalSubEditor = page.getByTestId('CodeEditor').locator('.CodeMirror-line');
     const globalSubRows = await globalSubEditor.allInnerTexts();
@@ -583,7 +581,7 @@ test.describe('pre-request features tests', () => {
     const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
     await insomnia.navigationSidebar.clickRequestOrFolder('update kv pair environment');
     // switch to table view environment
-    await page.getByLabel('Manage Environments').click();
+    await page.getByLabel('Select a Collection Environment').click();
     const manageBtn = page.getByRole('button', { name: 'Manage collection environments' });
     await expect.soft(manageBtn).toBeEnabled();
     await manageBtn.click();
@@ -604,7 +602,7 @@ test.describe('pre-request features tests', () => {
     await expect.soft(statusTag).toContainText('200 OK');
 
     // verify table environments have been updated
-    const verifyManageBtn = page.getByRole('button', { name: 'Manage Environments' });
+    const verifyManageBtn = page.getByLabel('Select a Collection Environment');
     await expect.soft(verifyManageBtn).toBeEnabled();
     await verifyManageBtn.click();
     const verifyCollectionBtn = page.getByRole('button', { name: 'Manage collection environments' });

--- a/packages/insomnia-smoke-test/tests/smoke/url-bar-undo.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/url-bar-undo.test.ts
@@ -131,13 +131,13 @@ test('URL bar: switching environment refreshes the rendered preview', async ({ p
   const tag = page.locator(TAG_SEL).first();
 
   // ExampleA -> subenvA0
-  await page.getByRole('button', { name: 'Manage Environments' }).click();
+  await page.getByLabel('Select a Collection Environment').click();
   await page.getByRole('option', { name: 'ExampleA' }).press('Enter');
   await page.getByRole('option', { name: 'ExampleA' }).press('Escape');
   await expect.soft(tag).toHaveAttribute('title', /subenvA0/);
 
   // ExampleB -> subenvB0 (preview must refresh on switch)
-  await page.getByRole('button', { name: 'Manage Environments' }).click();
+  await page.getByLabel('Select a Collection Environment').click();
   await page.getByRole('option', { name: 'ExampleB' }).press('Enter');
   await page.getByRole('option', { name: 'ExampleB' }).press('Escape');
   await expect.soft(tag).toHaveAttribute('title', /subenvB0/);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.tsx
@@ -13,7 +13,6 @@ import {
   MenuItem,
   MenuTrigger,
   Popover,
-  Text,
   ToggleButton,
   useDragAndDrop,
 } from 'react-aria-components';
@@ -42,6 +41,7 @@ import { showModal } from '~/ui/components/modals';
 import { AlertModal } from '~/ui/components/modals/alert-modal';
 import { InputVaultKeyModal } from '~/ui/components/modals/input-vault-key-modal';
 import { OrganizationTabList } from '~/ui/components/tabs/tab-list';
+import { Tooltip } from '~/ui/components/tooltip';
 import WorkspacePaneHeader from '~/ui/components/workspace/workspace-pane-header';
 import { useOrganizationPermissions } from '~/ui/hooks/use-organization-features';
 import { useToggleEnvironmentType } from '~/ui/hooks/use-toggle-environment-type';
@@ -154,8 +154,8 @@ const Component = ({ loaderData, params }: Route.ComponentProps) => {
   }[] = [
     {
       id: 'shared',
-      name: 'Shared environment',
-      description: `${isUsingGitSync ? 'Synced with Git Sync and exportable' : isUsingInsomniaCloudSync ? 'Synced with Insomnia Sync and exportable' : 'Exportable'}`,
+      name: 'Add Sub Environment',
+      description: `Sub environments are additional nested environments that ${isUsingGitSync ? 'sync with Git Sync' : isUsingInsomniaCloudSync ? 'sync with Insomnia Sync' : 'can be exported'} and are shared with your team.`,
       icon: isUsingGitSync ? ['fab', 'git-alt'] : isUsingInsomniaCloudSync ? 'globe-americas' : 'file-arrow-down',
       action: async () => {
         createEnvironmentFetcher.submit({
@@ -171,8 +171,8 @@ const Component = ({ loaderData, params }: Route.ComponentProps) => {
     },
     {
       id: 'private',
-      name: 'Private environment',
-      description: 'Local and not exportable',
+      name: 'Add Private Sub Environment',
+      description: 'Private sub environments stay local to your machine and are never exported, synced, or committed.',
       icon: 'lock',
       action: async () => {
         createEnvironmentFetcher.submit({
@@ -291,6 +291,21 @@ const Component = ({ loaderData, params }: Route.ComponentProps) => {
           minSize={10}
           collapsible
         >
+          <div className="flex shrink-0 flex-col gap-1 border-b border-solid border-(--hl-sm) p-1">
+            {createEnvironmentActionsList.map(action => (
+              <Tooltip key={action.id} position="bottom" message={action.description}>
+                <Button
+                  aria-label={action.name}
+                  data-testid={action.id === 'private' ? 'AddPrivateSubEnvironment' : 'AddSubEnvironment'}
+                  onPress={() => action.action(baseEnvironment)}
+                  className="flex w-full items-center gap-2 rounded-xs border border-solid border-(--hl-sm) px-4 py-2 text-sm whitespace-nowrap text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset"
+                >
+                  <Icon className="w-3.5" icon={action.icon} />
+                  <span className="truncate">{action.name}</span>
+                </Button>
+              </Tooltip>
+            ))}
+          </div>
           <GridList
             aria-label="Environments"
             items={[baseEnvironment, ...subEnvironments]}
@@ -379,45 +394,6 @@ const Component = ({ loaderData, params }: Route.ComponentProps) => {
                               >
                                 <Icon className="w-5" icon={item.icon} />
                                 <span>{item.name}</span>
-                              </MenuItem>
-                            )}
-                          </Menu>
-                        </Popover>
-                      </MenuTrigger>
-                    )}
-                    {item.parentId === workspaceId && (
-                      <MenuTrigger>
-                        <Button
-                          aria-label="Create Environment"
-                          data-testid="CreateEnvironmentDropdown"
-                          className="flex aspect-square h-6 items-center justify-center rounded-xs text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset data-pressed:bg-(--hl-sm)"
-                        >
-                          <Icon icon="plus-circle" />
-                        </Button>
-                        <Popover className="flex min-w-max flex-col overflow-y-hidden">
-                          <Menu
-                            aria-label="New Environment"
-                            selectionMode="single"
-                            onAction={key => {
-                              createEnvironmentActionsList.find(({ id }) => key === id)?.action(item);
-                            }}
-                            items={createEnvironmentActionsList}
-                            className="min-w-max overflow-y-auto rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) py-2 text-sm shadow-lg select-none focus:outline-hidden"
-                          >
-                            {item => (
-                              <MenuItem
-                                key={item.id}
-                                id={item.id}
-                                className="flex w-full flex-col gap-1 bg-transparent px-(--padding-md) py-2 whitespace-nowrap text-(--color-font) transition-colors hover:bg-(--hl-sm) focus:bg-(--hl-xs) focus:outline-hidden disabled:cursor-not-allowed aria-selected:font-bold"
-                                aria-label={item.name}
-                              >
-                                <div className="flex items-center gap-2">
-                                  <Icon className="w-5" icon={item.icon} />
-                                  <span>{item.name}</span>
-                                </div>
-                                <Text slot="description" className="text-xs text-(--hl)">
-                                  {item.description}
-                                </Text>
                               </MenuItem>
                             )}
                           </Menu>

--- a/packages/insomnia/src/ui/components/environment-picker.tsx
+++ b/packages/insomnia/src/ui/components/environment-picker.tsx
@@ -237,7 +237,7 @@ export const EnvironmentPicker = ({
                               `/organization/${organizationId}/project/${projectId}/workspace/${item.workspaceId}/environment`,
                             )
                           }
-                          className="hide aspect-square h-5 shrink-0 items-center justify-center rounded-xs text-xs text-(--color-font) opacity-0 ring-1 ring-transparent transition-all group-hover:flex group-hover:opacity-100 group-focus:opacity-100 hover:bg-(--hl-xs) focus:opacity-100 focus:ring-(--hl-md) focus:ring-inset"
+                          className="hide aspect-square h-5 shrink-0 items-center justify-center rounded-xs text-xs text-(--color-font) opacity-0 ring-1 ring-transparent transition-all group-hover:flex group-hover:opacity-100 group-focus:flex group-focus:opacity-100 hover:bg-(--hl-xs) focus:opacity-100 focus:ring-(--hl-md) focus:ring-inset"
                         >
                           <Icon icon="edit" />
                         </Button>

--- a/packages/insomnia/src/ui/components/environment-picker.tsx
+++ b/packages/insomnia/src/ui/components/environment-picker.tsx
@@ -1,37 +1,54 @@
-import type { IconName } from '@fortawesome/fontawesome-svg-core';
+import type { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { models } from 'insomnia-data';
-import { fuzzyMatch } from 'insomnia-data/common';
-import { Fragment } from 'react';
-import {
-  Button,
-  ComboBox,
-  Dialog,
-  DialogTrigger,
-  Heading,
-  Input,
-  ListBox,
-  ListBoxItem,
-  Popover,
-  Text,
-} from 'react-aria-components';
+import { Fragment, useState } from 'react';
+import { Button, Dialog, DialogTrigger, Heading, ListBox, ListBoxItem, Popover, Text } from 'react-aria-components';
 import { useNavigate, useParams } from 'react-router';
 
 import { useSetActiveEnvironmentFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.set-active';
 import { useEnvironmentSetActiveGlobalActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.set-active-global';
+import { NewWorkspaceModal } from '~/ui/components/modals/new-workspace-modal';
 import { Tooltip } from '~/ui/components/tooltip';
+import { useOrganizationStorageRule } from '~/ui/hooks/use-organization-storage-rule';
 
 import { useWorkspaceLoaderData } from '../../routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
 import uiEventBus from '../event-bus';
 import { useOrganizationPermissions } from '../hooks/use-organization-features';
 import { Icon } from './icon';
 
+const triggerButtonClassName =
+  'flex max-w-48 shrink-0 items-center gap-1.5 truncate rounded-xs px-2 py-1 text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm) data-open:bg-(--hl-sm)';
+
+// Capped so a long environment name truncates with an ellipsis instead of stretching the popover off-screen.
+const popoverClassName = 'z-10! flex max-h-[90vh] w-64 max-w-xs flex-col';
+const headingClassName =
+  'flex h-(--line-height-sm) shrink-0 items-center justify-between gap-2 px-3 py-1 text-sm font-bold text-(--hl)';
+const listBoxClassName =
+  'flex max-h-fit min-w-0 flex-1 flex-col overflow-y-auto p-2 text-sm select-none empty:p-0 focus:outline-hidden';
+const listBoxItemClassName =
+  'group flex h-(--line-height-xs) w-full min-w-0 flex-none items-center gap-2 rounded-sm bg-transparent pr-1 text-(--color-font) transition-colors hover:bg-(--hl-sm) focus:bg-(--hl-xs) focus:outline-hidden disabled:cursor-not-allowed';
+// Sub-environments indent by exactly one icon's width so they line up under the parent row's name, not a stray gap.
+const itemIndentClassName = (isBase: boolean) => (isBase ? 'pl-(--padding-sm)' : 'pl-[calc(var(--padding-sm)+1rem)]');
+
+const InheritanceTooltip = () => (
+  <Tooltip
+    position="top"
+    message="Environment values inherit downward. When the same variable is set in more than one scope, folder wins over collection, and collection wins over project."
+  >
+    <Icon icon="circle-info" className="shrink-0 text-(--hl)" />
+  </Tooltip>
+);
+
 export const EnvironmentPicker = ({
   isOpen,
   onOpenChange,
+  isProjectPickerOpen,
+  onProjectPickerOpenChange,
   onOpenEnvironmentSettingsModal,
 }: {
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
+  isProjectPickerOpen: boolean;
+  onProjectPickerOpenChange: (isOpen: boolean) => void;
   onOpenEnvironmentSettingsModal: () => void;
 }) => {
   const {
@@ -54,6 +71,7 @@ export const EnvironmentPicker = ({
   };
 
   const { features } = useOrganizationPermissions();
+  const storageRules = useOrganizationStorageRule(organizationId);
   const isUsingInsomniaCloudSync = Boolean(
     models.project.isRemoteProject(activeProject) && !activeWorkspaceMeta?.gitRepositoryId,
   );
@@ -73,162 +91,108 @@ export const EnvironmentPicker = ({
     : activeGlobalEnvironment?.parentId;
   const selectedGlobalBaseEnvironment = globalBaseEnvironments.find(e => e._id === selectedGlobalBaseEnvironmentId);
 
-  const globalEnvironmentList = selectedGlobalBaseEnvironment
-    ? [
-        selectedGlobalBaseEnvironment,
-        ...globalSubEnvironments.filter(e => e.parentId === selectedGlobalBaseEnvironment._id),
-      ].map(({ type, ...subEnvironment }) => ({
-        ...subEnvironment,
-        id: subEnvironment._id,
-        isBase: subEnvironment._id === selectedGlobalBaseEnvironment._id,
-      }))
-    : [];
-
   const activeGlobalBaseEnvironment = selectedGlobalBaseEnvironment;
   const activeBaseEnvironment = baseEnvironment;
   const activeSubEnvironment = subEnvironments.find(e => e._id === activeEnvironment._id);
+  const activeCollectionEnvironmentName = activeSubEnvironment ? activeSubEnvironment.name : activeBaseEnvironment.name;
 
   const navigate = useNavigate();
 
+  const [isNewProjectEnvironmentModalOpen, setIsNewProjectEnvironmentModalOpen] = useState(false);
+
+  const getEnvironmentIcon = (isPrivate?: boolean): IconProp =>
+    isPrivate
+      ? 'lock'
+      : isUsingGitSync
+        ? ['fab', 'git-alt']
+        : isUsingInsomniaCloudSync
+          ? 'globe-americas'
+          : 'file-arrow-down';
+
+  // Flattened list of every project environment file plus its sub-environments, so picking
+  // one is a single action instead of choosing a file first and then a sub-environment.
+  const projectEnvironmentItems: {
+    id: string;
+    name: string;
+    icon: IconProp;
+    color?: string | null;
+    isBase: boolean;
+    workspaceId?: string;
+  }[] = [
+    { id: '', name: 'No Project Environment', icon: 'cancel', isBase: true },
+    ...globalBaseEnvironments.flatMap(baseEnv => [
+      {
+        id: baseEnv._id,
+        name: baseEnv.workspaceName || baseEnv.name,
+        icon: getEnvironmentIcon(baseEnv.isPrivate),
+        color: baseEnv.color,
+        isBase: true,
+        workspaceId: baseEnv.parentId,
+      },
+      ...globalSubEnvironments
+        .filter(subEnv => subEnv.parentId === baseEnv._id)
+        .map(subEnv => ({
+          id: subEnv._id,
+          name: subEnv.name,
+          icon: getEnvironmentIcon(subEnv.isPrivate),
+          color: subEnv.color,
+          isBase: false,
+        })),
+    ]),
+  ];
+
   return (
-    <DialogTrigger isOpen={isOpen} onOpenChange={onOpenChange}>
-      <Button
-        aria-label="Manage Environments"
-        className="flex max-w-full items-start gap-2 truncate rounded-xs px-2 py-1 text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
-      >
-        {activeGlobalEnvironment && activeGlobalBaseEnvironment && (
-          <div className="flex w-full">
-            <div className="flex w-full items-center gap-2">
-              <Icon
-                icon={
-                  activeGlobalEnvironment.isPrivate
-                    ? 'lock'
-                    : isUsingGitSync
-                      ? ['fab', 'git-alt']
-                      : isUsingInsomniaCloudSync
-                        ? 'globe-americas'
-                        : 'file-arrow-down'
-                }
-                style={{ color: activeGlobalEnvironment.color || '' }}
-                className="w-5 shrink-0"
-              />
-              <Tooltip position="top" message="active global environment">
-                <span className="truncate">{activeGlobalEnvironment.name}</span>
-              </Tooltip>
-              <Icon icon="plus" className="w-3 shrink-0 text-(--hl)" />
-            </div>
-          </div>
-        )}
-        <div className="flex w-full flex-1 items-center gap-2">
+    <div className="flex items-center gap-1">
+      <DialogTrigger isOpen={isProjectPickerOpen} onOpenChange={onProjectPickerOpenChange}>
+        <Button aria-label="Select a Project Environment" className={triggerButtonClassName}>
           <Icon
-            icon={activeEnvironment.isPrivate ? 'lock' : 'code'}
-            style={{ color: activeEnvironment.color || '' }}
-            className="w-5 shrink-0"
+            icon={
+              activeGlobalEnvironment
+                ? activeGlobalEnvironment.isPrivate
+                  ? 'lock'
+                  : getEnvironmentIcon(false)
+                : 'cancel'
+            }
+            style={{ color: activeGlobalEnvironment?.color || '' }}
+            className="w-4 shrink-0"
           />
-          <Tooltip position="top" message="active collection environment">
+          <Tooltip position="top" message="Project environment — shared by every collection in this project.">
             <span className="truncate">
-              {activeSubEnvironment ? activeSubEnvironment.name : activeBaseEnvironment.name}
+              {activeGlobalEnvironment && activeGlobalBaseEnvironment
+                ? activeGlobalEnvironment.name
+                : 'No Project Environment'}
             </span>
           </Tooltip>
-        </div>
-      </Button>
-      <Popover className="z-10! flex max-h-[90vh] min-w-max flex-col" placement="bottom start" offset={8}>
-        <Dialog className="grid h-full w-full auto-cols-[min(260px,calc(40vw))_min(260px,calc(40vw))] grid-flow-col divide-x divide-solid divide-(--hl-md) overflow-hidden rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) text-sm shadow-lg select-none focus:outline-hidden">
-          <div className="relative flex h-full w-full flex-1 flex-col overflow-hidden">
-            <Heading className="flex h-(--line-height-sm) shrink-0 items-center justify-between gap-2 px-3 py-1 text-sm font-bold text-(--hl)">
-              <span>Project Environments</span>
-              <Button
-                aria-label="Manage project environment"
-                onPress={() =>
-                  selectedGlobalBaseEnvironment &&
-                  navigate(
-                    `/organization/${organizationId}/project/${projectId}/workspace/${selectedGlobalBaseEnvironment.parentId}/environment`,
-                  )
-                }
-                className={`flex aspect-square h-6 shrink-0 items-center justify-center rounded-xs text-sm text-(--color-font) ring-1 ring-transparent outline-hidden transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm) ${!selectedGlobalBaseEnvironment ? 'opacity-50' : ''}`}
+          <Icon icon="caret-down" className="w-2.5 shrink-0 text-(--hl)" />
+        </Button>
+        <Popover className={popoverClassName} placement="bottom start" offset={8}>
+          <Dialog className="flex h-full max-h-200 w-full flex-col overflow-hidden rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) text-sm shadow-lg select-none focus:outline-hidden">
+            <Heading className={headingClassName}>
+              <Tooltip
+                position="top"
+                message="Shared by every collection in this project. Hover a row to edit its file."
               >
-                <Icon icon="gear" />
-              </Button>
-            </Heading>
-            <div>
-              <ComboBox
-                aria-label="Project Environment"
-                shouldFocusWrap
-                allowsCustomValue={false}
-                menuTrigger="focus"
-                defaultFilter={(textValue, filter) => {
-                  const match = Boolean(fuzzyMatch(filter, textValue, { splitSpace: false, loose: true })?.indexes);
-
-                  return match;
-                }}
-                onSelectionChange={key => {
-                  if (key === 'all' || key === null) {
-                    return;
-                  }
-
-                  setActiveGlobalEnvironmentFetcher.submit({
-                    organizationId,
-                    projectId,
-                    workspaceId,
-                    environmentId: key.toString(),
-                  });
-                }}
-                defaultInputValue={
-                  selectedGlobalBaseEnvironment?.workspaceName ||
-                  selectedGlobalBaseEnvironment?.name ||
-                  'No Project Environment'
-                }
-                selectedKey={selectedGlobalBaseEnvironmentId || ''}
-                defaultItems={[
-                  { id: '', icon: 'cancel', name: 'No Project Environment', textValue: 'No Project Environment' },
-                  ...globalBaseEnvironments.map(baseEnv => {
-                    return {
-                      id: baseEnv._id,
-                      icon: 'code',
-                      name: baseEnv.workspaceName || baseEnv.name,
-                      textValue: baseEnv.workspaceName || baseEnv.name,
-                    };
-                  }),
-                ]}
-              >
-                <div className="group mx-2 my-2 flex items-center gap-2 rounded-xs border border-solid border-(--hl-sm) bg-(--color-bg) px-2 text-(--color-font) transition-colors focus:ring-1 focus:ring-(--hl-md) focus:outline-hidden">
-                  <Input
-                    aria-label="Project Environment"
-                    placeholder="Choose a project environment"
-                    className="w-full py-1 pr-7 pl-2 placeholder:italic"
-                  />
-                  <Button className="flex aspect-square items-center justify-center gap-2 truncate rounded-xs text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)">
-                    <Icon icon="caret-down" className="w-5 shrink-0" />
+                <span>Project Environments</span>
+              </Tooltip>
+              <div className="flex shrink-0 items-center gap-2">
+                <Tooltip position="top" message="Create a new project environment">
+                  <Button
+                    aria-label="Add Project Environment"
+                    onPress={() => setIsNewProjectEnvironmentModalOpen(true)}
+                    className="flex aspect-square h-6 shrink-0 items-center justify-center rounded-xs text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
+                  >
+                    <Icon icon="plus" />
                   </Button>
-                </div>
-                <Popover
-                  className="z-10! grid max-h-[90vh] min-w-max auto-cols-[min(250px,calc(45vw))] grid-flow-col divide-x divide-solid divide-(--hl-md) overflow-y-auto rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) text-sm shadow-lg select-none focus:outline-hidden"
-                  placement="bottom start"
-                  offset={8}
-                >
-                  <ListBox<{
-                    name: string;
-                    icon: IconName;
-                  }> className="flex h-full max-h-full min-w-max flex-col p-2 text-sm select-none focus:outline-hidden">
-                    {item => (
-                      <ListBoxItem
-                        textValue={item.name}
-                        className="flex h-(--line-height-xs) w-full items-center gap-2 rounded-sm bg-transparent px-(--padding-md) whitespace-nowrap text-(--color-font) transition-colors hover:bg-(--hl-sm) focus:bg-(--hl-xs) focus:outline-hidden disabled:cursor-not-allowed aria-disabled:cursor-not-allowed aria-disabled:opacity-30 aria-selected:bg-(--hl-sm) aria-selected:font-bold data-focused:bg-(--hl-xs)"
-                      >
-                        <Icon icon={item.icon} className="w-4" />
-                        <span className="truncate">{item.name}</span>
-                      </ListBoxItem>
-                    )}
-                  </ListBox>
-                </Popover>
-              </ComboBox>
-            </div>
+                </Tooltip>
+                <InheritanceTooltip />
+              </div>
+            </Heading>
             <ListBox
-              aria-label="Select a Global Environment"
+              aria-label="Select a Project Environment"
               selectionMode="single"
               disallowEmptySelection
-              key={activeGlobalEnvironment?._id}
-              items={globalEnvironmentList}
+              key={activeGlobalEnvironment?._id || 'none'}
+              items={projectEnvironmentItems}
               selectedKeys={[activeGlobalEnvironment?._id || activeGlobalBaseEnvironment?._id || '']}
               onSelectionChange={keys => {
                 if (keys === 'all' || !keys) {
@@ -243,48 +207,71 @@ export const EnvironmentPicker = ({
                   environmentId: environmentId.toString(),
                 });
               }}
-              className="flex max-h-fit min-w-max flex-1 flex-col overflow-y-auto p-2 text-sm select-none empty:p-0 focus:outline-hidden"
+              className={listBoxClassName}
             >
               {item => (
                 <ListBoxItem
                   textValue={item.name}
-                  className={`flex h-(--line-height-xs) w-full flex-none items-center gap-2 rounded-sm bg-transparent pr-1 whitespace-nowrap text-(--color-font) transition-colors hover:bg-(--hl-sm) focus:bg-(--hl-xs) focus:outline-hidden disabled:cursor-not-allowed ${item.isBase ? 'pl-(--padding-md)' : 'pl-8'}`}
+                  className={`${listBoxItemClassName} ${itemIndentClassName(item.isBase)}`}
                 >
                   {({ isSelected }) => (
                     <Fragment>
-                      <span
+                      <Icon
+                        icon={item.icon}
+                        className="w-5 shrink-0 text-xs"
                         style={{
-                          borderColor: item.color ?? 'var(--color-font)',
+                          color: item.color ?? 'var(--color-font)',
                         }}
-                      >
-                        <Icon
-                          icon={
-                            item.isPrivate
-                              ? 'lock'
-                              : isUsingGitSync
-                                ? ['fab', 'git-alt']
-                                : isUsingInsomniaCloudSync
-                                  ? 'globe-americas'
-                                  : 'file-arrow-down'
-                          }
-                          className="w-5 text-xs"
-                          style={{
-                            color: item.color ?? 'var(--color-font)',
-                          }}
-                        />
-                      </span>
-                      <Text slot="label" className="flex-1 truncate">
+                      />
+                      <Text slot="label" className="min-w-0 flex-1 truncate">
                         {item.name}
                       </Text>
-                      {isSelected && <Icon icon="check" className="justify-self-end px-2 text-(--color-success)" />}
+                      {isSelected && (
+                        <Icon icon="check" className="shrink-0 justify-self-end px-2 text-(--color-success)" />
+                      )}
+                      {item.workspaceId && (
+                        <Button
+                          aria-label={`Edit ${item.name}`}
+                          onPress={() =>
+                            navigate(
+                              `/organization/${organizationId}/project/${projectId}/workspace/${item.workspaceId}/environment`,
+                            )
+                          }
+                          className="hide aspect-square h-5 shrink-0 items-center justify-center rounded-xs text-xs text-(--color-font) opacity-0 ring-1 ring-transparent transition-all group-hover:flex group-hover:opacity-100 group-focus:opacity-100 hover:bg-(--hl-xs) focus:opacity-100 focus:ring-(--hl-md) focus:ring-inset"
+                        >
+                          <Icon icon="edit" />
+                        </Button>
+                      )}
                     </Fragment>
                   )}
                 </ListBoxItem>
               )}
             </ListBox>
-            <div className="relative contents w-full overflow-hidden">
-              <Heading className="flex h-7 shrink-0 items-center justify-between gap-2 px-3 py-1 text-sm font-bold text-(--hl)">
-                <span>Collection Environments</span>
+          </Dialog>
+        </Popover>
+      </DialogTrigger>
+      <DialogTrigger isOpen={isOpen} onOpenChange={onOpenChange}>
+        <Button aria-label="Select a Collection Environment" className={triggerButtonClassName}>
+          <Icon
+            icon={activeEnvironment.isPrivate ? 'lock' : 'code'}
+            style={{ color: activeEnvironment.color || '' }}
+            className="w-4 shrink-0"
+          />
+          <Tooltip position="top" message="Collection environment — used only by this collection.">
+            <span className="truncate">{activeCollectionEnvironmentName}</span>
+          </Tooltip>
+          <Icon icon="caret-down" className="w-2.5 shrink-0 text-(--hl)" />
+        </Button>
+        <Popover className={popoverClassName} placement="bottom start" offset={8}>
+          <Dialog className="flex h-full max-h-200 w-full flex-col overflow-hidden rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) text-sm shadow-lg select-none focus:outline-hidden">
+            <Heading className={headingClassName}>
+              <Tooltip
+                position="top"
+                message="Used only by this collection. Click the edit icon to manage its environments."
+              >
+                <span>Collection Environment</span>
+              </Tooltip>
+              <div className="flex shrink-0 items-center gap-2">
                 <Button
                   onPress={onOpenEnvironmentSettingsModal}
                   aria-label="Manage collection environments"
@@ -292,70 +279,78 @@ export const EnvironmentPicker = ({
                 >
                   <Icon icon="edit" />
                 </Button>
-              </Heading>
-              <ListBox
-                aria-label="Select a Collection Environment"
-                selectionMode="single"
-                key={activeEnvironment._id}
-                items={collectionEnvironmentList}
-                selectedKeys={[activeEnvironment._id || baseEnvironment._id || '']}
-                disallowEmptySelection
-                onSelectionChange={keys => {
-                  if (keys === 'all' || !keys) {
-                    return;
-                  }
-                  const [environmentId] = keys.values();
-                  setActiveEnvironmentFetcher.submit({
-                    organizationId,
-                    projectId,
-                    workspaceId,
-                    environmentId: environmentId.toString(),
-                  });
-                  uiEventBus.emit('CHANGE_ACTIVE_ENV', workspaceId);
-                }}
-                className="max-h-fit flex-1 overflow-y-auto p-2 text-sm select-none focus:outline-hidden"
-              >
-                {item => (
-                  <ListBoxItem
-                    textValue={item.name}
-                    className={`flex h-(--line-height-xs) w-full items-center gap-2 truncate rounded-sm bg-transparent pr-1 whitespace-nowrap text-(--color-font) transition-colors hover:bg-(--hl-sm) focus:bg-(--hl-xs) focus:outline-hidden ${item.isBase ? 'pl-(--padding-md)' : 'pl-8'}`}
-                  >
-                    {({ isSelected }) => (
-                      <Fragment>
-                        <span
-                          style={{
-                            borderColor: item.color ?? 'var(--color-font)',
-                          }}
-                        >
-                          <Icon
-                            icon={
-                              item.isPrivate
-                                ? 'lock'
-                                : isUsingGitSync
-                                  ? ['fab', 'git-alt']
-                                  : isUsingInsomniaCloudSync
-                                    ? 'globe-americas'
-                                    : 'file-arrow-down'
-                            }
-                            className="w-5 text-xs"
-                            style={{
-                              color: item.color ?? 'var(--color-font)',
-                            }}
-                          />
-                        </span>
-                        <Text slot="label" className="flex-1 truncate">
-                          {item.name}
-                        </Text>
-                        {isSelected && <Icon icon="check" className="justify-self-end px-2 text-(--color-success)" />}
-                      </Fragment>
-                    )}
-                  </ListBoxItem>
-                )}
-              </ListBox>
-            </div>
-          </div>
-        </Dialog>
-      </Popover>
-    </DialogTrigger>
+                <InheritanceTooltip />
+              </div>
+            </Heading>
+            <ListBox
+              aria-label="Select a Collection Environment"
+              selectionMode="single"
+              key={activeEnvironment._id}
+              items={collectionEnvironmentList}
+              selectedKeys={[activeEnvironment._id || baseEnvironment._id || '']}
+              disallowEmptySelection
+              onSelectionChange={keys => {
+                if (keys === 'all' || !keys) {
+                  return;
+                }
+                const [environmentId] = keys.values();
+                setActiveEnvironmentFetcher.submit({
+                  organizationId,
+                  projectId,
+                  workspaceId,
+                  environmentId: environmentId.toString(),
+                });
+                uiEventBus.emit('CHANGE_ACTIVE_ENV', workspaceId);
+              }}
+              className={listBoxClassName}
+            >
+              {item => (
+                <ListBoxItem
+                  textValue={item.name}
+                  className={`${listBoxItemClassName} ${itemIndentClassName(item.isBase)}`}
+                >
+                  {({ isSelected }) => (
+                    <Fragment>
+                      <Icon
+                        icon={
+                          item.isPrivate
+                            ? 'lock'
+                            : isUsingGitSync
+                              ? ['fab', 'git-alt']
+                              : isUsingInsomniaCloudSync
+                                ? 'globe-americas'
+                                : 'file-arrow-down'
+                        }
+                        className="w-5 shrink-0 text-xs"
+                        style={{
+                          color: item.color ?? 'var(--color-font)',
+                        }}
+                      />
+                      <Text slot="label" className="min-w-0 flex-1 truncate">
+                        {item.name}
+                      </Text>
+                      {isSelected && (
+                        <Icon icon="check" className="shrink-0 justify-self-end px-2 text-(--color-success)" />
+                      )}
+                    </Fragment>
+                  )}
+                </ListBoxItem>
+              )}
+            </ListBox>
+          </Dialog>
+        </Popover>
+      </DialogTrigger>
+      {isNewProjectEnvironmentModalOpen && (
+        <NewWorkspaceModal
+          isOpen
+          project={activeProject}
+          storageRules={storageRules}
+          scope="environment"
+          source="environment-picker"
+          redirectAfterCreate={false}
+          onOpenChange={setIsNewProjectEnvironmentModalOpen}
+        />
+      )}
+    </div>
   );
 };

--- a/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/workspace-environments-edit-modal.tsx
@@ -16,7 +16,6 @@ import {
   Modal,
   ModalOverlay,
   Popover,
-  Text,
   ToggleButton,
   useDragAndDrop,
 } from 'react-aria-components';
@@ -29,6 +28,7 @@ import { useEnvironmentCreateActionFetcher } from '~/routes/organization.$organi
 import { useEnvironmentDeleteActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.delete';
 import { useEnvironmentDuplicateActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.duplicate';
 import { useEnvironmentUpdateActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.update';
+import { Tooltip } from '~/ui/components/tooltip';
 import { useToggleEnvironmentType } from '~/ui/hooks/use-toggle-environment-type';
 
 import { docsAfterResponseScript, docsTemplateTags } from '../../../common/documentation';
@@ -135,8 +135,8 @@ export const WorkspaceEnvironmentsEditModal = ({ onClose }: { onClose: () => voi
   }[] = [
     {
       id: 'shared',
-      name: 'Shared environment',
-      description: `${isUsingGitSync ? 'Synced with Git Sync and exportable' : isUsingInsomniaCloudSync ? 'Synced with Insomnia Sync and exportable' : 'Exportable'}`,
+      name: 'Add Sub Environment',
+      description: `Sub environments are additional nested environments that ${isUsingGitSync ? 'sync with Git Sync' : isUsingInsomniaCloudSync ? 'sync with Insomnia Sync' : 'can be exported'} and are shared with your team.`,
       icon: isUsingGitSync ? ['fab', 'git-alt'] : isUsingInsomniaCloudSync ? 'globe-americas' : 'file-arrow-down',
       action: async () => {
         createEnvironmentFetcher.submit({
@@ -152,8 +152,8 @@ export const WorkspaceEnvironmentsEditModal = ({ onClose }: { onClose: () => voi
     },
     {
       id: 'private',
-      name: 'Private environment',
-      description: 'Local and not exportable',
+      name: 'Add Private Sub Environment',
+      description: 'Private sub environments stay local to your machine and are never exported, synced, or committed.',
       icon: 'lock',
       action: async () => {
         createEnvironmentFetcher.submit({
@@ -276,144 +276,122 @@ export const WorkspaceEnvironmentsEditModal = ({ onClose }: { onClose: () => voi
                 </Button>
               </div>
               <div className="flex w-full flex-1 basis-96 divide-x divide-solid divide-(--hl-md) overflow-hidden overflow-y-auto rounded-sm border border-solid border-(--hl-sm) select-none">
-                <GridList
-                  aria-label="Environments"
-                  items={[baseEnvironment, ...subEnvironments]}
-                  className="w-full max-w-xs shrink-0 overflow-y-auto py-(--padding-xs) data-empty:py-0"
-                  disallowEmptySelection
-                  selectionMode="single"
-                  selectionBehavior="replace"
-                  selectedKeys={[selectedEnvironmentId]}
-                  dragAndDropHooks={environmentsDragAndDrop.dragAndDropHooks}
-                  onSelectionChange={keys => {
-                    if (keys !== 'all') {
-                      const [environmentId] = keys.values();
-                      setSelectedEnvironmentId(environmentId.toString());
-                    }
-                  }}
-                >
-                  {item => {
-                    return (
-                      <GridListItem
-                        key={item._id}
-                        id={item._id}
-                        textValue={item.name}
-                        className="group outline-hidden select-none"
-                      >
-                        <div
-                          className={`${item.parentId === workspaceId ? 'pl-4' : 'pl-8'} relative flex h-(--line-height-xs) w-full items-center gap-2 overflow-hidden pr-4 text-(--hl) outline-hidden transition-colors select-none group-hover:bg-(--hl-xs) group-focus:bg-(--hl-sm) group-aria-selected:text-(--color-font)`}
+                <div className="flex w-full max-w-xs shrink-0 flex-col overflow-hidden">
+                  <div className="flex shrink-0 flex-col gap-1 border-b border-solid border-(--hl-sm) p-1">
+                    {createEnvironmentActionsList.map(action => (
+                      <Tooltip key={action.id} position="bottom" message={action.description}>
+                        <Button
+                          aria-label={action.name}
+                          data-testid={action.id === 'private' ? 'AddPrivateSubEnvironment' : 'AddSubEnvironment'}
+                          onPress={() => action.action(baseEnvironment)}
+                          className="flex w-full items-center gap-2 rounded-xs border border-solid border-(--hl-sm) px-4 py-2 text-sm whitespace-nowrap text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset"
                         >
-                          <span className="absolute top-0 left-0 h-full w-[2px] bg-transparent transition-colors group-aria-selected:bg-(--color-surprise)" />
-                          <Icon
-                            icon={
-                              item.isPrivate
-                                ? 'lock'
-                                : isUsingGitSync
-                                  ? ['fab', 'git-alt']
-                                  : isUsingInsomniaCloudSync
-                                    ? 'globe-americas'
-                                    : 'file-arrow-down'
-                            }
-                            className="w-5"
-                            style={{
-                              color: item.color || undefined,
-                            }}
-                          />
-                          <EditableInput
-                            value={item.name}
-                            name="name"
-                            ariaLabel="Environment name"
-                            className="flex-1 px-1 hover:bg-transparent!"
-                            onSubmit={name => {
-                              name &&
-                                updateEnvironmentFetcher.submit({
-                                  organizationId,
-                                  projectId,
-                                  workspaceId,
-                                  patch: {
-                                    name,
-                                  },
-                                  environmentId: item._id,
-                                });
-                            }}
-                          />
-                          {item.parentId !== workspaceId && (
-                            <MenuTrigger>
-                              <Button
-                                aria-label="Environment Actions"
-                                className="flex aspect-square h-6 items-center justify-center rounded-xs text-sm text-(--color-font) opacity-0 ring-1 ring-transparent transition-all group-hover:opacity-100 group-focus:opacity-100 hover:bg-(--hl-xs) hover:opacity-100 focus:opacity-100 focus:ring-(--hl-md) focus:ring-inset data-pressed:bg-(--hl-sm) data-pressed:opacity-100"
-                              >
-                                <Icon icon="caret-down" />
-                              </Button>
-                              <Popover className="flex min-w-max flex-col overflow-y-hidden">
-                                <Menu
-                                  aria-label="Environment Actions menu"
-                                  selectionMode="single"
-                                  onAction={key => {
-                                    environmentActionsList.find(({ id }) => key === id)?.action(item);
-                                  }}
-                                  items={environmentActionsList}
-                                  className="min-w-max overflow-y-auto rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) py-2 text-sm shadow-lg select-none focus:outline-hidden"
+                          <Icon className="w-3.5" icon={action.icon} />
+                          <span className="truncate">{action.name}</span>
+                        </Button>
+                      </Tooltip>
+                    ))}
+                  </div>
+                  <GridList
+                    aria-label="Environments"
+                    items={[baseEnvironment, ...subEnvironments]}
+                    className="w-full flex-1 overflow-y-auto py-(--padding-xs) data-empty:py-0"
+                    disallowEmptySelection
+                    selectionMode="single"
+                    selectionBehavior="replace"
+                    selectedKeys={[selectedEnvironmentId]}
+                    dragAndDropHooks={environmentsDragAndDrop.dragAndDropHooks}
+                    onSelectionChange={keys => {
+                      if (keys !== 'all') {
+                        const [environmentId] = keys.values();
+                        setSelectedEnvironmentId(environmentId.toString());
+                      }
+                    }}
+                  >
+                    {item => {
+                      return (
+                        <GridListItem
+                          key={item._id}
+                          id={item._id}
+                          textValue={item.name}
+                          className="group outline-hidden select-none"
+                        >
+                          <div
+                            className={`${item.parentId === workspaceId ? 'pl-4' : 'pl-8'} relative flex h-(--line-height-xs) w-full items-center gap-2 overflow-hidden pr-4 text-(--hl) outline-hidden transition-colors select-none group-hover:bg-(--hl-xs) group-focus:bg-(--hl-sm) group-aria-selected:text-(--color-font)`}
+                          >
+                            <span className="absolute top-0 left-0 h-full w-[2px] bg-transparent transition-colors group-aria-selected:bg-(--color-surprise)" />
+                            <Icon
+                              icon={
+                                item.isPrivate
+                                  ? 'lock'
+                                  : isUsingGitSync
+                                    ? ['fab', 'git-alt']
+                                    : isUsingInsomniaCloudSync
+                                      ? 'globe-americas'
+                                      : 'file-arrow-down'
+                              }
+                              className="w-5"
+                              style={{
+                                color: item.color || undefined,
+                              }}
+                            />
+                            <EditableInput
+                              value={item.name}
+                              name="name"
+                              ariaLabel="Environment name"
+                              className="flex-1 px-1 hover:bg-transparent!"
+                              onSubmit={name => {
+                                name &&
+                                  updateEnvironmentFetcher.submit({
+                                    organizationId,
+                                    projectId,
+                                    workspaceId,
+                                    patch: {
+                                      name,
+                                    },
+                                    environmentId: item._id,
+                                  });
+                              }}
+                            />
+                            {item.parentId !== workspaceId && (
+                              <MenuTrigger>
+                                <Button
+                                  aria-label="Environment Actions"
+                                  className="flex aspect-square h-6 items-center justify-center rounded-xs text-sm text-(--color-font) opacity-0 ring-1 ring-transparent transition-all group-hover:opacity-100 group-focus:opacity-100 hover:bg-(--hl-xs) hover:opacity-100 focus:opacity-100 focus:ring-(--hl-md) focus:ring-inset data-pressed:bg-(--hl-sm) data-pressed:opacity-100"
                                 >
-                                  {item => (
-                                    <MenuItem
-                                      key={item.id}
-                                      id={item.id}
-                                      className="flex h-(--line-height-xs) w-full items-center gap-2 bg-transparent px-(--padding-md) whitespace-nowrap text-(--color-font) transition-colors hover:bg-(--hl-sm) focus:bg-(--hl-xs) focus:outline-hidden disabled:cursor-not-allowed aria-selected:font-bold"
-                                      aria-label={item.name}
-                                    >
-                                      <Icon className="w-5" icon={item.icon} />
-                                      <span>{item.name}</span>
-                                    </MenuItem>
-                                  )}
-                                </Menu>
-                              </Popover>
-                            </MenuTrigger>
-                          )}
-                          {item.parentId === workspaceId && (
-                            <MenuTrigger>
-                              <Button
-                                aria-label="Create Environment"
-                                data-testid="CreateEnvironmentDropdown"
-                                className="flex aspect-square h-6 items-center justify-center rounded-xs text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset data-pressed:bg-(--hl-sm)"
-                              >
-                                <Icon icon="plus-circle" />
-                              </Button>
-                              <Popover className="flex min-w-max flex-col overflow-y-hidden">
-                                <Menu
-                                  aria-label="Create Environment menu"
-                                  selectionMode="single"
-                                  onAction={key => {
-                                    createEnvironmentActionsList.find(({ id }) => key === id)?.action(item);
-                                  }}
-                                  items={createEnvironmentActionsList}
-                                  className="min-w-max overflow-y-auto rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) py-2 text-sm shadow-lg select-none focus:outline-hidden"
-                                >
-                                  {item => (
-                                    <MenuItem
-                                      key={item.id}
-                                      id={item.id}
-                                      className="flex w-full flex-col gap-1 bg-transparent px-(--padding-md) py-2 whitespace-nowrap text-(--color-font) transition-colors hover:bg-(--hl-sm) focus:bg-(--hl-xs) focus:outline-hidden disabled:cursor-not-allowed aria-selected:font-bold"
-                                      aria-label={item.name}
-                                    >
-                                      <div className="flex items-center gap-2">
+                                  <Icon icon="caret-down" />
+                                </Button>
+                                <Popover className="flex min-w-max flex-col overflow-y-hidden">
+                                  <Menu
+                                    aria-label="Environment Actions menu"
+                                    selectionMode="single"
+                                    onAction={key => {
+                                      environmentActionsList.find(({ id }) => key === id)?.action(item);
+                                    }}
+                                    items={environmentActionsList}
+                                    className="min-w-max overflow-y-auto rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) py-2 text-sm shadow-lg select-none focus:outline-hidden"
+                                  >
+                                    {item => (
+                                      <MenuItem
+                                        key={item.id}
+                                        id={item.id}
+                                        className="flex h-(--line-height-xs) w-full items-center gap-2 bg-transparent px-(--padding-md) whitespace-nowrap text-(--color-font) transition-colors hover:bg-(--hl-sm) focus:bg-(--hl-xs) focus:outline-hidden disabled:cursor-not-allowed aria-selected:font-bold"
+                                        aria-label={item.name}
+                                      >
                                         <Icon className="w-5" icon={item.icon} />
                                         <span>{item.name}</span>
-                                      </div>
-                                      <Text slot="description" className="text-xs text-(--hl)">
-                                        {item.description}
-                                      </Text>
-                                    </MenuItem>
-                                  )}
-                                </Menu>
-                              </Popover>
-                            </MenuTrigger>
-                          )}
-                        </div>
-                      </GridListItem>
-                    );
-                  }}
-                </GridList>
+                                      </MenuItem>
+                                    )}
+                                  </Menu>
+                                </Popover>
+                              </MenuTrigger>
+                            )}
+                          </div>
+                        </GridListItem>
+                      );
+                    }}
+                  </GridList>
+                </div>
                 <div className="flex flex-1 flex-col divide-y divide-solid divide-(--hl-md) overflow-hidden">
                   <div className="flex w-full items-center justify-between gap-2 overflow-hidden px-(--padding-sm)">
                     <Heading className="flex grow items-center gap-2 overflow-hidden px-4 py-2 text-lg">

--- a/packages/insomnia/src/ui/components/workspace/workspace-pane-header.tsx
+++ b/packages/insomnia/src/ui/components/workspace/workspace-pane-header.tsx
@@ -40,6 +40,7 @@ export default function WorkspacePaneHeader({ hasSettings }: { hasSettings: bool
   }, [breadcrumbs]);
 
   const [isEnvironmentPickerOpen, setIsEnvironmentPickerOpen] = useState(false);
+  const [isProjectEnvironmentPickerOpen, setIsProjectEnvironmentPickerOpen] = useState(false);
   const [isEnvironmentModalOpen, setEnvironmentModalOpen] = useState(false);
   const [isCookieModalOpen, setIsCookieModalOpen] = useState(false);
   const [isCertificatesModalOpen, setCertificatesModalOpen] = useState(false);
@@ -47,6 +48,7 @@ export default function WorkspacePaneHeader({ hasSettings }: { hasSettings: bool
   useDocBodyKeyboardShortcuts({
     environment_showEditor: () => setEnvironmentModalOpen(true),
     environment_showSwitchMenu: () => setIsEnvironmentPickerOpen(true),
+    environment_showSwitchProjectMenu: () => setIsProjectEnvironmentPickerOpen(true),
     showCookiesEditor: () => setIsCookieModalOpen(true),
   });
 
@@ -71,6 +73,15 @@ export default function WorkspacePaneHeader({ hasSettings }: { hasSettings: bool
               isOpen={isEnvironmentPickerOpen}
               onOpenChange={isOpen => {
                 setIsEnvironmentPickerOpen(isOpen);
+                if (isOpen) {
+                  window.main.trackAnalyticsEvent({
+                    event: AnalyticsEvent.requestEnvironmentClicked,
+                  });
+                }
+              }}
+              isProjectPickerOpen={isProjectEnvironmentPickerOpen}
+              onProjectPickerOpenChange={isOpen => {
+                setIsProjectEnvironmentPickerOpen(isOpen);
                 if (isOpen) {
                   window.main.trackAnalyticsEvent({
                     event: AnalyticsEvent.requestEnvironmentClicked,


### PR DESCRIPTION
[INS-2793](https://konghq.atlassian.net/browse/INS-2793)

## Summary
- Splits the single "Manage Environments" popover into two independent dropdowns — project-level and collection-level — each with a scope tooltip and an inheritance-order hint (folder overrides collection, which overrides project).
- Replaces the hidden "+" menu in the collection environment editor and the project-level full-page environment editor with explicit, always-visible "Add Sub Environment" / "Add Private Sub Environment" buttons.
- Adds an "Add Project Environment" action to the project dropdown (does not auto-select the new environment).
- Adds a keyboard shortcut for the project dropdown (Cmd/Ctrl+Alt+E), alongside the existing collection-environment shortcut (Cmd/Ctrl+Shift+E).
- Fixes smoke tests broken by removing the old single-picker trigger, and adds new coverage for the split dropdowns and create flows.

## Test plan
- [x] `npm run lint` — clean (only 2 pre-existing unrelated warnings in generated vendor files)
- [x] `npm run type-check` — clean (packages/insomnia and insomnia-data)
- [x] Verified visually against the running app: independent dropdown open/close, tooltip copy, long-name truncation, project-environment creation flow, explicit sub-environment buttons
- [x] Ran updated/new Playwright smoke tests against the real app (environment-editor-interactions, global-environments) — passing

[INS-2793]: https://konghq.atlassian.net/browse/INS-2793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ