### PR TITLE
chore: fix playwright port detect

### DIFF
--- a/packages/insomnia-smoke-test/playwright.config.ts
+++ b/packages/insomnia-smoke-test/playwright.config.ts
@@ -33,8 +33,11 @@ const viteServer: PlaywrightTestConfig['webServer'] = {
   stdout: 'pipe',
   stderr: 'pipe',
   wait: {
-    stdout: /VITE\s+ready in/,
+    stdout: /ready in/,
   },
+  // Without this, Playwright SIGKILLs the process group on teardown, which the
+  // .vite-port cleanup in vite.config.ts can't intercept, leaving a stale port file.
+  gracefulShutdown: isWindows ? undefined : { signal: 'SIGTERM', timeout: 2000 },
 };
 const onlyStartWebServerInDev = !process.env.BUNDLE || process.env.BUNDLE === 'dev';
 const config: PlaywrightTestConfig = {

--- a/packages/insomnia-smoke-test/playwright.config.ts
+++ b/packages/insomnia-smoke-test/playwright.config.ts
@@ -33,7 +33,7 @@ const viteServer: PlaywrightTestConfig['webServer'] = {
   stdout: 'pipe',
   stderr: 'pipe',
   wait: {
-    stdout: /ready in/,
+    stdout: /VITE.+ready in/,
   },
   // Without this, Playwright SIGKILLs the process group on teardown, which the
   // .vite-port cleanup in vite.config.ts can't intercept, leaving a stale port file.

--- a/packages/insomnia/vite.config.ts
+++ b/packages/insomnia/vite.config.ts
@@ -19,6 +19,15 @@ function writePortFile(): Plugin {
           fs.writeFileSync(portFilePath, String(addr.port));
         }
       });
+      const cleanup = () => {
+        try { fs.unlinkSync(portFilePath); } catch {}
+        process.exit(0);
+      };
+      process.once('SIGINT', cleanup);
+      process.once('SIGTERM', cleanup);
+      process.once('exit', () => {
+        try { fs.unlinkSync(portFilePath); } catch {}
+      });
     },
   };
 }


### PR DESCRIPTION
## Background

- In the latest vite up gradation, the log is `VITE v7.3.1  ready in 1145 ms` instead of `VITE ready in`
- Playwright SIGKILLs the process by default, which leaves a stale .vite-port file

## Changes

- Update the wait pattern
- Use gracefulShutdown
- Always try to cleanup when receive any exit event