### PR TITLE
fix(ui): re-render pane templates on project environment switch

### DIFF
--- a/packages/insomnia/src/ui/components/mcp/mcp-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/mcp/mcp-request-pane.tsx
@@ -102,7 +102,7 @@ export const McpRequestPane: FC<Props> = ({
   const { activeRequest, activeRequestMeta, requestPayload } = useRequestLoaderData()! as McpRequestLoaderData;
   const latestRequestPayloadRef = useLatest(requestPayload);
 
-  const { activeProject } = useWorkspaceLoaderData()!;
+  const { activeProject, activeGlobalEnvironment } = useWorkspaceLoaderData()!;
 
   const [mcpParams, setMcpParams] = useState<Record<string, any>>(getParamsFromPayload(requestPayload?.params));
 
@@ -123,7 +123,7 @@ export const McpRequestPane: FC<Props> = ({
 
   // Reset the response pane state when we switch requests, the environment gets modified
   // Some of the UI(tokens) depends on the readyState, so we include it here as well
-  const uniqueKey = `${environment?.modified}::${requestId}::${activeRequestMeta?.activeResponseId}::${readyState}`;
+  const uniqueKey = `${environment?._id}::${environment?.modified}::${activeGlobalEnvironment?._id}::${activeGlobalEnvironment?.modified}::${requestId}::${activeRequestMeta?.activeResponseId}::${readyState}`;
   const requestAuth = getAuthObjectOrNull(activeRequest.authentication);
   const isNoneOrInherited = requestAuth?.type === 'none' || requestAuth === null;
   const jsonSchema = useMemo(() => {

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -77,9 +77,9 @@ export const RequestPane: FC<Props> = ({ environmentId, settings, onPaste }) => 
   };
   const gitVersion = useGitVCSVersion();
 
-  const { activeEnvironment, vcsVersion } = useWorkspaceLoaderData()!;
+  const { activeEnvironment, activeGlobalEnvironment, vcsVersion } = useWorkspaceLoaderData()!;
   // Force re-render when we switch requests, the environment gets modified, or the (Git|Sync)VCS version changes
-  const uniqueKey = `${activeEnvironment?.modified}::${requestId}::${gitVersion}::${vcsVersion}::${activeRequestMeta?.activeResponseId}`;
+  const uniqueKey = `${activeEnvironment?._id}::${activeEnvironment?.modified}::${activeGlobalEnvironment?._id}::${activeGlobalEnvironment?.modified}::${requestId}::${gitVersion}::${vcsVersion}::${activeRequestMeta?.activeResponseId}`;
 
   if (!activeRequest) {
     return <PlaceholderRequestPane />;


### PR DESCRIPTION
[INS-2791](https://konghq.atlassian.net/browse/INS-2791)

## Summary
- Switching a request's project environment (activeGlobalEnvironment) left the request pane's template values stale, since its remount `key` only tracked the workspace environment (activeEnvironment). 
- Added the project environment id/modified timestamp to the URL bar's remount key so it also refreshes on project environment switch.


[INS-2791]: https://konghq.atlassian.net/browse/INS-2791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ