### PR TITLE
fix: use unique id for remote files in command search to avoid the list jammed

### DIFF
--- a/packages/insomnia/src/routes/remote-files.tsx
+++ b/packages/insomnia/src/routes/remote-files.tsx
@@ -49,7 +49,9 @@ export async function clientLoader(_args: Route.ClientLoaderArgs) {
     const files = remoteFiles.map(file => {
       const parentProject = projects.find(project => project.remoteId === file.teamProjectId);
       return {
-        id: file.id,
+        // Use a composite ID to ensure uniqueness. Otherwise, some dirty remote files might collide with each other or with local db.
+        id: `${file.teamProjectId}:${file.id}`,
+        workspaceId: file.id,
         url: href('/organization/:organizationId', {
           organizationId: file.organizationId,
         }),


### PR DESCRIPTION
[INS-3646](https://konghq.atlassian.net/browse/INS-3646)

## Background

- Cloud Sync workspace uses local workspace id as its id, which may duplicate with the workspace id in the local db. (Clone a github repo -> convert to cloud sync -> clone it again)

## Changes

- Use team project id + project id as the unique id

[INS-3646]: https://konghq.atlassian.net/browse/INS-3646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ