### PR TITLE
fix: run inso Docker image as non-root user

### DIFF
--- a/packages/insomnia-inso/Dockerfile
+++ b/packages/insomnia-inso/Dockerfile
@@ -15,5 +15,7 @@ FROM docker.io/ubuntu:24.04
 COPY --from=fetch /usr/bin/inso /usr/bin/inso
 RUN chmod +x /usr/bin/inso
 RUN apt-get update && apt-get install -y libstdc++6 && rm -rf /var/lib/apt/lists/*
+RUN useradd --create-home --shell /usr/sbin/nologin inso
+USER inso
 
 ENTRYPOINT ["/usr/bin/inso"]


### PR DESCRIPTION
## Summary
- packages/insomnia-inso/Dockerfile - Added a non-root `inso` user and switched to it before ENTRYPOINT, so the final image no longer runs as root by default

## Test plan
- [x] Verified locally with Docker. 
- [x] `npm run lint`, `npm run type-check`, `npm test` all pass
- [x] CI green