### PR TITLE
fix: Update vault plugin version and trust proxy scope settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3157,9 +3157,9 @@
       }
     },
     "node_modules/@kong/insomnia-plugin-external-vault": {
-      "version": "0.1.5-dev.20260806050036",
-      "resolved": "https://npm.pkg.github.com/download/@kong/insomnia-plugin-external-vault/0.1.5-dev.20260806050036/764507d31c7a92146b75d00e871059bc255ed28a",
-      "integrity": "sha512-7JVgIPeMgRLpcu/56A+KBhXdpLJj8m9ZivFsF1PTl5M6h02ctvC4g5h8gaMvL7LxJrCfCkfpB+PAytVrVf0suw==",
+      "version": "0.1.5-dev.20260910023314",
+      "resolved": "https://npm.pkg.github.com/download/@kong/insomnia-plugin-external-vault/0.1.5-dev.20260910023314/55da1313ba18141895b8d7c62b4539b3ec7e9079",
+      "integrity": "sha512-zSNRpc4UGX92p7IlJCnH/6xUIUd8+fIv6XO9ZExUR9002I6xaKdn11+51tpDE0nlK/qXxHUuk2CXLwl1N2978Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -27611,7 +27611,7 @@
       },
       "optionalDependencies": {
         "@kong/insomnia-plugin-ai": "^1.0.11",
-        "@kong/insomnia-plugin-external-vault": "0.1.5-dev.20260806050036"
+        "@kong/insomnia-plugin-external-vault": "0.1.5-dev.20260910023314"
       }
     },
     "packages/insomnia-analytics": {
@@ -27677,7 +27677,7 @@
         "shellwords": "^1.0.1"
       },
       "optionalDependencies": {
-        "@kong/insomnia-plugin-external-vault": "0.1.5-dev.20260806050036"
+        "@kong/insomnia-plugin-external-vault": "0.1.5-dev.20260910023314"
       }
     },
     "packages/insomnia-inso/node_modules/@stoplight/types": {

--- a/packages/insomnia-inso/package.json
+++ b/packages/insomnia-inso/package.json
@@ -68,6 +68,6 @@
     "yaml": "^2.7.1"
   },
   "optionalDependencies": {
-    "@kong/insomnia-plugin-external-vault": "0.1.5-dev.20260806050036"
+    "@kong/insomnia-plugin-external-vault": "0.1.5-dev.20260910023314"
   }
 }

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -220,7 +220,7 @@
   },
   "optionalDependencies": {
     "@kong/insomnia-plugin-ai": "^1.0.11",
-    "@kong/insomnia-plugin-external-vault": "0.1.5-dev.20260806050036"
+    "@kong/insomnia-plugin-external-vault": "0.1.5-dev.20260910023314"
   },
   "dev": {
     "dev-server-port": 3334

--- a/packages/insomnia/src/plugins/context/network.ts
+++ b/packages/insomnia/src/plugins/context/network.ts
@@ -1,4 +1,5 @@
 import { services } from 'insomnia-data';
+import { ProxyScopes } from 'insomnia-data/common';
 import { v4 as uuidv4 } from 'uuid';
 
 import type { NodeCurlRequestOptions, NodeCurlResponseType, PluginTemplateTagContext } from '~/common/templating/types';
@@ -56,6 +57,10 @@ export function init(): {
       async sendRequestWithoutSideEffects(options: NodeCurlRequestOptions): Promise<NodeCurlResponseType> {
         const requestId = uuidv4();
         const settings = await services.settings.get();
+        if (settings.proxyScope !== ProxyScopes.all) {
+          // Disable proxying unless user chooses "All traffic sent by Insomnia" (all).
+          settings.proxyEnabled = false;
+        }
         const settingFollowRedirects = settings?.followRedirects ? 'on' : 'off';
         const { request: originRequest, caCertficatePath = null } = options;
         const curlRequest = __IS_RENDERER__


### PR DESCRIPTION
# Changes
- Update vault plugin version with the fix
- Apply proxy scope settings for plugin network interface

[INS-3769](https://konghq.atlassian.net/browse/INS-3769)

[INS-3769]: https://konghq.atlassian.net/browse/INS-3769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ