### PR TITLE
fix: prevent environment rename freeze caused by keyboard drag session

### DIFF
--- a/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
@@ -359,6 +359,14 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
           if (!cm) {
             return;
           }
+          // codeMirror.current is nulled asynchronously — by the useUnmount cleanup
+          // effect on unmount, and by reinitialize()'s cleanUpEditor() — so React
+          // schedules asynchronously and does not guarantee runs before the next rAF tick — so a
+          // stale loop can still see a non-null cm whose wrapper was already removed from the DOM.
+          // Bail here rather than steal focus into a zombie editor that's mid-teardown.
+          if (!document.body.contains(cm.getWrapperElement())) {
+            return;
+          }
           if (!cm.hasFocus()) {
             const active = document.activeElement as HTMLElement | null;
             // The row React Aria bounces focus to is a non-interactive container (role="row"/"option");

--- a/packages/insomnia/src/ui/components/editable-input.tsx
+++ b/packages/insomnia/src/ui/components/editable-input.tsx
@@ -23,6 +23,10 @@ export const EditableInput = ({
   // This state is used to keep track of the value while submitting when parent component value is not updated
   const [pendingValue, setPendingValue] = useState<string | null>(null);
   const editableRef = useRef<HTMLDivElement>(null);
+  // Removing the focused Input from the DOM (on Enter/Escape) fires a native blur
+  // synchronously, which would otherwise run onSubmit a second time (or commit after an
+  // Escape cancel) and race with the next double-click's FocusScope mount.
+  const settledRef = useRef(false);
 
   useEffect(() => {
     // set pending value to null if parent value is changed
@@ -32,6 +36,12 @@ export const EditableInput = ({
   useEffect(() => {
     setIsEditable(editable);
   }, [editable]);
+
+  useEffect(() => {
+    if (isEditable) {
+      settledRef.current = false;
+    }
+  }, [isEditable]);
 
   useEffect(() => {
     if (!isEditable) {
@@ -76,7 +86,14 @@ export const EditableInput = ({
         <span className="truncate">{pendingValue ?? value}</span>
       </div>
       {isEditable && (
-        <FocusScope contain restoreFocus autoFocus>
+        // No `restoreFocus`: on commit the input unmounts while the Enter keypress is
+        // still in flight, and restoring focus here races the RAC collection correction,
+        // landing DOM focus on a draggable row (e.g. the KV editor's trailing row) before
+        // the keyup fires. RAC then reads that keyup as a keyboard drag release and
+        // starts a drag session that aria-hides the whole page (frozen UI until Escape).
+        // Letting focus settle on the body keeps the collection unfocused, so the drag
+        // can never be armed.
+        <FocusScope contain autoFocus>
           <Input
             ref={el => el?.select()}
             className={`truncate ${className || 'px-2'}`}
@@ -84,9 +101,13 @@ export const EditableInput = ({
             aria-label={ariaLabel}
             defaultValue={value}
             onKeyDown={e => {
-              const value = e.currentTarget.value;
               if (e.key === 'Enter') {
                 e.stopPropagation();
+                if (settledRef.current) {
+                  return;
+                }
+                settledRef.current = true;
+                const value = e.currentTarget.value;
                 setPendingValue(value);
                 onSubmit(value);
                 setIsEditable(false);
@@ -95,11 +116,16 @@ export const EditableInput = ({
 
               if (e.key === 'Escape') {
                 e.stopPropagation();
+                settledRef.current = true;
                 setIsEditable(false);
                 onEditableChange?.(false);
               }
             }}
             onBlur={e => {
+              if (settledRef.current) {
+                return;
+              }
+              settledRef.current = true;
               const value = e.currentTarget.value;
               setPendingValue(value);
               onSubmit(value);


### PR DESCRIPTION
[INS-3703](https://konghq.atlassian.net/browse/INS-3703)

## Problem

In the environment editor, double-clicking an environment name (sidebar or header) to rename it and pressing Enter could freeze the entire page: nothing responded to clicks or keyboard until pressing Escape. Root cause found empirically (instrumented focus trace + CPU profile + pause stacks) and confirmed against the installed library source.

## Root cause

Committing the rename unmounts the focused input **while the Enter keypress is still in flight**. `FocusScope`'s `restoreFocus` (async rAF) then raced the RAC collection correction and landed DOM focus on a draggable row — the KV editor's trailing blank row — before the same keypress's keyup fired. `@react-aria/dnd`'s keyboard-drag handler (`useDrag.mjs` `onKeyUpCapture`: `if (target === currentTarget && key === 'Enter') startDragging(...)`) read that keyup as a drag release and started a `DragSession`, which:

- `ariaHideOutside`-hides everything on the page except the drag source/drop targets, and
- capture-phase `preventDefault`s every `focusin`/`focusout`/`mousedown`/`keydown`.

Result: the whole app is inert until Escape (the session's only user-facing exit). CPU profile showed the renderer ~92% idle — the page wasn't busy, it was locked.

## Fix

- **`EditableInput`**: drop `restoreFocus` from the `FocusScope`. On commit, focus settles on `document.body`, the collection stays unfocused, and the keyboard drag can never be armed (mechanism removed, not mitigated).
- **`EditableInput`**: `settledRef` guard so Enter/Escape/blur commit exactly once — the unmount blur previously fired `onSubmit` a second time (double mutation + double revalidation per rename). Side effect: **Escape now truly cancels** — previously the unmount blur committed the typed value after Escape.
- **`OneLineEditor`**: the `ensureFocus` rAF loop bails when the CodeMirror wrapper is detached from the DOM, so a stale loop from a remount cannot steal focus into a mid-teardown editor.

## Known behavior change

After committing/canceling a rename, focus settles on the document body instead of returning to the trigger element. Keyboard users need to Tab back into the tree/list. `restoreFocus` could not be kept without re-arming the freeze (the drag is armed precisely by focus landing on a draggable row mid-keypress); a safe follow-up would be restoring collection position only after the keyup completes.

## Validation

- `npm run type-check -w packages/insomnia` — clean
- `eslint` on both changed files — clean
- Smoke suites: `key-value-editor-blank-row` (4/4), `environment-editor-interactions` (5/5 — includes the exact dblclick → Enter rename gesture with real trusted key events), `design-document-naming` (2/2)
- Manual repro (double-click rename → Enter → freeze) verified fixed by the reporter; Escape-revival behavior no longer reachable
- 5-lane review (goal/constraints, code quality, security, hands-on QA, context mining): all PASS

## Follow-ups (non-blocking)

- Regression smoke test: rename env → Enter → assert page not `aria-hidden` and responsive (the freeze is mouse-timing-dependent, so determinism needs care)
- Upstream: react-aria keyboard-drag arming from a stray keyup is related to react-spectrum#8468; the `restoreFocus`-races-correction mechanism appears unreported
- Pre-existing, out of scope: no `isComposing` check on the Enter handler (CJK IME premature-commit risk); environment route passes a new `[]` identity per render to the KV editor's `dependencies`

[INS-3703]: https://konghq.atlassian.net/browse/INS-3703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ