### PR TITLE
feat(SSE): add stream summary extraction for SSE responses

### DIFF
--- a/packages/insomnia-data/src/models/request-meta.ts
+++ b/packages/insomnia-data/src/models/request-meta.ts
@@ -22,6 +22,8 @@ export interface BaseRequestMeta {
   downloadPath: string | null;
   expandedAccordionKeys: Partial<Record<RequestAccordionKeys, boolean>>;
   activeMcpPrimitive?: string | null;
+  streamSummaryPath: string | null;
+  streamSummaryRenderMarkdown: boolean;
 }
 
 export type RequestMeta = BaseModel & BaseRequestMeta;
@@ -41,5 +43,7 @@ export function init() {
     downloadPath: null,
     expandedAccordionKeys: {},
     activeMcpPrimitive: null,
+    streamSummaryPath: null,
+    streamSummaryRenderMarkdown: false,
   };
 }

--- a/packages/insomnia/src/common/stream-summary.test.ts
+++ b/packages/insomnia/src/common/stream-summary.test.ts
@@ -42,6 +42,12 @@ describe('extractStreamValueAtPath', () => {
     const payload = JSON.stringify({ value: 'hello' });
     expect(extractStreamValueAtPath(payload, '$.missing')).toBeNull();
   });
+
+  it('returns null (does not throw) for a truncated, still-streaming JSON payload', () => {
+    const payload = '{"choices":[{"delta":{"content":"hi"';
+    expect(() => extractStreamValueAtPath(payload, '$.choices[0].delta.content')).not.toThrow();
+    expect(extractStreamValueAtPath(payload, '$.choices[0].delta.content')).toBeNull();
+  });
 });
 
 describe('computeStreamSummary', () => {
@@ -54,6 +60,26 @@ describe('computeStreamSummary', () => {
     ];
     const result = computeStreamSummary(payloads, '$.choices[0].delta.content');
     expect(result).toEqual({ fragmentCount: 3, summary: 'Hello world' });
+  });
+
+  it('renders Gemini text progressively as the array grows, mid-stream, before it closes', () => {
+    const keyPath = '$.candidates[0].content.parts[0].text';
+    // Each call simulates the accumulated wire text at a point in time as more of Gemini's
+    // still-open array arrives; the array only closes on the last call.
+    const atFirstElement = candidateJsonPayloadsFromSseText(
+      '[{"candidates":[{"content":{"parts":[{"text":"Hel"}]}}]}',
+    );
+    expect(computeStreamSummary(atFirstElement, keyPath)).toEqual({ fragmentCount: 1, summary: 'Hel' });
+
+    const withSecondElementStillOpen = candidateJsonPayloadsFromSseText(
+      '[{"candidates":[{"content":{"parts":[{"text":"Hel"}]}}]}\n,\n{"candidates":[{"content":{"parts":[{"text":"lo',
+    );
+    expect(computeStreamSummary(withSecondElementStillOpen, keyPath)).toEqual({ fragmentCount: 1, summary: 'Hel' });
+
+    const afterClose = candidateJsonPayloadsFromSseText(
+      '[{"candidates":[{"content":{"parts":[{"text":"Hel"}]}}]}\n,\n{"candidates":[{"content":{"parts":[{"text":"lo"}]}}]}\n]',
+    );
+    expect(computeStreamSummary(afterClose, keyPath)).toEqual({ fragmentCount: 2, summary: 'Hello' });
   });
 });
 
@@ -115,6 +141,32 @@ describe('candidateJsonPayloadsFromSseText', () => {
     const text = '{"a":1}';
     expect(candidateJsonPayloadsFromSseText(text)).toEqual(['{"a":1}']);
   });
+
+  it('splits a bare top-level JSON array into one candidate per element (Gemini non-SSE streaming)', () => {
+    // Gemini's default streamGenerateContent (no ?alt=sse) sends one top-level JSON array
+    // with no blank lines between elements, not per-chunk `data:` frames.
+    const text = '[{"candidates":[{"content":{"parts":[{"text":"Hel"}]}}]}\n,\n{"candidates":[{"content":{"parts":[{"text":"lo"}]}}]}\n]';
+    expect(candidateJsonPayloadsFromSseText(text)).toEqual([
+      JSON.stringify({ candidates: [{ content: { parts: [{ text: 'Hel' }] } }] }),
+      JSON.stringify({ candidates: [{ content: { parts: [{ text: 'lo' }] } }] }),
+    ]);
+  });
+
+  it('returns only the elements that have closed so far from a still-open, unterminated array (does not throw)', () => {
+    // Same Gemini shape as above, but mid-stream: the array's closing `]` (and the second
+    // element's closing `}`) haven't arrived yet.
+    const text = '[{"candidates":[{"content":{"parts":[{"text":"Hel"}]}}]}\n,\n{"candidates":[{"content":{"parts":[{"text":"lo';
+    expect(() => candidateJsonPayloadsFromSseText(text)).not.toThrow();
+    expect(candidateJsonPayloadsFromSseText(text)).toEqual([
+      JSON.stringify({ candidates: [{ content: { parts: [{ text: 'Hel' }] } }] }),
+    ]);
+  });
+
+  it('returns nothing (does not throw) for a single element that has not closed yet', () => {
+    const text = '[{"candidates":[{"content":{"parts":[{"text":"Hel"';
+    expect(() => candidateJsonPayloadsFromSseText(text)).not.toThrow();
+    expect(candidateJsonPayloadsFromSseText(text)).toEqual([]);
+  });
 });
 
 describe('getCandidatePayloadsFromEvents', () => {
@@ -126,7 +178,7 @@ describe('getCandidatePayloadsFromEvents', () => {
       { type: 'message', direction: 'INCOMING', data: chunkB },
       { type: 'message', direction: 'INCOMING', data: chunkA },
     ];
-    expect(getCandidatePayloadsFromEvents(newestFirst, 'curl')).toEqual([
+    expect(getCandidatePayloadsFromEvents(newestFirst)).toEqual([
       '{"choices":[{"delta":{"content":"Hel"}}]}',
       '{"choices":[{"delta":{"content":"lo"}}]}',
     ]);
@@ -138,18 +190,7 @@ describe('getCandidatePayloadsFromEvents', () => {
       { type: 'message', direction: 'INCOMING', data: ':1}\n\n' },
       { type: 'message', direction: 'INCOMING', data: 'data: {"a"' },
     ];
-    expect(getCandidatePayloadsFromEvents(newestFirst, 'curl')).toEqual(['{"a":1}']);
-  });
-
-  it('orders WebSocket messages chronologically given a newest-first input array', () => {
-    const newestFirst = [
-      { type: 'message', direction: 'INCOMING', data: '{"delta":"lo"}' },
-      { type: 'message', direction: 'INCOMING', data: '{"delta":"Hel"}' },
-    ];
-    expect(getCandidatePayloadsFromEvents(newestFirst, 'webSocket')).toEqual([
-      '{"delta":"Hel"}',
-      '{"delta":"lo"}',
-    ]);
+    expect(getCandidatePayloadsFromEvents(newestFirst)).toEqual(['{"a":1}']);
   });
 
   it('ignores outgoing and non-message events', () => {
@@ -158,6 +199,6 @@ describe('getCandidatePayloadsFromEvents', () => {
       { type: 'message', direction: 'OUTGOING', data: '{"delta":"ignored"}' },
       { type: 'open', direction: '', data: '' },
     ];
-    expect(getCandidatePayloadsFromEvents(events, 'webSocket')).toEqual(['{"delta":"kept"}']);
+    expect(getCandidatePayloadsFromEvents(events)).toEqual(['{"delta":"kept"}']);
   });
 });

--- a/packages/insomnia/src/common/stream-summary.test.ts
+++ b/packages/insomnia/src/common/stream-summary.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  candidateJsonPayloadsFromSseText,
+  computeStreamSummary,
+  extractStreamValueAtPath,
+  getCandidatePayloadsFromEvents,
+  inferStreamSummaryPath,
+} from './stream-summary';
+
+describe('extractStreamValueAtPath', () => {
+  it('extracts a string field', () => {
+    const payload = JSON.stringify({ choices: [{ delta: { content: 'hello' } }] });
+    expect(extractStreamValueAtPath(payload, '$.choices[0].delta.content')).toBe('hello');
+  });
+
+  it('stringifies a numeric field instead of dropping it', () => {
+    const payload = JSON.stringify({ value: 42 });
+    expect(extractStreamValueAtPath(payload, '$.value')).toBe('42');
+  });
+
+  it('stringifies an object field instead of dropping it', () => {
+    const payload = JSON.stringify({ value: { foo: 'bar' } });
+    expect(extractStreamValueAtPath(payload, '$.value')).toBe(JSON.stringify({ foo: 'bar' }));
+  });
+
+  it('joins array results', () => {
+    const payload = JSON.stringify({ items: ['a', 'b', 'c'] });
+    expect(extractStreamValueAtPath(payload, '$.items[*]')).toBe('abc');
+  });
+
+  it('returns null for invalid JSON payload', () => {
+    expect(extractStreamValueAtPath('not json', '$.value')).toBeNull();
+  });
+
+  it('returns null for invalid JSONPath', () => {
+    const payload = JSON.stringify({ value: 'hello' });
+    expect(extractStreamValueAtPath(payload, '$[?(]')).toBeNull();
+  });
+
+  it('returns null when the path matches nothing', () => {
+    const payload = JSON.stringify({ value: 'hello' });
+    expect(extractStreamValueAtPath(payload, '$.missing')).toBeNull();
+  });
+});
+
+describe('computeStreamSummary', () => {
+  it('joins multiple payloads and reports fragmentCount', () => {
+    const payloads = [
+      JSON.stringify({ choices: [{ delta: { content: 'Hel' } }] }),
+      JSON.stringify({ choices: [{ delta: { content: 'lo ' } }] }),
+      JSON.stringify({ choices: [{ delta: {} }] }),
+      JSON.stringify({ choices: [{ delta: { content: 'world' } }] }),
+    ];
+    const result = computeStreamSummary(payloads, '$.choices[0].delta.content');
+    expect(result).toEqual({ fragmentCount: 3, summary: 'Hello world' });
+  });
+});
+
+describe('inferStreamSummaryPath', () => {
+  it('matches OpenAI chat completions', () => {
+    expect(inferStreamSummaryPath('https://api.openai.com/v1/chat/completions')).toBe('$.choices[0].delta.content');
+  });
+
+  it('matches OpenAI responses API on a proxy host', () => {
+    expect(inferStreamSummaryPath('https://my-proxy.example.com/v1/responses')).toBe('$.delta');
+  });
+
+  it('matches Anthropic messages API', () => {
+    expect(inferStreamSummaryPath('https://api.anthropic.com/v1/messages')).toBe('$.delta.text');
+  });
+
+  it('matches Google Gemini streamGenerateContent', () => {
+    expect(
+      inferStreamSummaryPath('https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:streamGenerateContent'),
+    ).toBe('$.candidates[0].content.parts[0].text');
+  });
+
+  it('returns null when no pathname matches', () => {
+    expect(inferStreamSummaryPath('https://example.com/v1/unknown')).toBeNull();
+  });
+
+  it('returns null for an invalid URL', () => {
+    expect(inferStreamSummaryPath('not a url')).toBeNull();
+  });
+});
+
+describe('candidateJsonPayloadsFromSseText', () => {
+  it('extracts a single data frame', () => {
+    const text = 'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n';
+    expect(candidateJsonPayloadsFromSseText(text)).toEqual([
+      '{"choices":[{"delta":{"content":"hi"}}]}',
+    ]);
+  });
+
+  it('extracts multiple frames separated by blank lines', () => {
+    const text = 'data: {"a":1}\n\ndata: {"b":2}\n\n';
+    expect(candidateJsonPayloadsFromSseText(text)).toEqual([
+      '{"a":1}',
+      '{"b":2}',
+    ]);
+  });
+
+  it('extracts a frame with event:/id: fields mixed in', () => {
+    const text = 'event: message\nid: 42\ndata: {"a":1}\n\n';
+    expect(candidateJsonPayloadsFromSseText(text)).toEqual(['{"a":1}']);
+  });
+
+  it('joins a multi-line data: continuation frame', () => {
+    const text = 'data: {"a":1,\ndata: "b":2}\n\n';
+    expect(candidateJsonPayloadsFromSseText(text)).toEqual(['{"a":1,\n"b":2}']);
+  });
+
+  it('falls back to a bare JSON blob with no data: prefix', () => {
+    const text = '{"a":1}';
+    expect(candidateJsonPayloadsFromSseText(text)).toEqual(['{"a":1}']);
+  });
+});
+
+describe('getCandidatePayloadsFromEvents', () => {
+  it('reconstructs curl SSE chunks in chronological order given a newest-first input array', () => {
+    const chunkA = 'data: {"choices":[{"delta":{"content":"Hel"}}]}\n\n';
+    const chunkB = 'data: {"choices":[{"delta":{"content":"lo"}}]}\n\n';
+    // findMany() returns newest-first, so the true arrival order (A then B) appears reversed here.
+    const newestFirst = [
+      { type: 'message', direction: 'INCOMING', data: chunkB },
+      { type: 'message', direction: 'INCOMING', data: chunkA },
+    ];
+    expect(getCandidatePayloadsFromEvents(newestFirst, 'curl')).toEqual([
+      '{"choices":[{"delta":{"content":"Hel"}}]}',
+      '{"choices":[{"delta":{"content":"lo"}}]}',
+    ]);
+  });
+
+  it('reconstructs curl SSE frames split across multiple chunks, given a newest-first input array', () => {
+    // True arrival order is 'data: {"a"' then ':1}\n\n'; findMany() returns newest-first.
+    const newestFirst = [
+      { type: 'message', direction: 'INCOMING', data: ':1}\n\n' },
+      { type: 'message', direction: 'INCOMING', data: 'data: {"a"' },
+    ];
+    expect(getCandidatePayloadsFromEvents(newestFirst, 'curl')).toEqual(['{"a":1}']);
+  });
+
+  it('orders WebSocket messages chronologically given a newest-first input array', () => {
+    const newestFirst = [
+      { type: 'message', direction: 'INCOMING', data: '{"delta":"lo"}' },
+      { type: 'message', direction: 'INCOMING', data: '{"delta":"Hel"}' },
+    ];
+    expect(getCandidatePayloadsFromEvents(newestFirst, 'webSocket')).toEqual([
+      '{"delta":"Hel"}',
+      '{"delta":"lo"}',
+    ]);
+  });
+
+  it('ignores outgoing and non-message events', () => {
+    const events = [
+      { type: 'message', direction: 'INCOMING', data: '{"delta":"kept"}' },
+      { type: 'message', direction: 'OUTGOING', data: '{"delta":"ignored"}' },
+      { type: 'open', direction: '', data: '' },
+    ];
+    expect(getCandidatePayloadsFromEvents(events, 'webSocket')).toEqual(['{"delta":"kept"}']);
+  });
+});

--- a/packages/insomnia/src/common/stream-summary.ts
+++ b/packages/insomnia/src/common/stream-summary.ts
@@ -72,6 +72,16 @@ export function candidateJsonPayloadsFromSseText(text: string): string[] {
       continue;
     }
 
+    if (trimmedBlock.startsWith('[')) {
+      // Gemini's default (non-SSE, no `?alt=sse`) streaming response is a single top-level
+      // JSON array with no blank lines between elements, so it lands here as one block.
+      // Extract whichever elements have arrived complete so far, even mid-stream before the
+      // array's closing `]` shows up, so the summary can render as chunks come in rather
+      // than only once the whole response finishes.
+      candidates.push(...extractCompleteTopLevelArrayElements(trimmedBlock));
+      continue;
+    }
+
     if (isParsableJson(trimmedBlock)) {
       candidates.push(trimmedBlock);
       continue;
@@ -94,6 +104,57 @@ export function candidateJsonPayloadsFromSseText(text: string): string[] {
   return candidates;
 }
 
+// Scans a (possibly unterminated) top-level JSON array and returns the substring of each
+// element that has closed so far, tracking bracket depth and string escaping by hand rather
+// than JSON.parse-ing the whole thing (which fails until the array's closing `]` arrives).
+// An element still being streamed simply never closes, so it's correctly left out.
+function extractCompleteTopLevelArrayElements(text: string): string[] {
+  const elements: string[] = [];
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  let elementStart = -1;
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+
+    if (char === '[' || char === '{') {
+      if (depth === 1 && elementStart === -1) {
+        elementStart = i;
+      }
+      depth++;
+      continue;
+    }
+
+    if (char === ']' || char === '}') {
+      depth--;
+      if (depth === 1 && elementStart !== -1) {
+        elements.push(text.slice(elementStart, i + 1));
+        elementStart = -1;
+      }
+      continue;
+    }
+  }
+
+  return elements;
+}
+
 function isParsableJson(value: string): boolean {
   try {
     JSON.parse(value);
@@ -109,17 +170,14 @@ export interface StreamMessageEvent {
   data: string;
 }
 
-export function getCandidatePayloadsFromEvents(events: StreamMessageEvent[], protocol: 'curl' | 'webSocket'): string[] {
-  // Both curl's and websocket's findMany() reverse the event log for "latest event
+export function getCandidatePayloadsFromEvents(events: StreamMessageEvent[]): string[] {
+  // curl's findMany() reverse the event log for "latest event
   // first" display, so undo that exact reversal here (rather than sort by timestamp,
   // which has only millisecond resolution and can't disambiguate SSE chunks that arrive
   // within the same millisecond) to get back true chronological order.
   const incoming = events.filter(event => event.type === 'message' && event.direction === 'INCOMING').reverse();
 
-  if (protocol === 'curl') {
-    return candidateJsonPayloadsFromSseText(incoming.map(event => event.data).join(''));
-  }
-  return incoming.map(event => event.data);
+  return candidateJsonPayloadsFromSseText(incoming.map(event => event.data).join(''));
 }
 
 const PATH_TO_JSONPATH: { pathname: string; jsonPath: string }[] = [
@@ -136,6 +194,8 @@ const PATH_TO_JSONPATH: { pathname: string; jsonPath: string }[] = [
 export const inferStreamSummaryPath = (url: string): string | null => {
   try {
     const { pathname } = new URL(url);
+    // Gemini uses a ":verb" suffix (.../models/gemini-pro:streamGenerateContent) rather than
+    // a fixed REST path, so it can't go in PATH_TO_JSONPATH's exact-match table below.
     if (pathname.toLowerCase().includes(':streamgeneratecontent')) {
       return '$.candidates[0].content.parts[0].text';
     }

--- a/packages/insomnia/src/common/stream-summary.ts
+++ b/packages/insomnia/src/common/stream-summary.ts
@@ -1,0 +1,147 @@
+import { JSONPath } from 'jsonpath-plus';
+
+const stringifyValue = (value: unknown): string | null => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value);
+  }
+  return JSON.stringify(value);
+};
+
+export const extractStreamValueAtPath = (payload: string, keyPath: string): string | null => {
+  try {
+    const parsed = JSON.parse(payload);
+    const path = keyPath.trim();
+    const result = JSONPath({ path, json: parsed });
+    if (Array.isArray(result)) {
+      // An empty array means the path matched nothing at all (as opposed to matching a
+      // field whose value happens to be an empty string), so it's treated the same as
+      // a null/undefined result rather than joined into an empty-but-present fragment.
+      if (result.length === 0) {
+        return null;
+      }
+      return result
+        .map(stringifyValue)
+        .filter((value): value is string => value !== null)
+        .join('');
+    }
+    return stringifyValue(result);
+  } catch {
+    return null;
+  }
+};
+
+export const computeStreamSummary = (
+  payloads: string[],
+  keyPath: string,
+): { fragmentCount: number; summary: string } => {
+  const fragments = payloads
+    .map(payload => extractStreamValueAtPath(payload, keyPath))
+    .filter((value): value is string => value !== null);
+  return { fragmentCount: fragments.length, summary: fragments.join('') };
+};
+
+const STANDARD_SSE_FIELD = /^(event|id|retry):/i;
+
+export function candidateJsonPayloadsFromSseText(text: string): string[] {
+  const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  const blocks = normalized.split(/\n{2,}/);
+  const candidates: string[] = [];
+
+  for (const block of blocks) {
+    const lines = block.split('\n');
+    const dataLines = lines
+      .map(line => /^data:(?: ?)(.*)$/.exec(line)?.[1])
+      .filter((line): line is string => line != null);
+
+    if (dataLines.length > 0) {
+      const payload = dataLines.join('\n').trim();
+      if (payload) {
+        candidates.push(payload);
+      }
+      continue;
+    }
+
+    const trimmedBlock = block.trim();
+    if (!trimmedBlock) {
+      continue;
+    }
+
+    if (isParsableJson(trimmedBlock)) {
+      candidates.push(trimmedBlock);
+      continue;
+    }
+
+    for (const line of lines) {
+      const trimmedLine = line.trim();
+      if (
+        !trimmedLine ||
+        trimmedLine.startsWith(':') ||
+        STANDARD_SSE_FIELD.test(trimmedLine) ||
+        !isParsableJson(trimmedLine)
+      ) {
+        continue;
+      }
+      candidates.push(trimmedLine);
+    }
+  }
+
+  return candidates;
+}
+
+function isParsableJson(value: string): boolean {
+  try {
+    JSON.parse(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface StreamMessageEvent {
+  type: string;
+  direction: string;
+  data: string;
+}
+
+export function getCandidatePayloadsFromEvents(events: StreamMessageEvent[], protocol: 'curl' | 'webSocket'): string[] {
+  // Both curl's and websocket's findMany() reverse the event log for "latest event
+  // first" display, so undo that exact reversal here (rather than sort by timestamp,
+  // which has only millisecond resolution and can't disambiguate SSE chunks that arrive
+  // within the same millisecond) to get back true chronological order.
+  const incoming = events.filter(event => event.type === 'message' && event.direction === 'INCOMING').reverse();
+
+  if (protocol === 'curl') {
+    return candidateJsonPayloadsFromSseText(incoming.map(event => event.data).join(''));
+  }
+  return incoming.map(event => event.data);
+}
+
+const PATH_TO_JSONPATH: { pathname: string; jsonPath: string }[] = [
+  // OpenAI: Chat Completions API
+  { pathname: '/v1/chat/completions', jsonPath: '$.choices[0].delta.content' },
+  // OpenAI: Completions API, Legacy
+  { pathname: '/v1/completions', jsonPath: '$.choices[0].text' },
+  // OpenAI Responses API
+  { pathname: '/v1/responses', jsonPath: '$.delta' },
+  // Anthropic Claude Messages API
+  { pathname: '/v1/messages', jsonPath: '$.delta.text' },
+];
+
+export const inferStreamSummaryPath = (url: string): string | null => {
+  try {
+    const { pathname } = new URL(url);
+    if (pathname.toLowerCase().includes(':streamgeneratecontent')) {
+      return '$.candidates[0].content.parts[0].text';
+    }
+    const match = PATH_TO_JSONPATH.find(entry => entry.pathname === pathname);
+    return match ? match.jsonPath : null;
+  } catch {
+    return null;
+  }
+};

--- a/packages/insomnia/src/ui/components/websockets/event-view.tsx
+++ b/packages/insomnia/src/ui/components/websockets/event-view.tsx
@@ -74,7 +74,7 @@ export const MessageEventView: FC<Props<CurlMessageEvent | WebSocketMessageEvent
           }}
         />
       </div>
-      <div className="grow p-4">
+      <div className="grow p-4 pb-0">
         <CodeEditor
           id="websocket-body-preview"
           hideLineNumbers

--- a/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
@@ -18,6 +18,7 @@ import {
   TabList,
   TabPanel,
   Tabs,
+  TextField,
   Tooltip,
   TooltipTrigger,
 } from 'react-aria-components';
@@ -66,26 +67,30 @@ const StreamSummaryPanel: FC<{ requestId: string; streamSummary: ReturnType<type
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center gap-(--padding-sm) p-(--padding-sm)">
-        <input
+        <TextField
           // Uncontrolled: `key` resets the field when switching requests, but typing isn't
           // clobbered by the round-trip through patchRequestMeta -> loader revalidation
           // (same reason code-editor.tsx's filter input uses defaultValue, not value).
           key={requestId}
           aria-label="Stream summary JSONPath"
-          placeholder={streamSummary.inferredPath ?? 'JSONPath, e.g. $.choices[0].delta.content'}
           defaultValue={streamSummary.resultPath ?? ''}
-          onKeyDown={e => {
-            if (e.key === 'Enter') {
-              streamSummary.setResultPath(e.currentTarget.value);
-            }
-          }}
-          onChange={e => {
-            if (e.currentTarget.value === '') {
+          onChange={value => {
+            if (value === '') {
               streamSummary.setResultPath('');
             }
           }}
-          className="w-full rounded-sm border border-solid border-(--hl-sm) bg-(--color-bg) px-2 py-1 text-(--color-font) transition-colors focus:ring-1 focus:ring-(--hl-md) focus:outline-hidden"
-        />
+          className="w-full"
+        >
+          <Input
+            placeholder={streamSummary.inferredPath ?? 'JSONPath, e.g. $.choices[0].delta.content'}
+            onKeyDown={e => {
+              if (e.key === 'Enter') {
+                streamSummary.setResultPath(e.currentTarget.value);
+              }
+            }}
+            className="w-full rounded-sm border border-solid border-(--hl-sm) bg-(--color-bg) px-2 py-1 text-(--color-font) transition-colors focus:ring-1 focus:ring-(--hl-md) focus:outline-hidden"
+          />
+        </TextField>
         {showWarning && (
           <TooltipTrigger>
             <Button
@@ -233,15 +238,14 @@ const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { readySt
 
   const allEvents = useRealtimeConnectionEvents({ responseId: response._id, protocol }) as EventType[];
   const allNotifications = useRealtimeConnectionNotifications({ responseId: response._id, protocol });
-  const showStreamSummaryTab = protocol === 'curl' || protocol === 'webSocket';
+  const showStreamSummaryTab = protocol === 'curl';
   const streamSummary = useStreamSummary({
     requestId: response.parentId,
     url: response.url,
-    // Only curl/webSocket carry stream-summary-shaped data — never feed socketIO's events
-    // in here mislabeled as one of those, even though showStreamSummaryTab already hides
-    // the UI for it.
-    events: showStreamSummaryTab ? (allEvents as (CurlEvent | WebSocketEvent)[]) : [],
-    protocol: protocol === 'curl' ? 'curl' : 'webSocket',
+    // Only curl carries stream-summary-shaped data — never feed socketIO's/webSocket's
+    // events in here mislabeled as curl, even though showStreamSummaryTab already hides
+    // the UI for those.
+    events: showStreamSummaryTab ? (allEvents as CurlEvent[]) : [],
   });
   const handleSelection = (event: EventType) => {
     setSelectedEvent((selected: EventType | null) => (selected?._id === event._id ? null : event));
@@ -371,7 +375,7 @@ const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { readySt
         key={response._id}
         aria-label="Request group tabs"
         className="flex h-full w-full flex-1 flex-col"
-        defaultSelectedKey={showStreamSummaryTab && streamSummary.inferredPath != null ? 'extracted-text' : 'events'}
+        defaultSelectedKey={showStreamSummaryTab && streamSummary.inferredPath != null ? 'summary' : 'events'}
       >
         <TabList
           className="flex h-(--line-height-sm) w-full shrink-0 items-center overflow-x-auto border-b border-solid border-b-(--hl-md) bg-(--color-bg)"
@@ -386,7 +390,7 @@ const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { readySt
           {showStreamSummaryTab && (
             <Tab
               className="flex h-full shrink-0 cursor-pointer items-center justify-between gap-2 px-3 py-1 text-(--hl) outline-hidden transition-colors duration-300 select-none hover:bg-(--hl-sm) hover:text-(--color-font) focus:bg-(--hl-sm) aria-selected:bg-(--hl-xs) aria-selected:text-(--color-font) aria-selected:hover:bg-(--hl-sm) aria-selected:focus:bg-(--hl-sm)"
-              id="extracted-text"
+              id="summary"
             >
               Summary
             </Tab>
@@ -530,7 +534,7 @@ const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { readySt
           </PanelGroup>
         </TabPanel>
         {showStreamSummaryTab && (
-          <TabPanel className="flex w-full flex-1 flex-col overflow-hidden" id="extracted-text">
+          <TabPanel className="flex w-full flex-1 flex-col overflow-hidden" id="summary">
             <StreamSummaryPanel requestId={response.parentId} streamSummary={streamSummary} />
           </TabPanel>
         )}

--- a/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
@@ -10,12 +10,23 @@ import type {
 import { models } from 'insomnia-data';
 import { deserializeNDJSON } from 'insomnia-data/common';
 import React, { type FC, useEffect, useMemo, useState } from 'react';
-import { Button, Input, SearchField, Tab, TabList, TabPanel, Tabs } from 'react-aria-components';
+import {
+  Button,
+  Input,
+  SearchField,
+  Tab,
+  TabList,
+  TabPanel,
+  Tabs,
+  Tooltip,
+  TooltipTrigger,
+} from 'react-aria-components';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 
 import { docsMcpAuthentication } from '~/common/documentation';
 import { useMcpReadyState } from '~/ui/hooks/use-mcp-ready-state';
 import { useRealtimeConnectionNotifications } from '~/ui/hooks/use-realtime-connection-notifications';
+import { useStreamSummary } from '~/ui/hooks/use-stream-summary';
 
 import { getSetCookieHeaders } from '../../../common/misc';
 import type { McpEvent } from '../../../main/mcp/types';
@@ -26,9 +37,11 @@ import { useRequestLoaderData } from '../../../routes/organization.$organization
 import { AnalyticsEvent } from '../../../ui/analytics';
 import { useReadyState } from '../../hooks/use-ready-state';
 import { useRealtimeConnectionEvents } from '../../hooks/use-realtime-connection-events';
+import { Dropdown, DropdownItem, DropdownSection, ItemContent } from '../base/dropdown';
 import { ResponseHistoryDropdown } from '../dropdowns/response-history-dropdown';
 import { ErrorBoundary } from '../error-boundary';
 import { Icon } from '../icon';
+import { MarkdownPreview } from '../markdown-preview';
 import { McpEventView } from '../mcp/event-view';
 import { McpNotificationTab } from '../mcp/mcp-notification-tab';
 import { Pane, PaneHeader } from '../panes/pane';
@@ -44,6 +57,90 @@ import { ResponseHeadersViewer } from '../viewers/response-headers-viewer';
 import { ResponseTimelineViewer } from '../viewers/response-timeline-viewer';
 import { EventLogView } from './event-log-view';
 import { EventView } from './event-view';
+
+const StreamSummaryPanel: FC<{ requestId: string; streamSummary: ReturnType<typeof useStreamSummary> }> = ({
+  requestId,
+  streamSummary,
+}) => {
+  const showWarning = Boolean(streamSummary.resultPath) && streamSummary.summary.fragmentCount === 0;
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-(--padding-sm) p-(--padding-sm)">
+        <input
+          // Uncontrolled: `key` resets the field when switching requests, but typing isn't
+          // clobbered by the round-trip through patchRequestMeta -> loader revalidation
+          // (same reason code-editor.tsx's filter input uses defaultValue, not value).
+          key={requestId}
+          aria-label="Stream summary JSONPath"
+          placeholder={streamSummary.inferredPath ?? 'JSONPath, e.g. $.choices[0].delta.content'}
+          defaultValue={streamSummary.resultPath ?? ''}
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              streamSummary.setResultPath(e.currentTarget.value);
+            }
+          }}
+          onChange={e => {
+            if (e.currentTarget.value === '') {
+              streamSummary.setResultPath('');
+            }
+          }}
+          className="w-full rounded-sm border border-solid border-(--hl-sm) bg-(--color-bg) px-2 py-1 text-(--color-font) transition-colors focus:ring-1 focus:ring-(--hl-md) focus:outline-hidden"
+        />
+        {showWarning && (
+          <TooltipTrigger>
+            <Button
+              aria-label="JSONPath matched no messages"
+              className="flex aspect-square h-full shrink-0 items-center justify-center text-(--color-warning)"
+            >
+              <Icon icon="triangle-exclamation" />
+            </Button>
+            <Tooltip
+              offset={8}
+              className="max-w-xs rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) px-3 py-2 text-sm text-(--color-font) shadow-lg select-none focus:outline-hidden"
+            >
+              This JSONPath did not match any incoming message.
+            </Tooltip>
+          </TooltipTrigger>
+        )}
+        <Dropdown
+          aria-label="Stream summary render mode dropdown"
+          triggerButton={
+            <Button className="tall shrink-0">
+              {streamSummary.renderMarkdown ? 'Markdown' : 'Plain text'}
+              <i className="fa fa-caret-down space-left" />
+            </Button>
+          }
+        >
+          <DropdownSection aria-label="Render as section" title="Render as">
+            <DropdownItem aria-label="Plain text">
+              <ItemContent
+                icon={streamSummary.renderMarkdown ? 'empty' : 'check'}
+                label="Plain text"
+                onClick={() => streamSummary.setRenderMarkdown(false)}
+              />
+            </DropdownItem>
+            <DropdownItem aria-label="Markdown">
+              <ItemContent
+                icon={streamSummary.renderMarkdown ? 'check' : 'empty'}
+                label="Markdown"
+                onClick={() => streamSummary.setRenderMarkdown(true)}
+              />
+            </DropdownItem>
+          </DropdownSection>
+        </Dropdown>
+      </div>
+      <div className="flex-1 overflow-auto p-(--padding-sm)">
+        {streamSummary.renderMarkdown ? (
+          <MarkdownPreview markdown={streamSummary.summary.summary} />
+        ) : (
+          <pre className="font-mono text-sm whitespace-pre-wrap text-(--color-font)">
+            {streamSummary.summary.summary}
+          </pre>
+        )}
+      </div>
+    </div>
+  );
+};
 
 export const RealtimeResponsePane: FC<{ requestId?: string }> = () => {
   const { activeResponse, responses, requestVersions } = useRequestLoaderData()!;
@@ -136,6 +233,16 @@ const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { readySt
 
   const allEvents = useRealtimeConnectionEvents({ responseId: response._id, protocol }) as EventType[];
   const allNotifications = useRealtimeConnectionNotifications({ responseId: response._id, protocol });
+  const showStreamSummaryTab = protocol === 'curl' || protocol === 'webSocket';
+  const streamSummary = useStreamSummary({
+    requestId: response.parentId,
+    url: response.url,
+    // Only curl/webSocket carry stream-summary-shaped data — never feed socketIO's events
+    // in here mislabeled as one of those, even though showStreamSummaryTab already hides
+    // the UI for it.
+    events: showStreamSummaryTab ? (allEvents as (CurlEvent | WebSocketEvent)[]) : [],
+    protocol: protocol === 'curl' ? 'curl' : 'webSocket',
+  });
   const handleSelection = (event: EventType) => {
     setSelectedEvent((selected: EventType | null) => (selected?._id === event._id ? null : event));
   };
@@ -260,7 +367,12 @@ const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { readySt
         </div>
         <ResponseHistoryDropdown activeResponse={response} requestVersions={requestVersions} responses={responses} />
       </PaneHeader>
-      <Tabs aria-label="Request group tabs" className="flex h-full w-full flex-1 flex-col">
+      <Tabs
+        key={response._id}
+        aria-label="Request group tabs"
+        className="flex h-full w-full flex-1 flex-col"
+        defaultSelectedKey={showStreamSummaryTab && streamSummary.inferredPath != null ? 'extracted-text' : 'events'}
+      >
         <TabList
           className="flex h-(--line-height-sm) w-full shrink-0 items-center overflow-x-auto border-b border-solid border-b-(--hl-md) bg-(--color-bg)"
           aria-label="Request pane tabs"
@@ -271,6 +383,14 @@ const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { readySt
           >
             Events
           </Tab>
+          {showStreamSummaryTab && (
+            <Tab
+              className="flex h-full shrink-0 cursor-pointer items-center justify-between gap-2 px-3 py-1 text-(--hl) outline-hidden transition-colors duration-300 select-none hover:bg-(--hl-sm) hover:text-(--color-font) focus:bg-(--hl-sm) aria-selected:bg-(--hl-xs) aria-selected:text-(--color-font) aria-selected:hover:bg-(--hl-sm) aria-selected:focus:bg-(--hl-sm)"
+              id="extracted-text"
+            >
+              Summary
+            </Tab>
+          )}
           {models.mcpResponse.isMcpResponse(response) && (
             <Tab
               className="flex h-full shrink-0 cursor-pointer items-center justify-between gap-2 px-3 py-1 text-(--hl) outline-hidden transition-colors duration-300 select-none hover:bg-(--hl-sm) hover:text-(--color-font) focus:bg-(--hl-sm) aria-selected:bg-(--hl-xs) aria-selected:text-(--color-font) aria-selected:hover:bg-(--hl-sm) aria-selected:focus:bg-(--hl-sm)"
@@ -409,6 +529,11 @@ const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { readySt
             )}
           </PanelGroup>
         </TabPanel>
+        {showStreamSummaryTab && (
+          <TabPanel className="flex w-full flex-1 flex-col overflow-hidden" id="extracted-text">
+            <StreamSummaryPanel requestId={response.parentId} streamSummary={streamSummary} />
+          </TabPanel>
+        )}
         {models.mcpResponse.isMcpResponse(response) && (
           <TabPanel className="flex w-full flex-1 flex-col overflow-hidden" id="notifications">
             <McpNotificationTab allEvents={allNotifications} />

--- a/packages/insomnia/src/ui/hooks/use-stream-summary.ts
+++ b/packages/insomnia/src/ui/hooks/use-stream-summary.ts
@@ -1,0 +1,54 @@
+import { useMemo } from 'react';
+
+import { computeStreamSummary, getCandidatePayloadsFromEvents, inferStreamSummaryPath, type StreamMessageEvent } from '~/common/stream-summary';
+
+import type { CurlEvent } from '../../main/network/curl';
+import type { WebSocketEvent } from '../../main/network/websocket';
+import {
+  type RequestLoaderData,
+  useRequestLoaderData,
+} from '../../routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId';
+import { useRequestMetaPatcher } from './use-request';
+
+const getCandidatePayloads = (events: (CurlEvent | WebSocketEvent)[], protocol: 'curl' | 'webSocket'): string[] => {
+  const streamEvents: StreamMessageEvent[] = events.map(event => ({
+    type: event.type,
+    direction: 'direction' in event ? event.direction : '',
+    data: 'data' in event ? (typeof event.data === 'string' ? event.data : event.data.toString()) : '',
+  }));
+  return getCandidatePayloadsFromEvents(streamEvents, protocol);
+};
+
+export const useStreamSummary = ({
+  requestId,
+  url,
+  events,
+  protocol,
+}: {
+  requestId: string;
+  url: string;
+  events: (CurlEvent | WebSocketEvent)[];
+  protocol: 'curl' | 'webSocket';
+}) => {
+  const { activeRequestMeta } = useRequestLoaderData() as RequestLoaderData;
+  const patchRequestMeta = useRequestMetaPatcher();
+
+  const inferredPath = useMemo(() => inferStreamSummaryPath(url), [url]);
+  const resultPath = useMemo(() => {
+    const path = activeRequestMeta.streamSummaryPath ?? inferredPath;
+    return path?.trim() || null;
+  }, [activeRequestMeta.streamSummaryPath, inferredPath]);
+
+  const summary = useMemo(() => {
+    if (!resultPath) {
+      return { fragmentCount: 0, summary: '' };
+    }
+    return computeStreamSummary(getCandidatePayloads(events, protocol), resultPath);
+  }, [events, protocol, resultPath]);
+
+  const setResultPath = (path: string) => patchRequestMeta(requestId, { streamSummaryPath: path });
+  const renderMarkdown = activeRequestMeta.streamSummaryRenderMarkdown;
+  const setRenderMarkdown = (value: boolean) => patchRequestMeta(requestId, { streamSummaryRenderMarkdown: value });
+
+  return { inferredPath, resultPath, summary, setResultPath, renderMarkdown, setRenderMarkdown };
+};

--- a/packages/insomnia/src/ui/hooks/use-stream-summary.ts
+++ b/packages/insomnia/src/ui/hooks/use-stream-summary.ts
@@ -1,34 +1,36 @@
 import { useMemo } from 'react';
 
-import { computeStreamSummary, getCandidatePayloadsFromEvents, inferStreamSummaryPath, type StreamMessageEvent } from '~/common/stream-summary';
-
-import type { CurlEvent } from '../../main/network/curl';
-import type { WebSocketEvent } from '../../main/network/websocket';
+import {
+  computeStreamSummary,
+  getCandidatePayloadsFromEvents,
+  inferStreamSummaryPath,
+  type StreamMessageEvent,
+} from '~/common/stream-summary';
+import type { CurlEvent } from '~/main/network/curl';
 import {
   type RequestLoaderData,
   useRequestLoaderData,
-} from '../../routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId';
+} from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId';
+
 import { useRequestMetaPatcher } from './use-request';
 
-const getCandidatePayloads = (events: (CurlEvent | WebSocketEvent)[], protocol: 'curl' | 'webSocket'): string[] => {
+const getCandidatePayloads = (events: CurlEvent[]): string[] => {
   const streamEvents: StreamMessageEvent[] = events.map(event => ({
     type: event.type,
     direction: 'direction' in event ? event.direction : '',
-    data: 'data' in event ? (typeof event.data === 'string' ? event.data : event.data.toString()) : '',
+    data: 'data' in event ? event.data : '',
   }));
-  return getCandidatePayloadsFromEvents(streamEvents, protocol);
+  return getCandidatePayloadsFromEvents(streamEvents);
 };
 
 export const useStreamSummary = ({
   requestId,
   url,
   events,
-  protocol,
 }: {
   requestId: string;
   url: string;
-  events: (CurlEvent | WebSocketEvent)[];
-  protocol: 'curl' | 'webSocket';
+  events: CurlEvent[];
 }) => {
   const { activeRequestMeta } = useRequestLoaderData() as RequestLoaderData;
   const patchRequestMeta = useRequestMetaPatcher();
@@ -43,8 +45,8 @@ export const useStreamSummary = ({
     if (!resultPath) {
       return { fragmentCount: 0, summary: '' };
     }
-    return computeStreamSummary(getCandidatePayloads(events, protocol), resultPath);
-  }, [events, protocol, resultPath]);
+    return computeStreamSummary(getCandidatePayloads(events), resultPath);
+  }, [events, resultPath]);
 
   const setResultPath = (path: string) => patchRequestMeta(requestId, { streamSummaryPath: path });
   const renderMarkdown = activeRequestMeta.streamSummaryRenderMarkdown;


### PR DESCRIPTION
[INS-3702](https://konghq.atlassian.net/browse/INS-3702)

## Summary
- Extracts a JSONPath from each streaming SSE message and concatenates it into one readable transcript, shown in a new "Summary" tab next to Events — useful for debugging LLM streaming APIs (OpenAI, Anthropic, Gemini) without scrolling through raw chunks.
- Auto-infers the JSONPath from the request URL for known provider endpoints (OpenAI Chat Completions/legacy Completions/Responses, Anthropic Messages, Google Gemini streamGenerateContent), matched by pathname only (not full URL/host), so self-hosted or reverse-proxied endpoints that keep the same path shape still match. Falls back to a manually-editable path otherwise.
- Handles curl's SSE event log being chunk-granular rather than frame-granular (a JSON payload can span multiple raw network reads, or multiple SSE frames can land in one chunk) by reconstructing the raw wire text and re-parsing `data:` frames properly.
- Handles Gemini's default `streamGenerateContent` response (no `?alt=sse`), which is a single top-level JSON array with no `data:` frames and no blank lines between elements, by scanning the array's bracket/brace depth by hand and pulling out whichever elements have fully closed so far — including mid-stream, before the array's closing `]` (or even the last element's own closing `}`) has arrived — so the summary renders progressively instead of only after the full response finishes.
- Summary tab defaults to selected when the URL matches a known provider, otherwise Events stays default. Plain text/Markdown render toggle for the summary output.
- Scoped to `curl` (SSE) responses only — WebSocket, `socketIO`, and `mcp` responses are untouched.

## Test plan
- [x] `npm run type-check` (all workspaces) — 0 errors
- [x] `npm run lint` (all workspaces) — 0 errors
- [x] `packages/insomnia` vitest: `src/common`, `src/ui/hooks` — 554/554 passing (2 pre-existing skipped), including truncated/still-streaming JSON cases (no throw, partial-array elements render progressively)
- [x] `packages/insomnia-data` vitest — 471/471 passing
- [x] Manual: verified in-app with real OpenAI/Anthropic streaming responses (correct chunk reconstruction order, resize handles behave correctly with the new tab)
- [x] Manual: Gemini's non-SSE array-response case is unit-tested only — not yet manually verified against a live Gemini streaming call

[INS-3702]: https://konghq.atlassian.net/browse/INS-3702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
