### PR TITLE
fix: initial entry

### DIFF
--- a/packages/insomnia/src/entry.client.tsx
+++ b/packages/insomnia/src/entry.client.tsx
@@ -147,9 +147,19 @@ applyColorScheme(appSettings);
 
 const initialEntry = await getInitialEntry();
 
-if (typeof initialEntry === 'string' && window.location.pathname !== initialEntry) {
-  console.log('[entry.client] Initial entry:', initialEntry);
-  window.location.pathname = initialEntry;
+// `getInitialEntry` returns either a bare pathname string or an object carrying router
+// `state` (e.g. `asyncTaskList`). Normalize both shapes, then set the URL and state before
+// hydration. We use `history.replaceState` rather than assigning `window.location.pathname`
+// (a full reload that would drop the `state`): in SPA mode `HydratedRouter` hydrates against
+// the current `window.location` and reads `location.state` from `window.history.state.usr`.
+if (initialEntry) {
+  const { pathname, state } =
+    typeof initialEntry === 'string' ? { pathname: initialEntry, state: undefined } : initialEntry;
+
+  if (pathname !== window.location.pathname || state) {
+    console.log('[entry.client] Initial entry:', pathname);
+    window.history.replaceState({ ...window.history.state, usr: state }, '', pathname);
+  }
 }
 
 startTransition(() => {


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

## Changes

- Replace history location and state in `entry.client.ts`, so that the app can land on the user's last active page.

close INS-3441