### PR TITLE
fix: Expand folder issue when no request group meta found

### DIFF
--- a/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
+++ b/packages/insomnia/src/ui/components/sidebar/project-navigation-sidebar/project-navigation-sidebar.tsx
@@ -774,7 +774,7 @@ const ProjectNavigationSidebarInner = (
         const requestGroupMeta = requestGroupMetas.find(meta => meta.parentId === requestGroupId);
         return {
           requestGroupId,
-          collapsed: collapsed ?? (requestGroupMeta ? !requestGroupMeta.collapsed : false),
+          collapsed: collapsed ?? (requestGroupMeta ? !requestGroupMeta.collapsed : true),
         };
       });
 


### PR DESCRIPTION
Fix the issue that when there's no request group meta for a folder (like sync from cloud sync/git sync), the default behavior when expand that folder is not correct