### PR TITLE
fix: prevent login failure with "undefined is not valid JSON" on Windows (#10452)

### DIFF
--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -36,7 +36,7 @@ import {
 import { useProjectNewActionFetcher } from '~/routes/organization.$organizationId.project.new';
 import { isLoggedIn } from '~/ui/account/session';
 import { AnalyticsEvent, PENDING_IMPORT_ATTRIBUTION_KEY, trackImportEvent } from '~/ui/analytics';
-import { getLoginUrl } from '~/ui/auth-session-provider.client';
+import { ensureSessionKeyPair, getLoginUrl } from '~/ui/auth-session-provider.client';
 import { CopyButton } from '~/ui/components/base/copy-button';
 import { Link } from '~/ui/components/base/link';
 import { Icon } from '~/ui/components/icon';
@@ -558,8 +558,16 @@ const Root = () => {
         });
       }
       if (urlWithoutParams === 'insomnia://app/auth/finish') {
+        const code = params.box?.trim();
+        if (!code) {
+          window.localStorage.setItem(
+            'logoutMessage',
+            'Login redirect was missing an authentication code. Please paste the token manually on the authorize page.',
+          );
+          return navigate(href('/auth/authorize'));
+        }
         return authorizeSubmit({
-          code: params.box,
+          code,
         });
       }
       if (urlWithoutParams === 'insomnia://app/open/organization') {
@@ -567,8 +575,11 @@ const Root = () => {
         // gracefully handle open org in app from browser
         const userSession = await services.userSession.get();
         if (!userSession.id || userSession.id === '') {
-          const url = new URL(getLoginUrl());
-          window.main.openInBrowser(url.toString());
+          await ensureSessionKeyPair();
+          const loginUrl = getLoginUrl();
+          if (loginUrl) {
+            window.main.openInBrowser(loginUrl);
+          }
           window.localStorage.setItem('specificOrgRedirectAfterAuthorize', params.organizationId);
           return navigate(href('/auth/authorize'));
         }

--- a/packages/insomnia/src/routes/auth.authorize.tsx
+++ b/packages/insomnia/src/routes/auth.authorize.tsx
@@ -1,13 +1,13 @@
 import { getVault } from 'insomnia-api';
 import { services } from 'insomnia-data';
-import { Fragment } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import { Button, Heading } from 'react-aria-components';
 import { href, redirect, useFetchers, useNavigate } from 'react-router';
 
 import { invariant } from '~/common/utils/invariant';
 import { getVaultKeyFromStorage } from '~/common/utils/vault';
 import { AnalyticsEvent } from '~/ui/analytics';
-import { getLoginUrl, submitAuthCode } from '~/ui/auth-session-provider.client';
+import { ensureSessionKeyPair, getLoginUrl, submitAuthCode } from '~/ui/auth-session-provider.client';
 import { Icon } from '~/ui/components/icon';
 import { createFetcherSubmitHook } from '~/ui/utils/router';
 import { validateVaultKey } from '~/ui/vault-key.client';
@@ -75,7 +75,21 @@ export const useAuthorizeActionFetcher = createFetcherSubmitHook(
 );
 
 const Component = () => {
-  const url = getLoginUrl();
+  const [url, setUrl] = useState('');
+  const [loginUrlError, setLoginUrlError] = useState<string | null>(null);
+
+  useEffect(() => {
+    ensureSessionKeyPair()
+      .then(() => {
+        setUrl(getLoginUrl());
+        setLoginUrlError(null);
+      })
+      .catch(error => {
+        const message = error instanceof Error ? error.message : 'Failed to prepare login URL.';
+        setLoginUrlError(message);
+      });
+  }, []);
+
   const copyUrl = () => {
     window.clipboard.writeText(url);
   };
@@ -104,21 +118,25 @@ const Component = () => {
               If you were not redirected back here after creating an account, please copy and paste the following URL
               into your browser to complete login.
             </p>
-            <div className="form-control form-control--outlined no-pad-top flex">
-              <input type="text" value={url} style={{ marginRight: 'var(--padding-sm)' }} readOnly />
-              <button
-                className="btn btn--super-compact btn--outlined"
-                onClick={copyUrl}
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 'var(--padding-xs)',
-                }}
-              >
-                <i className="fa fa-clipboard" aria-hidden="true" />
-                Copy
-              </button>
-            </div>
+            {loginUrlError ? (
+              <p>{loginUrlError}</p>
+            ) : (
+              <div className="form-control form-control--outlined no-pad-top flex">
+                <input type="text" value={url} style={{ marginRight: 'var(--padding-sm)' }} readOnly />
+                <button
+                  className="btn btn--super-compact btn--outlined"
+                  onClick={copyUrl}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 'var(--padding-xs)',
+                  }}
+                >
+                  <i className="fa fa-clipboard" aria-hidden="true" />
+                  Copy
+                </button>
+              </div>
+            )}
             <p className="text-start text-[rgba(var(--color-font-rgb),0.8)]">
               If your browser does not open the Insomnia app automatically you can manually add the generated token
               here.

--- a/packages/insomnia/src/routes/auth.login.tsx
+++ b/packages/insomnia/src/routes/auth.login.tsx
@@ -3,8 +3,9 @@ import { useEffect, useState } from 'react';
 import { Button } from 'react-aria-components';
 import { href, redirect, useNavigate } from 'react-router';
 
+import { invariant } from '~/common/utils/invariant';
 import { AnalyticsEvent } from '~/ui/analytics';
-import { getLoginUrl } from '~/ui/auth-session-provider.client';
+import { ensureSessionKeyPair, getLoginUrl } from '~/ui/auth-session-provider.client';
 import { Icon } from '~/ui/components/icon';
 import { Tooltip } from '~/ui/components/tooltip';
 import { createFetcherSubmitHook } from '~/ui/utils/router';
@@ -37,7 +38,12 @@ const GoogleIcon = (props: React.ReactSVGElement['props']) => {
 export async function clientAction({ request }: Route.ClientActionArgs) {
   const data = await request.formData();
   const provider = data.get('provider');
-  const url = new URL(getLoginUrl());
+
+  await ensureSessionKeyPair();
+  const loginUrl = getLoginUrl();
+  invariant(loginUrl, 'Login keys are not ready yet. Please wait a moment and try again.');
+
+  const url = new URL(loginUrl);
 
   if (typeof provider === 'string' && provider) {
     url.searchParams.set('provider', provider);

--- a/packages/insomnia/src/ui/__tests__/auth-session-provider.client.test.ts
+++ b/packages/insomnia/src/ui/__tests__/auth-session-provider.client.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+
+import { toUint8Array } from '../auth-session-provider.client';
+
+describe('auth-session-provider.client', () => {
+  it('toUint8Array accepts Uint8Array, arrays, and buffer-like IPC payloads', () => {
+    expect(Array.from(toUint8Array(new Uint8Array([9, 8])))).toEqual([9, 8]);
+    expect(Array.from(toUint8Array([7, 6]))).toEqual([7, 6]);
+    expect(Array.from(toUint8Array({ data: [5, 4] }))).toEqual([5, 4]);
+  });
+});

--- a/packages/insomnia/src/ui/account/__tests__/session.test.ts
+++ b/packages/insomnia/src/ui/account/__tests__/session.test.ts
@@ -126,6 +126,20 @@ describe('absorbKey', () => {
     expect(insomniaApi.getUserProfile).toHaveBeenCalledWith({ sessionId: SESSION_ID });
     expect(insomniaApi.getEncryptionKeys).toHaveBeenCalledWith({ sessionId: SESSION_ID });
   });
+
+  it('throws a readable error when encryption keys are missing from the API response', async () => {
+    vi.mocked(insomniaApi.getEncryptionKeys).mockResolvedValue({
+      public_key: JSON.stringify(MOCK_PUBLIC_KEY),
+      enc_private_key: JSON.stringify(MOCK_ENC_PRIVATE_KEY),
+      enc_symmetric_key: undefined as unknown as string,
+      salt_enc: 'salt',
+      enc_driver_key: '',
+    });
+
+    await expect(absorbKey(SESSION_ID, RAW_KEY)).rejects.toThrow(
+      'Missing encrypted symmetric key from account encryption keys',
+    );
+  });
 });
 
 describe('getPrivateKey', () => {

--- a/packages/insomnia/src/ui/account/session.ts
+++ b/packages/insomnia/src/ui/account/session.ts
@@ -4,6 +4,7 @@ import { models, services } from 'insomnia-data';
 
 import { getCurrentSessionId, type SessionData, setSessionData, unsetSessionData } from '~/common/account/session';
 import { AI_PLUGIN_NAME, LLM_BACKENDS } from '~/common/constants';
+import { invariant } from '~/common/utils/invariant';
 import { getRuntime } from '~/runtimes';
 
 // Re-export the isomorphic session core so renderer callers have a single
@@ -11,17 +12,38 @@ import { getRuntime } from '~/runtimes';
 // and therefore must live in the renderer context.
 export * from '~/common/account/session';
 
+function parseRequiredJson(value: string | undefined | null, fieldName: string) {
+  if (value === undefined || value === null || value === '') {
+    throw new Error(`Missing ${fieldName} from account encryption keys. Please try logging in again.`);
+  }
+
+  try {
+    return JSON.parse(value);
+  } catch {
+    throw new Error(`Invalid ${fieldName} from account encryption keys. Please try logging in again.`);
+  }
+}
+
 /** Creates a session from a sessionId and derived symmetric key. */
 export async function absorbKey(sessionId: string, key: string) {
+  invariant(typeof key === 'string' && key, 'Missing session key from authentication code.');
+
   // Get and store some extra info (salts and keys)
   const sessionIdResolved = sessionId || (await getCurrentSessionId());
+  invariant(sessionIdResolved, 'Missing session ID from authentication code.');
+
   const [profile, keys] = await Promise.all([
     getUserProfile({ sessionId: sessionIdResolved }),
     getEncryptionKeys({ sessionId: sessionIdResolved }),
   ]);
   const { public_key: publicKey, enc_private_key: encPrivateKey, enc_symmetric_key: encSymmetricKey } = keys;
   const { email, id: accountId, first_name: firstName, last_name: lastName } = profile;
-  const symmetricKeyStr = await getRuntime().crypto.decryptAES(key, JSON.parse(encSymmetricKey));
+  const encSymmetricKeyParsed = parseRequiredJson(encSymmetricKey, 'encrypted symmetric key');
+  const symmetricKeyStr = await getRuntime().crypto.decryptAES(key, encSymmetricKeyParsed);
+  invariant(
+    typeof symmetricKeyStr === 'string' && symmetricKeyStr,
+    'Failed to decrypt account encryption keys. Please try logging in again.',
+  );
 
   // Store the information for later
   await setSessionData(
@@ -30,9 +52,9 @@ export async function absorbKey(sessionId: string, key: string) {
     firstName,
     lastName,
     email,
-    JSON.parse(symmetricKeyStr),
-    JSON.parse(publicKey),
-    JSON.parse(encPrivateKey),
+    parseRequiredJson(symmetricKeyStr, 'symmetric key'),
+    parseRequiredJson(publicKey, 'public key'),
+    parseRequiredJson(encPrivateKey, 'encrypted private key'),
   );
 
   if (typeof window !== 'undefined' && window.main?.loginStateChange) {

--- a/packages/insomnia/src/ui/auth-session-provider.client.ts
+++ b/packages/insomnia/src/ui/auth-session-provider.client.ts
@@ -8,21 +8,57 @@ interface AuthBox {
   key: string;
 }
 
-const sessionKeyPairPromise = window.main.sealedBox.keyPair();
-sessionKeyPairPromise.then(async kp => {
-  try {
-    const pub = await encodeBase64(kp.publicKey);
-    window.localStorage.setItem('insomnia.publicKey', getInsomniaPublicKey() || pub);
-  } catch {
-    console.error('Failed to store public key in localStorage.');
+/** Normalize binary data returned from main-process IPC (may be Uint8Array, Buffer-like, or number[]). */
+export function toUint8Array(data: Uint8Array | number[] | ArrayBuffer | { data?: number[] }): Uint8Array {
+  if (data instanceof Uint8Array) {
+    return data;
   }
-  try {
-    const sec = await encodeBase64(kp.secretKey);
-    window.localStorage.setItem('insomnia.secretKey', getInsomniaSecretKey() || sec);
-  } catch {
-    console.error('Failed to store secret key in localStorage.');
+  if (data instanceof ArrayBuffer) {
+    return new Uint8Array(data);
   }
-});
+  if (Array.isArray(data)) {
+    return new Uint8Array(data);
+  }
+  if (data && typeof data === 'object' && Array.isArray(data.data)) {
+    return new Uint8Array(data.data);
+  }
+  throw new Error('Unexpected binary data format from authentication handshake.');
+}
+
+async function initSessionKeyPair(): Promise<void> {
+  const envPublicKey = getInsomniaPublicKey();
+  const envSecretKey = getInsomniaSecretKey();
+  if (envPublicKey && envSecretKey) {
+    window.localStorage.setItem('insomnia.publicKey', envPublicKey);
+    window.localStorage.setItem('insomnia.secretKey', envSecretKey);
+    return;
+  }
+
+  try {
+    const kp = await window.main.sealedBox.keyPair();
+    const pub = await encodeBase64(toUint8Array(kp.publicKey));
+    window.localStorage.setItem('insomnia.publicKey', pub);
+    const sec = await encodeBase64(toUint8Array(kp.secretKey));
+    window.localStorage.setItem('insomnia.secretKey', sec);
+  } catch (error) {
+    console.error('Failed to initialize login keypair.', error);
+    throw error;
+  }
+}
+
+const sessionKeyPairPromise = typeof window !== 'undefined' ? initSessionKeyPair() : Promise.resolve();
+
+/** Wait until the login handshake keypair is stored in localStorage before opening the browser or submitting a token. */
+export async function ensureSessionKeyPair(): Promise<void> {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  await sessionKeyPairPromise;
+  if (!window.localStorage.getItem('insomnia.publicKey') || !window.localStorage.getItem('insomnia.secretKey')) {
+    throw new Error('Login keys are not ready yet. Please wait a moment and try again.');
+  }
+}
 /**
  * Keypair used for the login handshake.
  * This keypair can be re-used for the entire session.
@@ -65,14 +101,21 @@ export async function encodeBase64(data: Uint8Array): Promise<string> {
 
 export async function submitAuthCode(code: string) {
   try {
-    const rawBox = await decodeBase64(code.trim());
+    await ensureSessionKeyPair();
+
+    const trimmedCode = code.trim();
+    invariant(trimmedCode, 'Authentication code is required.');
+
+    const rawBox = await decodeBase64(trimmedCode);
     const publicKey = await decodeBase64(window.localStorage.getItem('insomnia.publicKey') || '');
     const secretKey = await decodeBase64(window.localStorage.getItem('insomnia.secretKey') || '');
     const boxData = await window.main.sealedBox.open(rawBox, publicKey, secretKey);
-    invariant(boxData, 'Invalid authentication code.');
+    invariant(boxData, 'Invalid authentication code. The code may have expired or was generated for a different app session — try logging in again from the login page.');
 
     const decoder = new TextDecoder();
-    const box: AuthBox = JSON.parse(decoder.decode(boxData));
+    const box: AuthBox = JSON.parse(decoder.decode(toUint8Array(boxData)));
+    invariant(typeof box.token === 'string' && box.token, 'Invalid authentication code: missing session token.');
+    invariant(typeof box.key === 'string' && box.key, 'Invalid authentication code: missing session key.');
     await session.absorbKey(box.token, box.key);
   } catch (error) {
     console.error(error);
@@ -90,7 +133,7 @@ export function getLoginUrl() {
   const url = new URL(getAppWebsiteBaseURL());
 
   url.pathname = '/app/auth-app/';
-  url.searchParams.set('loginKey', encodeURIComponent(publicKey));
+  url.searchParams.set('loginKey', publicKey);
   url.searchParams.set('source_origin', 'desktop_app');
 
   return url.toString();


### PR DESCRIPTION
## Summary

- Fixes login failures reported in #10452 where Windows users could not sign in via redirect or manual token paste, seeing `"undefined" is not a valid JSON`.
- Waits for the async sealed-box keypair (introduced in #9996) to finish initializing before opening the browser or submitting an auth token, preventing mismatched/empty login keys.
- Replaces unguarded `JSON.parse(undefined)` calls in `absorbKey()` with validated parsing and readable error messages.
- Fixes double URL-encoding of `loginKey` in the login URL (`URLSearchParams.set` already encodes).
- Handles `insomnia://app/auth/finish` deep links that arrive without a `box` param by redirecting to the authorize page with a clear message.

## Root cause

After sealed-box crypto moved to main-process IPC (#9996), login could proceed before `insomnia.publicKey` / `insomnia.secretKey` were stored in localStorage. When token submission did reach `absorbKey()`, missing encryption-key fields caused `JSON.parse(undefined)`, producing the cryptic error.

## Test plan

- [x] `npm test -w packages/insomnia -- --run src/ui/account/__tests__/session.test.ts src/ui/__tests__/auth-session-provider.client.test.ts` (13/13 passed)
- [x] `npm run lint` (0 errors)
- [x] `npm run type-check` (all workspaces passed)
- [ ] Manual: on Windows, click "Continue with GitHub" and confirm browser opens with a valid login URL
- [ ] Manual: complete login via redirect (`insomnia://app/auth/finish?box=...`) and confirm session is created
- [ ] Manual: if redirect fails, paste token on `/auth/authorize` and confirm login succeeds (or shows a readable error instead of `"undefined" is not a valid JSON`)

Fixes #10452