### PR TITLE
fix(ci): use the release environment token for Docker workflows

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -38,6 +38,7 @@ jobs:
           upload-sbom-release-assets: false
   build-and-upload-release-artifacts:
     if: startsWith(github.ref_name, 'release/')
+    environment: release
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     permissions:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -20,13 +20,15 @@ env:
   IS_PRERELEASE: ${{ contains(github.event.inputs.version, 'alpha') || contains(github.event.inputs.version, 'beta') }}
   ARTIFACTS_DOWNLOAD_PATH: ${{ github.workspace }}/artifacts
   ARTIFACTS_VERIFY_DOWNLOAD_PATH: ${{ github.workspace }}/artifacts_verify
-  INSO_DOCKER_IMAGE: &INSO_DOCKER_IMAGE 'kong/inso' # By default, registry is docker.io
-  NOTARY_REPOSITORY: &NOTARY_REPOSITORY 'kong/notary' # All signatures will be pushed to public notary repository
+  INSO_DOCKER_IMAGE: 'kong/inso' # By default, registry is docker.io
+  NOTARY_REPOSITORY: 'kong/notary' # All signatures will be pushed to public notary repository
 
 permissions: {}
 
 jobs:
   publish:
+    if: startsWith(github.ref_name, 'release/')
+    environment: release
     timeout-minutes: 30
     runs-on: ubuntu-24.04
     outputs:
@@ -344,19 +346,30 @@ jobs:
 
   inso-image-provenance:
     needs: [publish]
+    if: startsWith(github.ref_name, 'release/')
+    environment: release
+    runs-on: ubuntu-24.04
     permissions:
-      id-token: write # needed for signing the images
-      actions: read # For getting workflow run info to build provenance
-      packages: write # Required for publishing provenance. Issue: https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#known-issues
-      # need to use non hash version because of: https://github.com/slsa-framework/slsa-github-generator/issues/3498
-      contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
-    with:
-      image: *INSO_DOCKER_IMAGE
-      digest: ${{ needs.publish.outputs.INSO_DOCKER_IMAGE_DIGEST }}
-      provenance-repository: *NOTARY_REPOSITORY
-    secrets:
-      registry-username: ${{ secrets.DOCKER_REGISTRY_USER }}
-      registry-password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
-      provenance-registry-username: ${{ secrets.DOCKER_REGISTRY_USER }}
-      provenance-registry-password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+      contents: read
+      packages: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKER_REGISTRY_USER }}
+          password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
+
+      - name: Generate Inso image provenance
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        with:
+          subject-name: docker.io/${{ needs.publish.outputs.INSO_DOCKER_IMAGE }}
+          subject-digest: ${{ needs.publish.outputs.INSO_DOCKER_IMAGE_DIGEST }}
+          push-to-registry: true


### PR DESCRIPTION
## Summary

- Configure the release build and publish jobs to use the `Release` environment, ensuring Docker operations use the Docker Hub organization token instead of the repository-level PAT.
- Restrict the relevant jobs to `release/*` branches.
- Replace the external `generator_container_slsa3` reusable workflow with GitHub Artifact Attestations because environment secrets cannot be passed to an externally managed reusable workflow.
- Keep `inso-image-provenance` as a separate job and publish the container provenance alongside `docker.io/kong/inso`.
- Leave the existing binary artifact provenance workflow unchanged.
