### PR TITLE
refactor: inject curl executor into scripting environment

### DIFF
--- a/packages/insomnia-scripting-environment/src/objects/insomnia.ts
+++ b/packages/insomnia-scripting-environment/src/objects/insomnia.ts
@@ -14,7 +14,7 @@ import { Request as ScriptRequest, type RequestOptions, toScriptRequestBody } fr
 import { RequestInfo } from './request-info';
 import type { Response as ScriptResponse } from './response';
 import { readBodyFromPath, toScriptResponse } from './response';
-import { sendRequest } from './send-request';
+import { type CurlRequestExecutor, sendRequest } from './send-request';
 import { skip, test, type TestHandler } from './test';
 import { resolveProtocolForProxy, toUrlObject } from './urls';
 import { checkIfUrlIncludesTag } from './utils';
@@ -45,6 +45,7 @@ export class InsomniaObject {
   private requestTestResults: RequestTestResult[];
 
   private parentFolders: ParentFolders;
+  private _curlRequest?: CurlRequestExecutor;
 
   constructor(rawObj: {
     globals: Environment;
@@ -62,6 +63,7 @@ export class InsomniaObject {
     response?: ScriptResponse;
     parentFolders: ParentFolders;
     vault?: Vault;
+    curlRequest?: CurlRequestExecutor;
   }) {
     this.globals = rawObj.globals;
     this.baseGlobals = rawObj.baseGlobals;
@@ -82,6 +84,7 @@ export class InsomniaObject {
 
     this.requestTestResults = new Array<RequestTestResult>();
     this.parentFolders = rawObj.parentFolders;
+    this._curlRequest = rawObj.curlRequest;
 
     return new Proxy(this, {
       get: (target, prop, receiver) => {
@@ -101,7 +104,10 @@ export class InsomniaObject {
   }
 
   sendRequest(request: string | ScriptRequest, cb: (error?: string, response?: ScriptResponse) => void) {
-    return sendRequest(request, cb, this._settings);
+    if (!this._curlRequest) {
+      throw new Error('sendRequest is not available in this execution context.');
+    }
+    return sendRequest(request, cb, this._settings, this._curlRequest);
   }
 
   test = () => {
@@ -141,7 +147,7 @@ export class InsomniaObject {
   };
 }
 
-export async function initInsomniaObject(rawObj: RequestContext, log: (...args: any[]) => void) {
+export async function initInsomniaObject(rawObj: RequestContext, log: (...args: any[]) => void, curlRequest?: CurlRequestExecutor) {
   // Mapping rule for the global environment:
   // - If global base environment is selected, both `baseGlobals` and `globals` point to the selected one.
   // - If one global sub environment is selected,  `baseGlobals` points to the base env of the selected one and `globals` points to the selected one.
@@ -286,5 +292,6 @@ export async function initInsomniaObject(rawObj: RequestContext, log: (...args: 
     response,
     execution,
     parentFolders,
+    curlRequest,
   });
 }

--- a/packages/insomnia-scripting-environment/src/objects/send-request.ts
+++ b/packages/insomnia-scripting-environment/src/objects/send-request.ts
@@ -1,4 +1,3 @@
-import type { CurlRequestOutput } from 'insomnia/src/main/network/libcurl-promise';
 import type { Settings } from 'insomnia-data';
 import { services } from 'insomnia-data';
 import { Cookie } from 'tough-cookie';
@@ -10,19 +9,24 @@ import type { CookieOptions } from './cookies';
 import { Request, type RequestOptions } from './request';
 import { Response } from './response';
 
+export interface CurlRequestOutput {
+  patch: { elapsedTime: number; bodyCompression?: 'zip' | null; error?: string };
+  headerResults: { code: number; reason: string; headers: { name: string; value: string }[] }[];
+  responseBodyPath?: string;
+}
+
+export type CurlRequestExecutor = (options: unknown) => Promise<CurlRequestOutput>;
+
 export async function sendRequest(
   request: string | Request | RequestOptions,
   cb: (error?: string, response?: Response) => void,
   settings: Settings,
+  curlRequest: CurlRequestExecutor,
 ): Promise<Response | void> {
   return new Promise(async (resolve, reject) => {
     try {
       const requestOptions = requestToCurlOptions(request, settings);
-      const nodejsCurlRequest = __IS_RENDERER__
-        ? window.bridge.curlRequest
-        : (await import('insomnia/src/main/network/libcurl-promise')).curlRequest;
-
-      const output = (await nodejsCurlRequest(requestOptions)) as CurlRequestOutput;
+      const output = await curlRequest(requestOptions);
       const transformedOutput = await curlOutputToResponse(output, request);
 
       if (cb) {

--- a/packages/insomnia-scripting-environment/tsconfig.json
+++ b/packages/insomnia-scripting-environment/tsconfig.json
@@ -10,9 +10,6 @@
     "moduleResolution": "bundler",
     "isolatedModules": true,
     "noEmit": true,
-    "paths": {
-      "~/*": ["../insomnia/src/*"]
-    },
     /* Strictness */
     "strict": true,
     "noImplicitReturns": true,
@@ -25,6 +22,6 @@
     /* If your code runs in the DOM: */
     "lib": ["es2023", "dom", "dom.iterable"]
   },
-  "include": ["../insomnia/types"],
+  "include": ["src/**/*.ts"],
   "exclude": ["**/__tests__", "node_modules"]
 }

--- a/packages/insomnia/src/script-executor.ts
+++ b/packages/insomnia/src/script-executor.ts
@@ -13,8 +13,10 @@ import {
   mergeSettings,
   type RequestContext,
 } from '../../insomnia-scripting-environment/src/objects';
+import { curlRequest } from './main/network/libcurl-promise';
 import { requireInterceptor } from './scripting/require-interceptor';
 
+const executeCurlRequest = (options: unknown) => curlRequest(options as Parameters<typeof curlRequest>[0]);
 export const runScript = async ({
   script,
   context,
@@ -25,7 +27,7 @@ export const runScript = async ({
   // console.log(script);
   const scriptConsole = getNewConsole();
 
-  const executionContext = await initInsomniaObject(context, scriptConsole.log);
+  const executionContext = await initInsomniaObject(context, scriptConsole.log, executeCurlRequest);
 
   const evalInterceptor = (script: string) => {
     invariant(script && typeof script === 'string', 'eval is called with invalid or empty value');

--- a/packages/insomnia/src/scripting/sandbox.ts
+++ b/packages/insomnia/src/scripting/sandbox.ts
@@ -335,7 +335,7 @@ export async function prepareSandbox(
     ({ names: maskNames, values: maskValues } = alwaysOnPolicy.buildMaskScope(checkSandboxViolations));
   }
 
-  const executionContext = await initInsomniaObject(sandboxContext, scriptConsole.log);
+  const executionContext = await initInsomniaObject(sandboxContext, scriptConsole.log, options => window.bridge.curlRequest(options));
 
   const bridgeOps: BridgeOps = {
     resetAsyncTasks: Object.freeze(window.bridge.resetAsyncTasks.bind(window.bridge)),


### PR DESCRIPTION
[INS-3767](https://konghq.atlassian.net/browse/INS-3767)

## Summary
- Remove the scripting environment dependency on Insomnia's libcurl module.
- Inject a curl request executor into InsomniaObject instead.
- Keep node execution on the node curl implementation and renderer execution on the hidden-window bridge.
- Enable TypeScript checking for the scripting-environment source after the application runtime dependency is removed.

## Risk isolation
This is intentionally stacked on #10482 so the curlRequest plumbing can be reviewed separately.

## Verification
- insomnia-data type-check
- insomnia-scripting-environment type-check with `src/**/*.ts` included
- insomnia type-check
- scripting environment tests: 127 passed
- QuickJS/sandbox tests: 131 passed
- circular-reference check: no new circular dependencies

Base branch: chore/cycle-reference-clean-up (PR #10482). This branch ultimately descends from the latest chore/cycle-reference-check.

[INS-3767]: https://konghq.atlassian.net/browse/INS-3767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ