### PR TITLE
Fix: Discard change or restore commit do not update vcs version

### DIFF
--- a/packages/insomnia-vcs/src/vcs.ts
+++ b/packages/insomnia-vcs/src/vcs.ts
@@ -572,6 +572,10 @@ export class VCS {
       throw new Error(`Failed to find commit by id ${snapshotId}`);
     }
 
+    // Update branch.modified so getVersion() changes after a rollback, so that editors with historyKey can detect working content change.
+    const branch = await this._getCurrentBranch();
+    await this._storeBranch(branch);
+
     const currentState: SnapshotState = candidates.map(candidate => ({
       key: candidate.key,
       blob: hashDocument(candidate.document).hash,


### PR DESCRIPTION
# Summary

- Fixes an issue where rolling back to a previous snapshot (VCS.rollback) did not update the current branch's modified timestamp.
- _storeBranch sets branch.modified = new Date(), and getVersion() derives its version string from branch.modified. Editors that key off historyKey use this version to detect that working content has changed. Without the fix, rollback left the editors' historyKey stale, so the UI wouldn't recognize that content had reverted.
- Added a call to _getCurrentBranch() + _storeBranch() at the top of rollback() (packages/insomnia-vcs/src/vcs.ts:575) so the branch's modified timestamp bumps and getVersion() returns a new value after every rollback.

[INS-3707](https://konghq.atlassian.net/browse/INS-3707)


[INS-3707]: https://konghq.atlassian.net/browse/INS-3707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ