### PR TITLE
feat(Git Diff): Add visual diff preview

### DIFF
--- a/packages/insomnia/src/entry.preload.ts
+++ b/packages/insomnia/src/entry.preload.ts
@@ -237,6 +237,7 @@ const git: GitServiceAPI = {
   multipleCommitToGitRepo: options => invokeWithNormalizedError('git.multipleCommitToGitRepo', options),
   stageChanges: options => invokeWithNormalizedError('git.stageChanges', options),
   unstageChanges: options => invokeWithNormalizedError('git.unstageChanges', options),
+  stagePartialContent: options => invokeWithNormalizedError('git.stagePartialContent', options),
   diffFileLoader: options => invokeWithNormalizedError('git.diffFileLoader', options),
   getRepositoryDirectoryTree: options => invokeWithNormalizedError('git.getRepositoryDirectoryTree', options),
   migrateLegacyInsomniaFolderToFile: options =>

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -3321,6 +3321,31 @@ export const unstageChangesAction = async ({
   }
 };
 
+export const stagePartialContentAction = async ({
+  projectId,
+  workspaceId,
+  filepath,
+  content,
+}: {
+  projectId: string;
+  workspaceId?: string;
+  filepath: string;
+  content: string;
+}): Promise<{
+  errors?: string[];
+}> => {
+  try {
+    await getGitRepository({ workspaceId, projectId });
+    await GitVCS.stagePartialContent(filepath, content);
+    return {};
+  } catch (e) {
+    const errorMessage = e instanceof Error ? e.message : 'Error while staging changes';
+    return {
+      errors: [errorMessage],
+    };
+  }
+};
+
 function getPreviewItemNameAndScope(previewDiffItem: { before: string; after: string }) {
   let prevName = '';
   let nextName = '';
@@ -3928,6 +3953,7 @@ export interface GitServiceAPI {
   diff: typeof diff;
   stageChanges: typeof stageChangesAction;
   unstageChanges: typeof unstageChangesAction;
+  stagePartialContent: typeof stagePartialContentAction;
   diffFileLoader: typeof diffFileLoader;
   getRepositoryDirectoryTree: typeof getRepositoryDirectoryTree;
   migrateLegacyInsomniaFolderToFile: typeof migrateLegacyInsomniaFolderToFile;
@@ -4037,6 +4063,9 @@ export const registerGitServiceAPI = () => {
   );
   ipcMainHandle('git.unstageChanges', (_, options: Parameters<typeof unstageChangesAction>[0]) =>
     unstageChangesAction(options),
+  );
+  ipcMainHandle('git.stagePartialContent', (_, options: Parameters<typeof stagePartialContentAction>[0]) =>
+    stagePartialContentAction(options),
   );
   ipcMainHandle('git.diffFileLoader', (_, options: Parameters<typeof diffFileLoader>[0]) => diffFileLoader(options));
   ipcMainHandle('git.getRepositoryDirectoryTree', (_, options: Parameters<typeof getRepositoryDirectoryTree>[0]) =>

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -91,6 +91,7 @@ export type HandleChannels =
   | 'git.getBranchRemoteInfo'
   | 'git.stageChanges'
   | 'git.unstageChanges'
+  | 'git.stagePartialContent'
   | 'git.updateGitRepo'
   | 'git.listGitProviders'
   | 'git.initSignInToGitProvider'

--- a/packages/insomnia/src/routes/git.stage-entity.tsx
+++ b/packages/insomnia/src/routes/git.stage-entity.tsx
@@ -1,0 +1,28 @@
+import { href } from 'react-router';
+
+import { createFetcherSubmitHook } from '~/ui/utils/router';
+
+import type { Route } from './+types/git.stage-entity';
+
+interface StagePartialGitChangeData {
+  filepath: string;
+  content: string;
+  projectId: string;
+  workspaceId?: string;
+}
+
+export async function clientAction({ request }: Route.ClientActionArgs) {
+  const data = (await request.json()) as StagePartialGitChangeData;
+  return window.main.git.stagePartialContent(data);
+}
+
+export const useGitProjectStagePartialContentActionFetcher = createFetcherSubmitHook(
+  submit => (data: StagePartialGitChangeData) => {
+    return submit(JSON.stringify(data), {
+      method: 'POST',
+      action: href('/git/stage-entity'),
+      encType: 'application/json',
+    });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/sync/git/git-vcs.ts
+++ b/packages/insomnia/src/sync/git/git-vcs.ts
@@ -2069,6 +2069,16 @@ export class GitVCS {
     }
   }
 
+  // Sets the git index entry for `filepath` to `content` directly, independent of
+  // whatever is currently on disk in the working directory. Used to stage/unstage a
+  // single entity out of a file that bundles many entities (eg. a whole workspace
+  // export) without staging the rest of that file's changes.
+  async stagePartialContent(filepath: string, content: string) {
+    const normalizedFilepath = convertToPosixSep(path.join('.', filepath));
+    const oid = await git.writeBlob({ ...this._baseOpts, blob: new TextEncoder().encode(content) });
+    await git.updateIndex({ ...this._baseOpts, filepath: normalizedFilepath, oid, add: true });
+  }
+
   async discardChanges(changes: { path: string; status: Status }[]) {
     for (const change of changes) {
       // If the file didn't exist in HEAD, handle based on staging status

--- a/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
@@ -1619,6 +1619,20 @@ const OriginalGitProjectStagingModal: FC<
     }
   }
 
+  // After staging/unstaging a single entity out of the currently-previewed file,
+  // refresh both the file list (staged/unstaged buckets) and the diff itself so
+  // the entity's card disappears/updates without switching away from this view.
+  function afterEntityStage() {
+    gitChangesFetcher.load({ projectId });
+    if (fileToDiff) {
+      diffChangesFetcherLoad({
+        projectId,
+        filePath: fileToDiff.path,
+        staged: fileToDiff.staged,
+      });
+    }
+  }
+
   async function stageChanges(paths: string[]) {
     await stageChangesFetcher.submit({
       projectId,
@@ -1836,7 +1850,14 @@ const OriginalGitProjectStagingModal: FC<
                           />
                         </div>
                       ) : (
-                        <EntityDiffList before={previewDiffItem.diff.before} after={previewDiffItem.diff.after} />
+                        <EntityDiffList
+                          before={previewDiffItem.diff.before}
+                          after={previewDiffItem.diff.after}
+                          projectId={projectId}
+                          filepath={previewDiffItem.filepath}
+                          staged={previewDiffItem.staged}
+                          onEntityStaged={afterEntityStage}
+                        />
                       )}
                     </div>
                   ) : (

--- a/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
@@ -67,6 +67,7 @@ import { DiffEditor } from '../diff-view-editor';
 import { Icon } from '../icon';
 import { showToast } from '../toast-notification';
 import { GitPullRequiredModal } from './git-pull-required-modal';
+import { EntityDiffList } from './visual-diff/entity-diff-list';
 
 export type StagingModalMode = 'default' | 'commit-and-pull';
 
@@ -1485,6 +1486,7 @@ const OriginalGitProjectStagingModal: FC<
   const [isGitPullRequiredModalOpen, setIsGitPullRequiredModalOpen] = useState(false);
   const [showConfirmDiscardAndPullModal, setShowConfirmDiscardAndPullModal] = React.useState(false);
   const [discardData, setDiscardData] = React.useState<DiscardData | null>(null);
+  const [diffViewMode, setDiffViewMode] = useState<'text' | 'visual'>('text');
 
   const gitChangesFetcher = useGitProjectChangesFetcher();
   const gitCredentialsFetcher = useGitCredentialsLoaderFetcher();
@@ -1802,6 +1804,20 @@ const OriginalGitProjectStagingModal: FC<
                             {!previewDiffItem.staged ? 'Stage this file' : 'Unstage this file'}
                           </BasicButton>
                         )}
+                        <div className="ml-auto flex items-center gap-1 rounded-xs bg-(--hl-xs) p-0.5">
+                          <Button
+                            className={`rounded-xs px-2 py-1 text-xs font-medium transition-colors ${diffViewMode === 'text' ? 'bg-(--hl-sm) text-(--color-font)' : 'text-(--hl)'}`}
+                            onPress={() => setDiffViewMode('text')}
+                          >
+                            Text
+                          </Button>
+                          <Button
+                            className={`rounded-xs px-2 py-1 text-xs font-medium transition-colors ${diffViewMode === 'visual' ? 'bg-(--hl-sm) text-(--color-font)' : 'text-(--hl)'}`}
+                            onPress={() => setDiffViewMode('visual')}
+                          >
+                            Visual [Preview]
+                          </Button>
+                        </div>
                       </Heading>
                       <p>
                         <Icon icon="info-circle" className="mr-2" />
@@ -1811,7 +1827,7 @@ const OriginalGitProjectStagingModal: FC<
                         </LearnMoreLink>
                         , which is determined by the system and cannot be discarded.
                       </p>
-                      {previewDiffItem && (
+                      {diffViewMode === 'text' ? (
                         <div className="flex-1 overflow-hidden rounded-xs bg-(--hl-xs) p-2 text-(--color-font)">
                           <DiffEditor
                             original={previewDiffItem.diff.before}
@@ -1819,6 +1835,8 @@ const OriginalGitProjectStagingModal: FC<
                             highlightSystemChange
                           />
                         </div>
+                      ) : (
+                        <EntityDiffList before={previewDiffItem.diff.before} after={previewDiffItem.diff.after} />
                       )}
                     </div>
                   ) : (

--- a/packages/insomnia/src/ui/components/modals/visual-diff/diff-engine.ts
+++ b/packages/insomnia/src/ui/components/modals/visual-diff/diff-engine.ts
@@ -1,0 +1,371 @@
+import { parse as parseYaml } from 'yaml';
+
+/**
+ * Visual diff card coverage tracker.
+ *
+ * A git-tracked file is a whole Insomnia v5 workspace export (see
+ * `common/import-v5-parser.ts`), containing many entities in one YAML blob.
+ * This module walks both sides of the diff, matches entities by `meta.id`,
+ * and produces one `EntityDiff` per changed/added/removed entity so the UI
+ * can render a dedicated card per entity instead of one big text diff.
+ *
+ * Entities without a dedicated card fall back to `GenericEntityDiffCard`
+ * (bullet list of raw field changes). Status of dedicated visual cards:
+ *
+ * - [x] Request (HTTP)      -> RequestDiffCard
+ * - [x] Environment          -> EnvironmentDiffCard
+ * - [ ] Request Group (folder)
+ * - [ ] WebSocket Request
+ * - [ ] gRPC Request
+ * - [ ] Socket.IO Request
+ * - [ ] MCP Request
+ * - [ ] Mock Route
+ * - [ ] Cookie Jar
+ */
+
+export type VisualDiffEntityType =
+  | 'request'
+  | 'grpc_request'
+  | 'websocket_request'
+  | 'socketio_request'
+  | 'request_group'
+  | 'environment'
+  | 'mock_route'
+  | 'mcp_request'
+  | 'cookie_jar'
+  | 'unknown';
+
+export type EntityChangeStatus = 'added' | 'removed' | 'modified';
+
+export interface FieldChange {
+  path: string;
+  label: string;
+  before: unknown;
+  after: unknown;
+}
+
+export interface EntityDiff {
+  id: string;
+  type: VisualDiffEntityType;
+  status: EntityChangeStatus;
+  name: string;
+  before: any;
+  after: any;
+  fieldChanges: FieldChange[];
+}
+
+export interface VisualDiffResult {
+  entities: EntityDiff[];
+  // True when neither side could be parsed as a recognizable Insomnia v5 file.
+  unparseable: boolean;
+}
+
+interface CollectedEntity {
+  type: VisualDiffEntityType;
+  name: string;
+  node: any;
+}
+
+function sortDeep(value: any): any {
+  if (Array.isArray(value)) {
+    return value.map(sortDeep);
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.keys(value).sort().map(key => [key, sortDeep(value[key])]));
+  }
+  return value;
+}
+
+// undefined, null and empty string are treated as equivalent so schema defaults don't create noise
+function emptyValueReplacer(_key: string, value: any) {
+  if (value === null || value === '') {
+    return;
+  }
+  return value;
+}
+
+export function valuesEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(sortDeep(a), emptyValueReplacer) === JSON.stringify(sortDeep(b), emptyValueReplacer);
+}
+
+function cleanMeta(meta: any) {
+  if (!meta || typeof meta !== 'object') {
+    return meta;
+  }
+  const { modified, created, sortKey, id, ...rest } = meta;
+  return rest;
+}
+
+// Keys that are structural (handled by entity matching itself) rather than displayable fields
+const STRUCTURAL_KEYS = new Set(['children', 'subEnvironments']);
+
+export function computeFieldChanges(before: any, after: any): FieldChange[] {
+  const keys = new Set([...Object.keys(before ?? {}), ...Object.keys(after ?? {})]);
+  const changes: FieldChange[] = [];
+
+  for (const key of keys) {
+    if (STRUCTURAL_KEYS.has(key)) {
+      continue;
+    }
+
+    if (key === 'meta') {
+      const beforeMeta = cleanMeta(before?.meta);
+      const afterMeta = cleanMeta(after?.meta);
+      if (!valuesEqual(beforeMeta, afterMeta)) {
+        changes.push({
+          path: 'meta.description',
+          label: 'Description',
+          before: beforeMeta?.description,
+          after: afterMeta?.description,
+        });
+      }
+      continue;
+    }
+
+    const beforeValue = before?.[key];
+    const afterValue = after?.[key];
+    if (!valuesEqual(beforeValue, afterValue)) {
+      changes.push({ path: key, label: humanizeKey(key), before: beforeValue, after: afterValue });
+    }
+  }
+
+  return changes;
+}
+
+export function humanizeKey(key: string): string {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .replace(/^./, c => c.toUpperCase());
+}
+
+export interface KeyedDiffRow {
+  key: string;
+  status: EntityChangeStatus;
+  before?: unknown;
+  after?: unknown;
+}
+
+// Diffs two arrays of objects by matching a key field (eg. header/parameter `name`) instead of position
+export function diffByKey<T extends Record<string, any>>(
+  before: T[] = [],
+  after: T[] = [],
+  keyField: keyof T = 'name' as keyof T,
+): KeyedDiffRow[] {
+  const rows: KeyedDiffRow[] = [];
+
+  const beforeMap = new Map<string, T>();
+  (before ?? []).forEach((item, i) => beforeMap.set(String(item?.[keyField] ?? `#${i}`), item));
+
+  const afterMap = new Map<string, T>();
+  (after ?? []).forEach((item, i) => afterMap.set(String(item?.[keyField] ?? `#${i}`), item));
+
+  afterMap.forEach((afterItem, key) => {
+    const beforeItem = beforeMap.get(key);
+    if (!beforeItem) {
+      rows.push({ key, status: 'added', after: afterItem });
+    } else if (!valuesEqual(beforeItem, afterItem)) {
+      rows.push({ key, status: 'modified', before: beforeItem, after: afterItem });
+    }
+  });
+
+  beforeMap.forEach((beforeItem, key) => {
+    if (!afterMap.has(key)) {
+      rows.push({ key, status: 'removed', before: beforeItem });
+    }
+  });
+
+  return rows;
+}
+
+// Diffs a plain key/value record (eg. environment `data`) by key
+export function diffRecord(before: Record<string, any> = {}, after: Record<string, any> = {}): KeyedDiffRow[] {
+  const rows: KeyedDiffRow[] = [];
+  const keys = new Set([...Object.keys(before ?? {}), ...Object.keys(after ?? {})]);
+
+  keys.forEach(key => {
+    const hasBefore = before != null && Object.prototype.hasOwnProperty.call(before, key);
+    const hasAfter = after != null && Object.prototype.hasOwnProperty.call(after, key);
+    const beforeValue = before?.[key];
+    const afterValue = after?.[key];
+
+    if (!hasBefore) {
+      rows.push({ key, status: 'added', after: afterValue });
+    } else if (!hasAfter) {
+      rows.push({ key, status: 'removed', before: beforeValue });
+    } else if (!valuesEqual(beforeValue, afterValue)) {
+      rows.push({ key, status: 'modified', before: beforeValue, after: afterValue });
+    }
+  });
+
+  return rows;
+}
+
+function classifyCollectionNode(node: any): VisualDiffEntityType {
+  const id: string = node?.meta?.id ?? '';
+  if (id.startsWith('ws-req')) {
+    return 'websocket_request';
+  }
+  if (id.startsWith('socketio-req')) {
+    return 'socketio_request';
+  }
+  if (id.startsWith('greq')) {
+    return 'grpc_request';
+  }
+  if (id.startsWith('fld')) {
+    return 'request_group';
+  }
+  if (id.startsWith('req')) {
+    return 'request';
+  }
+  // Fall back to structural shape in case an id is missing/unrecognized
+  if (Array.isArray(node?.children)) {
+    return 'request_group';
+  }
+  if (typeof node?.method === 'string') {
+    return 'request';
+  }
+  return 'unknown';
+}
+
+function collectEntities(file: any): Map<string, CollectedEntity> {
+  const map = new Map<string, CollectedEntity>();
+  if (!file || typeof file !== 'object') {
+    return map;
+  }
+
+  const addCollectionNode = (node: any) => {
+    if (!node || typeof node !== 'object') {
+      return;
+    }
+    const id = node.meta?.id;
+    if (id) {
+      map.set(id, { type: classifyCollectionNode(node), name: node.name || 'Untitled', node });
+    }
+    if (Array.isArray(node.children)) {
+      node.children.forEach(addCollectionNode);
+    }
+  };
+
+  const addEnvironmentTree = (env: any, fallbackName: string) => {
+    if (!env || typeof env !== 'object') {
+      return;
+    }
+    const id = env.meta?.id;
+    if (id) {
+      map.set(id, { type: 'environment', name: env.name || fallbackName, node: env });
+    }
+    (env.subEnvironments ?? []).forEach((sub: any, index: number) => {
+      const subId = sub?.meta?.id;
+      if (subId) {
+        map.set(subId, { type: 'environment', name: sub.name || `Environment ${index}`, node: sub });
+      }
+    });
+  };
+
+  if (Array.isArray(file.collection)) {
+    file.collection.forEach(addCollectionNode);
+  }
+
+  if (file.environments) {
+    addEnvironmentTree(file.environments, 'Base Environment');
+  }
+
+  if (Array.isArray(file.routes)) {
+    file.routes.forEach((route: any) => {
+      const id = route?.meta?.id;
+      if (id) {
+        map.set(id, { type: 'mock_route', name: route.name || route.pattern || 'Mock Route', node: route });
+      }
+    });
+  }
+
+  if (file.mcpRequest) {
+    const id = file.mcpRequest.meta?.id;
+    if (id) {
+      map.set(id, { type: 'mcp_request', name: file.mcpRequest.name || 'MCP Request', node: file.mcpRequest });
+    }
+  }
+
+  if (file.cookieJar) {
+    const id = file.cookieJar.meta?.id ?? 'cookie-jar';
+    map.set(id, { type: 'cookie_jar', name: file.cookieJar.name || 'Cookie Jar', node: file.cookieJar });
+  }
+
+  return map;
+}
+
+function safeParseYaml(text: string): any {
+  if (!text) {
+    return undefined;
+  }
+  try {
+    return parseYaml(text);
+  } catch {
+    return undefined;
+  }
+}
+
+export function computeVisualDiff(beforeText: string, afterText: string): VisualDiffResult {
+  const beforeFile = safeParseYaml(beforeText);
+  const afterFile = safeParseYaml(afterText);
+
+  const beforeEntities = collectEntities(beforeFile);
+  const afterEntities = collectEntities(afterFile);
+
+  const entities: EntityDiff[] = [];
+  const visited = new Set<string>();
+
+  afterEntities.forEach((afterEntity, id) => {
+    visited.add(id);
+    const beforeEntity = beforeEntities.get(id);
+
+    if (!beforeEntity) {
+      entities.push({
+        id,
+        type: afterEntity.type,
+        status: 'added',
+        name: afterEntity.name,
+        before: undefined,
+        after: afterEntity.node,
+        fieldChanges: [],
+      });
+      return;
+    }
+
+    const fieldChanges = computeFieldChanges(beforeEntity.node, afterEntity.node);
+    if (fieldChanges.length === 0) {
+      return;
+    }
+
+    entities.push({
+      id,
+      type: afterEntity.type,
+      status: 'modified',
+      name: afterEntity.name,
+      before: beforeEntity.node,
+      after: afterEntity.node,
+      fieldChanges,
+    });
+  });
+
+  beforeEntities.forEach((beforeEntity, id) => {
+    if (visited.has(id)) {
+      return;
+    }
+    entities.push({
+      id,
+      type: beforeEntity.type,
+      status: 'removed',
+      name: beforeEntity.name,
+      before: beforeEntity.node,
+      after: undefined,
+      fieldChanges: [],
+    });
+  });
+
+  return {
+    entities,
+    unparseable: beforeFile === undefined && afterFile === undefined,
+  };
+}

--- a/packages/insomnia/src/ui/components/modals/visual-diff/diff-engine.ts
+++ b/packages/insomnia/src/ui/components/modals/visual-diff/diff-engine.ts
@@ -146,6 +146,38 @@ export interface KeyedDiffRow {
   after?: unknown;
 }
 
+// Single status representing a set of rows (eg. for a tab/chip badge): all-added
+// or all-removed collapse to that status, anything mixed (or any modified row)
+// reads as 'modified'.
+export function dominantStatus(statuses: EntityChangeStatus[]): EntityChangeStatus {
+  const hasAdded = statuses.includes('added');
+  const hasRemoved = statuses.includes('removed');
+  const hasModified = statuses.includes('modified');
+  if (hasModified || (hasAdded && hasRemoved)) {
+    return 'modified';
+  }
+  if (hasAdded) {
+    return 'added';
+  }
+  if (hasRemoved) {
+    return 'removed';
+  }
+  return 'modified';
+}
+
+// Status for a single before/after block (eg. a request's body or auth config)
+// based only on which side has content — content only on one side reads as
+// added/removed even when the entity itself is 'modified'.
+export function sideStatus(hasBefore: boolean, hasAfter: boolean): EntityChangeStatus {
+  if (!hasBefore && hasAfter) {
+    return 'added';
+  }
+  if (hasBefore && !hasAfter) {
+    return 'removed';
+  }
+  return 'modified';
+}
+
 // Diffs two arrays of objects by matching a key field (eg. header/parameter `name`) instead of position
 export function diffByKey<T extends Record<string, any>>(
   before: T[] = [],

--- a/packages/insomnia/src/ui/components/modals/visual-diff/entity-diff-list.tsx
+++ b/packages/insomnia/src/ui/components/modals/visual-diff/entity-diff-list.tsx
@@ -1,6 +1,9 @@
-import { type FC, useMemo } from 'react';
+import { type FC, useCallback, useMemo, useState } from 'react';
+
+import { useGitProjectStagePartialContentActionFetcher } from '~/routes/git.stage-entity';
 
 import { computeVisualDiff } from './diff-engine';
+import { applyEntityChange } from './entity-splice';
 import { EnvironmentDiffCard } from './environment-diff-card';
 import { GenericEntityDiffCard } from './generic-entity-diff-card';
 import { RequestDiffCard } from './request-diff-card';
@@ -8,10 +11,38 @@ import { RequestDiffCard } from './request-diff-card';
 interface Props {
   before: string;
   after: string;
+  projectId: string;
+  workspaceId?: string;
+  filepath: string;
+  // Whether this diff is HEAD..INDEX (staged, `before`=head/`after`=stage) or
+  // INDEX..WORKDIR (unstaged, `before`=stage/`after`=workdir) — determines the
+  // direction of "stage"/"unstage" and which side each entity's action pulls from.
+  staged: boolean;
+  onEntityStaged?: () => void;
 }
 
-export const EntityDiffList: FC<Props> = ({ before, after }) => {
+export const EntityDiffList: FC<Props> = ({ before, after, projectId, workspaceId, filepath, staged, onEntityStaged }) => {
   const { entities, unparseable } = useMemo(() => computeVisualDiff(before, after), [before, after]);
+  const stagePartialContentFetcher = useGitProjectStagePartialContentActionFetcher();
+  const [pendingEntityId, setPendingEntityId] = useState<string | null>(null);
+
+  const handleStage = useCallback(async (entityId: string) => {
+    setPendingEntityId(entityId);
+    try {
+      // Unstaged view: graft the entity's workdir state onto the current index.
+      // Staged view: graft the entity's HEAD state back onto the index (ie. unstage it).
+      const content = staged ? applyEntityChange(after, before, entityId) : applyEntityChange(before, after, entityId);
+      await stagePartialContentFetcher.submit({
+        filepath,
+        content,
+        projectId,
+        workspaceId,
+      });
+      onEntityStaged?.();
+    } finally {
+      setPendingEntityId(null);
+    }
+  }, [staged, before, after, filepath, projectId, workspaceId, stagePartialContentFetcher, onEntityStaged]);
 
   if (unparseable) {
     return (
@@ -32,15 +63,21 @@ export const EntityDiffList: FC<Props> = ({ before, after }) => {
   return (
     <div className="flex flex-1 flex-col gap-3 overflow-y-auto">
       {entities.map(diff => {
+        const actionProps = {
+          staged,
+          isPending: pendingEntityId === diff.id,
+          onStage: () => handleStage(diff.id),
+        };
+
         switch (diff.type) {
           case 'request': {
-            return <RequestDiffCard key={diff.id} diff={diff} />;
+            return <RequestDiffCard key={diff.id} diff={diff} {...actionProps} />;
           }
           case 'environment': {
-            return <EnvironmentDiffCard key={diff.id} diff={diff} />;
+            return <EnvironmentDiffCard key={diff.id} diff={diff} {...actionProps} />;
           }
           default: {
-            return <GenericEntityDiffCard key={diff.id} diff={diff} />;
+            return <GenericEntityDiffCard key={diff.id} diff={diff} {...actionProps} />;
           }
         }
       })}

--- a/packages/insomnia/src/ui/components/modals/visual-diff/entity-diff-list.tsx
+++ b/packages/insomnia/src/ui/components/modals/visual-diff/entity-diff-list.tsx
@@ -60,27 +60,45 @@ export const EntityDiffList: FC<Props> = ({ before, after, projectId, workspaceI
     );
   }
 
-  return (
-    <div className="flex flex-1 flex-col gap-3 overflow-y-auto">
-      {entities.map(diff => {
-        const actionProps = {
-          staged,
-          isPending: pendingEntityId === diff.id,
-          onStage: () => handleStage(diff.id),
-        };
+  const summary = entities.reduce(
+    (acc, entity) => {
+      acc[entity.status] += 1;
+      return acc;
+    },
+    { added: 0, removed: 0, modified: 0 },
+  );
 
-        switch (diff.type) {
-          case 'request': {
-            return <RequestDiffCard key={diff.id} diff={diff} {...actionProps} />;
+  return (
+    <div className="flex flex-1 flex-col gap-3 overflow-hidden">
+      <div className="flex shrink-0 items-center gap-3 text-xs">
+        <span className="font-semibold text-(--color-font)">
+          {entities.length} {entities.length === 1 ? 'entity' : 'entities'} changed
+        </span>
+        {summary.added > 0 && <span className="text-(--color-font-success)">{summary.added} added</span>}
+        {summary.modified > 0 && <span className="text-(--color-font-notice)">{summary.modified} modified</span>}
+        {summary.removed > 0 && <span className="text-(--color-font-danger)">{summary.removed} removed</span>}
+      </div>
+      <div className="flex flex-1 flex-col gap-3 overflow-y-auto">
+        {entities.map(diff => {
+          const actionProps = {
+            staged,
+            isPending: pendingEntityId === diff.id,
+            onStage: () => handleStage(diff.id),
+          };
+
+          switch (diff.type) {
+            case 'request': {
+              return <RequestDiffCard key={diff.id} diff={diff} {...actionProps} />;
+            }
+            case 'environment': {
+              return <EnvironmentDiffCard key={diff.id} diff={diff} {...actionProps} />;
+            }
+            default: {
+              return <GenericEntityDiffCard key={diff.id} diff={diff} {...actionProps} />;
+            }
           }
-          case 'environment': {
-            return <EnvironmentDiffCard key={diff.id} diff={diff} {...actionProps} />;
-          }
-          default: {
-            return <GenericEntityDiffCard key={diff.id} diff={diff} {...actionProps} />;
-          }
-        }
-      })}
+        })}
+      </div>
     </div>
   );
 };

--- a/packages/insomnia/src/ui/components/modals/visual-diff/entity-diff-list.tsx
+++ b/packages/insomnia/src/ui/components/modals/visual-diff/entity-diff-list.tsx
@@ -1,0 +1,49 @@
+import { type FC, useMemo } from 'react';
+
+import { computeVisualDiff } from './diff-engine';
+import { EnvironmentDiffCard } from './environment-diff-card';
+import { GenericEntityDiffCard } from './generic-entity-diff-card';
+import { RequestDiffCard } from './request-diff-card';
+
+interface Props {
+  before: string;
+  after: string;
+}
+
+export const EntityDiffList: FC<Props> = ({ before, after }) => {
+  const { entities, unparseable } = useMemo(() => computeVisualDiff(before, after), [before, after]);
+
+  if (unparseable) {
+    return (
+      <div className="flex h-full flex-1 items-center justify-center p-4 text-center text-(--hl)">
+        Unable to parse this file for a visual diff. Try the Text view instead.
+      </div>
+    );
+  }
+
+  if (entities.length === 0) {
+    return (
+      <div className="flex h-full flex-1 items-center justify-center p-4 text-center text-(--hl)">
+        No structured changes detected in this file. Try the Text view to see the raw diff.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-3 overflow-y-auto">
+      {entities.map(diff => {
+        switch (diff.type) {
+          case 'request': {
+            return <RequestDiffCard key={diff.id} diff={diff} />;
+          }
+          case 'environment': {
+            return <EnvironmentDiffCard key={diff.id} diff={diff} />;
+          }
+          default: {
+            return <GenericEntityDiffCard key={diff.id} diff={diff} />;
+          }
+        }
+      })}
+    </div>
+  );
+};

--- a/packages/insomnia/src/ui/components/modals/visual-diff/entity-splice.ts
+++ b/packages/insomnia/src/ui/components/modals/visual-diff/entity-splice.ts
@@ -1,0 +1,220 @@
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
+
+/**
+ * Builds the YAML content for "stage/unstage just this one entity": start from
+ * `baseText` (the side that should stay as-is for every other entity) and graft
+ * in only `entityId`'s node from `sourceText` (added/replaced/removed), leaving
+ * the rest of the tree untouched.
+ *
+ * Note: the result is produced by parsing both sides into plain objects and
+ * re-serializing the whole file, so untouched entities can come out with
+ * different (but semantically identical) YAML formatting than the original —
+ * the app's own diff/status logic already normalizes past that (see
+ * `significant-diff-detection.ts`), but a raw text diff of the result may show
+ * cosmetic-only changes outside the staged entity.
+ */
+export function applyEntityChange(baseText: string, sourceText: string, entityId: string): string {
+  const baseFile = safeParse(baseText);
+  const sourceFile = safeParse(sourceText);
+
+  if (!baseFile && !sourceFile) {
+    return baseText;
+  }
+
+  const location = locateEntity(sourceFile, entityId) ?? locateEntity(baseFile, entityId);
+  if (!location) {
+    return baseText;
+  }
+
+  const merged = baseFile ?? {};
+
+  // Backfill file-identity fields so a brand-new (never-committed) file stays
+  // valid YAML once the first entity is staged out of it.
+  for (const key of ['type', 'schema_version', 'name', 'meta']) {
+    if (merged[key] === undefined && sourceFile?.[key] !== undefined) {
+      merged[key] = sourceFile[key];
+    }
+  }
+
+  applyChange(merged, sourceFile ?? {}, entityId, location);
+
+  return stringifyYaml(merged);
+}
+
+function safeParse(text: string): any {
+  if (!text) {
+    return undefined;
+  }
+  try {
+    return parseYaml(text);
+  } catch {
+    return undefined;
+  }
+}
+
+interface EntityLocation {
+  section: 'collection' | 'environments-base' | 'sub-environment' | 'routes' | 'mcp-request' | 'cookie-jar';
+  // ids of ancestor folders, root to the entity's direct parent (collection section only)
+  folderPath: string[];
+}
+
+function findInCollection(nodes: any[], entityId: string, path: string[]): EntityLocation | null {
+  for (const node of nodes ?? []) {
+    if (node?.meta?.id === entityId) {
+      return { section: 'collection', folderPath: path };
+    }
+    if (Array.isArray(node?.children)) {
+      const found = findInCollection(node.children, entityId, [...path, node.meta?.id]);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return null;
+}
+
+function locateEntity(file: any, entityId: string): EntityLocation | null {
+  if (!file || typeof file !== 'object') {
+    return null;
+  }
+
+  if (Array.isArray(file.collection)) {
+    const found = findInCollection(file.collection, entityId, []);
+    if (found) {
+      return found;
+    }
+  }
+
+  if (file.environments) {
+    if (file.environments.meta?.id === entityId) {
+      return { section: 'environments-base', folderPath: [] };
+    }
+    if ((file.environments.subEnvironments ?? []).some((env: any) => env?.meta?.id === entityId)) {
+      return { section: 'sub-environment', folderPath: [] };
+    }
+  }
+
+  if (Array.isArray(file.routes) && file.routes.some((route: any) => route?.meta?.id === entityId)) {
+    return { section: 'routes', folderPath: [] };
+  }
+
+  if (file.mcpRequest?.meta?.id === entityId) {
+    return { section: 'mcp-request', folderPath: [] };
+  }
+
+  if (file.cookieJar && (file.cookieJar.meta?.id ?? 'cookie-jar') === entityId) {
+    return { section: 'cookie-jar', folderPath: [] };
+  }
+
+  return null;
+}
+
+// Replaces/inserts/removes the entry matching `entityId` in `baseArray`, using
+// `sourceArray`'s version of it (or its absence, for removal).
+function spliceById(baseArray: any[] = [], sourceArray: any[] = [], entityId: string): any[] {
+  const result = [...(baseArray ?? [])];
+  const sourceIndex = (sourceArray ?? []).findIndex(item => item?.meta?.id === entityId);
+  const baseIndex = result.findIndex(item => item?.meta?.id === entityId);
+
+  if (sourceIndex === -1) {
+    if (baseIndex !== -1) {
+      result.splice(baseIndex, 1);
+    }
+    return result;
+  }
+
+  const sourceItem = sourceArray[sourceIndex];
+  if (baseIndex === -1) {
+    const insertAt = Math.min(sourceIndex, result.length);
+    result.splice(insertAt, 0, sourceItem);
+  } else {
+    result[baseIndex] = sourceItem;
+  }
+  return result;
+}
+
+// Walks `folderPath` inside the base tree being mutated, creating minimal
+// folder shells (cloned from the source tree, with empty children) for any
+// ancestor that doesn't exist in base yet — otherwise there'd be nowhere to
+// graft a newly-added nested entity into.
+function descendToContainer(baseFile: any, sourceFile: any, folderPath: string[]): { parent: any; key: string; sourceArray: any[] } {
+  if (!Array.isArray(baseFile.collection)) {
+    baseFile.collection = [];
+  }
+  let parent: any = baseFile;
+  let key = 'collection';
+  let sourceArray: any[] = Array.isArray(sourceFile.collection) ? sourceFile.collection : [];
+
+  for (const folderId of folderPath) {
+    const baseArray: any[] = parent[key];
+    let folderNode = baseArray.find((node: any) => node?.meta?.id === folderId);
+    const sourceFolderNode = sourceArray.find((node: any) => node?.meta?.id === folderId);
+
+    if (!folderNode) {
+      const shell = sourceFolderNode
+        ? { ...sourceFolderNode, children: [] }
+        : { meta: { id: folderId }, name: 'Untitled Folder', children: [] };
+      const sourceIndex = sourceArray.findIndex((node: any) => node?.meta?.id === folderId);
+      const insertAt = sourceIndex === -1 ? baseArray.length : Math.min(sourceIndex, baseArray.length);
+      baseArray.splice(insertAt, 0, shell);
+      folderNode = shell;
+    }
+    if (!Array.isArray(folderNode.children)) {
+      folderNode.children = [];
+    }
+
+    parent = folderNode;
+    key = 'children';
+    sourceArray = sourceFolderNode?.children ?? [];
+  }
+
+  return { parent, key, sourceArray };
+}
+
+function applyChange(baseFile: any, sourceFile: any, entityId: string, location: EntityLocation) {
+  switch (location.section) {
+    case 'collection': {
+      const { parent, key, sourceArray } = descendToContainer(baseFile, sourceFile, location.folderPath);
+      parent[key] = spliceById(parent[key], sourceArray, entityId);
+      return;
+    }
+    case 'environments-base': {
+      const sourceEnv = sourceFile.environments ?? {};
+      const baseEnv = baseFile.environments ?? {};
+      baseFile.environments = {
+        ...baseEnv,
+        ...sourceEnv,
+        // Sub-environments are staged as their own entities — don't let a base
+        // environment stage pull in unrelated sub-environment changes.
+        subEnvironments: baseEnv.subEnvironments,
+      };
+      return;
+    }
+    case 'sub-environment': {
+      if (!baseFile.environments) {
+        baseFile.environments = sourceFile.environments ? { ...sourceFile.environments, subEnvironments: [] } : { subEnvironments: [] };
+      }
+      if (!Array.isArray(baseFile.environments.subEnvironments)) {
+        baseFile.environments.subEnvironments = [];
+      }
+      const sourceSubs = sourceFile.environments?.subEnvironments ?? [];
+      baseFile.environments.subEnvironments = spliceById(baseFile.environments.subEnvironments, sourceSubs, entityId);
+      return;
+    }
+    case 'routes': {
+      baseFile.routes = spliceById(baseFile.routes ?? [], sourceFile.routes ?? [], entityId);
+      return;
+    }
+    case 'mcp-request': {
+      baseFile.mcpRequest = sourceFile.mcpRequest;
+      return;
+    }
+    case 'cookie-jar': {
+      baseFile.cookieJar = sourceFile.cookieJar;
+      return;
+    }
+    default: {
+      return;
+    }
+  }
+}

--- a/packages/insomnia/src/ui/components/modals/visual-diff/environment-diff-card.tsx
+++ b/packages/insomnia/src/ui/components/modals/visual-diff/environment-diff-card.tsx
@@ -1,0 +1,106 @@
+import { models } from 'insomnia-data';
+import type { FC } from 'react';
+
+import { diffRecord, type EntityDiff } from './diff-engine';
+import { DiffCardShell, formatValue, StatusBadge, ValueChange } from './shared';
+
+const { vaultEnvironmentPath, vaultEnvironmentMaskValue } = models.environment;
+
+export const EnvironmentDiffCard: FC<{ diff: EntityDiff }> = ({ diff }) => {
+  const environment = diff.after ?? diff.before;
+
+  const beforeData = diff.before?.data ?? {};
+  const afterData = diff.after?.data ?? {};
+
+  const variableRows = diffRecord(
+    Object.fromEntries(Object.entries(beforeData).filter(([key]) => key !== vaultEnvironmentPath)),
+    Object.fromEntries(Object.entries(afterData).filter(([key]) => key !== vaultEnvironmentPath)),
+  );
+
+  const secretRows = diffRecord(beforeData[vaultEnvironmentPath] ?? {}, afterData[vaultEnvironmentPath] ?? {});
+
+  const nameChanged = diff.fieldChanges.find(c => c.path === 'name');
+  const colorChanged = diff.fieldChanges.find(c => c.path === 'color');
+
+  return (
+    <DiffCardShell status={diff.status}>
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          {environment?.color && (
+            <span
+              className="inline-block size-3 shrink-0 rounded-full"
+              style={{ backgroundColor: environment.color }}
+            />
+          )}
+          <span className="font-semibold">{diff.name}</span>
+        </div>
+        <StatusBadge status={diff.status} />
+      </div>
+
+      {diff.status !== 'modified' && Object.keys(afterData || beforeData).length > 0 && (
+        <span className="text-sm text-(--hl)">
+          {Object.keys((diff.status === 'removed' ? beforeData : afterData)).filter(key => key !== vaultEnvironmentPath).length} variable(s)
+        </span>
+      )}
+
+      {diff.status === 'modified' && (
+        <>
+          {nameChanged && (
+            <div className="flex flex-col gap-1">
+              <span className="text-xs text-(--hl)">Name</span>
+              <ValueChange before={nameChanged.before} after={nameChanged.after} />
+            </div>
+          )}
+          {colorChanged && (
+            <div className="flex flex-col gap-1">
+              <span className="text-xs text-(--hl)">Color</span>
+              <ValueChange before={colorChanged.before} after={colorChanged.after} />
+            </div>
+          )}
+
+          {variableRows.length > 0 && (
+            <div className="flex flex-col gap-2">
+              <span className="text-sm font-semibold">Variables</span>
+              <ul className="flex flex-col gap-2">
+                {variableRows.map(row => (
+                  <li key={row.key} className="flex flex-col gap-1 rounded-xs bg-(--color-bg) p-2">
+                    <div className="flex items-center gap-2">
+                      <StatusBadge status={row.status} />
+                      <span className="font-mono text-sm">{row.key}</span>
+                    </div>
+                    {row.status === 'modified' && <ValueChange before={row.before} after={row.after} />}
+                    {row.status === 'added' && (
+                      <pre className="overflow-x-auto rounded-xs bg-(--color-success)/10 px-2 py-1 text-sm whitespace-pre-wrap text-(--color-font-success)">
+                        {formatValue(row.after)}
+                      </pre>
+                    )}
+                    {row.status === 'removed' && (
+                      <pre className="overflow-x-auto rounded-xs bg-(--color-danger)/10 px-2 py-1 text-sm whitespace-pre-wrap text-(--color-font-danger)">
+                        {formatValue(row.before)}
+                      </pre>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {secretRows.length > 0 && (
+            <div className="flex flex-col gap-2">
+              <span className="text-sm font-semibold">Secrets</span>
+              <ul className="flex flex-col gap-2">
+                {secretRows.map(row => (
+                  <li key={row.key} className="flex items-center gap-2 rounded-xs bg-(--color-bg) p-2">
+                    <StatusBadge status={row.status} />
+                    <span className="font-mono text-sm">{row.key}</span>
+                    <span className="text-sm text-(--hl)">{vaultEnvironmentMaskValue}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </>
+      )}
+    </DiffCardShell>
+  );
+};

--- a/packages/insomnia/src/ui/components/modals/visual-diff/environment-diff-card.tsx
+++ b/packages/insomnia/src/ui/components/modals/visual-diff/environment-diff-card.tsx
@@ -2,11 +2,16 @@ import { models } from 'insomnia-data';
 import type { FC } from 'react';
 
 import { diffRecord, type EntityDiff } from './diff-engine';
-import { DiffCardShell, formatValue, StatusBadge, ValueChange } from './shared';
+import { CardHeaderActions, DiffCardShell, type EntityCardActionProps, formatValue, StatusBadge, ValueChange } from './shared';
 
 const { vaultEnvironmentPath, vaultEnvironmentMaskValue } = models.environment;
 
-export const EnvironmentDiffCard: FC<{ diff: EntityDiff }> = ({ diff }) => {
+export const EnvironmentDiffCard: FC<{ diff: EntityDiff } & EntityCardActionProps> = ({
+  diff,
+  staged,
+  isPending,
+  onStage,
+}) => {
   const environment = diff.after ?? diff.before;
 
   const beforeData = diff.before?.data ?? {};
@@ -34,7 +39,7 @@ export const EnvironmentDiffCard: FC<{ diff: EntityDiff }> = ({ diff }) => {
           )}
           <span className="font-semibold">{diff.name}</span>
         </div>
-        <StatusBadge status={diff.status} />
+        <CardHeaderActions status={diff.status} staged={staged} isPending={isPending} onStage={onStage} />
       </div>
 
       {diff.status !== 'modified' && Object.keys(afterData || beforeData).length > 0 && (

--- a/packages/insomnia/src/ui/components/modals/visual-diff/generic-entity-diff-card.tsx
+++ b/packages/insomnia/src/ui/components/modals/visual-diff/generic-entity-diff-card.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 
 import type { EntityDiff } from './diff-engine';
-import { DiffCardShell, entityTypeLabel, formatValue, StatusBadge, ValueChange } from './shared';
+import { DiffCardShell, entityTypeLabel, FieldDiffRow, formatValue, StatusBadge } from './shared';
 
 // Fallback card for entity types that don't have a dedicated visual layout yet.
 // Renders a bullet list of raw field changes rather than a purpose-built layout.
@@ -31,9 +31,8 @@ export const GenericEntityDiffCard: FC<{ diff: EntityDiff }> = ({ diff }) => {
       {diff.status === 'modified' && (
         <ul className="flex flex-col gap-2">
           {diff.fieldChanges.map(change => (
-            <li key={change.path} className="flex flex-col gap-1">
-              <span className="text-sm font-medium text-(--hl)">{change.label}</span>
-              <ValueChange before={change.before} after={change.after} />
+            <li key={change.path}>
+              <FieldDiffRow label={change.label} before={change.before} after={change.after} />
             </li>
           ))}
         </ul>

--- a/packages/insomnia/src/ui/components/modals/visual-diff/generic-entity-diff-card.tsx
+++ b/packages/insomnia/src/ui/components/modals/visual-diff/generic-entity-diff-card.tsx
@@ -1,0 +1,43 @@
+import type { FC } from 'react';
+
+import type { EntityDiff } from './diff-engine';
+import { DiffCardShell, entityTypeLabel, formatValue, StatusBadge, ValueChange } from './shared';
+
+// Fallback card for entity types that don't have a dedicated visual layout yet.
+// Renders a bullet list of raw field changes rather than a purpose-built layout.
+export const GenericEntityDiffCard: FC<{ diff: EntityDiff }> = ({ diff }) => {
+  return (
+    <DiffCardShell status={diff.status}>
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex flex-col">
+          <span className="font-semibold">{diff.name}</span>
+          <span className="text-xs text-(--hl)">{entityTypeLabel(diff.type)}</span>
+        </div>
+        <StatusBadge status={diff.status} />
+      </div>
+
+      {diff.status === 'added' && (
+        <pre className="overflow-x-auto rounded-xs bg-(--color-success)/10 px-2 py-1 text-sm whitespace-pre-wrap text-(--color-font-success)">
+          {formatValue(diff.after)}
+        </pre>
+      )}
+
+      {diff.status === 'removed' && (
+        <pre className="overflow-x-auto rounded-xs bg-(--color-danger)/10 px-2 py-1 text-sm whitespace-pre-wrap text-(--color-font-danger)">
+          {formatValue(diff.before)}
+        </pre>
+      )}
+
+      {diff.status === 'modified' && (
+        <ul className="flex flex-col gap-2">
+          {diff.fieldChanges.map(change => (
+            <li key={change.path} className="flex flex-col gap-1">
+              <span className="text-sm font-medium text-(--hl)">{change.label}</span>
+              <ValueChange before={change.before} after={change.after} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </DiffCardShell>
+  );
+};

--- a/packages/insomnia/src/ui/components/modals/visual-diff/generic-entity-diff-card.tsx
+++ b/packages/insomnia/src/ui/components/modals/visual-diff/generic-entity-diff-card.tsx
@@ -1,11 +1,16 @@
 import type { FC } from 'react';
 
 import type { EntityDiff } from './diff-engine';
-import { DiffCardShell, entityTypeLabel, FieldDiffRow, formatValue, StatusBadge } from './shared';
+import { CardHeaderActions, DiffCardShell, type EntityCardActionProps, entityTypeLabel, FieldDiffRow, formatValue } from './shared';
 
 // Fallback card for entity types that don't have a dedicated visual layout yet.
 // Renders a bullet list of raw field changes rather than a purpose-built layout.
-export const GenericEntityDiffCard: FC<{ diff: EntityDiff }> = ({ diff }) => {
+export const GenericEntityDiffCard: FC<{ diff: EntityDiff } & EntityCardActionProps> = ({
+  diff,
+  staged,
+  isPending,
+  onStage,
+}) => {
   return (
     <DiffCardShell status={diff.status}>
       <div className="flex items-center justify-between gap-2">
@@ -13,7 +18,7 @@ export const GenericEntityDiffCard: FC<{ diff: EntityDiff }> = ({ diff }) => {
           <span className="font-semibold">{diff.name}</span>
           <span className="text-xs text-(--hl)">{entityTypeLabel(diff.type)}</span>
         </div>
-        <StatusBadge status={diff.status} />
+        <CardHeaderActions status={diff.status} staged={staged} isPending={isPending} onStage={onStage} />
       </div>
 
       {diff.status === 'added' && (

--- a/packages/insomnia/src/ui/components/modals/visual-diff/request-diff-card.tsx
+++ b/packages/insomnia/src/ui/components/modals/visual-diff/request-diff-card.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react';
 
 import { formatMethodName, getRequestBadgeClassName } from '../../tags/method-tag';
 import { computeFieldChanges, diffByKey, type EntityDiff, type KeyedDiffRow } from './diff-engine';
-import { DiffCardShell, FieldDiffRow, StatusBadge } from './shared';
+import { CardHeaderActions, DiffCardShell, type EntityCardActionProps, FieldDiffRow, StatusBadge } from './shared';
 
 const HANDLED_FIELD_PATHS = new Set([
   'name',
@@ -67,7 +67,7 @@ const KeyValueDiffRows: FC<{ title: string; rows: KeyedDiffRow[] }> = ({ title, 
   );
 };
 
-export const RequestDiffCard: FC<{ diff: EntityDiff }> = ({ diff }) => {
+export const RequestDiffCard: FC<{ diff: EntityDiff } & EntityCardActionProps> = ({ diff, staged, isPending, onStage }) => {
   const request = diff.after ?? diff.before;
   const method = request?.method || 'GET';
 
@@ -100,7 +100,7 @@ export const RequestDiffCard: FC<{ diff: EntityDiff }> = ({ diff }) => {
           </span>
           <span className="truncate font-mono text-sm text-(--hl)">{request?.url || '(no url)'}</span>
         </div>
-        <StatusBadge status={diff.status} />
+        <CardHeaderActions status={diff.status} staged={staged} isPending={isPending} onStage={onStage} />
       </div>
 
       <span className="font-semibold">{diff.name}</span>

--- a/packages/insomnia/src/ui/components/modals/visual-diff/request-diff-card.tsx
+++ b/packages/insomnia/src/ui/components/modals/visual-diff/request-diff-card.tsx
@@ -1,9 +1,30 @@
-import type { FC } from 'react';
+import { type FC, useMemo, useState } from 'react';
+import { Tab, TabList, TabPanel, Tabs } from 'react-aria-components';
 
 import { formatMethodName, getRequestBadgeClassName } from '../../tags/method-tag';
-import { computeFieldChanges, diffByKey, type EntityDiff, type KeyedDiffRow } from './diff-engine';
-import { CardHeaderActions, DiffCardShell, type EntityCardActionProps, FieldDiffRow, StatusBadge } from './shared';
+import {
+  computeFieldChanges,
+  diffByKey,
+  dominantStatus,
+  type EntityChangeStatus,
+  type EntityDiff,
+  type KeyedDiffRow,
+  sideStatus,
+  valuesEqual,
+} from './diff-engine';
+import {
+  CardHeaderActions,
+  ChangeChip,
+  CollapseToggleButton,
+  DiffCardShell,
+  type EntityCardActionProps,
+  FieldDiffRow,
+  StatusBadge,
+  StatusDot,
+} from './shared';
 
+// Fields already surfaced by a dedicated tab/header row — everything else
+// modified on the request node falls into the (diff-only) Settings tab.
 const HANDLED_FIELD_PATHS = new Set([
   'name',
   'url',
@@ -13,18 +34,31 @@ const HANDLED_FIELD_PATHS = new Set([
   'pathParameters',
   'body',
   'authentication',
+  'scripts',
   'meta.description',
 ]);
 
+function isMeaningfulAuth(auth: any) {
+  return Boolean(auth?.type) && auth.type !== 'none';
+}
+
+function hasBodyContent(body: any) {
+  return Boolean(body?.mimeType || body?.text || body?.params?.length);
+}
+
+function hasScriptContent(scripts: any) {
+  return Boolean(scripts?.preRequest || scripts?.afterResponse);
+}
+
 // Renders a name/value key-value row the same way the app's own header/param
 // editors do, instead of dumping the raw {name, value, disabled} object as JSON.
-const KeyValueDiffRows: FC<{ title: string; rows: KeyedDiffRow[] }> = ({ title, rows }) => {
+const KeyValueDiffRows: FC<{ title?: string; rows: KeyedDiffRow[] }> = ({ title, rows }) => {
   if (rows.length === 0) {
     return null;
   }
   return (
     <div className="flex flex-col gap-2">
-      <span className="text-sm font-semibold">{title}</span>
+      {title && <span className="text-xs font-bold text-(--hl) uppercase">{title}</span>}
       <ul className="flex flex-col gap-2">
         {rows.map(row => {
           const item = (row.after ?? row.before) as { value?: string; fileName?: string; disabled?: boolean } | undefined;
@@ -67,110 +101,240 @@ const KeyValueDiffRows: FC<{ title: string; rows: KeyedDiffRow[] }> = ({ title, 
   );
 };
 
+interface RequestTabDef {
+  id: string;
+  label: string;
+  status: EntityChangeStatus;
+  count?: number;
+  content: FC;
+}
+
+const TAB_CLASS =
+  'flex h-full shrink-0 cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-(--hl) outline-hidden transition-colors select-none hover:bg-(--hl-sm) hover:text-(--color-font) aria-selected:bg-(--color-bg) aria-selected:text-(--color-font) data-focus-visible:ring-2 data-focus-visible:ring-(--hl-md) data-focus-visible:ring-inset';
+
 export const RequestDiffCard: FC<{ diff: EntityDiff } & EntityCardActionProps> = ({ diff, staged, isPending, onStage }) => {
+  const [isExpanded, setIsExpanded] = useState(true);
+  const [selectedTabId, setSelectedTabId] = useState<string | null>(null);
+
   const request = diff.after ?? diff.before;
   const method = request?.method || 'GET';
 
-  const headerRows = diffByKey(diff.before?.headers, diff.after?.headers, 'name');
-  const parameterRows = diffByKey(diff.before?.parameters, diff.after?.parameters, 'name');
-  const pathParameterRows = diffByKey(diff.before?.pathParameters, diff.after?.pathParameters, 'name');
-  const bodyParamRows = diffByKey(diff.before?.body?.params, diff.after?.body?.params, 'name');
+  const headerRows = useMemo(() => diffByKey(diff.before?.headers, diff.after?.headers, 'name'), [diff.before, diff.after]);
+  const parameterRows = useMemo(() => diffByKey(diff.before?.parameters, diff.after?.parameters, 'name'), [diff.before, diff.after]);
+  const pathParameterRows = useMemo(
+    () => diffByKey(diff.before?.pathParameters, diff.after?.pathParameters, 'name'),
+    [diff.before, diff.after],
+  );
+  const bodyParamRows = useMemo(
+    () => diffByKey(diff.before?.body?.params, diff.after?.body?.params, 'name'),
+    [diff.before, diff.after],
+  );
+  const authFieldChanges = useMemo(
+    () => computeFieldChanges(diff.before?.authentication, diff.after?.authentication),
+    [diff.before, diff.after],
+  );
+  const scriptFieldChanges = useMemo(
+    () => computeFieldChanges(diff.before?.scripts, diff.after?.scripts),
+    [diff.before, diff.after],
+  );
 
   const nameChanged = diff.fieldChanges.find(c => c.path === 'name');
   const urlChanged = diff.fieldChanges.find(c => c.path === 'url');
   const methodChanged = diff.fieldChanges.find(c => c.path === 'method');
-  const bodyChanged = diff.fieldChanges.find(c => c.path === 'body');
-  const authChanged = diff.fieldChanges.find(c => c.path === 'authentication');
-  const descriptionChanged = diff.fieldChanges.find(c => c.path === 'meta.description');
+  const bodyMimeTypeChanged = !valuesEqual(diff.before?.body?.mimeType, diff.after?.body?.mimeType);
+  const bodyTextChanged = !valuesEqual(diff.before?.body?.text, diff.after?.body?.text);
+  const descriptionBefore = diff.before?.meta?.description;
+  const descriptionAfter = diff.after?.meta?.description;
+  const descriptionChanged = !valuesEqual(descriptionBefore, descriptionAfter);
+
+  const hasAuthContent = isMeaningfulAuth(diff.before?.authentication) || isMeaningfulAuth(diff.after?.authentication);
 
   const otherChanges = diff.fieldChanges.filter(c => !HANDLED_FIELD_PATHS.has(c.path));
 
-  const bodyMimeTypeChanged =
-    diff.status === 'modified' && diff.before?.body?.mimeType !== diff.after?.body?.mimeType;
-  const bodyTextChanged = diff.status === 'modified' && diff.before?.body?.text !== diff.after?.body?.text;
+  const tabs: RequestTabDef[] = [];
 
-  const authFieldChanges = authChanged ? computeFieldChanges(diff.before?.authentication, diff.after?.authentication) : [];
+  if (parameterRows.length > 0 || pathParameterRows.length > 0) {
+    tabs.push({
+      id: 'params',
+      label: 'Params',
+      status: dominantStatus([...parameterRows, ...pathParameterRows].map(row => row.status)),
+      count: parameterRows.length + pathParameterRows.length,
+      content: () => (
+        <div className="flex flex-col gap-3">
+          <KeyValueDiffRows title="Query Parameters" rows={parameterRows} />
+          <KeyValueDiffRows title="Path Parameters" rows={pathParameterRows} />
+        </div>
+      ),
+    });
+  }
+
+  if (bodyMimeTypeChanged || bodyTextChanged || bodyParamRows.length > 0) {
+    tabs.push({
+      id: 'body',
+      label: 'Body',
+      status: sideStatus(hasBodyContent(diff.before?.body), hasBodyContent(diff.after?.body)),
+      content: () => (
+        <div className="flex flex-col gap-3">
+          {bodyMimeTypeChanged && (
+            <FieldDiffRow label="Content Type" before={diff.before?.body?.mimeType} after={diff.after?.body?.mimeType} />
+          )}
+          {bodyTextChanged && <FieldDiffRow label="Content" before={diff.before?.body?.text} after={diff.after?.body?.text} />}
+          <KeyValueDiffRows title="Form Parameters" rows={bodyParamRows} />
+        </div>
+      ),
+    });
+  }
+
+  if (hasAuthContent && authFieldChanges.length > 0) {
+    tabs.push({
+      id: 'auth',
+      label: 'Auth',
+      status: sideStatus(isMeaningfulAuth(diff.before?.authentication), isMeaningfulAuth(diff.after?.authentication)),
+      content: () => (
+        <div className="flex flex-col gap-3">
+          {authFieldChanges.map(change => (
+            <FieldDiffRow key={change.path} label={change.label} before={change.before} after={change.after} />
+          ))}
+        </div>
+      ),
+    });
+  }
+
+  if (headerRows.length > 0) {
+    tabs.push({
+      id: 'headers',
+      label: 'Headers',
+      status: dominantStatus(headerRows.map(row => row.status)),
+      count: headerRows.length,
+      content: () => <KeyValueDiffRows rows={headerRows} />,
+    });
+  }
+
+  if (scriptFieldChanges.length > 0) {
+    tabs.push({
+      id: 'scripts',
+      label: 'Scripts',
+      status: sideStatus(hasScriptContent(diff.before?.scripts), hasScriptContent(diff.after?.scripts)),
+      content: () => (
+        <div className="flex flex-col gap-3">
+          {scriptFieldChanges.map(change => (
+            <FieldDiffRow key={change.path} label={change.label} before={change.before} after={change.after} />
+          ))}
+        </div>
+      ),
+    });
+  }
+
+  if (descriptionChanged && (descriptionBefore || descriptionAfter)) {
+    tabs.push({
+      id: 'docs',
+      label: 'Docs',
+      status: sideStatus(Boolean(descriptionBefore), Boolean(descriptionAfter)),
+      content: () => <FieldDiffRow label="Description" before={descriptionBefore} after={descriptionAfter} />,
+    });
+  }
+
+  if (otherChanges.length > 0) {
+    tabs.push({
+      id: 'settings',
+      label: 'Settings',
+      status: 'modified',
+      count: otherChanges.length,
+      content: () => (
+        <div className="flex flex-col gap-3">
+          {otherChanges.map(change => (
+            <FieldDiffRow key={change.path} label={change.label} before={change.before} after={change.after} />
+          ))}
+        </div>
+      ),
+    });
+  }
+
+  const activeTabId = selectedTabId && tabs.some(t => t.id === selectedTabId) ? selectedTabId : tabs[0]?.id;
+
+  function openTab(tabId: string) {
+    setSelectedTabId(tabId);
+    setIsExpanded(true);
+  }
 
   return (
     <DiffCardShell status={diff.status}>
       <div className="flex items-start justify-between gap-2">
-        <div className="flex flex-1 items-center gap-2 overflow-hidden">
-          <span className={`shrink-0 rounded-xs px-1.5 py-0.5 text-xs font-bold ${getRequestBadgeClassName(formatMethodName(method))}`}>
-            {formatMethodName(method)}
-          </span>
-          <span className="truncate font-mono text-sm text-(--hl)">{request?.url || '(no url)'}</span>
+        <div className="flex flex-1 items-center gap-1 overflow-hidden">
+          <CollapseToggleButton isExpanded={isExpanded} onPress={() => setIsExpanded(!isExpanded)} />
+          <div className="flex flex-1 flex-col gap-1 overflow-hidden">
+            <div className="flex items-center gap-2 overflow-hidden">
+              <span className={`shrink-0 rounded-xs px-1.5 py-0.5 text-xs font-bold ${getRequestBadgeClassName(formatMethodName(method))}`}>
+                {formatMethodName(method)}
+              </span>
+              <span className="truncate font-mono text-sm text-(--hl)">{request?.url || '(no url)'}</span>
+            </div>
+            {(urlChanged || methodChanged) && (
+              <div className="flex items-center gap-2 overflow-hidden opacity-60">
+                <span
+                  className={`shrink-0 rounded-xs px-1.5 py-0.5 text-[10px] font-bold line-through ${getRequestBadgeClassName(formatMethodName(diff.before?.method || method))}`}
+                >
+                  {formatMethodName(diff.before?.method || method)}
+                </span>
+                <span className="truncate font-mono text-xs text-(--color-font-danger) line-through">
+                  {diff.before?.url || '(no url)'}
+                </span>
+              </div>
+            )}
+          </div>
         </div>
         <CardHeaderActions status={diff.status} staged={staged} isPending={isPending} onStage={onStage} />
       </div>
 
-      <span className="font-semibold">{diff.name}</span>
+      <span className="pl-7 font-semibold">
+        {diff.name}
+        {nameChanged && (
+          <span className="ml-2 text-xs font-normal text-(--hl) line-through">{String(nameChanged.before ?? '')}</span>
+        )}
+      </span>
 
-      {diff.status !== 'modified' && (
-        <div className="flex flex-col gap-1 text-sm text-(--hl)">
-          {(request?.headers?.length ?? 0) > 0 && <span>{request.headers.length} header(s)</span>}
-          {(request?.parameters?.length ?? 0) > 0 && <span>{request.parameters.length} query parameter(s)</span>}
-          {request?.authentication?.type && request.authentication.type !== 'none' && (
-            <span>Authentication: {request.authentication.type}</span>
-          )}
+      {!isExpanded && tabs.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 pl-7">
+          {tabs.map(tab => (
+            <ChangeChip key={tab.id} label={tab.label} status={tab.status} count={tab.count} onPress={() => openTab(tab.id)} />
+          ))}
         </div>
       )}
 
-      {diff.status === 'modified' && (
-        <>
-          {(nameChanged || urlChanged || methodChanged || descriptionChanged) && (
-            <div className="flex flex-col gap-2">
-              <span className="text-sm font-semibold">Overview</span>
-              {nameChanged && <FieldDiffRow label="Name" before={nameChanged.before} after={nameChanged.after} />}
-              {urlChanged && <FieldDiffRow label="URL" before={urlChanged.before} after={urlChanged.after} />}
-              {methodChanged && <FieldDiffRow label="Method" before={methodChanged.before} after={methodChanged.after} />}
-              {descriptionChanged && (
-                <FieldDiffRow label="Description" before={descriptionChanged.before} after={descriptionChanged.after} />
-              )}
-            </div>
-          )}
-
-          <KeyValueDiffRows title="Headers" rows={headerRows} />
-          <KeyValueDiffRows title="Query Parameters" rows={parameterRows} />
-          <KeyValueDiffRows title="Path Parameters" rows={pathParameterRows} />
-
-          {bodyChanged && (
-            <div className="flex flex-col gap-2">
-              <span className="text-sm font-semibold">Body</span>
-              {bodyMimeTypeChanged && (
-                <FieldDiffRow label="Content Type" before={diff.before?.body?.mimeType} after={diff.after?.body?.mimeType} />
-              )}
-              {bodyTextChanged && (
-                <FieldDiffRow label="Content" before={diff.before?.body?.text} after={diff.after?.body?.text} />
-              )}
-              <KeyValueDiffRows title="Body Parameters" rows={bodyParamRows} />
-            </div>
-          )}
-
-          {authFieldChanges.length > 0 && (
-            <div className="flex flex-col gap-2">
-              <span className="text-sm font-semibold">Authentication</span>
-              <div className="flex flex-col gap-2 pl-1">
-                {authFieldChanges.map(change => (
-                  <FieldDiffRow key={change.path} label={change.label} before={change.before} after={change.after} />
-                ))}
-              </div>
-            </div>
-          )}
-
-          {otherChanges.length > 0 && (
-            <div className="flex flex-col gap-2">
-              <span className="text-sm font-semibold">Other Changes</span>
-              <ul className="flex flex-col gap-2">
-                {otherChanges.map(change => (
-                  <li key={change.path}>
-                    <FieldDiffRow label={change.label} before={change.before} after={change.after} />
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </>
+      {isExpanded && tabs.length > 0 && (
+        <Tabs
+          className="flex flex-col overflow-hidden"
+          selectedKey={activeTabId}
+          onSelectionChange={key => setSelectedTabId(String(key))}
+        >
+          <TabList
+            aria-label="Changed sections"
+            className="flex shrink-0 items-center gap-1 overflow-x-auto border-b border-solid border-b-(--hl-sm)"
+          >
+            {tabs.map(tab => (
+              <Tab key={tab.id} id={tab.id} className={TAB_CLASS}>
+                <StatusDot status={tab.status} />
+                {tab.label}
+                {tab.count !== undefined && tab.count > 0 && (
+                  <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-(--hl-sm) px-1 text-xs">
+                    {tab.count}
+                  </span>
+                )}
+              </Tab>
+            ))}
+          </TabList>
+          {tabs.map(tab => {
+            const Content = tab.content;
+            return (
+              <TabPanel key={tab.id} id={tab.id} className="pt-3">
+                <Content />
+              </TabPanel>
+            );
+          })}
+        </Tabs>
       )}
+
+      {isExpanded && tabs.length === 0 && <span className="pl-7 text-sm text-(--hl)">No further details to show.</span>}
     </DiffCardShell>
   );
 };

--- a/packages/insomnia/src/ui/components/modals/visual-diff/request-diff-card.tsx
+++ b/packages/insomnia/src/ui/components/modals/visual-diff/request-diff-card.tsx
@@ -1,0 +1,176 @@
+import type { FC } from 'react';
+
+import { formatMethodName, getRequestBadgeClassName } from '../../tags/method-tag';
+import { diffByKey, type EntityDiff, type KeyedDiffRow } from './diff-engine';
+import { DiffCardShell, formatValue, StatusBadge, ValueChange } from './shared';
+
+const HANDLED_FIELD_PATHS = new Set([
+  'name',
+  'url',
+  'method',
+  'headers',
+  'parameters',
+  'pathParameters',
+  'body',
+  'authentication',
+  'meta.description',
+]);
+
+const KeyedDiffRows: FC<{ title: string; rows: KeyedDiffRow[] }> = ({ title, rows }) => {
+  if (rows.length === 0) {
+    return null;
+  }
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-sm font-semibold">{title}</span>
+      <ul className="flex flex-col gap-2">
+        {rows.map(row => (
+          <li key={row.key} className="flex flex-col gap-1 rounded-xs bg-(--color-bg) p-2">
+            <div className="flex items-center gap-2">
+              <StatusBadge status={row.status} />
+              <span className="font-mono text-sm">{row.key}</span>
+            </div>
+            {row.status === 'modified' && <ValueChange before={row.before} after={row.after} />}
+            {row.status === 'added' && (
+              <pre className="overflow-x-auto rounded-xs bg-(--color-success)/10 px-2 py-1 text-sm whitespace-pre-wrap text-(--color-font-success)">
+                {formatValue(row.after)}
+              </pre>
+            )}
+            {row.status === 'removed' && (
+              <pre className="overflow-x-auto rounded-xs bg-(--color-danger)/10 px-2 py-1 text-sm whitespace-pre-wrap text-(--color-font-danger)">
+                {formatValue(row.before)}
+              </pre>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export const RequestDiffCard: FC<{ diff: EntityDiff }> = ({ diff }) => {
+  const request = diff.after ?? diff.before;
+  const method = request?.method || 'GET';
+
+  const headerRows = diffByKey(diff.before?.headers, diff.after?.headers, 'name');
+  const parameterRows = diffByKey(diff.before?.parameters, diff.after?.parameters, 'name');
+  const pathParameterRows = diffByKey(diff.before?.pathParameters, diff.after?.pathParameters, 'name');
+  const bodyParamRows = diffByKey(diff.before?.body?.params, diff.after?.body?.params, 'name');
+
+  const nameChanged = diff.fieldChanges.find(c => c.path === 'name');
+  const urlChanged = diff.fieldChanges.find(c => c.path === 'url');
+  const methodChanged = diff.fieldChanges.find(c => c.path === 'method');
+  const bodyChanged = diff.fieldChanges.find(c => c.path === 'body');
+  const authChanged = diff.fieldChanges.find(c => c.path === 'authentication');
+  const descriptionChanged = diff.fieldChanges.find(c => c.path === 'meta.description');
+
+  const otherChanges = diff.fieldChanges.filter(c => !HANDLED_FIELD_PATHS.has(c.path));
+
+  const bodyMimeTypeChanged =
+    diff.status === 'modified' && diff.before?.body?.mimeType !== diff.after?.body?.mimeType;
+  const bodyTextChanged = diff.status === 'modified' && diff.before?.body?.text !== diff.after?.body?.text;
+
+  return (
+    <DiffCardShell status={diff.status}>
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex flex-1 items-center gap-2 overflow-hidden">
+          <span className={`shrink-0 rounded-xs px-1.5 py-0.5 text-xs font-bold ${getRequestBadgeClassName(formatMethodName(method))}`}>
+            {formatMethodName(method)}
+          </span>
+          <span className="truncate font-mono text-sm text-(--hl)">{request?.url || '(no url)'}</span>
+        </div>
+        <StatusBadge status={diff.status} />
+      </div>
+
+      <span className="font-semibold">{diff.name}</span>
+
+      {diff.status !== 'modified' && (
+        <div className="flex flex-col gap-1 text-sm text-(--hl)">
+          {(request?.headers?.length ?? 0) > 0 && <span>{request.headers.length} header(s)</span>}
+          {(request?.parameters?.length ?? 0) > 0 && <span>{request.parameters.length} query parameter(s)</span>}
+          {request?.authentication?.type && request.authentication.type !== 'none' && (
+            <span>Authentication: {request.authentication.type}</span>
+          )}
+        </div>
+      )}
+
+      {diff.status === 'modified' && (
+        <>
+          {(nameChanged || urlChanged || methodChanged || descriptionChanged) && (
+            <div className="flex flex-col gap-2">
+              <span className="text-sm font-semibold">Overview</span>
+              {nameChanged && (
+                <div className="flex flex-col gap-1">
+                  <span className="text-xs text-(--hl)">Name</span>
+                  <ValueChange before={nameChanged.before} after={nameChanged.after} />
+                </div>
+              )}
+              {urlChanged && (
+                <div className="flex flex-col gap-1">
+                  <span className="text-xs text-(--hl)">URL</span>
+                  <ValueChange before={urlChanged.before} after={urlChanged.after} />
+                </div>
+              )}
+              {methodChanged && (
+                <div className="flex flex-col gap-1">
+                  <span className="text-xs text-(--hl)">Method</span>
+                  <ValueChange before={methodChanged.before} after={methodChanged.after} />
+                </div>
+              )}
+              {descriptionChanged && (
+                <div className="flex flex-col gap-1">
+                  <span className="text-xs text-(--hl)">Description</span>
+                  <ValueChange before={descriptionChanged.before} after={descriptionChanged.after} />
+                </div>
+              )}
+            </div>
+          )}
+
+          <KeyedDiffRows title="Headers" rows={headerRows} />
+          <KeyedDiffRows title="Query Parameters" rows={parameterRows} />
+          <KeyedDiffRows title="Path Parameters" rows={pathParameterRows} />
+
+          {bodyChanged && (
+            <div className="flex flex-col gap-2">
+              <span className="text-sm font-semibold">Body</span>
+              {bodyMimeTypeChanged && (
+                <div className="flex flex-col gap-1">
+                  <span className="text-xs text-(--hl)">Content Type</span>
+                  <ValueChange before={diff.before?.body?.mimeType} after={diff.after?.body?.mimeType} />
+                </div>
+              )}
+              {bodyTextChanged && (
+                <div className="flex flex-col gap-1">
+                  <span className="text-xs text-(--hl)">Content</span>
+                  <ValueChange before={diff.before?.body?.text} after={diff.after?.body?.text} />
+                </div>
+              )}
+              <KeyedDiffRows title="Body Parameters" rows={bodyParamRows} />
+            </div>
+          )}
+
+          {authChanged && (
+            <div className="flex flex-col gap-1">
+              <span className="text-sm font-semibold">Authentication</span>
+              <ValueChange before={diff.before?.authentication} after={diff.after?.authentication} />
+            </div>
+          )}
+
+          {otherChanges.length > 0 && (
+            <div className="flex flex-col gap-2">
+              <span className="text-sm font-semibold">Other Changes</span>
+              <ul className="flex flex-col gap-2">
+                {otherChanges.map(change => (
+                  <li key={change.path} className="flex flex-col gap-1">
+                    <span className="text-xs text-(--hl)">{change.label}</span>
+                    <ValueChange before={change.before} after={change.after} />
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </>
+      )}
+    </DiffCardShell>
+  );
+};

--- a/packages/insomnia/src/ui/components/modals/visual-diff/request-diff-card.tsx
+++ b/packages/insomnia/src/ui/components/modals/visual-diff/request-diff-card.tsx
@@ -1,8 +1,8 @@
 import type { FC } from 'react';
 
 import { formatMethodName, getRequestBadgeClassName } from '../../tags/method-tag';
-import { diffByKey, type EntityDiff, type KeyedDiffRow } from './diff-engine';
-import { DiffCardShell, formatValue, StatusBadge, ValueChange } from './shared';
+import { computeFieldChanges, diffByKey, type EntityDiff, type KeyedDiffRow } from './diff-engine';
+import { DiffCardShell, FieldDiffRow, StatusBadge } from './shared';
 
 const HANDLED_FIELD_PATHS = new Set([
   'name',
@@ -16,7 +16,9 @@ const HANDLED_FIELD_PATHS = new Set([
   'meta.description',
 ]);
 
-const KeyedDiffRows: FC<{ title: string; rows: KeyedDiffRow[] }> = ({ title, rows }) => {
+// Renders a name/value key-value row the same way the app's own header/param
+// editors do, instead of dumping the raw {name, value, disabled} object as JSON.
+const KeyValueDiffRows: FC<{ title: string; rows: KeyedDiffRow[] }> = ({ title, rows }) => {
   if (rows.length === 0) {
     return null;
   }
@@ -24,25 +26,42 @@ const KeyedDiffRows: FC<{ title: string; rows: KeyedDiffRow[] }> = ({ title, row
     <div className="flex flex-col gap-2">
       <span className="text-sm font-semibold">{title}</span>
       <ul className="flex flex-col gap-2">
-        {rows.map(row => (
-          <li key={row.key} className="flex flex-col gap-1 rounded-xs bg-(--color-bg) p-2">
-            <div className="flex items-center gap-2">
-              <StatusBadge status={row.status} />
-              <span className="font-mono text-sm">{row.key}</span>
-            </div>
-            {row.status === 'modified' && <ValueChange before={row.before} after={row.after} />}
-            {row.status === 'added' && (
-              <pre className="overflow-x-auto rounded-xs bg-(--color-success)/10 px-2 py-1 text-sm whitespace-pre-wrap text-(--color-font-success)">
-                {formatValue(row.after)}
-              </pre>
-            )}
-            {row.status === 'removed' && (
-              <pre className="overflow-x-auto rounded-xs bg-(--color-danger)/10 px-2 py-1 text-sm whitespace-pre-wrap text-(--color-font-danger)">
-                {formatValue(row.before)}
-              </pre>
-            )}
-          </li>
-        ))}
+        {rows.map(row => {
+          const item = (row.after ?? row.before) as { value?: string; fileName?: string; disabled?: boolean } | undefined;
+
+          if (row.status === 'modified') {
+            const fieldChanges = computeFieldChanges(row.before, row.after);
+            return (
+              <li key={row.key} className="flex flex-col gap-2 rounded-xs bg-(--color-bg) p-2">
+                <div className="flex items-center gap-2">
+                  <StatusBadge status={row.status} />
+                  <span className="font-mono text-sm font-medium">{row.key}</span>
+                </div>
+                <div className="flex flex-col gap-2 pl-1">
+                  {fieldChanges.map(change => (
+                    <FieldDiffRow key={change.path} label={change.label} before={change.before} after={change.after} />
+                  ))}
+                </div>
+              </li>
+            );
+          }
+
+          const isAdded = row.status === 'added';
+          return (
+            <li key={row.key} className="flex flex-wrap items-center justify-between gap-2 rounded-xs bg-(--color-bg) p-2">
+              <div className="flex items-center gap-2">
+                <StatusBadge status={row.status} />
+                <span className="font-mono text-sm font-medium">{row.key}</span>
+                {item?.disabled && <span className="text-xs text-(--hl)">(disabled)</span>}
+              </div>
+              <span
+                className={`truncate font-mono text-sm ${isAdded ? 'text-(--color-font-success)' : 'text-(--color-font-danger) line-through'}`}
+              >
+                {item?.value ?? item?.fileName ?? '(empty)'}
+              </span>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );
@@ -69,6 +88,8 @@ export const RequestDiffCard: FC<{ diff: EntityDiff }> = ({ diff }) => {
   const bodyMimeTypeChanged =
     diff.status === 'modified' && diff.before?.body?.mimeType !== diff.after?.body?.mimeType;
   const bodyTextChanged = diff.status === 'modified' && diff.before?.body?.text !== diff.after?.body?.text;
+
+  const authFieldChanges = authChanged ? computeFieldChanges(diff.before?.authentication, diff.after?.authentication) : [];
 
   return (
     <DiffCardShell status={diff.status}>
@@ -99,60 +120,40 @@ export const RequestDiffCard: FC<{ diff: EntityDiff }> = ({ diff }) => {
           {(nameChanged || urlChanged || methodChanged || descriptionChanged) && (
             <div className="flex flex-col gap-2">
               <span className="text-sm font-semibold">Overview</span>
-              {nameChanged && (
-                <div className="flex flex-col gap-1">
-                  <span className="text-xs text-(--hl)">Name</span>
-                  <ValueChange before={nameChanged.before} after={nameChanged.after} />
-                </div>
-              )}
-              {urlChanged && (
-                <div className="flex flex-col gap-1">
-                  <span className="text-xs text-(--hl)">URL</span>
-                  <ValueChange before={urlChanged.before} after={urlChanged.after} />
-                </div>
-              )}
-              {methodChanged && (
-                <div className="flex flex-col gap-1">
-                  <span className="text-xs text-(--hl)">Method</span>
-                  <ValueChange before={methodChanged.before} after={methodChanged.after} />
-                </div>
-              )}
+              {nameChanged && <FieldDiffRow label="Name" before={nameChanged.before} after={nameChanged.after} />}
+              {urlChanged && <FieldDiffRow label="URL" before={urlChanged.before} after={urlChanged.after} />}
+              {methodChanged && <FieldDiffRow label="Method" before={methodChanged.before} after={methodChanged.after} />}
               {descriptionChanged && (
-                <div className="flex flex-col gap-1">
-                  <span className="text-xs text-(--hl)">Description</span>
-                  <ValueChange before={descriptionChanged.before} after={descriptionChanged.after} />
-                </div>
+                <FieldDiffRow label="Description" before={descriptionChanged.before} after={descriptionChanged.after} />
               )}
             </div>
           )}
 
-          <KeyedDiffRows title="Headers" rows={headerRows} />
-          <KeyedDiffRows title="Query Parameters" rows={parameterRows} />
-          <KeyedDiffRows title="Path Parameters" rows={pathParameterRows} />
+          <KeyValueDiffRows title="Headers" rows={headerRows} />
+          <KeyValueDiffRows title="Query Parameters" rows={parameterRows} />
+          <KeyValueDiffRows title="Path Parameters" rows={pathParameterRows} />
 
           {bodyChanged && (
             <div className="flex flex-col gap-2">
               <span className="text-sm font-semibold">Body</span>
               {bodyMimeTypeChanged && (
-                <div className="flex flex-col gap-1">
-                  <span className="text-xs text-(--hl)">Content Type</span>
-                  <ValueChange before={diff.before?.body?.mimeType} after={diff.after?.body?.mimeType} />
-                </div>
+                <FieldDiffRow label="Content Type" before={diff.before?.body?.mimeType} after={diff.after?.body?.mimeType} />
               )}
               {bodyTextChanged && (
-                <div className="flex flex-col gap-1">
-                  <span className="text-xs text-(--hl)">Content</span>
-                  <ValueChange before={diff.before?.body?.text} after={diff.after?.body?.text} />
-                </div>
+                <FieldDiffRow label="Content" before={diff.before?.body?.text} after={diff.after?.body?.text} />
               )}
-              <KeyedDiffRows title="Body Parameters" rows={bodyParamRows} />
+              <KeyValueDiffRows title="Body Parameters" rows={bodyParamRows} />
             </div>
           )}
 
-          {authChanged && (
-            <div className="flex flex-col gap-1">
+          {authFieldChanges.length > 0 && (
+            <div className="flex flex-col gap-2">
               <span className="text-sm font-semibold">Authentication</span>
-              <ValueChange before={diff.before?.authentication} after={diff.after?.authentication} />
+              <div className="flex flex-col gap-2 pl-1">
+                {authFieldChanges.map(change => (
+                  <FieldDiffRow key={change.path} label={change.label} before={change.before} after={change.after} />
+                ))}
+              </div>
             </div>
           )}
 
@@ -161,9 +162,8 @@ export const RequestDiffCard: FC<{ diff: EntityDiff }> = ({ diff }) => {
               <span className="text-sm font-semibold">Other Changes</span>
               <ul className="flex flex-col gap-2">
                 {otherChanges.map(change => (
-                  <li key={change.path} className="flex flex-col gap-1">
-                    <span className="text-xs text-(--hl)">{change.label}</span>
-                    <ValueChange before={change.before} after={change.after} />
+                  <li key={change.path}>
+                    <FieldDiffRow label={change.label} before={change.before} after={change.after} />
                   </li>
                 ))}
               </ul>

--- a/packages/insomnia/src/ui/components/modals/visual-diff/shared.tsx
+++ b/packages/insomnia/src/ui/components/modals/visual-diff/shared.tsx
@@ -22,10 +22,25 @@ export function entityTypeLabel(type: VisualDiffEntityType): string {
   return ENTITY_TYPE_LABELS[type] ?? 'Item';
 }
 
-const STATUS_STYLES: Record<EntityChangeStatus, { className: string; icon: IconProp; label: string }> = {
-  added: { className: 'bg-(--color-success)/20 text-(--color-font-success)', icon: 'plus', label: 'Added' },
-  removed: { className: 'bg-(--color-danger)/20 text-(--color-font-danger)', icon: 'minus', label: 'Removed' },
-  modified: { className: 'bg-(--color-notice)/20 text-(--color-font-notice)', icon: 'pencil', label: 'Modified' },
+const STATUS_STYLES: Record<EntityChangeStatus, { className: string; dotClassName: string; icon: IconProp; label: string }> = {
+  added: {
+    className: 'bg-(--color-success)/20 text-(--color-font-success)',
+    dotClassName: 'bg-(--color-success)',
+    icon: 'plus',
+    label: 'Added',
+  },
+  removed: {
+    className: 'bg-(--color-danger)/20 text-(--color-font-danger)',
+    dotClassName: 'bg-(--color-danger)',
+    icon: 'minus',
+    label: 'Removed',
+  },
+  modified: {
+    className: 'bg-(--color-notice)/20 text-(--color-font-notice)',
+    dotClassName: 'bg-(--color-notice)',
+    icon: 'pencil',
+    label: 'Modified',
+  },
 };
 
 export const StatusBadge: FC<{ status: EntityChangeStatus }> = ({ status }) => {
@@ -36,6 +51,54 @@ export const StatusBadge: FC<{ status: EntityChangeStatus }> = ({ status }) => {
     </span>
   );
 };
+
+// Small colored dot conveying a section's dominant change status — used on tab
+// labels and chips, where a full StatusBadge would be too heavy.
+export const StatusDot: FC<{ status: EntityChangeStatus }> = ({ status }) => (
+  <span className={`inline-block size-2 shrink-0 rounded-full ${STATUS_STYLES[status].dotClassName}`} />
+);
+
+// Compact pill summarizing one changed section (eg. "Headers 2") — shown in a
+// card's collapsed state as a stand-in for the section's (hidden) tab, and
+// clickable to expand straight into that tab.
+export const ChangeChip: FC<{ label: string; status: EntityChangeStatus; count?: number; onPress?: () => void }> = ({
+  label,
+  status,
+  count,
+  onPress,
+}) => {
+  const content = (
+    <span className="flex items-center gap-1.5 rounded-full bg-(--color-bg) px-2 py-0.5 text-xs font-medium text-(--color-font)">
+      <StatusDot status={status} />
+      {label}
+      {count !== undefined && count > 0 && <span className="text-(--hl)">{count}</span>}
+    </span>
+  );
+
+  if (!onPress) {
+    return content;
+  }
+
+  return (
+    <Button
+      onPress={onPress}
+      className="cursor-pointer rounded-full ring-1 ring-transparent transition-all hover:brightness-110 focus:ring-(--hl-md) focus:ring-inset"
+    >
+      {content}
+    </Button>
+  );
+};
+
+// Chevron toggle for a card's collapsed/expanded state.
+export const CollapseToggleButton: FC<{ isExpanded: boolean; onPress: () => void }> = ({ isExpanded, onPress }) => (
+  <Button
+    onPress={onPress}
+    aria-label={isExpanded ? 'Collapse' : 'Expand'}
+    className="flex aspect-square h-6 shrink-0 items-center justify-center rounded-xs text-sm text-(--hl) ring-1 ring-transparent transition-all hover:bg-(--hl-sm) hover:text-(--color-font) focus:ring-(--hl-md) focus:ring-inset"
+  >
+    <Icon icon={isExpanded ? 'chevron-down' : 'chevron-right'} />
+  </Button>
+);
 
 // Props every visual diff card accepts for its per-entity stage/unstage button.
 export interface EntityCardActionProps {

--- a/packages/insomnia/src/ui/components/modals/visual-diff/shared.tsx
+++ b/packages/insomnia/src/ui/components/modals/visual-diff/shared.tsx
@@ -1,5 +1,6 @@
 import type { IconProp } from '@fortawesome/fontawesome-svg-core';
 import type { FC, ReactNode } from 'react';
+import { Button } from 'react-aria-components';
 
 import { Icon } from '../../icon';
 import type { EntityChangeStatus, VisualDiffEntityType } from './diff-engine';
@@ -35,6 +36,34 @@ export const StatusBadge: FC<{ status: EntityChangeStatus }> = ({ status }) => {
     </span>
   );
 };
+
+// Props every visual diff card accepts for its per-entity stage/unstage button.
+export interface EntityCardActionProps {
+  staged: boolean;
+  isPending: boolean;
+  onStage: () => void;
+}
+
+// Groups the status badge with the per-entity stage/unstage action, shown at
+// the top-right of every visual diff card.
+export const CardHeaderActions: FC<{ status: EntityChangeStatus } & EntityCardActionProps> = ({
+  status,
+  staged,
+  isPending,
+  onStage,
+}) => (
+  <div className="flex shrink-0 items-center gap-2">
+    <StatusBadge status={status} />
+    <Button
+      isDisabled={isPending}
+      onPress={onStage}
+      className="flex items-center gap-1 rounded-xs bg-(--hl-xs) px-2 py-1 text-xs font-medium text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-sm) focus:ring-(--hl-md) focus:ring-inset disabled:opacity-50"
+    >
+      <Icon icon={isPending ? 'spinner' : staged ? 'minus' : 'plus'} className={isPending ? 'animate-spin' : ''} />
+      {staged ? 'Unstage' : 'Stage'}
+    </Button>
+  </div>
+);
 
 export const DiffCardShell: FC<{ status: EntityChangeStatus; children: ReactNode }> = ({ status, children }) => {
   const borderColor =

--- a/packages/insomnia/src/ui/components/modals/visual-diff/shared.tsx
+++ b/packages/insomnia/src/ui/components/modals/visual-diff/shared.tsx
@@ -1,0 +1,90 @@
+import type { IconProp } from '@fortawesome/fontawesome-svg-core';
+import type { FC, ReactNode } from 'react';
+
+import { Icon } from '../../icon';
+import type { EntityChangeStatus, VisualDiffEntityType } from './diff-engine';
+
+const ENTITY_TYPE_LABELS: Record<VisualDiffEntityType, string> = {
+  request: 'Request',
+  grpc_request: 'gRPC Request',
+  websocket_request: 'WebSocket Request',
+  socketio_request: 'Socket.IO Request',
+  request_group: 'Folder',
+  environment: 'Environment',
+  mock_route: 'Mock Route',
+  mcp_request: 'MCP Request',
+  cookie_jar: 'Cookie Jar',
+  unknown: 'Item',
+};
+
+export function entityTypeLabel(type: VisualDiffEntityType): string {
+  return ENTITY_TYPE_LABELS[type] ?? 'Item';
+}
+
+const STATUS_STYLES: Record<EntityChangeStatus, { className: string; icon: IconProp; label: string }> = {
+  added: { className: 'bg-(--color-success)/20 text-(--color-font-success)', icon: 'plus', label: 'Added' },
+  removed: { className: 'bg-(--color-danger)/20 text-(--color-font-danger)', icon: 'minus', label: 'Removed' },
+  modified: { className: 'bg-(--color-notice)/20 text-(--color-font-notice)', icon: 'pencil', label: 'Modified' },
+};
+
+export const StatusBadge: FC<{ status: EntityChangeStatus }> = ({ status }) => {
+  const { className, icon, label } = STATUS_STYLES[status];
+  return (
+    <span className={`flex items-center gap-1 rounded-xs px-1.5 py-0.5 text-xs font-medium ${className}`}>
+      <Icon icon={icon} /> {label}
+    </span>
+  );
+};
+
+export const DiffCardShell: FC<{ status: EntityChangeStatus; children: ReactNode }> = ({ status, children }) => {
+  const borderColor =
+    status === 'added'
+      ? 'border-l-(--color-success)'
+      : status === 'removed'
+        ? 'border-l-(--color-danger)'
+        : 'border-l-(--color-notice)';
+  return (
+    <div className={`flex flex-col gap-2 rounded-xs border border-solid border-(--hl-sm) border-l-2 bg-(--hl-xs) p-3 ${borderColor}`}>
+      {children}
+    </div>
+  );
+};
+
+export function formatValue(value: unknown): string {
+  if (value === undefined) {
+    return '—';
+  }
+  if (value === null || value === '') {
+    return '(empty)';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'boolean' || typeof value === 'number') {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+export const ValueChange: FC<{ before: unknown; after: unknown }> = ({ before, after }) => {
+  const hasBefore = before !== undefined;
+  const hasAfter = after !== undefined;
+  return (
+    <div className="flex flex-col gap-1 text-sm">
+      {hasBefore && (
+        <pre className="overflow-x-auto rounded-xs bg-(--color-danger)/10 px-2 py-1 whitespace-pre-wrap text-(--color-font-danger) line-through">
+          {formatValue(before)}
+        </pre>
+      )}
+      {hasAfter && (
+        <pre className="overflow-x-auto rounded-xs bg-(--color-success)/10 px-2 py-1 whitespace-pre-wrap text-(--color-font-success)">
+          {formatValue(after)}
+        </pre>
+      )}
+    </div>
+  );
+};

--- a/packages/insomnia/src/ui/components/modals/visual-diff/shared.tsx
+++ b/packages/insomnia/src/ui/components/modals/visual-diff/shared.tsx
@@ -70,21 +70,30 @@ export function formatValue(value: unknown): string {
   }
 }
 
+// Lays before/after side-by-side when there's room for both (flex-wrap falls
+// back to stacked once the combined width no longer fits the container).
 export const ValueChange: FC<{ before: unknown; after: unknown }> = ({ before, after }) => {
   const hasBefore = before !== undefined;
   const hasAfter = after !== undefined;
   return (
-    <div className="flex flex-col gap-1 text-sm">
+    <div className="flex flex-wrap items-start gap-2 text-sm">
       {hasBefore && (
-        <pre className="overflow-x-auto rounded-xs bg-(--color-danger)/10 px-2 py-1 whitespace-pre-wrap text-(--color-font-danger) line-through">
+        <pre className="min-w-40 flex-1 overflow-x-auto rounded-xs bg-(--color-danger)/10 px-2 py-1 whitespace-pre-wrap text-(--color-font-danger) line-through">
           {formatValue(before)}
         </pre>
       )}
       {hasAfter && (
-        <pre className="overflow-x-auto rounded-xs bg-(--color-success)/10 px-2 py-1 whitespace-pre-wrap text-(--color-font-success)">
+        <pre className="min-w-40 flex-1 overflow-x-auto rounded-xs bg-(--color-success)/10 px-2 py-1 whitespace-pre-wrap text-(--color-font-success)">
           {formatValue(after)}
         </pre>
       )}
     </div>
   );
 };
+
+export const FieldDiffRow: FC<{ label: string; before: unknown; after: unknown }> = ({ label, before, after }) => (
+  <div className="flex flex-col gap-1">
+    <span className="text-xs text-(--hl)">{label}</span>
+    <ValueChange before={before} after={after} />
+  </div>
+);


### PR DESCRIPTION
## Overview

Adds a **Visual Diff** view to the git staging/commit modal, as a "[Preview]" toggle alongside the existing raw text diff (Text / Visual switch above the diff panel).

**The problem:** a git-tracked file in Insomnia isn't one entity — it's a whole workspace export bundled into a single YAML blob (a collection's requests and folders, an environment's base + sub-environments, etc.). The existing diff view is a raw side-by-side text diff of that entire blob, which makes it hard to tell *what actually changed* when many entities live in one file, and forces staging/committing at the granularity of "the whole file" even when the user only cares about one request.

**How it works:**

- **Entity-level diffing** — instead of diffing the file as one text blob, the two sides of the diff are parsed and walked as a tree, matching up requests, folders, environments, sub-environments, mock routes, etc. by their internal id. This turns one file-level diff into a list of per-entity changes (added / removed / modified), each with its own field-level breakdown.
- **Purpose-built cards per entity** — each changed entity renders as its own card instead of a wall of YAML:
  - **Requests** get the richest treatment: a method/URL header, tabs mirroring the real request editor (Params, Body, Auth, Headers, Scripts, Docs, plus a diff-only Settings catch-all), with each tab only shown if that section actually changed and marked with a colored dot for added/removed/modified. Cards can collapse to a compact summary of colored chips so a file with many changed requests stays scannable, and clicking a chip jumps straight into that tab.
  - **Environments** show variable-by-variable changes, with vault-backed secrets always masked rather than diffed in the clear.
  - Everything else (folders, WebSocket/gRPC/Socket.IO/MCP requests, mock routes, cookie jar) falls back to a generic bullet-style card, so no entity type is silently unsupported — it just doesn't have a tailored layout yet.
- **Per-entity stage/unstage** — every card has a Stage (or Unstage, when viewing already-staged changes) button, so a user can commit just one request's change out of a file without pulling in every other unrelated change in that same file. This works by writing a synthetic blob straight into git's index (base content with only that one entity's node grafted in) rather than the usual whole-file `git add`, using a low-level isomorphic-git primitive that lets the index diverge from the on-disk working file.

This is intentionally shipped as a "[Preview]" toggle next to the existing Text view, not a replacement — the raw diff remains the source of truth for anyone who wants to see exactly what git will commit.

## Next steps

**Entity types still needing a dedicated visual card** (currently render via the generic fallback):
- [ ] Request Group (folder)
- [ ] WebSocket Request
- [ ] gRPC Request
- [ ] Socket.IO Request
- [ ] MCP Request
- [ ] Mock Route
- [ ] Cookie Jar

**Other follow-ups:**
- [ ] Collapse/expand + tabbed layout is only implemented for Request cards so far — worth extending to Environment/Generic cards for a consistent feel once the pattern is validated
- [ ] Per-entity staging re-serializes the whole file (parse → mutate → stringify), so untouched entities can come out with different (but semantically identical) YAML formatting. The app's existing diff/status logic already normalizes past this, but the raw **Text** view of a partially-staged file may show cosmetic-only noise outside the entity that was actually staged — worth revisiting with an AST-preserving splice if this proves noisy in practice
- [ ] No automated test coverage yet for the entity-diff engine, the splice/staging logic, or the new IPC staging action — needed before this graduates out of preview
- [ ] Hasn't been manually verified end-to-end that a file with *both* staged and unstaged entity changes correctly shows up in both the "Staged" and "Unstaged" lists simultaneously (the underlying git status logic should already support this, but it's untested by hand)
- [ ] Decide on rollout gating (behind a setting/flag?) before this reaches users broadly, given the "[Preview]" status
