### PR TITLE
fix: set persist-credentials: false on non-pushing actions/checkout steps

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -392,6 +392,8 @@ jobs:
 
       - name: Checkout branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Get release version
         id: release_version

--- a/.github/workflows/release-recurring.yml
+++ b/.github/workflows/release-recurring.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Checkout branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -36,6 +36,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: develop
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -27,4 +27,6 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: Kong/public-shared-actions/security-actions/semgrep@a18abf762d6e2444bcbfd20de70451ea1e3bc1b1 # 4.0.1

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Checkout branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -78,6 +78,8 @@ jobs:
 
       - name: Checkout branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           path: insomnia-base
+          persist-credentials: false
 
       - name: Setup Node (base branch tree)
         if: github.event_name == 'pull_request' && always()


### PR DESCRIPTION
## Summary
Set `persist-credentials: false` on actions/checkout steps that don't push, to prevent GITHUB_TOKEN from being persisted in git config unnecessarily:

- release-build.yml (`update-pull-request` job) - only runs `gh pr edit` via `GH_TOKEN` env, no git push
- release-recurring.yml - only packages app + uploads artifact
- release-start.yml - later push uses an explicit token-in-URL remote, not persisted creds
- sast.yml - only uploads SARIF, no git ops
- test-cli.yml - build/unit/e2e steps only, no git push in file
- test-e2e.yml (`test` job) - downloads artifact, runs smoke tests, no git ops
- test.yml - read-only tree for circular-dep report

update-changelog.yml was left unchanged: its checkout is followed by `stefanzweifel/git-auto-commit-action`, which pushes using the credential helper `actions/checkout` configures and takes no token input of its own — disabling persistence there would break the changelog push.

## Test plan
- [x] Validated YAML syntax of all 7 changed files with js-yaml
- [ ] CI runs green on this branch (workflows still checkout/build/test successfully)